### PR TITLE
Add service programs for Fireworks board module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ path = "src/bin/snd-firewire-digi00x-ctl-service.rs"
 [[bin]]
 name = "snd-firewire-tascam-ctl-service"
 path = "src/bin/snd-firewire-tascam-ctl-service.rs"
+
+[[bin]]
+name = "snd-fireworks-ctl-service"
+path = "src/bin/snd-fireworks-ctl-service.rs"

--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ snd-firewire-digi00x-ctl-service
    For sound card bound to ALSA firewire-digi00x driver (snd-firewire-digi00x)
 snd-firewire-tascam-ctl-service
    For sound card bound to ALSA firewire-tascam driver (snd-firewire-tascam), or TASCAM FE-8.
+snd-fireworks-ctl-service
+   For sound card bound to ALSA fireworks driver (snd-fireworks)
 
 License
 =======
@@ -75,6 +77,19 @@ your device, please contact to developer.
   * Tascam FW-1804
   * Tascam FE-8
 
+* snd-fireowrks-ctl-service
+
+  * Mackie (Loud) Onyx 1200F
+  * Mackie (Loud) Onyx 400F
+  * Echo Audio Audiofire 12 (till Jul 2009)
+  * Echo Audio Audiofire 8 (till Jul 2009)
+  * Echo Audio Audiofire 12 (since Jul 2009)
+  * Echo Audio Audiofire 8 (since Jul 2009)
+  * Echo Audio Audiofire 2
+  * Echo Audio Audiofire 4
+  * Echo Audio Audiofire Pre8
+  * Gibson Robot Interface Pack (RIP) for Robot Guitar series
+
 Supported protocols
 ===================
 
@@ -84,6 +99,7 @@ Supported protocols
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)
+   * Protocol for Fireworks board module of Echo Digital Audio
 
 Design note
 ===========

--- a/src/bin/snd-fireworks-ctl-service.rs
+++ b/src/bin/snd-fireworks-ctl-service.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use snd_fw_ctl_services::efw;
+
+use std::env;
+
+fn print_help() {
+    println!("
+Usage:
+  snd-fireworks-ctl-service CARD_ID
+
+  where:
+    CARD_ID: The numerical ID of sound card.
+    ");
+}
+
+fn main() {
+    // Check arguments in command line.
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_help();
+        std::process::exit(libc::EXIT_FAILURE);
+    }
+
+    let card_id = match args[1].parse::<u32>() {
+        Ok(card_id) => card_id,
+        Err(err) => {
+            println!("{:?}", err);
+            print_help();
+            std::process::exit(libc::EXIT_FAILURE);
+        }
+    };
+
+    let err = match efw::unit::EfwUnit::new(card_id) {
+        Err(err) => {
+            println!("The card {} is not for fireworks device: {}",
+                     card_id, err);
+            Err(err)
+        }
+        Ok(mut unit) => {
+            if let Err(err) = unit.listen() {
+                println!("Fail to listen events: {}", err);
+                Err(err)
+            } else {
+                unit.run();
+                Ok(())
+            }
+        }
+    };
+
+    if err.is_err() {
+        std::process::exit(libc::EXIT_FAILURE)
+    }
+
+    std::process::exit(libc::EXIT_SUCCESS)
+}

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -1,0 +1,1 @@
+pub mod unit;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -1,3 +1,5 @@
 pub mod unit;
 
 mod model;
+
+mod transactions;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -8,3 +8,4 @@ mod clk_ctl;
 mod mixer_ctl;
 mod output_ctl;
 mod input_ctl;
+mod port_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -7,3 +7,4 @@ mod transactions;
 mod clk_ctl;
 mod mixer_ctl;
 mod output_ctl;
+mod input_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -3,3 +3,5 @@ pub mod unit;
 mod model;
 
 mod transactions;
+
+mod clk_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -1,1 +1,3 @@
 pub mod unit;
+
+mod model;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -10,3 +10,4 @@ mod output_ctl;
 mod input_ctl;
 mod port_ctl;
 mod meter_ctl;
+mod guitar_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -5,3 +5,4 @@ mod model;
 mod transactions;
 
 mod clk_ctl;
+mod mixer_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -6,3 +6,4 @@ mod transactions;
 
 mod clk_ctl;
 mod mixer_ctl;
+mod output_ctl;

--- a/src/efw.rs
+++ b/src/efw.rs
@@ -9,3 +9,4 @@ mod mixer_ctl;
 mod output_ctl;
 mod input_ctl;
 mod port_ctl;
+mod meter_ctl;

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -115,8 +115,12 @@ impl<'a> ClkCtl {
                 if !unit.get_property_streaming() {
                     let mut vals = [0];
                     new.get_enum(&mut vals);
-                    EfwHwCtl::set_clock(unit, Some(ClkSrc::from(vals[0] as usize)), None)?;
-                    Ok(true)
+                    if let Some(&src) = self.srcs.iter().nth(vals[0] as usize) {
+                        EfwHwCtl::set_clock(unit, Some(src), None)?;
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
                 } else {
                     Ok(false)
                 }

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -129,8 +129,12 @@ impl<'a> ClkCtl {
                 if !unit.get_property_streaming() {
                     let mut vals = [0];
                     new.get_enum(&mut vals);
-                    EfwHwCtl::set_clock(unit, None, Some(vals[0]))?;
-                    Ok(true)
+                    if let Some(&rate) = self.rates.iter().nth(vals[0] as usize) {
+                        EfwHwCtl::set_clock(unit, None, Some(rate))?;
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
                 } else {
                     Ok(false)
                 }

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+use hinawa::SndUnitExt;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{ClkSrc, HwInfo, EfwHwCtl};
+
+pub struct ClkCtl {
+    srcs: Vec<ClkSrc>,
+    rates: Vec<u32>,
+}
+
+impl<'a> ClkCtl {
+    const SRC_NAME: &'a str = "clock-source";
+    const RATE_NAME: &'a str = "clock-rate";
+
+    pub fn new() -> Self {
+        ClkCtl {
+            srcs: Vec::new(),
+            rates: Vec::new(),
+        }
+    }
+
+    pub fn load(
+        &mut self,
+        hwinfo: &HwInfo,
+        card_cntr: &mut card_cntr::CardCntr,
+    ) -> Result<(), Error> {
+        self.srcs.extend_from_slice(&hwinfo.clk_srcs);
+        self.rates.extend_from_slice(&hwinfo.clk_rates);
+
+        let labels: Vec<&str> = self
+            .srcs
+            .iter()
+            .map(|src| match *src {
+                ClkSrc::Internal => "Internal",
+                ClkSrc::WordClock => "WordClock",
+                ClkSrc::Spdif => "S/PDIF",
+                ClkSrc::Adat => "ADAT",
+                ClkSrc::Adat2 => "ADAT2",
+                ClkSrc::Continuous => "Continuous",
+                ClkSrc::Unknown(_) => "Unknown",
+            })
+            .collect();
+
+        let elem_id =
+            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, Self::SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<&str> = hwinfo
+            .clk_rates
+            .iter()
+            .map(|rate| match *rate {
+                32000 => "32000",
+                44100 => "44100",
+                48000 => "48000",
+                88200 => "88200",
+                96000 => "96000",
+                176400 => "176400",
+                192000 => "192000",
+                _ => "Unknown",
+            })
+            .collect();
+
+        let elem_id =
+            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, Self::RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::SRC_NAME => {
+                let (src, _) = EfwHwCtl::get_clock(unit)?;
+                if let Some(pos) = self.srcs.iter().position(|s| *s == src) {
+                    elem_value.set_enum(&[pos as u32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::RATE_NAME => {
+                let (_, rate) = EfwHwCtl::get_clock(unit)?;
+                if let Some(pos) = self.rates.iter().position(|r| *r == rate) {
+                    elem_value.set_enum(&[pos as u32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        old: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::SRC_NAME => {
+                if !unit.get_property_streaming() {
+                    let mut vals = [0; 2];
+                    old.get_enum(&mut vals[0..1]);
+                    new.get_enum(&mut vals[1..]);
+                    if vals[0] != vals[1] {
+                        EfwHwCtl::set_clock(unit, Some(ClkSrc::from(vals[0] as usize)), None)?;
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::RATE_NAME => {
+                if !unit.get_property_streaming() {
+                    let mut vals = [0; 2];
+                    old.get_enum(&mut vals[0..1]);
+                    new.get_enum(&mut vals[1..]);
+                    if vals[0] != vals[1] {
+                        EfwHwCtl::set_clock(unit, None, Some(vals[0]))?;
+                    }
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -107,18 +107,15 @@ impl<'a> ClkCtl {
         &mut self,
         unit: &hinawa::SndEfw,
         elem_id: &alsactl::ElemId,
-        old: &alsactl::ElemValue,
+        _: &alsactl::ElemValue,
         new: &alsactl::ElemValue,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             Self::SRC_NAME => {
                 if !unit.get_property_streaming() {
-                    let mut vals = [0; 2];
-                    old.get_enum(&mut vals[0..1]);
-                    new.get_enum(&mut vals[1..]);
-                    if vals[0] != vals[1] {
-                        EfwHwCtl::set_clock(unit, Some(ClkSrc::from(vals[0] as usize)), None)?;
-                    }
+                    let mut vals = [0];
+                    new.get_enum(&mut vals);
+                    EfwHwCtl::set_clock(unit, Some(ClkSrc::from(vals[0] as usize)), None)?;
                     Ok(true)
                 } else {
                     Ok(false)
@@ -126,12 +123,9 @@ impl<'a> ClkCtl {
             }
             Self::RATE_NAME => {
                 if !unit.get_property_streaming() {
-                    let mut vals = [0; 2];
-                    old.get_enum(&mut vals[0..1]);
-                    new.get_enum(&mut vals[1..]);
-                    if vals[0] != vals[1] {
-                        EfwHwCtl::set_clock(unit, None, Some(vals[0]))?;
-                    }
+                    let mut vals = [0];
+                    new.get_enum(&mut vals);
+                    EfwHwCtl::set_clock(unit, None, Some(vals[0]))?;
                     Ok(true)
                 } else {
                     Ok(false)

--- a/src/efw/guitar_ctl.rs
+++ b/src/efw/guitar_ctl.rs
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use super::transactions::{HwInfo, HwCap, EfwGuitar};
+
+pub struct GuitarCtl {}
+
+impl<'a> GuitarCtl {
+    const MANUAL_CHARGE_NAME: &'a str = "guitar-manual-chage";
+    const AUTO_CHARGE_NAME: &'a str = "guitar-auto-chage";
+    const SUSPEND_TO_CHARGE: &'a str = "guitar-suspend-to-charge";
+
+    const MIN_SEC: i32 = 0;
+    const MAX_SEC: i32 = 60 * 60;   // = One hour.
+    const STEP_SEC: i32 = 1;
+
+    pub fn new() -> Self {
+        GuitarCtl{}
+    }
+
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        let has_guitar_charge = hwinfo.caps.iter().find(|&e| *e == HwCap::GuitarCharging).is_some();
+
+        if has_guitar_charge {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::MANUAL_CHARGE_NAME, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::AUTO_CHARGE_NAME, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::SUSPEND_TO_CHARGE, 0);
+            let _ = card_cntr.add_int_elems(&elem_id, 1,
+                Self::MIN_SEC, Self::MAX_SEC, Self::STEP_SEC, 1, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MANUAL_CHARGE_NAME => {
+                let state = EfwGuitar::get_charge_state(unit)?;
+                elem_value.set_bool(&[state.manual_charge]);
+                Ok(true)
+            }
+            Self::AUTO_CHARGE_NAME => {
+                let state = EfwGuitar::get_charge_state(unit)?;
+                elem_value.set_bool(&[state.auto_charge]);
+                Ok(true)
+            }
+            Self::SUSPEND_TO_CHARGE => {
+                let state = EfwGuitar::get_charge_state(unit)?;
+                elem_value.set_int(&[state.suspend_to_charge as i32]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        _: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MANUAL_CHARGE_NAME => {
+                let mut vals = [false];
+                new.get_bool(&mut vals);
+                let mut state = EfwGuitar::get_charge_state(unit)?;
+                state.manual_charge = vals[0];
+                EfwGuitar::set_charge_state(unit, &state)?;
+                Ok(true)
+            }
+            Self::AUTO_CHARGE_NAME => {
+                let mut vals = [false];
+                new.get_bool(&mut vals);
+                let mut state = EfwGuitar::get_charge_state(unit)?;
+                state.auto_charge = vals[0];
+                EfwGuitar::set_charge_state(unit, &state)?;
+                Ok(true)
+            }
+            Self::SUSPEND_TO_CHARGE => {
+                let mut vals = [0];
+                new.get_int(&mut vals);
+                let mut state = EfwGuitar::get_charge_state(unit)?;
+                state.suspend_to_charge = vals[0] as u32;
+                EfwGuitar::set_charge_state(unit, &state)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/input_ctl.rs
+++ b/src/efw/input_ctl.rs
@@ -10,6 +10,7 @@ use super::transactions::{HwCap, EfwPhysInput, NominalLevel, HwInfo};
 
 pub struct InputCtl {
     phys_inputs: usize,
+    cache: Option<Vec::<NominalLevel>>,
 }
 
 impl<'a> InputCtl {
@@ -19,10 +20,10 @@ impl<'a> InputCtl {
     const IN_NOMINAL_LEVELS: &'a [NominalLevel] = &[NominalLevel::PlusFour, NominalLevel::MinusTen];
 
     pub fn new() -> Self {
-        InputCtl { phys_inputs: 0 }
+        InputCtl { phys_inputs: 0, cache: None}
     }
 
-    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+    pub fn load(&mut self, unit: &hinawa::SndEfw, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         self.phys_inputs = hwinfo.phys_inputs.iter().fold(0, |accm, entry| accm + entry.group_count);
@@ -32,6 +33,19 @@ impl<'a> InputCtl {
                 alsactl::ElemIfaceType::Mixer, 0, 0, Self::IN_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
                 self.phys_inputs, Self::IN_NOMINAL_LABELS, None, true)?;
+        }
+
+        // FPGA models return invalid state of nominal level. Here, initialize them and cache the
+        // state instead.
+        let has_fpga = hwinfo.caps.iter().find(|&cap| *cap == HwCap::Fpga).is_some();
+        if has_fpga {
+            let cache = vec![NominalLevel::PlusFour;self.phys_inputs];
+            cache.iter().enumerate()
+                .try_for_each( |(i, &level)| {
+                    EfwPhysInput::set_nominal(unit, i, level)?;
+                    Ok(())
+                })?;
+            self.cache = Some(cache);
         }
 
         Ok(())
@@ -46,13 +60,24 @@ impl<'a> InputCtl {
         match elem_id.get_name().as_str() {
             Self::IN_NOMINAL_NAME => {
                 let mut vals = vec![0; self.phys_inputs];
-                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
-                    let level = EfwPhysInput::get_nominal(unit, i)?;
-                    if let Some(pos) = Self::IN_NOMINAL_LEVELS.iter().position(|&l| l == level) {
-                        *val = pos as u32;
+                match &self.cache {
+                    // For models with FPGA.
+                    Some(cache) => {
+                        vals.iter_mut().zip(cache.iter()).for_each(|(val, &level)| {
+                            *val = u32::from(level)
+                        });
                     }
-                    Ok(())
-                })?;
+                    // For models with DSP.
+                    None => {
+                        vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                            let level = EfwPhysInput::get_nominal(unit, i)?;
+                            if let Some(pos) = Self::IN_NOMINAL_LEVELS.iter().position(|&l| l == level) {
+                                *val = pos as u32;
+                            }
+                            Ok(())
+                        })?;
+                    }
+                }
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
@@ -80,6 +105,14 @@ impl<'a> InputCtl {
                     }
                     Ok(())
                 })?;
+
+                // For FPGA models.
+                if let Some(cache) = &mut self.cache {
+                    cache.iter_mut().zip(vals[0..self.phys_inputs].iter()).for_each(|(c, &val)| {
+                        *c = NominalLevel::from(val);
+                    });
+                }
+
                 Ok(true)
             }
             _ => Ok(false),

--- a/src/efw/input_ctl.rs
+++ b/src/efw/input_ctl.rs
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{HwCap, EfwPhysInput, NominalLevel, HwInfo};
+
+pub struct InputCtl {
+    phys_inputs: usize,
+}
+
+impl<'a> InputCtl {
+    const IN_NOMINAL_NAME: &'a str = "input-nominal";
+
+    const IN_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "0", "-10dBV"];
+
+    pub fn new() -> Self {
+        InputCtl { phys_inputs: 0 }
+    }
+
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        self.phys_inputs = hwinfo.phys_inputs.iter().fold(0, |accm, entry| accm + entry.group_count);
+
+        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::NominalInput).is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::IN_NOMINAL_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1,
+                self.phys_inputs, Self::IN_NOMINAL_LABELS, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::IN_NOMINAL_NAME => {
+                let mut vals = vec![0; self.phys_inputs];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = match EfwPhysInput::get_nominal(unit, i)? {
+                        NominalLevel::MinusTen => 2,
+                        NominalLevel::Medium => 1,
+                        NominalLevel::PlusFour => 0,
+                    };
+                    Ok(())
+                })?;
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        old: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::IN_NOMINAL_NAME => {
+                let mut vals = vec![0; self.phys_inputs * 2];
+                new.get_enum(&mut vals[..self.phys_inputs]);
+                old.get_enum(&mut vals[self.phys_inputs..]);
+                (0..self.phys_inputs).try_for_each(|i| {
+                    if vals[i] != vals[self.phys_inputs + i] {
+                        let level = match vals[i] {
+                            2 => NominalLevel::MinusTen,
+                            1 => NominalLevel::Medium,
+                            _ => NominalLevel::PlusFour,
+                        };
+                        EfwPhysInput::set_nominal(unit, i, level)?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/meter_ctl.rs
+++ b/src/efw/meter_ctl.rs
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use crate::card_cntr;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{HwMeter, EfwInfo, HwInfo, HwCap};
+
+pub struct MeterCtl {
+    pub monitored_elems: Vec<alsactl::ElemId>,
+    meters: Option<HwMeter>,
+    midi_inputs: usize,
+    midi_outputs: usize,
+}
+
+impl<'a> MeterCtl {
+    const CLK_DETECT: &'a str = "clock-detect";
+    const MIDI_IN_DETECT: &'a str = "midi-in-detect";
+    const MIDI_OUT_DETECT: &'a str = "midi-out-detect";
+    const INPUT_METERS: &'a str = "input-meter";
+    const OUTPUT_METERS: &'a str = "output-meter";
+    const GUITAR_STEREO_CONNECT: &'a str = "guitar-stereo-detect";
+    const GUITAR_HEX_SIGNAL: &'a str = "guitar-hex-signal-detect";
+    const GUITAR_CHARGE_STATE: &'a str = "guitar-charge-state-detect";
+
+    const COEF_MIN: i32 = 0;
+    const COEF_MAX: i32 = 0x007fffff;
+    const COEF_STEP: i32 = 1;
+
+    pub fn new() -> Self {
+        MeterCtl {
+            monitored_elems: Vec::new(),
+            meters: None,
+            midi_inputs: 0,
+            midi_outputs: 0,
+        }
+    }
+
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        self.meters = Some(HwMeter::new(
+            &hwinfo.clk_srcs,
+            hwinfo.mixer_captures,
+            hwinfo.mixer_playbacks,
+        ));
+        self.midi_inputs = hwinfo.midi_inputs;
+        self.midi_outputs = hwinfo.midi_outputs;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, Self::CLK_DETECT, 0);
+        let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, hwinfo.clk_srcs.len(), false)?;
+        self.monitored_elems.extend_from_slice(&elem_id_list);
+
+        if self.midi_inputs > 0 {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::MIDI_IN_DETECT, 0);
+
+            let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, self.midi_inputs, false)?;
+            self.monitored_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.midi_outputs > 0 {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::MIDI_OUT_DETECT, 0);
+            let elem_id_list =
+                card_cntr.add_bool_elems(&elem_id, 1, self.midi_outputs, false)?;
+            self.monitored_elems.extend_from_slice(&elem_id_list);
+        }
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::INPUT_METERS, 0);
+        let elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+            Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+            hwinfo.mixer_captures, None, false)?;
+        self.monitored_elems.extend_from_slice(&elem_id_list);
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUTPUT_METERS, 0);
+        let elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+            Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+            hwinfo.mixer_playbacks, None, false)?;
+        self.monitored_elems.extend_from_slice(&elem_id_list);
+
+        let has_robot_guitar = hwinfo.caps.iter().find(|&e| *e == HwCap::RobotGuitar).is_some();
+        if has_robot_guitar {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::GUITAR_STEREO_CONNECT, 0);
+            let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+            self.monitored_elems.extend_from_slice(&elem_id_list);
+
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::GUITAR_HEX_SIGNAL, 0);
+            let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+            self.monitored_elems.extend_from_slice(&elem_id_list);
+        }
+
+        let has_guitar_charge = hwinfo.caps.iter().find(|&e| *e == HwCap::GuitarCharging).is_some();
+        if has_guitar_charge {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Card, 0, 0, Self::GUITAR_CHARGE_STATE, 0);
+            let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+            self.monitored_elems.extend_from_slice(&elem_id_list);
+        }
+
+        Ok(())
+    }
+
+    pub fn monitor_unit(&mut self, unit: &hinawa::SndEfw) -> Result<(), Error> {
+        match &mut self.meters {
+            Some(meters) => EfwInfo::get_meter(unit, meters),
+            None => {
+                let label = "Metering data is not prepared.";
+                Err(Error::new(FileError::Nxio, &label))
+            }
+        }
+    }
+
+    pub fn monitor_elems(
+        &mut self,
+        _: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        _: &alsactl::ElemValue,
+        new: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::CLK_DETECT => {
+                if let Some(meters) = &self.meters {
+                    let vals: Vec<bool> = meters
+                        .detected_clk_srcs
+                        .iter()
+                        .map(|(_, detected)| *detected)
+                        .collect();
+                    new.set_bool(&vals);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::MIDI_IN_DETECT => {
+                if let Some(meters) = &self.meters {
+                    let vals: Vec<bool> = (0..self.midi_inputs)
+                        .map(|i| meters.detected_midi_inputs[i])
+                        .collect();
+                    new.set_bool(&vals);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::MIDI_OUT_DETECT => {
+                if let Some(meters) = &self.meters {
+                    let vals: Vec<bool> = (0..self.midi_outputs)
+                        .map(|i| meters.detected_midi_inputs[i])
+                        .collect();
+                    new.set_bool(&vals);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::INPUT_METERS => {
+                if let Some(meters) = &self.meters {
+                    new.set_int(&meters.phys_input_meters);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::OUTPUT_METERS => {
+                if let Some(meters) = &self.meters {
+                    new.set_int(&meters.phys_output_meters);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::GUITAR_STEREO_CONNECT => {
+                if let Some(meters) = &self.meters {
+                    new.set_bool(&[meters.guitar_stereo_connect]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::GUITAR_HEX_SIGNAL => {
+                if let Some(meters) = &self.meters {
+                    new.set_bool(&[meters.guitar_hex_signal]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::GUITAR_CHARGE_STATE => {
+                if let Some(meters) = &self.meters {
+                    new.set_bool(&[meters.guitar_charging]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/mixer_ctl.rs
+++ b/src/efw/mixer_ctl.rs
@@ -1,0 +1,265 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{HwInfo, EfwPlayback, EfwMonitor};
+
+pub struct MixerCtl {
+    playbacks: usize,
+    captures: usize,
+}
+
+impl<'a> MixerCtl {
+    const PLAYBACK_VOL_NAME: &'a str = "playback-volume";
+    const PLAYBACK_MUTE_NAME: &'a str = "playback-mute";
+    const PLAYBACK_SOLO_NAME: &'a str = "playback-solo";
+
+    const MONITOR_GAIN_NAME: &'a str = "monitor-gain";
+    const MONITOR_MUTE_NAME: &'a str = "monitor-mute";
+    const MONITOR_SOLO_NAME: &'a str = "monitor-solo";
+    const MONITOR_PAN_NAME: &'a str = "monitor-pan";
+
+    // The fixed point number of 8.24 format.
+    const COEF_MIN: i32 = 0x00000000;
+    const COEF_MAX: i32 = 0x02000000;
+    const COEF_STEP: i32 = 0x00000001;
+    const COEF_TLV: &'a [i32] = &[5, 8, -14400, 6];
+
+    const PAN_MIN: i32 = 0;
+    const PAN_MAX: i32 = 255;
+    const PAN_STEP: i32 = 1;
+
+    pub fn new() -> Self {
+        MixerCtl {
+            playbacks: 0,
+            captures: 0,
+        }
+    }
+
+    pub fn load(
+        &mut self,
+        hwinfo: &HwInfo,
+        card_cntr: &mut card_cntr::CardCntr,
+    ) -> Result<(), Error> {
+        self.playbacks = hwinfo.mixer_playbacks;
+        self.captures = hwinfo.mixer_captures;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_VOL_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1,
+            Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+            self.playbacks, Some(Self::COEF_TLV), true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_MUTE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_SOLO_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,
+            Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+            self.captures, Some(Self::COEF_TLV), true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_MUTE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, self.playbacks, self.captures, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_SOLO_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, self.playbacks, self.captures, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_PAN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,
+            Self::PAN_MIN, Self::PAN_MAX, Self::PAN_STEP,
+            self.captures, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PLAYBACK_VOL_NAME => {
+                let mut vals = vec![0; self.playbacks];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = EfwPlayback::get_vol(unit, i)?;
+                    Ok(())
+                })?;
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::PLAYBACK_MUTE_NAME => {
+                let mut vals = vec![false; self.playbacks];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = EfwPlayback::get_mute(unit, i)?;
+                    Ok(())
+                })?;
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::PLAYBACK_SOLO_NAME => {
+                let mut vals = vec![false; self.playbacks];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = EfwPlayback::get_solo(unit, i)?;
+                    Ok(())
+                })?;
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::MONITOR_GAIN_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![0; self.captures];
+                vals.iter_mut().enumerate().try_for_each(|(src, val)| {
+                    *val = EfwMonitor::get_vol(unit, dst, src)?;
+                    Ok(())
+                })?;
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::MONITOR_MUTE_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![false; self.captures];
+                vals.iter_mut().enumerate().try_for_each(|(src, val)| {
+                    *val = EfwMonitor::get_mute(unit, dst, src)?;
+                    Ok(())
+                })?;
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::MONITOR_SOLO_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![false; self.captures];
+                vals.iter_mut().enumerate().try_for_each(|(src, val)| {
+                    *val = EfwMonitor::get_solo(unit, dst, src)?;
+                    Ok(())
+                })?;
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::MONITOR_PAN_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![0; self.captures];
+                vals.iter_mut().enumerate().try_for_each(|(src, val)| {
+                    *val = EfwMonitor::get_pan(unit, dst, src)? as i32;
+                    Ok(())
+                })?;
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        old: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PLAYBACK_VOL_NAME => {
+                let mut vals = vec![0; self.playbacks * 2];
+                new.get_int(&mut vals[..self.playbacks]);
+                old.get_int(&mut vals[self.playbacks..]);
+                (0..self.playbacks).try_for_each(|i| {
+                    if vals[i] != vals[self.playbacks + i] {
+                        EfwPlayback::set_vol(unit, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::PLAYBACK_MUTE_NAME => {
+                let mut vals = vec![false; self.playbacks * 2];
+                new.get_bool(&mut vals[..self.playbacks]);
+                old.get_bool(&mut vals[self.playbacks..]);
+                (0..self.playbacks).try_for_each(|i| {
+                    if vals[i] != vals[self.playbacks + i] {
+                        EfwPlayback::set_mute(unit, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::PLAYBACK_SOLO_NAME => {
+                let mut vals = vec![false; self.playbacks * 2];
+                new.get_bool(&mut vals[..self.playbacks]);
+                old.get_bool(&mut vals[self.playbacks..]);
+                (0..self.playbacks).try_for_each(|i| {
+                    if vals[i] != vals[self.playbacks + i] {
+                        EfwPlayback::set_solo(unit, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::MONITOR_GAIN_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![0; self.captures * 2];
+                new.get_int(&mut vals[..self.captures]);
+                old.get_int(&mut vals[self.captures..]);
+                (0..self.captures).try_for_each(|i| {
+                    if vals[i] != vals[self.captures + i] {
+                        EfwMonitor::set_vol(unit, dst, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::MONITOR_MUTE_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![false; self.captures * 2];
+                new.get_bool(&mut vals[..self.captures]);
+                old.get_bool(&mut vals[self.captures..]);
+                (0..self.captures).try_for_each(|src| {
+                    if vals[src] != vals[self.captures + src] {
+                        EfwMonitor::set_mute(unit, dst, src, vals[src])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::MONITOR_SOLO_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![false; self.captures * 2];
+                new.get_bool(&mut vals[..self.captures]);
+                old.get_bool(&mut vals[self.captures..]);
+                (0..self.captures).try_for_each(|src| {
+                    if vals[src] != vals[self.captures + src] {
+                        EfwMonitor::set_solo(unit, dst, src, vals[src])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::MONITOR_PAN_NAME => {
+                let dst = elem_id.get_index() as usize;
+                let mut vals = vec![0; self.captures * 2];
+                new.get_int(&mut vals[..self.captures]);
+                old.get_int(&mut vals[self.captures..]);
+                (0..self.captures).try_for_each(|src| {
+                    if vals[src] != vals[self.captures + src] {
+                        EfwMonitor::set_pan(unit, dst, src, vals[src] as u8)?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -14,6 +14,7 @@ use super::output_ctl;
 use super::input_ctl;
 use super::port_ctl;
 use super::meter_ctl;
+use super::guitar_ctl;
 
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
@@ -22,6 +23,7 @@ pub struct EfwModel {
     input_ctl: input_ctl::InputCtl,
     port_ctl: port_ctl::PortCtl,
     meter_ctl: meter_ctl::MeterCtl,
+    guitar_ctl: guitar_ctl::GuitarCtl,
 }
 
 impl EfwModel {
@@ -57,6 +59,7 @@ impl EfwModel {
                         input_ctl: input_ctl::InputCtl::new(),
                         port_ctl: port_ctl::PortCtl::new(),
                         meter_ctl: meter_ctl::MeterCtl::new(),
+                        guitar_ctl: guitar_ctl::GuitarCtl::new(),
                     };
                     Ok(model)
                 },
@@ -83,6 +86,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         self.input_ctl.load(&hwinfo, card_cntr)?;
         self.port_ctl.load(&hwinfo, card_cntr)?;
         self.meter_ctl.load(&hwinfo, card_cntr)?;
+        self.guitar_ctl.load(&hwinfo, card_cntr)?;
         Ok(())
     }
 
@@ -98,6 +102,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.input_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else if self.port_ctl.read(unit, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.guitar_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -120,6 +126,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.input_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else if self.port_ctl.write(unit, elem_id, old, new)? {
+            Ok(true)
+        } else if self.guitar_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -12,12 +12,14 @@ use super::clk_ctl;
 use super::mixer_ctl;
 use super::output_ctl;
 use super::input_ctl;
+use super::port_ctl;
 
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
     mixer_ctl: mixer_ctl::MixerCtl,
     output_ctl: output_ctl::OutputCtl,
     input_ctl: input_ctl::InputCtl,
+    port_ctl: port_ctl::PortCtl,
 }
 
 impl EfwModel {
@@ -51,6 +53,7 @@ impl EfwModel {
                         mixer_ctl: mixer_ctl::MixerCtl::new(),
                         output_ctl: output_ctl::OutputCtl::new(),
                         input_ctl: input_ctl::InputCtl::new(),
+                        port_ctl: port_ctl::PortCtl::new(),
                     };
                     Ok(model)
                 },
@@ -75,6 +78,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
         self.output_ctl.load(&hwinfo, card_cntr)?;
         self.input_ctl.load(&hwinfo, card_cntr)?;
+        self.port_ctl.load(&hwinfo, card_cntr)?;
         Ok(())
     }
 
@@ -88,6 +92,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.output_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(unit, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -108,6 +114,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.output_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else if self.input_ctl.write(unit, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -4,6 +4,9 @@ use glib::{Error, FileError};
 
 use crate::ta1394;
 
+use crate::card_cntr;
+use card_cntr::CtlModel;
+
 pub struct EfwModel {}
 
 impl EfwModel {
@@ -45,5 +48,26 @@ impl EfwModel {
                 Err(Error::new(FileError::Noent, label))
             }
         }
+    }
+}
+
+impl CtlModel<hinawa::SndEfw> for EfwModel {
+    fn load(&mut self, _: &hinawa::SndEfw, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndEfw, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    fn write(
+        &mut self,
+        _: &hinawa::SndEfw,
+        _: &alsactl::ElemId,
+        _: &alsactl::ElemValue,
+        _: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        Ok(false)
     }
 }

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -7,6 +7,8 @@ use crate::ta1394;
 use crate::card_cntr;
 use card_cntr::CtlModel;
 
+use super::transactions::EfwInfo;
+
 pub struct EfwModel {}
 
 impl EfwModel {
@@ -52,7 +54,9 @@ impl EfwModel {
 }
 
 impl CtlModel<hinawa::SndEfw> for EfwModel {
-    fn load(&mut self, _: &hinawa::SndEfw, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &hinawa::SndEfw, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        let hwinfo = EfwInfo::get_hwinfo(unit)?;
+
         Ok(())
     }
 

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -11,11 +11,13 @@ use super::transactions::EfwInfo;
 use super::clk_ctl;
 use super::mixer_ctl;
 use super::output_ctl;
+use super::input_ctl;
 
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
     mixer_ctl: mixer_ctl::MixerCtl,
     output_ctl: output_ctl::OutputCtl,
+    input_ctl: input_ctl::InputCtl,
 }
 
 impl EfwModel {
@@ -48,6 +50,7 @@ impl EfwModel {
                         clk_ctl: clk_ctl::ClkCtl::new(),
                         mixer_ctl: mixer_ctl::MixerCtl::new(),
                         output_ctl: output_ctl::OutputCtl::new(),
+                        input_ctl: input_ctl::InputCtl::new(),
                     };
                     Ok(model)
                 },
@@ -71,6 +74,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         self.clk_ctl.load(&hwinfo, card_cntr)?;
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
         self.output_ctl.load(&hwinfo, card_cntr)?;
+        self.input_ctl.load(&hwinfo, card_cntr)?;
         Ok(())
     }
 
@@ -82,6 +86,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.mixer_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(unit, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -100,6 +106,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         } else if self.mixer_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else if self.output_ctl.write(unit, elem_id, old, new)? {
+            Ok(true)
+        } else if self.input_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -9,9 +9,11 @@ use card_cntr::CtlModel;
 
 use super::transactions::EfwInfo;
 use super::clk_ctl;
+use super::mixer_ctl;
 
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
+    mixer_ctl: mixer_ctl::MixerCtl,
 }
 
 impl EfwModel {
@@ -42,6 +44,7 @@ impl EfwModel {
                 (0x00075b, 0x00afb9) => {
                     let model = EfwModel {
                         clk_ctl: clk_ctl::ClkCtl::new(),
+                        mixer_ctl: mixer_ctl::MixerCtl::new(),
                     };
                     Ok(model)
                 },
@@ -63,6 +66,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         -> Result<(), Error> {
         let hwinfo = EfwInfo::get_hwinfo(unit)?;
         self.clk_ctl.load(&hwinfo, card_cntr)?;
+        self.mixer_ctl.load(&hwinfo, card_cntr)?;
         Ok(())
     }
 
@@ -70,6 +74,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error> {
         if self.clk_ctl.read(unit, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -84,6 +90,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         new: &alsactl::ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, old, new)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use crate::ta1394;
+
+pub struct EfwModel {}
+
+impl EfwModel {
+    pub fn new(data: &[u8]) -> Result<Self, Error> {
+        match ta1394::config_rom::parse_entries(&data) {
+            Some((v, m)) => match (v.vendor_id, m.model_id) {
+                // Mackie/Loud Onyx 400F.
+                (0x000ff2, 0x00400f) |
+                // Mackie/Loud Onyx 1200F.
+                (0x000ff2, 0x01200f) |
+                // Echo Digital Audio, AudioFire 12.
+                (0x001486, 0x00af12) |
+                // Echo Digital Audio, AudioFire 12.
+                (0x001486, 0x0af12d) |
+                // Echo Digital Audio, AudioFire 12.
+                (0x001486, 0x0af12a) |
+                // Echo Digital Audio, AudioFire 8.
+                (0x001486, 0x000af8) |
+                // Echo Digital Audio, AudioFire 2.
+                (0x001486, 0x000af2) |
+                // Echo Digital Audio, AudioFire 4.
+                (0x001486, 0x000af4) |
+                // Echo Digital Audio, AudioFire 8/Pre8.
+                (0x001486, 0x000af9) |
+                // Gibson, Robot Interface Pack (RIP) for Robot Guitar series.
+                (0x00075b, 0x00afb2) |
+                // Gibson, Robot Interface Pack (RIP) for Dark Fire series.
+                (0x00075b, 0x00afb9) => {
+                    let model = EfwModel {};
+                    Ok(model)
+                },
+                _ => {
+                    let label = "Not supported.";
+                    Err(Error::new(FileError::Noent, label))
+                },
+            },
+            None => {
+                let label = "Fail to detect information of unit";
+                Err(Error::new(FileError::Noent, label))
+            }
+        }
+    }
+}

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -10,10 +10,12 @@ use card_cntr::CtlModel;
 use super::transactions::EfwInfo;
 use super::clk_ctl;
 use super::mixer_ctl;
+use super::output_ctl;
 
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
     mixer_ctl: mixer_ctl::MixerCtl,
+    output_ctl: output_ctl::OutputCtl,
 }
 
 impl EfwModel {
@@ -45,6 +47,7 @@ impl EfwModel {
                     let model = EfwModel {
                         clk_ctl: clk_ctl::ClkCtl::new(),
                         mixer_ctl: mixer_ctl::MixerCtl::new(),
+                        output_ctl: output_ctl::OutputCtl::new(),
                     };
                     Ok(model)
                 },
@@ -67,6 +70,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         let hwinfo = EfwInfo::get_hwinfo(unit)?;
         self.clk_ctl.load(&hwinfo, card_cntr)?;
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
+        self.output_ctl.load(&hwinfo, card_cntr)?;
         Ok(())
     }
 
@@ -76,6 +80,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         if self.clk_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(unit, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(unit, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -92,6 +98,8 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         if self.clk_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else if self.mixer_ctl.write(unit, elem_id, old, new)? {
+            Ok(true)
+        } else if self.output_ctl.write(unit, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -83,7 +83,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         self.clk_ctl.load(&hwinfo, card_cntr)?;
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
         self.output_ctl.load(&hwinfo, card_cntr)?;
-        self.input_ctl.load(&hwinfo, card_cntr)?;
+        self.input_ctl.load(unit, &hwinfo, card_cntr)?;
         self.port_ctl.load(&hwinfo, card_cntr)?;
         self.meter_ctl.load(&hwinfo, card_cntr)?;
         self.guitar_ctl.load(&hwinfo, card_cntr)?;

--- a/src/efw/model.rs
+++ b/src/efw/model.rs
@@ -122,3 +122,23 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         }
     }
 }
+
+impl card_cntr::MonitorModel<hinawa::SndEfw> for EfwModel {
+    fn get_monitored_elems(&mut self, _: &mut Vec<alsactl::ElemId>) {
+        ()
+    }
+
+    fn monitor_unit(&mut self, _: &hinawa::SndEfw) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn monitor_elems(
+        &mut self,
+        _: &hinawa::SndEfw,
+        _: &alsactl::ElemId,
+        _: &alsactl::ElemValue,
+        _: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+}

--- a/src/efw/output_ctl.rs
+++ b/src/efw/output_ctl.rs
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{HwCap, PhysGroupType, NominalLevel, EfwPhysOutput, HwInfo};
+
+pub struct OutputCtl {
+    phys_outputs: usize,
+}
+
+impl<'a> OutputCtl {
+    const OUT_VOL_NAME: &'a str = "output-volume";
+    const OUT_MUTE_NAME: &'a str = "output-mute";
+    const OUT_NOMINAL_NAME: &'a str = "output-nominal";
+
+    // The fixed point number of 8.24 format.
+    const COEF_MIN: i32 = 0x00000000;
+    const COEF_MAX: i32 = 0x02000000;
+    const COEF_STEP: i32 = 0x00000001;
+    const COEF_TLV: &'a [i32] = &[5, 8, -14400, 6];
+
+    const OUT_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "0", "-10dBV"];
+
+    pub fn new() -> Self {
+        OutputCtl { phys_outputs: 0 }
+    }
+
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        self.phys_outputs = hwinfo.phys_outputs.iter().fold(0, |accm, entry| {
+            if entry.group_type != PhysGroupType::AnalogMirror {
+                accm + entry.group_count
+            } else {
+                accm
+            }
+        });
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_VOL_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1,
+            Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+            self.phys_outputs, Some(Self::COEF_TLV), true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(
+            alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_MUTE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.phys_outputs, true)?;
+
+        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::NominalOutput).is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_NOMINAL_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1,
+                self.phys_outputs, Self::OUT_NOMINAL_LABELS, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::OUT_VOL_NAME => {
+                let mut vals = vec![0; self.phys_outputs];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = EfwPhysOutput::get_vol(unit, i)?;
+                    Ok(())
+                })?;
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::OUT_MUTE_NAME => {
+                let mut vals = vec![false; self.phys_outputs];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = EfwPhysOutput::get_mute(unit, i)?;
+                    Ok(())
+                })?;
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::OUT_NOMINAL_NAME => {
+                let mut vals = vec![0; self.phys_outputs];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = match EfwPhysOutput::get_nominal(unit, i)? {
+                        NominalLevel::MinusTen => 2,
+                        NominalLevel::Medium => 1,
+                        NominalLevel::PlusFour => 0,
+                    };
+                    Ok(())
+                })?;
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        old: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::OUT_VOL_NAME => {
+                let mut vals = vec![0; self.phys_outputs * 2];
+                new.get_int(&mut vals[..self.phys_outputs]);
+                old.get_int(&mut vals[self.phys_outputs..]);
+                (0..self.phys_outputs).try_for_each(|i| {
+                    if vals[i] != vals[self.phys_outputs + i] {
+                        EfwPhysOutput::set_vol(unit, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::OUT_MUTE_NAME => {
+                let mut vals = vec![false; self.phys_outputs * 2];
+                new.get_bool(&mut vals[..self.phys_outputs]);
+                old.get_bool(&mut vals[self.phys_outputs..]);
+                (0..self.phys_outputs).try_for_each(|i| {
+                    if vals[i] != vals[self.phys_outputs + i] {
+                        EfwPhysOutput::set_mute(unit, i, vals[i])?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            Self::OUT_NOMINAL_NAME => {
+                let mut vals = vec![0; self.phys_outputs * 2];
+                new.get_enum(&mut vals[..self.phys_outputs]);
+                old.get_enum(&mut vals[self.phys_outputs..]);
+                (0..self.phys_outputs).try_for_each(|i| {
+                    if vals[i] != vals[self.phys_outputs + i] {
+                        let level = match vals[i] {
+                            2 => NominalLevel::MinusTen,
+                            1 => NominalLevel::Medium,
+                            _ => NominalLevel::PlusFour,
+                        };
+                        EfwPhysOutput::set_nominal(unit, i, level)?;
+                    }
+                    Ok(())
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/efw/port_ctl.rs
+++ b/src/efw/port_ctl.rs
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use super::transactions::{HwCap, DigitalMode, EfwPortConf, PhysGroupType, HwInfo};
+
+pub struct PortCtl {
+    dig_modes: Vec<DigitalMode>,
+    phys_in_pairs: usize,
+    phys_out_pairs: usize,
+    rx_pairs: usize,
+    tx_pairs: usize,
+}
+
+impl<'a> PortCtl {
+    const MIRROR_OUTPUT_NAME: &'a str = "mirror-output";
+    const DIG_MODE_NAME: &'a str = "digital-mode";
+    const PHANTOM_NAME: &'a str = "phantom-powering";
+    const RX_MAP_NAME: &'a str = "stream-playback-routing";
+    const TX_MAP_NAME: &'a str = "stream-capture-routing";
+
+    const DIG_MODES: &'a [(HwCap, DigitalMode)] = &[
+        (HwCap::SpdifCoax, DigitalMode::SpdifCoax),
+        (HwCap::AesebuXlr, DigitalMode::AesebuXlr),
+        (HwCap::SpdifOpt, DigitalMode::SpdifOpt),
+        (HwCap::AdatOpt, DigitalMode::AdatOpt),
+    ];
+
+    pub fn new() -> Self {
+        PortCtl {
+            dig_modes: Vec::new(),
+            phys_in_pairs: 0,
+            phys_out_pairs: 0,
+            tx_pairs: 0,
+            rx_pairs: 0,
+        }
+    }
+
+    fn add_mapping_ctl(
+        &self,
+        card_cntr: &mut card_cntr::CardCntr,
+        name: &'a str,
+        phys_pairs: usize,
+        stream_pairs: usize,
+    ) -> Result<(), Error> {
+        let list: Vec<String> = (0..stream_pairs)
+            .map(|pair| format!("Stream-{}/{}", pair * 2 + 1, pair * 2 + 2))
+            .collect();
+        let labels: Vec<&str> = list.iter().map(|entry| entry.as_str()).collect();
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, name, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, phys_pairs, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::MirrorOutput).is_some() {
+            let mut list = Vec::new();
+            hwinfo.phys_outputs.iter().for_each(|entry| {
+                if entry.group_type != PhysGroupType::AnalogMirror {
+                    (0..(entry.group_count / 2)).for_each(|i| {
+                        let name = String::from(&entry.group_type);
+                        list.push(format!("{}-{}/{}", name, i * 2 + 1, i * 2 + 2))
+                    })
+                }
+            });
+            let labels: Vec<&str> = list.iter().map(|entry| entry.as_str()).collect();
+
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::MIRROR_OUTPUT_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        }
+
+        Self::DIG_MODES.iter().for_each(|(cap, mode)| {
+            if hwinfo.caps.iter().find(|&c| *c == *cap).is_some() {
+                self.dig_modes.push(*mode);
+            }
+        });
+        if self.dig_modes.len() > 0 {
+            let modes: Vec<String> = self.dig_modes.iter()
+                .map(|mode| String::from(mode))
+                .collect();
+            let labels: Vec<&str> = modes.iter()
+                .map(|label| label.as_str())
+                .collect();
+
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::DIG_MODE_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        }
+
+        if hwinfo.caps.iter().position(|cap| *cap == HwCap::PhantomPowering).is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(
+                alsactl::ElemIfaceType::Mixer, 0, 0, Self::PHANTOM_NAME, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        }
+
+        if hwinfo.caps.iter().position(|cap| *cap == HwCap::OutputMapping).is_some() {
+            self.phys_out_pairs = hwinfo.phys_outputs.iter()
+                .fold(0, |accm, entry| accm + entry.group_count)
+                / 2;
+            self.rx_pairs = hwinfo.rx_channels[0] / 2;
+
+            self.add_mapping_ctl(card_cntr, Self::RX_MAP_NAME, self.phys_out_pairs, self.rx_pairs)?;
+        }
+
+        if hwinfo.caps.iter().position(|cap| *cap == HwCap::InputMapping).is_some() {
+            self.phys_in_pairs = hwinfo.phys_inputs.iter()
+                .fold(0, |accm, entry| accm + entry.group_count) / 2;
+            self.tx_pairs = hwinfo.tx_channels[0] / 2;
+
+            self.add_mapping_ctl(
+                card_cntr,
+                Self::TX_MAP_NAME,
+                self.phys_in_pairs,
+                self.tx_pairs,
+            )?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        elem_value: &mut alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MIRROR_OUTPUT_NAME => {
+                let pair = EfwPortConf::get_output_mirror(unit)?;
+                elem_value.set_enum(&[pair as u32]);
+                Ok(true)
+            }
+            Self::DIG_MODE_NAME => {
+                let mode = EfwPortConf::get_digital_mode(unit)?;
+                if let Some(pos) = self.dig_modes.iter().position(|&m| m == mode) {
+                    elem_value.set_enum(&[pos as u32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::PHANTOM_NAME => {
+                let state = EfwPortConf::get_phantom_powering(unit)?;
+                elem_value.set_bool(&[state]);
+                Ok(true)
+            }
+            Self::RX_MAP_NAME => {
+                let (rx_entries, _) = EfwPortConf::get_stream_map(unit)?;
+                let vals: Vec<u32> = rx_entries.iter().map(|entry| *entry as u32).collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::TX_MAP_NAME => {
+                let (_, tx_entries) = EfwPortConf::get_stream_map(unit)?;
+                let vals: Vec<u32> = tx_entries.iter().map(|entry| *entry as u32).collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &hinawa::SndEfw,
+        elem_id: &alsactl::ElemId,
+        old: &alsactl::ElemValue,
+        new: &alsactl::ElemValue,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MIRROR_OUTPUT_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                EfwPortConf::set_output_mirror(unit, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::DIG_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                if self.dig_modes.len() > vals[0] as usize {
+                    EfwPortConf::set_digital_mode(unit, self.dig_modes[vals[0] as usize])?;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::PHANTOM_NAME => {
+                let mut vals = [false];
+                new.get_bool(&mut vals);
+                EfwPortConf::set_phantom_powering(unit, vals[0])?;
+                Ok(true)
+            }
+            Self::RX_MAP_NAME => {
+                let mut vals = vec![0; self.rx_pairs * 2];
+                new.get_enum(&mut vals[..self.rx_pairs]);
+                old.get_enum(&mut vals[self.rx_pairs..]);
+                if vals[..self.rx_pairs] != vals[self.rx_pairs..] {
+                    let entries: Vec<usize> = vals[..self.rx_pairs]
+                        .iter()
+                        .map(|entry| *entry as usize)
+                        .collect();
+                    EfwPortConf::set_stream_map(unit, Some(entries), None)?;
+                }
+                Ok(true)
+            }
+            Self::TX_MAP_NAME => {
+                let mut vals = vec![0; self.tx_pairs * 2];
+                new.get_enum(&mut vals[..self.tx_pairs]);
+                old.get_enum(&mut vals[self.tx_pairs..]);
+                if vals[..self.tx_pairs] != vals[self.tx_pairs..] {
+                    let entries: Vec<usize> = vals[..self.tx_pairs]
+                        .iter()
+                        .map(|entry| *entry as usize)
+                        .collect();
+                    EfwPortConf::set_stream_map(unit, None, Some(entries))?;
+                }
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+impl From<&PhysGroupType> for String {
+    fn from(group_type: &PhysGroupType) -> String {
+        match group_type {
+            PhysGroupType::Analog       => "Analog",
+            PhysGroupType::Spdif        => "S/PDIF",
+            PhysGroupType::Adat         => "ADAT",
+            PhysGroupType::SpdifOrAdat  => "S/PDIForADAT",
+            PhysGroupType::AnalogMirror => "AnalogMirror",
+            PhysGroupType::Headphones   => "HeadPhones",
+            PhysGroupType::I2s          => "I2S",
+            PhysGroupType::Guitar       => "Guitar",
+            PhysGroupType::PiezoGuitar  => "PiezoGuitar",
+            PhysGroupType::GuitarString => "GuitarString",
+            PhysGroupType::Unknown(_)   => "Unknown",
+        }.to_string()
+    }
+}
+
+impl From<&DigitalMode> for String {
+    fn from(mode: &DigitalMode) -> String {
+        match mode {
+            DigitalMode::SpdifCoax  => "S/PDIF-Coaxial",
+            DigitalMode::AesebuXlr  => "AES/EBU-XLR",
+            DigitalMode::SpdifOpt   => "S/PDIF-Optical",
+            DigitalMode::AdatOpt    => "ADAT-Optical",
+            DigitalMode::Unknown(_) => "Unknown",
+        }.to_string()
+    }
+}

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -654,7 +654,7 @@ impl EfwMonitor {
             &args,
             &mut params,
         )?;
-        Ok(params[1] as i32)
+        Ok(params[2] as i32)
     }
 
     pub fn set_mute(
@@ -683,7 +683,7 @@ impl EfwMonitor {
             &args,
             &mut params,
         )?;
-        Ok(params[1] > 0)
+        Ok(params[2] > 0)
     }
 
     pub fn set_solo(
@@ -712,7 +712,7 @@ impl EfwMonitor {
             &args,
             &mut params,
         )?;
-        Ok(params[1] > 0)
+        Ok(params[2] > 0)
     }
 
     pub fn set_pan(unit: &hinawa::SndEfw, dst: usize, src: usize, pan: u8) -> Result<(), Error> {
@@ -736,7 +736,7 @@ impl EfwMonitor {
             &args,
             &mut params,
         )?;
-        Ok(params[1] as u8)
+        Ok(params[2] as u8)
     }
 }
 

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -413,6 +413,7 @@ impl EfwHwCtl {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq)]
 pub enum NominalLevel {
     PlusFour,
     Medium,

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -1,0 +1,280 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use hinawa::SndEfwExtManual;
+
+enum Category {
+    Info,
+}
+
+impl From<Category> for u32 {
+    fn from(cat: Category) -> Self {
+        match cat {
+            Category::Info => 0x00,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum HwCap {
+    ChangeableRespAddr,
+    MirrorOutput,
+    SpdifCoax,
+    AesebuXlr,
+    Dsp,
+    Fpga,
+    PhantomPowering,
+    OutputMapping,
+    InputGain,
+    SpdifOpt,
+    AdatOpt,
+    NominalInput,
+    NominalOutput,
+    SoftClip,
+    RobotGuitar,
+    GuitarCharging,
+    Unknown(usize),
+    // For my purpose.
+    InputMapping,
+}
+
+impl From<usize> for HwCap {
+    fn from(val: usize) -> Self {
+        match val {
+            0 => HwCap::ChangeableRespAddr,
+            1 => HwCap::MirrorOutput,
+            2 => HwCap::SpdifCoax,
+            3 => HwCap::AesebuXlr,
+            4 => HwCap::Dsp,
+            5 => HwCap::Fpga,
+            6 => HwCap::PhantomPowering,
+            7 => HwCap::OutputMapping,
+            8 => HwCap::InputGain,
+            9 => HwCap::SpdifOpt,
+            10 => HwCap::AdatOpt,
+            11 => HwCap::NominalInput,
+            12 => HwCap::NominalOutput,
+            13 => HwCap::SoftClip,
+            14 => HwCap::RobotGuitar,
+            15 => HwCap::GuitarCharging,
+            _ => HwCap::Unknown(val),
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum ClkSrc {
+    Internal,
+    WordClock,
+    Spdif,
+    Adat,
+    Adat2,
+    Continuous,
+    Unknown(usize),
+}
+
+impl From<usize> for ClkSrc {
+    fn from(val: usize) -> Self {
+        match val {
+            0 => ClkSrc::Internal,
+            2 => ClkSrc::WordClock,
+            3 => ClkSrc::Spdif,
+            4 => ClkSrc::Adat,
+            5 => ClkSrc::Adat2,
+            6 => ClkSrc::Continuous,
+            _ => ClkSrc::Unknown(val),
+        }
+    }
+}
+
+impl From<ClkSrc> for usize {
+    fn from(src: ClkSrc) -> Self {
+        match src {
+            ClkSrc::Internal => 0,
+            ClkSrc::WordClock => 2,
+            ClkSrc::Spdif => 3,
+            ClkSrc::Adat => 4,
+            ClkSrc::Adat2 => 5,
+            ClkSrc::Continuous => 6,
+            ClkSrc::Unknown(val) => val,
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum PhysGroupType {
+    Analog,
+    Spdif,
+    Adat,
+    SpdifOrAdat,
+    AnalogMirror,
+    Headphones,
+    I2s,
+    Guitar,
+    PiezoGuitar,
+    GuitarString,
+    Unknown(usize),
+}
+
+impl From<usize> for PhysGroupType {
+    fn from(val: usize) -> Self {
+        match val {
+            0 => PhysGroupType::Analog,
+            1 => PhysGroupType::Spdif,
+            2 => PhysGroupType::Adat,
+            3 => PhysGroupType::SpdifOrAdat,
+            4 => PhysGroupType::AnalogMirror,
+            5 => PhysGroupType::Headphones,
+            6 => PhysGroupType::I2s,
+            7 => PhysGroupType::Guitar,
+            8 => PhysGroupType::PiezoGuitar,
+            9 => PhysGroupType::GuitarString,
+            _ => PhysGroupType::Unknown(val),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct PhysGroupEntry {
+    pub group_type: PhysGroupType,
+    pub group_count: usize,
+}
+
+#[derive(Debug)]
+pub struct HwInfo {
+    pub caps: Vec<HwCap>,
+    pub guid: u64,
+    pub hw_type: u32,
+    pub hw_version: u32,
+    pub vendor_name: String,
+    pub model_name: String,
+    pub clk_srcs: Vec<ClkSrc>,
+    pub rx_channels: [usize; 3],
+    pub tx_channels: [usize; 3],
+    pub phys_outputs: Vec<PhysGroupEntry>,
+    pub phys_inputs: Vec<PhysGroupEntry>,
+    pub midi_outputs: usize,
+    pub midi_inputs: usize,
+    pub clk_rates: Vec<u32>,
+    pub dsp_version: u32,
+    pub arm_version: u32,
+    pub mixer_playbacks: usize,
+    pub mixer_captures: usize,
+    pub fpga_version: u32,
+}
+
+impl HwInfo {
+    const SIZE: usize = 65;
+
+    fn new(data: &[u32;Self::SIZE]) -> Result<Self, Error> {
+        let model_name = Self::parse_text(&data[13..21])?;
+        let info = HwInfo {
+            caps: Self::parse_caps(data[0], &model_name),
+            guid: ((data[1] as u64) << 32) | (data[2] as u64),
+            hw_type: data[3],
+            hw_version: data[4],
+            vendor_name: Self::parse_text(&data[5..13])?,
+            model_name: model_name,
+            clk_srcs: Self::parse_supported_clk_srcs(data[21]),
+            rx_channels: [
+                data[22] as usize,
+                data[45] as usize,
+                data[47] as usize,
+            ],
+            tx_channels: [
+                data[23] as usize,
+                data[46] as usize,
+                data[48] as usize,
+            ],
+            phys_outputs: Self::parse_phys_groups(&data[26..31]),
+            phys_inputs: Self::parse_phys_groups(&data[31..36]),
+            midi_outputs: data[36] as usize,
+            midi_inputs: data[37] as usize,
+            clk_rates: Self::parse_supported_clk_rates(data[38], data[39]),
+            dsp_version: data[40],
+            arm_version: data[41],
+            mixer_playbacks: data[42] as usize,
+            mixer_captures: data[43] as usize,
+            fpga_version: data[44],
+        };
+        Ok(info)
+    }
+
+    fn parse_caps(flags: u32, model_name: &str) -> Vec<HwCap> {
+        let mut caps = Vec::new();
+        (0..16).for_each(|i| {
+            if (1 << i) & flags > 0 {
+                caps.push(HwCap::from(i))
+            }
+        });
+        if model_name == "Onyx 1200F" {
+            caps.push(HwCap::InputMapping);
+        }
+        caps
+    }
+
+    fn parse_text(quads: &[u32]) -> Result<String, Error> {
+        let mut literal = Vec::new();
+        quads.iter().for_each(|quad| {
+            literal.extend_from_slice(&quad.to_be_bytes());
+        });
+        if let Ok(text) = std::str::from_utf8(&literal) {
+            if let Some(pos) = text.find('\0') {
+                return Ok(text[0..pos].to_string());
+            }
+        }
+        Err(Error::new(FileError::Io, "Fail to parse string."))
+    }
+
+    fn parse_supported_clk_srcs(flags: u32) -> Vec<ClkSrc> {
+        let mut srcs = Vec::new();
+        (0..6).for_each(|i| {
+            if (1 << i) & flags > 0 {
+                srcs.push(ClkSrc::from(i));
+            }
+        });
+        srcs
+    }
+
+    fn parse_supported_clk_rates(max: u32, min: u32) -> Vec<u32> {
+        let mut rates = Vec::new();
+        [32000, 44100, 48000, 88200, 96000, 176400, 192000].iter().for_each(|rate| {
+            if *rate >= min && *rate <= max {
+                rates.push(*rate);
+            }
+        });
+        rates
+    }
+
+    fn parse_phys_groups(quads: &[u32]) -> Vec<PhysGroupEntry> {
+        let mut groups = Vec::new();
+        let mut bytes = Vec::new();
+        let count = quads[0] as usize;
+        quads[1..].iter().for_each(|quad| {
+            bytes.extend_from_slice(&quad.to_be_bytes());
+        });
+        (0..count).for_each(|i| {
+            let group_type = PhysGroupType::from(bytes[i * 2] as usize);
+            let group_count = bytes[i * 2 + 1] as usize;
+            groups.push(PhysGroupEntry {
+                group_type,
+                group_count,
+            });
+        });
+        groups
+    }
+}
+
+pub struct EfwInfo {}
+
+impl EfwInfo {
+    const CMD_HWINFO: u32 = 0;
+
+    pub fn get_hwinfo(unit: &hinawa::SndEfw) -> Result<HwInfo, Error> {
+        let mut data = [0; HwInfo::SIZE];
+        let _ = unit.transaction(u32::from(Category::Info), Self::CMD_HWINFO,
+                                 &[], &mut data)?;
+        HwInfo::new(&data)
+    }
+}

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -12,6 +12,7 @@ enum Category {
     Playback,
     Monitor,
     PortConf,
+    Guitar,
 }
 
 impl From<Category> for u32 {
@@ -24,6 +25,7 @@ impl From<Category> for u32 {
             Category::Playback => 0x06,
             Category::Monitor => 0x08,
             Category::PortConf => 0x09,
+            Category::Guitar=> 0x0a,
         }
     }
 }
@@ -901,5 +903,51 @@ impl EfwPortConf {
             .map(|pos| (params[38 + pos] / 2) as usize)
             .collect();
         Ok((rx_entries, tx_entries))
+    }
+}
+
+#[derive(Debug)]
+pub struct GuitarChargeState {
+    pub manual_charge: bool,
+    pub auto_charge: bool,
+    pub suspend_to_charge: u32,
+}
+
+pub struct EfwGuitar {}
+
+impl EfwGuitar {
+    const CMD_SET_CHARGE_STATE: u32 = 7;
+    const CMD_GET_CHARGE_STATE: u32 = 8;
+
+    pub fn get_charge_state(unit: &hinawa::SndEfw) -> Result<GuitarChargeState, Error> {
+        let mut params = [0;3];
+        let _ = unit.transaction(
+            u32::from(Category::Guitar),
+            Self::CMD_GET_CHARGE_STATE,
+            &[],
+            &mut params,
+        )?;
+        let state = GuitarChargeState{
+            manual_charge: params[0] > 0,
+            auto_charge: params[1] > 0,
+            suspend_to_charge: params[2],
+        };
+        Ok(state)
+    }
+
+    pub fn set_charge_state(unit: &hinawa::SndEfw, state: &GuitarChargeState) -> Result<(), Error> {
+        let args = [
+            state.manual_charge as u32,
+            state.auto_charge as u32,
+            state.suspend_to_charge,
+        ];
+        let mut params = [0;3];
+        let _ = unit.transaction(
+            u32::from(Category::Guitar),
+            Self::CMD_SET_CHARGE_STATE,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
     }
 }

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -8,6 +8,7 @@ enum Category {
     Info,
     HwCtl,
     PhysOutput,
+    PhysInput,
     Playback,
     Monitor,
 }
@@ -18,6 +19,7 @@ impl From<Category> for u32 {
             Category::Info => 0x00,
             Category::HwCtl => 0x03,
             Category::PhysOutput => 0x04,
+            Category::PhysInput => 0x05,
             Category::Playback => 0x06,
             Category::Monitor => 0x08,
         }
@@ -438,6 +440,38 @@ impl EfwPhysOutput {
         Ok(NominalLevel::from(params[1]))
     }
 }
+
+pub struct EfwPhysInput {}
+
+impl EfwPhysInput {
+    const CMD_SET_NOMINAL: u32 = 8;
+    const CMD_GET_NOMINAL: u32 = 9;
+
+    pub fn set_nominal(unit: &hinawa::SndEfw, ch: usize, level: NominalLevel) -> Result<(), Error> {
+        let args = [ch as u32, u32::from(level)];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::PhysInput),
+            Self::CMD_SET_NOMINAL,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_nominal(unit: &hinawa::SndEfw, ch: usize) -> Result<NominalLevel, Error> {
+        let args = [ch as u32, 0];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::PhysInput),
+            Self::CMD_GET_NOMINAL,
+            &args,
+            &mut params,
+        )?;
+        Ok(NominalLevel::from(params[1]))
+    }
+}
+
 pub struct EfwPlayback {}
 
 impl EfwPlayback {

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -182,6 +182,11 @@ impl HwInfo {
     const SIZE: usize = 65;
 
     const O1200F: u32 = 0x0001200f;
+    const AF2: u32 = 0x00000af2;
+    const AF4: u32 = 0x00000af4;
+    const AF8: u32 = 0x00000af8;
+    const AFP8: u32 = 0x00000af9;
+    const AF12: u32 = 0x0000af12;
 
     fn new(data: &[u32;Self::SIZE]) -> Result<Self, Error> {
         let info = HwInfo {
@@ -225,6 +230,14 @@ impl HwInfo {
         });
         match hw_type {
             Self::O1200F => caps.push(HwCap::InputMapping),
+            Self::AF2 |
+            Self::AF4 |
+            Self::AF8 |
+            Self::AFP8 |
+            Self::AF12 => {
+                caps.push(HwCap::NominalInput);
+                caps.push(HwCap::NominalOutput);
+            }
             _ => (),
         }
         caps

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -8,6 +8,7 @@ enum Category {
     Info,
     HwCtl,
     Playback,
+    Monitor,
 }
 
 impl From<Category> for u32 {
@@ -16,6 +17,7 @@ impl From<Category> for u32 {
             Category::Info => 0x00,
             Category::HwCtl => 0x03,
             Category::Playback => 0x06,
+            Category::Monitor => 0x08,
         }
     }
 }
@@ -406,5 +408,124 @@ impl EfwPlayback {
             &mut params,
         )?;
         Ok(params[1] > 0)
+    }
+}
+
+pub struct EfwMonitor {}
+
+impl EfwMonitor {
+    const CMD_SET_VOL: u32 = 0;
+    const CMD_GET_VOL: u32 = 1;
+    const CMD_SET_MUTE: u32 = 2;
+    const CMD_GET_MUTE: u32 = 3;
+    const CMD_SET_SOLO: u32 = 4;
+    const CMD_GET_SOLO: u32 = 5;
+    const CMD_SET_PAN: u32 = 4;
+    const CMD_GET_PAN: u32 = 5;
+
+    pub fn set_vol(unit: &hinawa::SndEfw, dst: usize, src: usize, vol: i32) -> Result<(), Error> {
+        let args = [src as u32, dst as u32, vol as u32];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_SET_VOL,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_vol(unit: &hinawa::SndEfw, dst: usize, src: usize) -> Result<i32, Error> {
+        let args = [src as u32, dst as u32, 0];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_GET_VOL,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] as i32)
+    }
+
+    pub fn set_mute(
+        unit: &hinawa::SndEfw,
+        dst: usize,
+        src: usize,
+        mute: bool,
+    ) -> Result<(), Error> {
+        let args = [src as u32, dst as u32, mute as u32];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_SET_MUTE,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_mute(unit: &hinawa::SndEfw, dst: usize, src: usize) -> Result<bool, Error> {
+        let args = [src as u32, dst as u32, 0];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_GET_MUTE,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] > 0)
+    }
+
+    pub fn set_solo(
+        unit: &hinawa::SndEfw,
+        dst: usize,
+        src: usize,
+        solo: bool,
+    ) -> Result<(), Error> {
+        let args = [src as u32, dst as u32, solo as u32];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_SET_SOLO,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_solo(unit: &hinawa::SndEfw, dst: usize, src: usize) -> Result<bool, Error> {
+        let args = [src as u32, dst as u32, 0];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_GET_SOLO,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] > 0)
+    }
+
+    pub fn set_pan(unit: &hinawa::SndEfw, dst: usize, src: usize, pan: u8) -> Result<(), Error> {
+        let args = [src as u32, dst as u32, pan as u32];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_SET_PAN,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_pan(unit: &hinawa::SndEfw, dst: usize, src: usize) -> Result<u8, Error> {
+        let args = [src as u32, dst as u32, 0];
+        let mut params = [0; 3];
+        let _ = unit.transaction(
+            u32::from(Category::Monitor),
+            Self::CMD_GET_PAN,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] as u8)
     }
 }

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -630,8 +630,8 @@ impl EfwMonitor {
     const CMD_GET_MUTE: u32 = 3;
     const CMD_SET_SOLO: u32 = 4;
     const CMD_GET_SOLO: u32 = 5;
-    const CMD_SET_PAN: u32 = 4;
-    const CMD_GET_PAN: u32 = 5;
+    const CMD_SET_PAN: u32 = 6;
+    const CMD_GET_PAN: u32 = 7;
 
     pub fn set_vol(unit: &hinawa::SndEfw, dst: usize, src: usize, vol: i32) -> Result<(), Error> {
         let args = [src as u32, dst as u32, vol as u32];

--- a/src/efw/transactions.rs
+++ b/src/efw/transactions.rs
@@ -7,6 +7,7 @@ use hinawa::SndEfwExtManual;
 enum Category {
     Info,
     HwCtl,
+    Playback,
 }
 
 impl From<Category> for u32 {
@@ -14,6 +15,7 @@ impl From<Category> for u32 {
         match cat {
             Category::Info => 0x00,
             Category::HwCtl => 0x03,
+            Category::Playback => 0x06,
         }
     }
 }
@@ -321,5 +323,88 @@ impl EfwHwCtl {
             &mut params,
         )?;
         Ok((ClkSrc::from(params[0] as usize), params[1]))
+    }
+}
+
+pub struct EfwPlayback {}
+
+impl EfwPlayback {
+    const CMD_SET_VOL: u32 = 0;
+    const CMD_GET_VOL: u32 = 1;
+    const CMD_SET_MUTE: u32 = 2;
+    const CMD_GET_MUTE: u32 = 3;
+    const CMD_SET_SOLO: u32 = 4;
+    const CMD_GET_SOLO: u32 = 5;
+
+    pub fn set_vol(unit: &hinawa::SndEfw, ch: usize, vol: i32) -> Result<(), Error> {
+        let args = [ch as u32, vol as u32];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_SET_VOL,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_vol(unit: &hinawa::SndEfw, ch: usize) -> Result<i32, Error> {
+        let args = [ch as u32, 0];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_GET_VOL,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] as i32)
+    }
+
+    pub fn set_mute(unit: &hinawa::SndEfw, ch: usize, mute: bool) -> Result<(), Error> {
+        let args = [ch as u32, mute as u32];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_SET_MUTE,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_mute(unit: &hinawa::SndEfw, ch: usize) -> Result<bool, Error> {
+        let args = [ch as u32, 0];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_GET_MUTE,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] > 0)
+    }
+
+    pub fn set_solo(unit: &hinawa::SndEfw, ch: usize, solo: bool) -> Result<(), Error> {
+        let args = [ch as u32, solo as u32];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_SET_SOLO,
+            &args,
+            &mut params,
+        )?;
+        Ok(())
+    }
+
+    pub fn get_solo(unit: &hinawa::SndEfw, ch: usize) -> Result<bool, Error> {
+        let args = [ch as u32, 0];
+        let mut params = [0; 2];
+        let _ = unit.transaction(
+            u32::from(Category::Playback),
+            Self::CMD_GET_SOLO,
+            &args,
+            &mut params,
+        )?;
+        Ok(params[1] > 0)
     }
 }

--- a/src/efw/unit.rs
+++ b/src/efw/unit.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+use glib::source;
+use nix::sys::signal;
+use std::sync::mpsc;
+
+use hinawa::{FwNodeExt, SndUnitExt, SndEfwExt};
+
+use crate::dispatcher;
+
+enum Event {
+    Shutdown,
+    Disconnected,
+    BusReset(u32),
+}
+
+pub struct EfwUnit {
+    unit: hinawa::SndEfw,
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
+
+impl Drop for EfwUnit {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> EfwUnit {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    pub fn new(card_id: u32) -> Result<Self, Error> {
+        let unit = hinawa::SndEfw::new();
+        unit.open(&format!("/dev/snd/hwC{}D0", card_id))?;
+
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        let dispatchers = Vec::new();
+
+        Ok(EfwUnit {
+            unit,
+            rx,
+            tx,
+            dispatchers,
+        })
+    }
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_unit(&self.unit, move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_fw_node(&self.unit.get_node(), move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        self.unit.get_node().connect_bus_update(move |node| {
+            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    pub fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) {
+        loop {
+            let ev = match self.rx.recv() {
+                Ok(ev) => ev,
+                Err(_) => continue,
+            };
+
+            match ev {
+                Event::Shutdown | Event::Disconnected => break,
+                Event::BusReset(generation) => {
+                    println!("IEEE 1394 bus is updated: {}", generation);
+                }
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,3 +9,4 @@ pub mod card_cntr;
 
 pub mod dg00x;
 pub mod tascam;
+pub mod efw;


### PR DESCRIPTION
Background
----------

The models with Fireworks board module are already supported by ALSA
fireworks driver for their isochronous packet stream functionality
and vendor-specific transaction. Although the driver allows userspace
applications to process PCM frames and MIDI messages in the packet
streaming, it doesn't support the other functionalities such as volume
control since it can be achieved by any usespace application which
executes ioctl(2) to ALSA hwdep character device for the transaction.

The service program is to satisfy the demand to control the models.
ALSA control applications can request the control by IPC to the service
program.

In detail of mechanism, please read README.rst in the repository[1].
You can see some illustrations.

How to build
-------------

The project depends on several libraries in below repositories:

* glib[2]
* alsa-gobject v0.1.0[3]
* libhinawa v2.0.0[4]

Before building it, please install them with gobject-introspection support.

The project is written by Rust programming language[5] and packaged by
cargo[6]. To build, just run below commands in the environment to connect
to internet:

```
$ git clone https://github.com/alsa-project/snd-firewire-ctl-services.git -b topic/service-for-efw
$ cd snd-firewire-ctl-services
$ cargo build
```

All of required crates are downloaded automatically, then start build.

Executables
-----------

After building, `snd-fireworks-ctl-service` executable is available.

When running, the program adds and maintains control elements, then enter
event loop to dispatch events. The added elements are visible and manipulable
for any userspace applications. The program dispatch any manipulation
The executable has an option for the numerical ID of sound card.

```
Usage:
  snd-fireworks-ctl-service CARD_ID

  where:
    CARD_ID: The numerical ID of sound card.
```

It's easy to run the executables by cargo, like:

```
$ cargo run --bin snd-fireworks-ctl-service 2
```

Receiving SIGTERM signal terminates the event loop, then the program
finishes.

During runtime, any ALSA control applications can enumerate and manipulate
the added control elements. This is an example of Echo Audio AudioFire 2:

```
$ amixer -c 2 controls
numid=33,iface=MIXER,name='clock-detect'
numid=2,iface=MIXER,name='clock-rate'
numid=1,iface=MIXER,name='clock-source'
numid=36,iface=MIXER,name='input-meter'
numid=34,iface=MIXER,name='midi-in-detect'
numid=35,iface=MIXER,name='midi-out-detect'
numid=6,iface=MIXER,name='monitor-gain'
numid=7,iface=MIXER,name='monitor-gain',index=1
numid=8,iface=MIXER,name='monitor-gain',index=2
numid=9,iface=MIXER,name='monitor-gain',index=3
numid=10,iface=MIXER,name='monitor-gain',index=4
numid=11,iface=MIXER,name='monitor-gain',index=5
numid=12,iface=MIXER,name='monitor-mute'
numid=13,iface=MIXER,name='monitor-mute',index=1
numid=14,iface=MIXER,name='monitor-mute',index=2
numid=15,iface=MIXER,name='monitor-mute',index=3
numid=16,iface=MIXER,name='monitor-mute',index=4
numid=17,iface=MIXER,name='monitor-mute',index=5
numid=24,iface=MIXER,name='monitor-pan'
numid=25,iface=MIXER,name='monitor-pan',index=1
numid=26,iface=MIXER,name='monitor-pan',index=2
numid=27,iface=MIXER,name='monitor-pan',index=3
numid=28,iface=MIXER,name='monitor-pan',index=4
numid=29,iface=MIXER,name='monitor-pan',index=5
numid=18,iface=MIXER,name='monitor-solo'
numid=19,iface=MIXER,name='monitor-solo',index=1
numid=20,iface=MIXER,name='monitor-solo',index=2
numid=21,iface=MIXER,name='monitor-solo',index=3
numid=22,iface=MIXER,name='monitor-solo',index=4
numid=23,iface=MIXER,name='monitor-solo',index=5
numid=38,iface=MIXER,name='monitoring'
numid=37,iface=MIXER,name='output-meter'
numid=31,iface=MIXER,name='output-mute'
numid=30,iface=MIXER,name='output-volume'
numid=4,iface=MIXER,name='playback-mute'
numid=5,iface=MIXER,name='playback-solo'
numid=3,iface=MIXER,name='playback-volume'
numid=32,iface=MIXER,name='stream-playback-routing'
```

Access permissions for relevant character devices
--------------------------------------------------

The executables manipulate below character devices to dispatch, and emit
events from end to end. The '%u' is the numerical number of instance in
each subsystem:

 * ALSA control character device (/dev/snd/controlC%u)
 * ALSA hwdep character device (/dev/snd/hwC%uD%u)
 * Linux firewire character device (/dev/fw%u)

Feedback
--------

Any feedback is welcome. For questions, please use mailing list of alsa-devel
or alsa-users[7]. For issues, please use service of github.com[8].

Issues
------

The name of control elements are not fixed yet since the convention of
name for element set is not clear yet for recording equipment.

Users may feel inconvenience to which channel corresponds to which physical
port. Furthermore, in the case that element set includes several elements,
it's unclear that which element corresponds to which physical port as well.
ALSA control core has no feature for the above issues at present.

[1] https://github.com/alsa-project/snd-firewire-ctl-services
[2] https://gitlab.gnome.org/GNOME/glib
[3] https://github.com/alsa-project/alsa-gobject/
[4] https://github.com/alsa-project/libhinawa
[5] https://www.rust-lang.org/
[6] https://doc.rust-lang.org/cargo/
[7] https://www.alsa-project.org/wiki/Mailing-lists
[8] https://github.com/alsa-project/snd-firewire-ctl-services/issues