### PR TITLE
motu: add service program for devices in MOTU FireWire series

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,7 @@ path = "src/bin/snd-firewire-tascam-ctl-service.rs"
 [[bin]]
 name = "snd-fireworks-ctl-service"
 path = "src/bin/snd-fireworks-ctl-service.rs"
+
+[[bin]]
+name = "snd-firewire-motu-ctl-service"
+path = "src/bin/snd-firewire-motu-ctl-service.rs"

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,8 @@ snd-firewire-tascam-ctl-service
    For sound card bound to ALSA firewire-tascam driver (snd-firewire-tascam), or TASCAM FE-8.
 snd-fireworks-ctl-service
    For sound card bound to ALSA fireworks driver (snd-fireworks)
+snd-firewire-motu-ctl-service
+   For sound card bound to ALSA firewire-motu driver (snd-firewire-motu)
 
 License
 =======
@@ -90,6 +92,17 @@ your device, please contact to developer.
   * Echo Audio Audiofire Pre8
   * Gibson Robot Interface Pack (RIP) for Robot Guitar series
 
+* snd-firewire-motu-ctl-service
+
+  * MOTU Traveler
+  * MOTU 828mkII
+  * MOTU UltraLite
+  * MOTU 8pre
+  * MOTU 828mk3
+  * MOTU UltraLite mk3
+  * MOTU 4pre
+  * MOTU AudioExpress
+
 Supported protocols
 ===================
 
@@ -100,6 +113,7 @@ Supported protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)
    * Protocol for Fireworks board module of Echo Digital Audio
+   * Protocol for Mark of the Unicorn (MOTU) FireWire series
 
 Design note
 ===========

--- a/src/bin/snd-firewire-motu-ctl-service.rs
+++ b/src/bin/snd-firewire-motu-ctl-service.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use snd_fw_ctl_services::motu;
+
+use std::env;
+
+fn print_help() {
+    println!("
+Usage:
+  snd-firewire-motu-ctl-service CARD_ID
+
+  where:
+    CARD_ID: The numerical ID of sound card.
+    ");
+}
+
+fn main() {
+    // Check arguments in command line.
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        print_help();
+        std::process::exit(libc::EXIT_FAILURE);
+    }
+
+    let card_id = match args[1].parse::<u32>() {
+        Ok(card_id) => card_id,
+        Err(err) => {
+            println!("{:?}", err);
+            print_help();
+            std::process::exit(libc::EXIT_FAILURE);
+        }
+    };
+
+    let err = match motu::unit::MotuUnit::new(card_id) {
+        Err(err) => {
+            println!("The card {} is not for motu device: {}",
+                     card_id, err);
+            Err(err)
+        }
+        Ok(mut unit) => {
+            if let Err(err) = unit.listen() {
+                println!("Fail to listen events: {}", err);
+                Err(err)
+            } else {
+                unit.run();
+                Ok(())
+            }
+        }
+    };
+
+    if err.is_err() {
+        std::process::exit(libc::EXIT_FAILURE)
+    }
+
+    std::process::exit(libc::EXIT_SUCCESS)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,3 +10,4 @@ pub mod card_cntr;
 pub mod dg00x;
 pub mod tascam;
 pub mod efw;
+pub mod motu;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub mod unit;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -10,6 +10,7 @@ mod f828mk3;
 mod ultralite;
 mod traveler;
 mod f8pre;
+mod f828mk2;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -7,6 +7,7 @@ mod ultralite_mk3;
 mod audioexpress;
 mod h4pre;
 mod f828mk3;
+mod ultralite;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -8,6 +8,7 @@ mod audioexpress;
 mod h4pre;
 mod f828mk3;
 mod ultralite;
+mod traveler;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -5,3 +5,4 @@ pub mod unit;
 mod model;
 
 mod common_proto;
+mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -6,6 +6,7 @@ mod model;
 mod ultralite_mk3;
 mod audioexpress;
 mod h4pre;
+mod f828mk3;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -14,3 +14,5 @@ mod v2_proto;
 
 mod v3_clk_ctls;
 mod v3_port_ctls;
+
+mod v2_clk_ctls;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -3,6 +3,7 @@
 pub mod unit;
 
 mod model;
+mod ultralite_mk3;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -4,6 +4,7 @@ pub mod unit;
 
 mod model;
 mod ultralite_mk3;
+mod audioexpress;
 mod h4pre;
 
 mod common_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -4,6 +4,7 @@ pub mod unit;
 
 mod model;
 mod ultralite_mk3;
+mod h4pre;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -10,6 +10,7 @@ mod f828mk3;
 
 mod common_proto;
 mod v3_proto;
+mod v2_proto;
 
 mod v3_clk_ctls;
 mod v3_port_ctls;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -8,3 +8,4 @@ mod common_proto;
 mod v3_proto;
 
 mod v3_clk_ctls;
+mod v3_port_ctls;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -9,6 +9,7 @@ mod h4pre;
 mod f828mk3;
 mod ultralite;
 mod traveler;
+mod f8pre;
 
 mod common_proto;
 mod v3_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -16,3 +16,4 @@ mod v3_clk_ctls;
 mod v3_port_ctls;
 
 mod v2_clk_ctls;
+mod v2_port_ctls;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -3,3 +3,5 @@
 pub mod unit;
 
 mod model;
+
+mod common_proto;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod unit;
+
+mod model;

--- a/src/motu.rs
+++ b/src/motu.rs
@@ -6,3 +6,5 @@ mod model;
 
 mod common_proto;
 mod v3_proto;
+
+mod v3_clk_ctls;

--- a/src/motu/audioexpress.rs
+++ b/src/motu/audioexpress.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v3_clk_ctls::V3ClkCtl;
+use super::v3_port_ctls::V3PortCtl;
+
+pub struct AudioExpress<'a> {
+    req: FwReq,
+    clk_ctls: V3ClkCtl<'a>,
+    port_ctls: V3PortCtl<'a>,
+}
+
+impl<'a> AudioExpress<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF-on-coax",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",    // = Stream-1/2
+        "Main-1/2",     // = Stream-5/6
+        "Andlog-1/2",   // = Stream-3/4
+        "S/PDIF-1/2",   // = Stream-7/8
+        // Blank for Stream-9/10
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[0x01, 0x02, 0x06, 0x07];
+
+    pub fn new() -> Self {
+        AudioExpress{
+            req: FwReq::new(),
+            clk_ctls: V3ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, false),
+            port_ctls: V3PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      false, false, false, false),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for AudioExpress<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/common_proto.rs
+++ b/src/motu/common_proto.rs
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+use hinawa::FwTcode;
+use hinawa::FwReqExtManual;
+use hinawa::{SndUnitExt};
+
+pub trait CommonProto<'a> {
+    const BASE_OFFSET: u64 = 0xfffff0000000;
+
+    const TIMEOUT: u32 = 100;
+
+    const OFFSET_CLK: u32 = 0x0b14;
+    const OFFSET_PORT: u32 = 0x0c04;
+    const OFFSET_CLK_DISPLAY: u32 = 0x0c60;
+
+    const WORD_OUT_LABEL: &'a str = "word out";
+    const WORD_OUT_MASK: u32 = 0x08000000;
+    const WORD_OUT_SHIFT: usize = 27;
+
+    const PORT_PHONE_LABEL: &'a str = "phone assign";
+    const PORT_PHONE_MASK: u32 = 0x0000000f;
+    const PORT_PHONE_SHIFT: usize = 0;
+
+    const DISPLAY_CHARS: usize = 4 * 4;
+
+    fn read_quad(&self, unit: &hinawa::SndMotu, offset: u32) -> Result<u32, Error>;
+    fn write_quad(&self, unit: &hinawa::SndMotu, offset: u32, quad: u32) -> Result<(), Error>;
+
+    fn get_idx_from_val(&self, offset: u32, mask: u32, shift: usize, label: &str,
+                        unit: &hinawa::SndMotu, vals: &[u8])
+        -> Result<usize, Error>;
+    fn set_idx_to_val(&self, offset: u32, mask: u32, shift: usize, label: &str,
+                      unit: &hinawa::SndMotu, vals: &[u8], idx: usize)
+        -> Result<(), Error>;
+
+    fn get_word_out(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_word_out(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_phone_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_phone_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn update_clk_disaplay(&self, unit: &hinawa::SndMotu, label: &str) -> Result<(), Error>;
+}
+
+impl<'a> CommonProto<'a> for hinawa::FwReq {
+    fn read_quad(&self, unit: &hinawa::SndMotu, offset: u32) -> Result<u32, Error> {
+        let mut frame = [0;4];
+        self.transaction_sync(&unit.get_node(), FwTcode::ReadQuadletRequest,
+                              Self::BASE_OFFSET + offset as u64, 4, &mut frame, Self::TIMEOUT)?;
+        Ok(u32::from_be_bytes(frame))
+    }
+
+    fn write_quad(&self, unit: &hinawa::SndMotu, offset: u32, quad: u32) -> Result<(), Error> {
+        let mut frame = [0;4];
+        frame.copy_from_slice(&quad.to_be_bytes());
+        self.transaction_sync(&unit.get_node(), FwTcode::WriteQuadletRequest,
+                              Self::BASE_OFFSET + offset as u64, 4, &mut frame, Self::TIMEOUT)
+    }
+
+    fn get_idx_from_val(&self, offset: u32, mask: u32, shift: usize, label: &str, unit: &hinawa::SndMotu,
+                        vals: &[u8])
+        -> Result<usize, Error>
+    {
+        let quad = self.read_quad(unit, offset)?;
+        let val = ((quad & mask) >> shift) as u8;
+        vals.iter().position(|&v| v == val).ok_or_else(|| {
+            let label = format!("Detect invalid value for {}: {:02x}", label, val);
+            Error::new(FileError::Io, &label)
+        })
+    }
+
+    fn set_idx_to_val(&self, offset: u32, mask: u32, shift: usize, label: &str, unit: &hinawa::SndMotu,
+                      vals: &[u8], idx: usize)
+        -> Result<(), Error>
+    {
+        if idx >= vals.len() {
+            let label = format!("Invalid argument for {}: {} {}", label, vals.len(), idx);
+            return Err(Error::new(FileError::Inval, &label));
+        }
+        let mut quad = self.read_quad(unit, offset)?;
+        quad &= !mask;
+        quad |= (vals[idx] as u32) << shift;
+        self.write_quad(unit, offset, quad)
+    }
+
+    fn get_word_out(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error> {
+        self.get_idx_from_val(Self::OFFSET_CLK, Self::WORD_OUT_MASK, Self::WORD_OUT_SHIFT,
+                              Self::WORD_OUT_LABEL, unit, vals)
+    }
+
+    fn set_word_out(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error> {
+        self.set_idx_to_val(Self::OFFSET_CLK, Self::WORD_OUT_MASK, Self::WORD_OUT_SHIFT,
+                            Self::WORD_OUT_LABEL, unit, vals, idx)
+    }
+
+    fn get_phone_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error> {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::PORT_PHONE_MASK, Self::PORT_PHONE_SHIFT,
+                              Self::PORT_PHONE_LABEL, unit, vals)
+    }
+
+    fn set_phone_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error> {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::PORT_PHONE_MASK, Self::PORT_PHONE_SHIFT,
+                            Self::PORT_PHONE_LABEL, unit, vals, idx)
+    }
+
+    fn update_clk_disaplay(&self, unit: &hinawa::SndMotu, label: &str) -> Result<(), Error> {
+        let mut chars = [0;Self::DISPLAY_CHARS];
+        chars.iter_mut().zip(label.bytes()).for_each(|(c, l)| *c = l);
+
+        (0..(Self::DISPLAY_CHARS / 4)).try_for_each(|i| {
+            let mut frame = [0;4];
+            frame.copy_from_slice(&chars[(i * 4)..(i * 4 + 4)]);
+            frame.reverse();
+            let quad = u32::from_ne_bytes(frame);
+            let offset = Self::OFFSET_CLK_DISPLAY + 4 * i as u32;
+            self.write_quad(unit, offset, quad)
+        })
+    }
+}

--- a/src/motu/f828mk2.rs
+++ b/src/motu/f828mk2.rs
@@ -4,7 +4,7 @@ use glib::Error;
 
 use hinawa::{SndMotu, FwReq};
 
-use crate::card_cntr::{CardCntr, CtlModel};
+use crate::card_cntr::{CardCntr, CtlModel, NotifyModel};
 
 use super::v2_clk_ctls::V2ClkCtl;
 use super::v2_port_ctls::V2PortCtl;
@@ -13,9 +13,12 @@ pub struct F828mk2<'a> {
     req: FwReq,
     clk_ctls: V2ClkCtl<'a>,
     port_ctls: V2PortCtl<'a>,
+    msg_cache: u32,
 }
 
 impl<'a> F828mk2<'a> {
+    const NOTIFY_PORT_CHANGE: u32 = 0x40000000;
+
     const CLK_RATE_LABELS: &'a [&'a str] = &[
         "44100", "48000",
         "88200", "96000",
@@ -56,6 +59,7 @@ impl<'a> F828mk2<'a> {
                                     Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
             port_ctls: V2PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
                                       false, true, true, true),
+            msg_cache: 0,
         }
     }
 }
@@ -90,6 +94,29 @@ impl<'a> CtlModel<SndMotu> for F828mk2<'a> {
             Ok(true)
         } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
             Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl<'a> NotifyModel<SndMotu, u32> for F828mk2<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.port_ctls.notified_elems);
+    }
+
+    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+        self.msg_cache = *msg;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.msg_cache & Self::NOTIFY_PORT_CHANGE > 0 {
+            let res = self.port_ctls.read(unit, &self.req, elem_id, elem_value)?;
+            Ok(res)
         } else {
             Ok(false)
         }

--- a/src/motu/f828mk2.rs
+++ b/src/motu/f828mk2.rs
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v2_clk_ctls::V2ClkCtl;
+use super::v2_port_ctls::V2PortCtl;
+
+pub struct F828mk2<'a> {
+    req: FwReq,
+    clk_ctls: V2ClkCtl<'a>,
+    port_ctls: V2PortCtl<'a>,
+}
+
+impl<'a> F828mk2<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "Signal-on-opt",
+        "S/PDIF-on-coax",
+        "Word-clock",
+        "ADAT-on-Dsub",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x04, 0x05];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",    // = Stream-1/2
+        "Analog-1/2",   // = Stream-3/4
+        "Analog-3/4",   // = Stream-5/6
+        "Analog-5/6",   // = Stream-7/8
+        "Analog-7/8",   // = Stream-9/10
+        "Main-1/2",     // = Stream-11/12
+        "S/PDIF-1/2",   // = Stream-13/14
+        "ADAT-1/2",     // = Stream-15/16
+        "ADAT-3/4",     // = Stream-17/18
+        "ADAT-5/6",     // = Stream-19/20
+        "ADAT-7/8",     // = Stream-21/22
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b,
+    ];
+
+    pub fn new() -> Self {
+        F828mk2{
+            req: FwReq::new(),
+            clk_ctls: V2ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
+            port_ctls: V2PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      false, true, true, true),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for F828mk2<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/f828mk3.rs
+++ b/src/motu/f828mk3.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v3_clk_ctls::V3ClkCtl;
+use super::v3_port_ctls::V3PortCtl;
+
+pub struct F828mk3<'a> {
+    req: FwReq,
+    clk_ctls: V3ClkCtl<'a>,
+    port_ctls: V3PortCtl<'a>,
+}
+
+impl<'a> F828mk3<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+        "176400", "192000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "Word-clock",
+        "S/PDIF-on-coax",
+        "Signal-on-opt-A",
+        "Signal-on-opt-B",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01, 0x10, 0x18, 0x19];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Main-1/2",         // = Stream-11/12
+        "Analog-1/2",       // = Stream-3/4
+        "Analog-3/4",       // = Stream-5/6
+        "Analog-5/6",       // = Stream-7/8
+        "Analog-7/8",       // = Stream-9/10
+        "S/PDIF-1/2",       // = Stream-13/14
+        "Phone-1/2",        // = Stream-1/2
+        "Optical-A-1/2",    // = Stream-15/16
+        "Optical-A-3/4",    // = Stream-17/18
+        "Optical-A-5/6",    // = Stream-19/20
+        "Optical-A-7/8",    // = Stream-21/22
+        "Optical-B-1/2",    // = Stream-23/24
+        "Optical-B-3/4",    // = Stream-25/26
+        "Optical-B-5/6",    // = Stream-27/28
+        "Optical-B-7/8",    // = Stream-29/30
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[
+        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e,
+    ];
+
+    pub fn new() -> Self {
+        F828mk3{
+            req: FwReq::new(),
+            clk_ctls: V3ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
+            port_ctls: V3PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      true, true, true, true),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for F828mk3<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/f8pre.rs
+++ b/src/motu/f8pre.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v2_clk_ctls::V2ClkCtl;
+use super::v2_port_ctls::V2PortCtl;
+
+pub struct F8pre<'a> {
+    req: FwReq,
+    clk_ctls: V2ClkCtl<'a>,
+    port_ctls: V2PortCtl<'a>,
+}
+
+impl<'a> F8pre<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "ADAT-on-opt",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const PHONE_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",
+        "Main-1/2",
+    ];
+    const PHONE_ASSIGN_VALS: &'a [u8] = &[0x01, 0x02];
+
+    pub fn new() -> Self {
+        F8pre{
+            req: FwReq::new(),
+            clk_ctls: V2ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, false),
+            port_ctls: V2PortCtl::new(Self::PHONE_ASSIGN_LABELS, Self::PHONE_ASSIGN_VALS,
+                                      false, false, true, false),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for F8pre<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/h4pre.rs
+++ b/src/motu/h4pre.rs
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v3_clk_ctls::V3ClkCtl;
+use super::v3_port_ctls::V3PortCtl;
+
+pub struct H4pre<'a> {
+    req: FwReq,
+    clk_ctls: V3ClkCtl<'a>,
+    port_ctls: V3PortCtl<'a>,
+}
+
+impl<'a> H4pre<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF-on-coax",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",    // = Stream-1/2
+        "Main-1/2",     // = Stream-5/6
+        "Andlog-1/2",   // = Stream-3/4
+        "S/PDIF-1/2",   // = Stream-7/8
+        // Blank for Stream-9/10
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[0x01, 0x02, 0x06, 0x07];
+
+    pub fn new() -> Self {
+        H4pre{
+            req: FwReq::new(),
+            clk_ctls: V3ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, false),
+            port_ctls: V3PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      false, false, false, false),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for H4pre<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -16,4 +16,17 @@ impl MotuModel {
             },
         }
     }
+
+    pub fn load(&mut self, unit: &hinawa::SndMotu, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+
+    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndMotu, card_cntr: &mut card_cntr::CardCntr,
+                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
 }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -5,6 +5,7 @@ use glib::{Error, FileError};
 use crate::card_cntr::{CardCntr, CtlModel};
 
 use super::ultralite_mk3::UltraLiteMk3;
+use super::audioexpress::AudioExpress;
 use super::h4pre::H4pre;
 
 pub struct MotuModel<'a> {
@@ -14,6 +15,7 @@ pub struct MotuModel<'a> {
 
 enum MotuCtlModel<'a> {
     UltraLiteMk3(UltraLiteMk3<'a>),
+    AudioExpress(AudioExpress<'a>),
     H4pre(H4pre<'a>),
 }
 
@@ -21,6 +23,7 @@ impl<'a> MotuModel<'a> {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
+            0x000033 => MotuCtlModel::AudioExpress(AudioExpress::new()),
             0x000045 => MotuCtlModel::H4pre(H4pre::new()),
             _ => {
                 let label = format!("Unsupported model ID: 0x{:06x}", model_id);
@@ -39,6 +42,7 @@ impl<'a> MotuModel<'a> {
     {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
+            MotuCtlModel::AudioExpress(m) => m.load(unit, card_cntr),
             MotuCtlModel::H4pre(m) => m.load(unit, card_cntr),
         }
     }
@@ -49,6 +53,7 @@ impl<'a> MotuModel<'a> {
     {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::AudioExpress(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::H4pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -71,6 +71,7 @@ impl<'a> MotuModel<'a> {
 
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
+            MotuCtlModel::F828mk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
             _ => (),
         }
 
@@ -100,6 +101,7 @@ impl<'a> MotuModel<'a> {
 
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
+            MotuCtlModel::F828mk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             _ => Ok(()),
         }
     }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -6,6 +6,7 @@ use crate::card_cntr::{CardCntr, CtlModel};
 
 use super::ultralite_mk3::UltraLiteMk3;
 use super::audioexpress::AudioExpress;
+use super::f828mk3::F828mk3;
 use super::h4pre::H4pre;
 
 pub struct MotuModel<'a> {
@@ -16,6 +17,7 @@ pub struct MotuModel<'a> {
 enum MotuCtlModel<'a> {
     UltraLiteMk3(UltraLiteMk3<'a>),
     AudioExpress(AudioExpress<'a>),
+    F828mk3(F828mk3<'a>),
     H4pre(H4pre<'a>),
 }
 
@@ -24,6 +26,8 @@ impl<'a> MotuModel<'a> {
         let ctl_model = match model_id {
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
             0x000033 => MotuCtlModel::AudioExpress(AudioExpress::new()),
+            0x000015 |  // Firewire only.
+            0x000035 => MotuCtlModel::F828mk3(F828mk3::new()),
             0x000045 => MotuCtlModel::H4pre(H4pre::new()),
             _ => {
                 let label = format!("Unsupported model ID: 0x{:06x}", model_id);
@@ -43,6 +47,7 @@ impl<'a> MotuModel<'a> {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
             MotuCtlModel::AudioExpress(m) => m.load(unit, card_cntr),
+            MotuCtlModel::F828mk3(m) => m.load(unit, card_cntr),
             MotuCtlModel::H4pre(m) => m.load(unit, card_cntr),
         }
     }
@@ -54,6 +59,7 @@ impl<'a> MotuModel<'a> {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::AudioExpress(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::F828mk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::H4pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -5,6 +5,7 @@ use glib::{Error, FileError};
 use crate::card_cntr::{CardCntr, CtlModel};
 
 use super::ultralite_mk3::UltraLiteMk3;
+use super::h4pre::H4pre;
 
 pub struct MotuModel<'a> {
     firmware_version: u32,
@@ -13,12 +14,14 @@ pub struct MotuModel<'a> {
 
 enum MotuCtlModel<'a> {
     UltraLiteMk3(UltraLiteMk3<'a>),
+    H4pre(H4pre<'a>),
 }
 
 impl<'a> MotuModel<'a> {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
+            0x000045 => MotuCtlModel::H4pre(H4pre::new()),
             _ => {
                 let label = format!("Unsupported model ID: 0x{:06x}", model_id);
                 return Err(Error::new(FileError::Noent, &label));
@@ -36,6 +39,7 @@ impl<'a> MotuModel<'a> {
     {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
+            MotuCtlModel::H4pre(m) => m.load(unit, card_cntr),
         }
     }
 
@@ -45,6 +49,7 @@ impl<'a> MotuModel<'a> {
     {
         match &mut self.ctl_model {
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::H4pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }
 }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -70,6 +70,7 @@ impl<'a> MotuModel<'a> {
         }?;
 
         match &mut self.ctl_model {
+            MotuCtlModel::UltraLite(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::UltraLiteMk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::F828mk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
             _ => (),
@@ -100,6 +101,7 @@ impl<'a> MotuModel<'a> {
         let elem_id_list = &self.notified_elems;
 
         match &mut self.ctl_model {
+            MotuCtlModel::UltraLite(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::F828mk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             _ => Ok(()),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -6,6 +6,7 @@ use crate::card_cntr::{CardCntr, CtlModel};
 
 use super::traveler::Traveler;
 use super::ultralite::UltraLite;
+use super::f8pre::F8pre;
 use super::ultralite_mk3::UltraLiteMk3;
 use super::audioexpress::AudioExpress;
 use super::f828mk3::F828mk3;
@@ -19,6 +20,7 @@ pub struct MotuModel<'a> {
 enum MotuCtlModel<'a> {
     Traveler(Traveler<'a>),
     UltraLite(UltraLite<'a>),
+    F8pre(F8pre<'a>),
     UltraLiteMk3(UltraLiteMk3<'a>),
     AudioExpress(AudioExpress<'a>),
     F828mk3(F828mk3<'a>),
@@ -30,6 +32,7 @@ impl<'a> MotuModel<'a> {
         let ctl_model = match model_id {
             0x000009 => MotuCtlModel::Traveler(Traveler::new()),
             0x00000d => MotuCtlModel::UltraLite(UltraLite::new()),
+            0x00000f => MotuCtlModel::F8pre(F8pre::new()),
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
             0x000033 => MotuCtlModel::AudioExpress(AudioExpress::new()),
             0x000015 |  // Firewire only.
@@ -53,6 +56,7 @@ impl<'a> MotuModel<'a> {
         match &mut self.ctl_model {
             MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
+            MotuCtlModel::F8pre(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
             MotuCtlModel::AudioExpress(m) => m.load(unit, card_cntr),
             MotuCtlModel::F828mk3(m) => m.load(unit, card_cntr),
@@ -67,6 +71,7 @@ impl<'a> MotuModel<'a> {
         match &mut self.ctl_model {
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::F8pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::AudioExpress(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F828mk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use crate::card_cntr;
+
+pub struct MotuModel {
+}
+
+impl MotuModel {
+    pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
+        match model_id {
+            _ => {
+                let label = format!("Unsupported model ID: 0x{:06x}", model_id);
+                return Err(Error::new(FileError::Noent, &label));
+            },
+        }
+    }
+}

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -4,6 +4,7 @@ use glib::{Error, FileError};
 
 use crate::card_cntr::{CardCntr, CtlModel};
 
+use super::ultralite::UltraLite;
 use super::ultralite_mk3::UltraLiteMk3;
 use super::audioexpress::AudioExpress;
 use super::f828mk3::F828mk3;
@@ -15,6 +16,7 @@ pub struct MotuModel<'a> {
 }
 
 enum MotuCtlModel<'a> {
+    UltraLite(UltraLite<'a>),
     UltraLiteMk3(UltraLiteMk3<'a>),
     AudioExpress(AudioExpress<'a>),
     F828mk3(F828mk3<'a>),
@@ -24,6 +26,7 @@ enum MotuCtlModel<'a> {
 impl<'a> MotuModel<'a> {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
+            0x00000d => MotuCtlModel::UltraLite(UltraLite::new()),
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
             0x000033 => MotuCtlModel::AudioExpress(AudioExpress::new()),
             0x000015 |  // Firewire only.
@@ -45,6 +48,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
             MotuCtlModel::AudioExpress(m) => m.load(unit, card_cntr),
             MotuCtlModel::F828mk3(m) => m.load(unit, card_cntr),
@@ -57,6 +61,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::AudioExpress(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F828mk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -4,6 +4,7 @@ use glib::{Error, FileError};
 
 use crate::card_cntr::{CardCntr, CtlModel};
 
+use super::f828mk2::F828mk2;
 use super::traveler::Traveler;
 use super::ultralite::UltraLite;
 use super::f8pre::F8pre;
@@ -18,6 +19,7 @@ pub struct MotuModel<'a> {
 }
 
 enum MotuCtlModel<'a> {
+    F828mk2(F828mk2<'a>),
     Traveler(Traveler<'a>),
     UltraLite(UltraLite<'a>),
     F8pre(F8pre<'a>),
@@ -30,6 +32,7 @@ enum MotuCtlModel<'a> {
 impl<'a> MotuModel<'a> {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
+            0x000003 => MotuCtlModel::F828mk2(F828mk2::new()),
             0x000009 => MotuCtlModel::Traveler(Traveler::new()),
             0x00000d => MotuCtlModel::UltraLite(UltraLite::new()),
             0x00000f => MotuCtlModel::F8pre(F8pre::new()),
@@ -54,6 +57,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::F828mk2(m) => m.load(unit, card_cntr),
             MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
             MotuCtlModel::F8pre(m) => m.load(unit, card_cntr),
@@ -69,6 +73,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::F828mk2(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F8pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -70,6 +70,7 @@ impl<'a> MotuModel<'a> {
         }?;
 
         match &mut self.ctl_model {
+            MotuCtlModel::Traveler(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::UltraLite(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::UltraLiteMk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::F828mk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
@@ -101,6 +102,7 @@ impl<'a> MotuModel<'a> {
         let elem_id_list = &self.notified_elems;
 
         match &mut self.ctl_model {
+            MotuCtlModel::Traveler(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::F828mk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -4,6 +4,7 @@ use glib::{Error, FileError};
 
 use crate::card_cntr::{CardCntr, CtlModel};
 
+use super::traveler::Traveler;
 use super::ultralite::UltraLite;
 use super::ultralite_mk3::UltraLiteMk3;
 use super::audioexpress::AudioExpress;
@@ -16,6 +17,7 @@ pub struct MotuModel<'a> {
 }
 
 enum MotuCtlModel<'a> {
+    Traveler(Traveler<'a>),
     UltraLite(UltraLite<'a>),
     UltraLiteMk3(UltraLiteMk3<'a>),
     AudioExpress(AudioExpress<'a>),
@@ -26,6 +28,7 @@ enum MotuCtlModel<'a> {
 impl<'a> MotuModel<'a> {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
+            0x000009 => MotuCtlModel::Traveler(Traveler::new()),
             0x00000d => MotuCtlModel::UltraLite(UltraLite::new()),
             0x000019 => MotuCtlModel::UltraLiteMk3(UltraLiteMk3::new()),
             0x000033 => MotuCtlModel::AudioExpress(AudioExpress::new()),
@@ -48,6 +51,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLiteMk3(m) => m.load(unit, card_cntr),
             MotuCtlModel::AudioExpress(m) => m.load(unit, card_cntr),
@@ -61,6 +65,7 @@ impl<'a> MotuModel<'a> {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::AudioExpress(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use crate::card_cntr::{CardCntr, CtlModel};
+use crate::card_cntr::{CardCntr, CtlModel, NotifyModel};
 
 use super::f828mk2::F828mk2;
 use super::traveler::Traveler;
@@ -82,5 +82,11 @@ impl<'a> MotuModel<'a> {
             MotuCtlModel::F828mk3(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::H4pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
+    }
+
+    pub fn dispatch_notification(&mut self, unit: &hinawa::SndMotu, msg: &u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
     }
 }

--- a/src/motu/model.rs
+++ b/src/motu/model.rs
@@ -70,6 +70,7 @@ impl<'a> MotuModel<'a> {
         }?;
 
         match &mut self.ctl_model {
+            MotuCtlModel::F828mk2(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::Traveler(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::UltraLite(m) => m.get_notified_elem_list(&mut self.notified_elems),
             MotuCtlModel::UltraLiteMk3(m) => m.get_notified_elem_list(&mut self.notified_elems),
@@ -102,6 +103,7 @@ impl<'a> MotuModel<'a> {
         let elem_id_list = &self.notified_elems;
 
         match &mut self.ctl_model {
+            MotuCtlModel::F828mk2(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),
             MotuCtlModel::UltraLiteMk3(m) => card_cntr.dispatch_notification(unit, msg, elem_id_list, m),

--- a/src/motu/traveler.rs
+++ b/src/motu/traveler.rs
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v2_clk_ctls::V2ClkCtl;
+use super::v2_port_ctls::V2PortCtl;
+
+pub struct Traveler<'a> {
+    req: FwReq,
+    clk_ctls: V2ClkCtl<'a>,
+    port_ctls: V2PortCtl<'a>,
+}
+
+impl<'a> Traveler<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+        "176400", "192000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "Signal-on-opt",
+        "S/PDIF-on-coax",
+        "Word-clock",
+        "ADAT-on-Dsub",
+        "AES/EBU-on-XLR",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x04, 0x05, 0x07];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",    // = Stream-1/2
+        "Analog-1/2",   // = Stream-3/4
+        "Analog-3/4",   // = Stream-5/6
+        "Analog-5/6",   // = Stream-7/8
+        "Analog-7/8",   // = Stream-9/10
+        "AES/EBU-1/2",  // = Stream-11/12
+        "S/PDIF-1/2",   // = Stream-13/14
+        "ADAT-1/2",     // = Stream-15/16
+        "ADAT-3/4",     // = Stream-17/18
+        "ADAT-5/6",     // = Stream-19/20
+        "ADAT-7/8",     // = Stream-21/22
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[
+        0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+        0x09, 0x0a, 0x0b,
+    ];
+
+    pub fn new() -> Self {
+        Traveler{
+            req: FwReq::new(),
+            clk_ctls: V2ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
+            port_ctls: V2PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      false, true, true, true),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for Traveler<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/traveler.rs
+++ b/src/motu/traveler.rs
@@ -4,7 +4,7 @@ use glib::Error;
 
 use hinawa::{SndMotu, FwReq};
 
-use crate::card_cntr::{CardCntr, CtlModel};
+use crate::card_cntr::{CardCntr, CtlModel, NotifyModel};
 
 use super::v2_clk_ctls::V2ClkCtl;
 use super::v2_port_ctls::V2PortCtl;
@@ -13,9 +13,13 @@ pub struct Traveler<'a> {
     req: FwReq,
     clk_ctls: V2ClkCtl<'a>,
     port_ctls: V2PortCtl<'a>,
+    msg_cache: u32,
 }
 
 impl<'a> Traveler<'a> {
+    const NOTIFY_PORT_CHANGE: u32 = 0x40000000;
+    //const NOTIFY_FORMAT_CHANGE: u32 = 0x08000000; // The format for payload of isochronous packet is changed.
+
     const CLK_RATE_LABELS: &'a [&'a str] = &[
         "44100", "48000",
         "88200", "96000",
@@ -58,6 +62,7 @@ impl<'a> Traveler<'a> {
                                     Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
             port_ctls: V2PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
                                       false, true, true, true),
+            msg_cache: 0,
         }
     }
 }
@@ -92,6 +97,29 @@ impl<'a> CtlModel<SndMotu> for Traveler<'a> {
             Ok(true)
         } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
             Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl<'a> NotifyModel<SndMotu, u32> for Traveler<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.port_ctls.notified_elems);
+    }
+
+    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+        self.msg_cache = *msg;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.msg_cache & Self::NOTIFY_PORT_CHANGE > 0 {
+            let res = self.port_ctls.read(unit, &self.req, elem_id, elem_value)?;
+            Ok(res)
         } else {
             Ok(false)
         }

--- a/src/motu/ultralite.rs
+++ b/src/motu/ultralite.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v2_clk_ctls::V2ClkCtl;
+use super::v2_port_ctls::V2PortCtl;
+
+pub struct UltraLite<'a> {
+    req: FwReq,
+    clk_ctls: V2ClkCtl<'a>,
+    port_ctls: V2PortCtl<'a>,
+}
+
+impl<'a> UltraLite<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF-on-coax",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x02];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Phone-1/2",    // Stream-1/2
+        "Analog-1/2",   // Stream-3/4
+        "Analog-3/4",   // Stream-5/6
+        "Analog-5/6",   // Stream-7/8
+        "Analog-7/8",   // Stream-9/10
+        "Main-1/2",     // Stream-11/12
+        "S/PDIF-1/2",   // Stream-13/14
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+    pub fn new() -> Self {
+        UltraLite{
+            req: FwReq::new(),
+            clk_ctls: V2ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
+            port_ctls: V2PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      true, false, false, false),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for UltraLite<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/ultralite_mk3.rs
+++ b/src/motu/ultralite_mk3.rs
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, FwReq};
+
+use crate::card_cntr::{CardCntr, CtlModel};
+
+use super::v3_clk_ctls::V3ClkCtl;
+use super::v3_port_ctls::V3PortCtl;
+
+pub struct UltraLiteMk3<'a> {
+    req: FwReq,
+    clk_ctls: V3ClkCtl<'a>,
+    port_ctls: V3PortCtl<'a>,
+}
+
+impl<'a> UltraLiteMk3<'a> {
+    const CLK_RATE_LABELS: &'a [&'a str] = &[
+        "44100", "48000",
+        "88200", "96000",
+    ];
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF-on-coax",
+    ];
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const PORT_ASSIGN_LABELS: &'a [&'a str] = &[
+        "Main-1/2",     // = Stream-1/2
+        "Analog-1/2",   // = Stream-3/4
+        "Analog-3/4",   // = Stream-5/6
+        "Analog-5/6",   // = Stream-7/8
+        "Analog-7/8",   // = Stream-9/10
+        "S/PDIF-1/2",   // = Stream-13/14
+        "Phone-1/2",    // = Stream-11/12
+    ];
+    const PORT_ASSIGN_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06];
+
+    pub fn new() -> Self {
+        UltraLiteMk3{
+            req: FwReq::new(),
+            clk_ctls: V3ClkCtl::new(Self::CLK_RATE_LABELS, Self::CLK_RATE_VALS,
+                                    Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
+            port_ctls: V3PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
+                                      true, true, false, false),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndMotu> for UltraLiteMk3<'a> {
+    fn load(&mut self, unit: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        self.clk_ctls.load(unit, card_cntr)?;
+        self.port_ctls.load(unit, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctls.read(unit, &self.req, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.clk_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/src/motu/ultralite_mk3.rs
+++ b/src/motu/ultralite_mk3.rs
@@ -4,7 +4,7 @@ use glib::Error;
 
 use hinawa::{SndMotu, FwReq};
 
-use crate::card_cntr::{CardCntr, CtlModel};
+use crate::card_cntr::{CardCntr, CtlModel, NotifyModel};
 
 use super::v3_clk_ctls::V3ClkCtl;
 use super::v3_port_ctls::V3PortCtl;
@@ -13,9 +13,14 @@ pub struct UltraLiteMk3<'a> {
     req: FwReq,
     clk_ctls: V3ClkCtl<'a>,
     port_ctls: V3PortCtl<'a>,
+    msg_cache: u32,
 }
 
 impl<'a> UltraLiteMk3<'a> {
+    const NOTIFY_OPERATED: u32 = 0x40000000;
+    const NOTIFY_COMPLETED: u32 = 0x00000002;
+    const NOTIFY_OPERATED_AND_COMPLETED: u32 = Self::NOTIFY_OPERATED | Self::NOTIFY_COMPLETED;
+
     const CLK_RATE_LABELS: &'a [&'a str] = &[
         "44100", "48000",
         "88200", "96000",
@@ -46,6 +51,7 @@ impl<'a> UltraLiteMk3<'a> {
                                     Self::CLK_SRC_LABELS, Self::CLK_SRC_VALS, true),
             port_ctls: V3PortCtl::new(Self::PORT_ASSIGN_LABELS, Self::PORT_ASSIGN_VALS,
                                       true, true, false, false),
+            msg_cache: 0,
         }
     }
 }
@@ -80,6 +86,29 @@ impl<'a> CtlModel<SndMotu> for UltraLiteMk3<'a> {
             Ok(true)
         } else if self.port_ctls.write(unit, &self.req, elem_id, old, new)? {
             Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl<'a> NotifyModel<SndMotu, u32> for UltraLiteMk3<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.port_ctls.notified_elems);
+    }
+
+    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+        self.msg_cache = *msg;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.msg_cache & (Self::NOTIFY_OPERATED_AND_COMPLETED) == Self::NOTIFY_OPERATED_AND_COMPLETED {
+            let res = self.port_ctls.read(unit, &self.req, elem_id, elem_value)?;
+            Ok(res)
         } else {
             Ok(false)
         }

--- a/src/motu/unit.rs
+++ b/src/motu/unit.rs
@@ -24,23 +24,23 @@ enum Event {
     Elem((alsactl::ElemId, alsactl::ElemEventMask)),
 }
 
-pub struct MotuUnit {
+pub struct MotuUnit<'a> {
     unit: hinawa::SndMotu,
-    model: MotuModel,
+    model: MotuModel<'a>,
     card_cntr: card_cntr::CardCntr,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
 }
 
-impl Drop for MotuUnit {
+impl<'a> Drop for MotuUnit<'a> {
     fn drop(&mut self) {
         // Finish I/O threads.
         self.dispatchers.clear();
     }
 }
 
-impl<'a> MotuUnit {
+impl<'a> MotuUnit<'a> {
     const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
     const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
 

--- a/src/motu/unit.rs
+++ b/src/motu/unit.rs
@@ -13,6 +13,8 @@ use crate::dispatcher;
 use crate::ieee1212;
 use crate::card_cntr;
 
+use super::model::MotuModel;
+
 const OUI_MOTU: u32 = 0x0001f2;
 
 enum Event {
@@ -23,6 +25,7 @@ enum Event {
 
 pub struct MotuUnit {
     unit: hinawa::SndMotu,
+    model: MotuModel,
     card_cntr: card_cntr::CardCntr,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
@@ -46,6 +49,7 @@ impl<'a> MotuUnit {
 
         let node = unit.get_node();
         let (model_id, version) = detect_model(&node)?;
+        let model = MotuModel::new(model_id, version)?;
 
         let card_cntr = card_cntr::CardCntr::new();
         card_cntr.card.open(card_id, 0)?;
@@ -57,6 +61,7 @@ impl<'a> MotuUnit {
 
         Ok(MotuUnit {
             unit,
+            model,
             card_cntr,
             rx,
             tx,

--- a/src/motu/unit.rs
+++ b/src/motu/unit.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+use glib::source;
+use nix::sys::signal;
+use std::sync::mpsc;
+
+use hinawa::{FwNodeExt, SndUnitExt, SndMotuExt};
+
+use crate::dispatcher;
+
+enum Event {
+    Shutdown,
+    Disconnected,
+    BusReset(u32),
+}
+
+pub struct MotuUnit {
+    unit: hinawa::SndMotu,
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
+
+impl Drop for MotuUnit {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> MotuUnit {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    pub fn new(card_id: u32) -> Result<Self, Error> {
+        let unit = hinawa::SndMotu::new();
+        unit.open(&format!("/dev/snd/hwC{}D0", card_id))?;
+
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        let dispatchers = Vec::new();
+
+        Ok(MotuUnit {
+            unit,
+            rx,
+            tx,
+            dispatchers,
+        })
+    }
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_unit(&self.unit, move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_fw_node(&self.unit.get_node(), move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        self.unit.get_node().connect_bus_update(move |node| {
+            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    pub fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) {
+        loop {
+            let ev = match self.rx.recv() {
+                Ok(ev) => ev,
+                Err(_) => continue,
+            };
+
+            match ev {
+                Event::Shutdown | Event::Disconnected => break,
+                Event::BusReset(generation) => {
+                    println!("IEEE 1394 bus is updated: {}", generation);
+                }
+            }
+        }
+    }
+}

--- a/src/motu/v2_clk_ctls.rs
+++ b/src/motu/v2_clk_ctls.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, SndMotu};
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr::CardCntr;
+
+use super::common_proto::CommonProto;
+use super::v2_proto::V2Proto;
+
+pub struct V2ClkCtl<'a> {
+    rate_labels: &'a [&'a str],
+    rate_vals: &'a [u8],
+    src_labels: &'a [&'a str],
+    src_vals: &'a [u8],
+    has_lcd: bool,
+}
+
+impl<'a> V2ClkCtl<'a> {
+    const RATE_NAME: &'a str = "sampling- rate";
+    const SRC_NAME: &'a str = "clock-source";
+
+    pub fn new(rate_labels: &'a [&'a str], rate_vals: &'a [u8],
+               src_labels: &'a[&'a str], src_vals: &'a [u8], has_lcd: bool) -> Self {
+        V2ClkCtl {rate_labels, rate_vals, src_labels, src_vals, has_lcd}
+    }
+
+    pub fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.rate_labels, None, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.src_labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                let val = req.get_clk_rate(unit, &self.rate_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::SRC_NAME => {
+                let val = req.get_clk_src(unit, &self.src_vals)?;
+                if self.has_lcd {
+                    req.update_clk_disaplay(unit, &self.src_labels[val])?;
+                }
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                unit.lock()?;
+                let res = req.set_clk_rate(unit, &self.rate_vals, vals[0] as usize);
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
+            }
+            Self::SRC_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let prev_src = req.get_clk_src(unit, &self.src_vals)?;
+                unit.lock()?;
+                let mut res = req.set_clk_src(unit, &self.src_vals, vals[0] as usize);
+                if res.is_ok() && self.has_lcd {
+                    res = req.update_clk_disaplay(unit, self.src_labels[vals[0] as usize]);
+                    if res.is_err() {
+                        let _ = req.set_clk_src(unit, &self.src_vals, prev_src);
+                    }
+                }
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/motu/v2_port_ctls.rs
+++ b/src/motu/v2_port_ctls.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, SndMotu};
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr::CardCntr;
+
+use super::common_proto::CommonProto;
+use super::v2_proto::V2Proto;
+
+pub struct V2PortCtl<'a> {
+    phone_assign_labels: &'a [&'a str],
+    phone_assign_vals: &'a [u8],
+    has_main_vol: bool,
+    has_word_bnc: bool,
+    has_opt_ifaces: bool,
+    has_spdif_opt: bool,
+
+    pub notified_elems: Vec<alsactl::ElemId>,
+}
+
+impl<'a> V2PortCtl<'a> {
+    const PHONE_ASSIGN_NAME: &'a str = "phone-assign";
+    const MAIN_VOL_TARGET_NAME: &'a str = "main-volume-target";
+    const WORD_OUT_MODE_NAME: &'a str = "word-out-mode";
+    const OPT_IN_IFACE_MODE_NAME: &'a str = "optical-iface-in-mode";
+    const OPT_OUT_IFACE_MODE_NAME: &'a str = "optical-iface-out-mode";
+
+    const MAIN_VOL_TARGET_LABELS: &'a [&'a str] = &[
+        "Main-out-1/2",
+        "Analog-1/2/3/4/5/6",
+        "Analog-1/2/3/4/5/6/7/8",
+        "S/PDIF-1/2",
+    ];
+    const MAIN_VOL_TARGET_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+
+    const WORD_OUT_MODE_LABELS: &'a [&'a str] = &[
+        "Force 44.1/48.0 kHz",
+        "Follow to system clock",
+    ];
+    const WORD_OUT_MODE_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const OPT_IFACE_MODE_LABELS: &'a [&'a str] = &[
+        "None",
+        "ADAT",
+        "S/PDIF",
+    ];
+    const OPT_IFACE_MODE_VALS: &'a [u8] = &[0x00, 0x01, 0x02];
+
+    pub fn new(phone_assign_labels: &'a [&str], phone_assign_vals: &'a [u8], has_main_vol: bool,
+               has_word_bnc: bool, has_opt_ifaces: bool, has_spdif_opt: bool) -> Self {
+        V2PortCtl{
+            phone_assign_labels,
+            phone_assign_vals,
+            has_main_vol,
+            has_word_bnc,
+            has_opt_ifaces,
+            has_spdif_opt,
+            notified_elems: Vec::new(),
+        }
+    }
+
+    pub fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::PHONE_ASSIGN_NAME, 0);
+        let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.phone_assign_labels, None, true)?;
+        self.notified_elems.extend_from_slice(&elem_id_list);
+
+        if self.has_main_vol {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::MAIN_VOL_TARGET_NAME, 0);
+            let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &Self::MAIN_VOL_TARGET_LABELS,
+                                                        None, true)?;
+            self.notified_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.has_word_bnc {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::WORD_OUT_MODE_NAME, 0);
+            let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::WORD_OUT_MODE_LABELS,
+                                                        None, true)?;
+            self.notified_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.has_opt_ifaces {
+            let mut labels: Vec<&str> = Self::OPT_IFACE_MODE_LABELS.iter().map(|&l| l).collect();
+            if !self.has_spdif_opt {
+                labels.pop();
+            }
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::OPT_IN_IFACE_MODE_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::OPT_OUT_IFACE_MODE_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PHONE_ASSIGN_NAME => {
+                let val = req.get_phone_assign(unit, &self.phone_assign_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::MAIN_VOL_TARGET_NAME => {
+                let val = req.get_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::WORD_OUT_MODE_NAME => {
+                let val = req.get_word_out(unit, &Self::WORD_OUT_MODE_VALS)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::OPT_IN_IFACE_MODE_NAME => {
+                let val = req.get_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                let val = req.get_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PHONE_ASSIGN_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_phone_assign(unit, &self.phone_assign_vals, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::MAIN_VOL_TARGET_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::WORD_OUT_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_word_out(unit, &Self::WORD_OUT_MODE_VALS, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::OPT_IN_IFACE_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                unit.lock()?;
+                let res = req.set_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, vals[0] as usize);
+                unit.unlock()?;
+                match res {
+                    Ok(()) => Ok(true),
+                    Err(err) => Err(err),
+                }
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                unit.lock()?;
+                let res = req.set_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, vals[0] as usize);
+                unit.unlock()?;
+                match res {
+                    Ok(()) => Ok(true),
+                    Err(err) => Err(err),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/motu/v2_proto.rs
+++ b/src/motu/v2_proto.rs
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use super::common_proto::CommonProto;
+
+pub trait V2Proto<'a> : CommonProto<'a> {
+    const CLK_RATE_LABEL: &'a str = "sampling rate";
+    const CLK_RATE_MASK: u32 = 0x00000038;
+    const CLK_RATE_SHIFT: usize = 3;
+
+    const CLK_SRC_LABEL: &'a str = "clock source";
+    const CLK_SRC_MASK: u32 = 0x00000007;
+    const CLK_SRC_SHIFT: usize = 0;
+
+    const MAIN_VOL_LABEL: &'a str = "main vol target";
+    const MAIN_VOL_MASK: u32 = 0x000f0000;
+    const MAIN_VOL_SHIFT: usize = 16;
+
+    const OPT_IN_IFACE_LABEL: &'a str = "optical input interface";
+    const OPT_IN_IFACE_MASK: u32 = 0x00000300;
+    const OPT_IN_IFACE_SHIFT: usize = 8;
+
+    const OPT_OUT_IFACE_LABEL: &'a str = "optical output interface";
+    const OPT_OUT_IFACE_MASK: u32 = 0x00000c00;
+    const OPT_OUT_IFACE_SHIFT: usize = 10;
+
+    fn get_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_main_vol_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_main_vol_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_opt_in_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_opt_in_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_opt_out_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_opt_out_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+}
+
+impl<'a> V2Proto<'a> for hinawa::FwReq {
+    fn get_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_CLK, Self::CLK_RATE_MASK, Self::CLK_RATE_SHIFT,
+                              Self::CLK_RATE_LABEL, unit, vals)
+    }
+
+    fn set_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_CLK, Self::CLK_RATE_MASK, Self::CLK_RATE_SHIFT,
+                            Self::CLK_RATE_LABEL, unit, vals, idx)
+    }
+
+    fn get_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_CLK, Self::CLK_SRC_MASK, Self::CLK_SRC_SHIFT,
+                              Self::CLK_SRC_LABEL, unit, vals)
+    }
+
+    fn set_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_CLK, Self::CLK_SRC_MASK, Self::CLK_SRC_SHIFT,
+                            Self::CLK_SRC_LABEL, unit, vals, idx)
+    }
+
+    fn get_main_vol_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error> {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::MAIN_VOL_MASK, Self::MAIN_VOL_SHIFT,
+                              Self::MAIN_VOL_LABEL, unit, vals)
+    }
+
+    fn set_main_vol_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error> {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::MAIN_VOL_MASK, Self::MAIN_VOL_SHIFT,
+                            Self::MAIN_VOL_LABEL, unit, vals, idx)
+    }
+
+    fn get_opt_in_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::OPT_IN_IFACE_MASK, Self::OPT_IN_IFACE_SHIFT,
+                              Self::OPT_IN_IFACE_LABEL, unit, vals)
+    }
+
+    fn set_opt_in_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::OPT_IN_IFACE_MASK, Self::OPT_IN_IFACE_SHIFT,
+                            Self::OPT_IN_IFACE_LABEL, unit, vals, idx)
+    }
+
+    fn get_opt_out_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::OPT_OUT_IFACE_MASK, Self::OPT_OUT_IFACE_SHIFT,
+                              Self::OPT_OUT_IFACE_LABEL, unit, vals)
+    }
+
+    fn set_opt_out_iface_mode(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::OPT_OUT_IFACE_MASK, Self::OPT_OUT_IFACE_SHIFT,
+                            Self::OPT_OUT_IFACE_LABEL, unit, vals, idx)
+    }
+}

--- a/src/motu/v3_clk_ctls.rs
+++ b/src/motu/v3_clk_ctls.rs
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, SndMotu};
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr::CardCntr;
+
+use super::common_proto::CommonProto;
+use super::v3_proto::V3Proto;
+
+pub struct V3ClkCtl<'a> {
+    rate_labels: &'a [&'a str],
+    rate_vals: &'a [u8],
+    src_labels: &'a [&'a str],
+    src_vals: &'a [u8],
+    has_lcd: bool,
+}
+
+impl<'a> V3ClkCtl<'a> {
+    const RATE_NAME: &'a str = "sampling- rate";
+    const SRC_NAME: &'a str = "clock-source";
+
+    pub fn new(rate_labels: &'a [&'a str], rate_vals: &'a [u8],
+               src_labels: &'a [&'a str], src_vals: &'a [u8], has_lcd: bool) -> Self {
+        V3ClkCtl{rate_labels, rate_vals, src_labels, src_vals, has_lcd}
+    }
+
+    pub fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.rate_labels, None, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.src_labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                let val = req.get_clk_rate(unit, &self.rate_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::SRC_NAME => {
+                let val = req.get_clk_src(unit, &self.src_vals)?;
+                if self.has_lcd {
+                    req.update_clk_disaplay(unit, &self.src_labels[val])?;
+                }
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                unit.lock()?;
+                let res = req.set_clk_rate(unit, &self.rate_vals, vals[0] as usize);
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
+            }
+            Self::SRC_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let prev_src = req.get_clk_src(unit, &self.src_vals)?;
+                unit.lock()?;
+                let mut res = req.set_clk_src(unit, &self.src_vals, vals[0] as usize);
+                if res.is_ok() && self.has_lcd {
+                    res = req.update_clk_disaplay(unit, self.src_labels[vals[0] as usize]);
+                    if res.is_err() {
+                        let _ = req.set_clk_src(unit, &self.src_vals, prev_src);
+                    }
+                }
+                let _ = unit.unlock();
+                match res {
+                    Err(err) => Err(err),
+                    Ok(()) => Ok(true),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/motu/v3_port_ctls.rs
+++ b/src/motu/v3_port_ctls.rs
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use hinawa::{SndUnitExt, SndMotu};
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr::CardCntr;
+
+use super::common_proto::CommonProto;
+use super::v3_proto::V3Proto;
+
+pub struct V3PortCtl<'a> {
+    assign_labels: &'a [&'a str],
+    assign_vals: &'a [u8],
+    has_main_assign: bool,
+    has_return_assign: bool,
+    has_word_bnc: bool,
+    has_opt_ifaces: bool,
+
+    pub notified_elems: Vec<alsactl::ElemId>,
+}
+
+impl<'a> V3PortCtl<'a> {
+    const PHONE_ASSIGN_NAME: &'a str = "phone-assign";
+    const MAIN_ASSIGN_NAME: &'a str = "main-assign";
+    const RETURN_ASSIGN_NAME: &'a str = "return-assign";
+    const WORD_OUT_MODE_NAME: &'a str = "word-out-mode";
+    const OPT_IFACE_IN_MODE_NAME: &'a str = "optical-iface-in-mode";
+    const OPT_IFACE_OUT_MODE_NAME: &'a str = "optical-iface-out-mode";
+
+    const WORD_OUT_MODE_LABELS: &'a [&'a str] = &[
+        "Force 44.1/48.0 kHz",
+        "Follow to system clock",
+    ];
+    const WORD_OUT_MODE_VALS: &'a [u8] = &[0x00, 0x01];
+
+    const OPT_IFACE_MODE_LABELS: &'a [&'a str] = &[
+        "None",
+        "ADAT",
+        "S/PDIF",
+    ];
+
+    pub fn new(assign_labels: &'a [&'a str], assign_vals: &'a [u8], has_main_assign: bool,
+               has_return_assign: bool, has_opt_ifaces: bool, has_word_bnc: bool) -> Self {
+        V3PortCtl{
+            assign_labels,
+            assign_vals,
+            has_main_assign,
+            has_return_assign,
+            has_word_bnc,
+            has_opt_ifaces,
+            notified_elems: Vec::new(),
+        }
+    }
+
+    pub fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::PHONE_ASSIGN_NAME, 0);
+        let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.assign_labels, None, true)?;
+        self.notified_elems.extend_from_slice(&elem_id_list);
+
+        if self.has_main_assign {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::MAIN_ASSIGN_NAME, 0);
+            let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.assign_labels, None, true)?;
+            self.notified_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.has_return_assign {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::RETURN_ASSIGN_NAME, 0);
+            let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.assign_labels, None, true)?;
+            self.notified_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.has_word_bnc {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::WORD_OUT_MODE_NAME, 0);
+            let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1,
+                                                        Self::WORD_OUT_MODE_LABELS, None, true)?;
+            self.notified_elems.extend_from_slice(&elem_id_list);
+        }
+
+        if self.has_opt_ifaces {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::OPT_IFACE_IN_MODE_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 2, Self::OPT_IFACE_MODE_LABELS, None, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::OPT_IFACE_OUT_MODE_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 2, Self::OPT_IFACE_MODE_LABELS, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    fn get_opt_iface_mode(&mut self, unit: &SndMotu, req: &hinawa::FwReq, is_out: bool, is_b: bool)
+        -> Result<u32, Error>
+    {
+        let (enabled, no_adat) = req.get_opt_iface_mode(unit, is_out, is_b)?;
+
+        let idx = match enabled {
+            false => 0,
+            true => {
+                match no_adat {
+                    false => 1,
+                    true => 2,
+                }
+            }
+        };
+        Ok(idx)
+    }
+
+    fn set_opt_iface_mode(&mut self, unit: &SndMotu, req: &hinawa::FwReq, is_out: bool, is_b: bool,
+                          mode: u32)
+        -> Result<(), Error>
+    {
+        let (enabled, no_adat) = match mode {
+            0 => (false, false),
+            1 => (true, false),
+            2 => (true, true),
+            _ => {
+                let label = format!("Invalid argument for optical interface: {}", mode);
+                return Err(Error::new(FileError::Nxio, &label));
+            }
+        };
+        req.set_opt_iface_mode(unit, is_out, is_b, enabled, no_adat)
+    }
+
+    pub fn read(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PHONE_ASSIGN_NAME => {
+                let val = req.get_phone_assign(unit, &self.assign_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::MAIN_ASSIGN_NAME => {
+                let val = req.get_main_assign(unit, &self.assign_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::RETURN_ASSIGN_NAME => {
+                let val = req.get_return_assign(unit, &self.assign_vals)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::WORD_OUT_MODE_NAME => {
+                let val = req.get_word_out(unit, &Self::WORD_OUT_MODE_VALS)?;
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            Self::OPT_IFACE_IN_MODE_NAME => {
+                let mut vals = [0;2];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = self.get_opt_iface_mode(unit, req, false, i > 0)?;
+                    Ok(())
+                })?;
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::OPT_IFACE_OUT_MODE_NAME => {
+                let mut vals = [0;2];
+                vals.iter_mut().enumerate().try_for_each(|(i, val)| {
+                    *val = self.get_opt_iface_mode(unit, req, true, i > 0)?;
+                    Ok(())
+                })?;
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &SndMotu, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+                 old: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PHONE_ASSIGN_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_phone_assign(unit, &self.assign_vals, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::MAIN_ASSIGN_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_main_assign(unit, &self.assign_vals, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::RETURN_ASSIGN_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_return_assign(unit, &self.assign_vals, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::WORD_OUT_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                req.set_word_out(unit, &Self::WORD_OUT_MODE_VALS, vals[0] as usize)?;
+                Ok(true)
+            }
+            Self::OPT_IFACE_IN_MODE_NAME => {
+                let mut vals = [0;4];
+                old.get_enum(&mut vals[2..]);
+                new.get_enum(&mut vals[..2]);
+                unit.lock()?;
+                let res = vals[..2].iter().zip(vals[2..].iter()).enumerate()
+                    .filter(|(_, (new, old))| new != old)
+                    .try_for_each(|(i, (v, _))| {
+                        self.set_opt_iface_mode(unit, req, false, i > 0, *v)
+                    });
+                let _ = unit.unlock();
+                match res {
+                    Ok(()) => Ok(true),
+                    Err(err) => Err(err)
+                }
+            }
+            Self::OPT_IFACE_OUT_MODE_NAME => {
+                let mut vals = [0;4];
+                old.get_enum(&mut vals[2..]);
+                new.get_enum(&mut vals[..2]);
+                unit.lock()?;
+                let res = vals[..2].iter().zip(vals[2..].iter()).enumerate()
+                    .filter(|(_, (new, old))| new != old)
+                    .try_for_each(|(i, (v, _))| {
+                        self.set_opt_iface_mode(unit, req, true, i > 0, *v)
+                    });
+                let _ = unit.unlock();
+                match res {
+                    Ok(()) => Ok(true),
+                    Err(err) => Err(err)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/motu/v3_proto.rs
+++ b/src/motu/v3_proto.rs
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use super::common_proto::CommonProto;
+
+pub trait V3Proto<'a> : CommonProto<'a> {
+    const OFFSET_OPT: u32 = 0x0c94;
+
+    const CLK_RATE_LABEL: &'a str = "sampling rate";
+    const CLK_RATE_MASK: u32 = 0x0000ff00;
+    const CLK_RATE_SHIFT: usize = 8;
+
+    const CLK_SRC_LABEL: &'a str = "clock source";
+    const CLK_SRC_MASK: u32 = 0x000000ff;
+    const CLK_SRC_SHIFT: usize = 0;
+
+    const PORT_MAIN_LABEL: &'a str = "main out assign";
+    const PORT_MAIN_MASK: u32 = 0x000000f0;
+    const PORT_MAIN_SHIFT: usize = 4;
+
+    const PORT_RETURN_LABEL: &'a str = "return assign";
+    const PORT_RETURN_MASK: u32 = 0x00000f00;
+    const PORT_RETURN_SHIFT: usize = 8;
+
+    fn get_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_main_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_main_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_return_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>;
+    fn set_return_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>;
+
+    fn get_opt_iface_masks(&self, is_out: bool, is_b: bool) -> (u32, u32) {
+        let mut enabled_mask = 0x00000001;
+        if is_out {
+            enabled_mask <<= 8;
+        }
+        if is_b {
+            enabled_mask <<= 1;
+        }
+
+        let mut no_adat_mask = 0x00010000;
+        if is_out {
+            no_adat_mask <<= 2;
+        }
+        if is_b {
+            no_adat_mask <<= 4;
+        }
+
+        (enabled_mask, no_adat_mask)
+    }
+
+    fn set_opt_iface_mode(&self, unit: &hinawa::SndMotu, is_out: bool, is_b: bool,
+                          enable: bool, no_adat: bool)
+        -> Result<(), Error>;
+
+    fn get_opt_iface_mode(&self, unit: &hinawa::SndMotu, is_out: bool, is_b: bool)
+        -> Result<(bool, bool), Error>;
+}
+
+impl<'a> V3Proto<'a> for hinawa::FwReq {
+    fn get_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_CLK, Self::CLK_RATE_MASK, Self::CLK_RATE_SHIFT,
+                              Self::CLK_RATE_LABEL, unit, vals)
+    }
+
+    fn set_clk_rate(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_CLK, Self::CLK_RATE_MASK, Self::CLK_RATE_SHIFT,
+                            Self::CLK_RATE_LABEL, unit, vals, idx)
+    }
+
+    fn get_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error>
+    {
+        self.get_idx_from_val(Self::OFFSET_CLK, Self::CLK_SRC_MASK, Self::CLK_SRC_SHIFT,
+                              Self::CLK_SRC_LABEL, unit, vals)
+    }
+
+    fn set_clk_src(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error>
+    {
+        self.set_idx_to_val(Self::OFFSET_CLK, Self::CLK_SRC_MASK, Self::CLK_SRC_SHIFT,
+                            Self::CLK_SRC_LABEL, unit, vals, idx)
+    }
+
+    fn get_main_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error> {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::PORT_MAIN_MASK, Self::PORT_MAIN_SHIFT,
+                              Self::PORT_MAIN_LABEL, unit, vals)
+    }
+
+    fn set_main_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error> {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::PORT_MAIN_MASK, Self::PORT_MAIN_SHIFT,
+                            Self::PORT_MAIN_LABEL, unit, vals, idx)
+    }
+
+    fn get_return_assign(&self, unit: &hinawa::SndMotu, vals: &[u8]) -> Result<usize, Error> {
+        self.get_idx_from_val(Self::OFFSET_PORT, Self::PORT_RETURN_MASK, Self::PORT_RETURN_SHIFT,
+                              Self::PORT_RETURN_LABEL, unit, vals)
+    }
+
+    fn set_return_assign(&self, unit: &hinawa::SndMotu, vals: &[u8], idx: usize) -> Result<(), Error> {
+        self.set_idx_to_val(Self::OFFSET_PORT, Self::PORT_RETURN_MASK, Self::PORT_RETURN_SHIFT,
+                            Self::PORT_RETURN_LABEL, unit, vals, idx)
+    }
+
+    fn set_opt_iface_mode(&self, unit: &hinawa::SndMotu, is_out: bool, is_b: bool,
+                          enable: bool, no_adat: bool)
+        -> Result<(), Error>
+    {
+        let (enabled_mask, no_adat_mask) = self.get_opt_iface_masks(is_out, is_b);
+        let mut quad = self.read_quad(unit, Self::OFFSET_OPT)?;
+        quad &= !enabled_mask;
+        quad &= !no_adat_mask;
+        if enable {
+            quad |= enabled_mask;
+        }
+        if no_adat {
+            quad |= no_adat_mask;
+        }
+        self.write_quad(unit, Self::OFFSET_OPT, quad)
+    }
+
+    fn get_opt_iface_mode(&self, unit: &hinawa::SndMotu, is_out: bool, is_b: bool)
+        -> Result<(bool, bool), Error>
+    {
+        let quad = self.read_quad(unit, Self::OFFSET_OPT)?;
+
+        let (enabled_mask, no_adat_mask) = self.get_opt_iface_masks(is_out, is_b);
+        let enabled = (quad & enabled_mask) > 0;
+        let no_adat = (quad & no_adat_mask) > 0;
+
+        Ok((enabled, no_adat))
+    }
+}


### PR DESCRIPTION
This patchset adds service program for devices in MOTU FireWire series.

The devices in MOTU FireWire series are categorized to three generations. The patchset supports the devices in second and third generation. The added service program allows ALSA control applications to operate for device features which are controlled by MOTU Audio Console, therefore the feature of CueMix is not supported yet.