### PR TITLE
dg00x/tascam/efw: lock kernel streaming during changing clock rate and source

### DIFF
--- a/src/dg00x/common_ctl.rs
+++ b/src/dg00x/common_ctl.rs
@@ -141,30 +141,41 @@ impl<'a> CommonCtl {
         _: &alsactl::ElemValue,
         new: &alsactl::ElemValue,
     ) -> Result<bool, Error> {
-        if unit.get_property_streaming() {
-            return Ok(false);
-        }
-
         let node = unit.get_node();
 
         match elem_id.get_name().as_str() {
             Self::CLK_SRC_NAME => {
                 let mut vals = [0];
                 new.get_enum(&mut vals);
-                req.write_quadlet(&node, Self::CLK_SRC_OFFSET, vals[0])?;
-                Ok(true)
+                unit.lock()?;
+                let res = req.write_quadlet(&node, Self::CLK_SRC_OFFSET, vals[0]);
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
             }
             Self::CLK_LOCAL_RATE_NAME => {
                 let mut vals = [0];
                 new.get_enum(&mut vals);
-                req.write_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET, vals[0])?;
-                Ok(true)
+                unit.lock()?;
+                let res = req.write_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET, vals[0]);
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
             }
             Self::OPT_IFACE_NAME => {
                 let mut vals = [0];
                 new.get_enum(&mut vals);
-                req.write_quadlet(&node, Self::OPT_IFACE_OFFSET, vals[0])?;
-                Ok(true)
+                unit.lock()?;
+                let res = req.write_quadlet(&node, Self::OPT_IFACE_OFFSET, vals[0]);
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
             }
             _ => Ok(false),
         }

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -112,28 +112,30 @@ impl<'a> ClkCtl {
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             Self::SRC_NAME => {
-                if !unit.get_property_streaming() {
-                    let mut vals = [0];
-                    new.get_enum(&mut vals);
-                    if let Some(&src) = self.srcs.iter().nth(vals[0] as usize) {
-                        EfwHwCtl::set_clock(unit, Some(src), None)?;
-                        Ok(true)
-                    } else {
-                        Ok(false)
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                if let Some(&src) = self.srcs.iter().nth(vals[0] as usize) {
+                    unit.lock()?;
+                    let res = EfwHwCtl::set_clock(unit, Some(src), None);
+                    let _ = unit.unlock();
+                    match res {
+                        Err(err) => Err(err),
+                        Ok(()) => Ok(true),
                     }
                 } else {
                     Ok(false)
                 }
             }
             Self::RATE_NAME => {
-                if !unit.get_property_streaming() {
-                    let mut vals = [0];
-                    new.get_enum(&mut vals);
-                    if let Some(&rate) = self.rates.iter().nth(vals[0] as usize) {
-                        EfwHwCtl::set_clock(unit, None, Some(rate))?;
-                        Ok(true)
-                    } else {
-                        Ok(false)
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                if let Some(&rate) = self.rates.iter().nth(vals[0] as usize) {
+                    unit.lock()?;
+                    let res = EfwHwCtl::set_clock(unit, None, Some(rate));
+                    let _ = unit.unlock();
+                    match res {
+                        Err(err) => Err(err),
+                        Ok(()) => Ok(true),
                     }
                 } else {
                     Ok(false)


### PR DESCRIPTION
The operation to change sampling rate or clock source is invalid during
packet streaming.

This commit locks kernel packet streaming before changing them, then
unlock after. During kernel packet streaming, error returns.