### PR TITLE
ta1394: add support for AV/C transaction and some commands

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,7 @@ Supported protocols
    * AV/C Digital Interface Command Set General Specification Version 4.2 (September 1, 2004. TA Document 2004006)
    * Audio and Music Data Transmission Protocol 2.3 (April 24, 2012. Document 2009013)
    * AV/C Connection and Compatibility Management Specification 1.1 (March 19, 2003. TA Document 2002010)
+   * AV/C Audio Subunit Specification 1.0 (October 24, 2000. TA Document 1999008)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/README.rst
+++ b/README.rst
@@ -111,6 +111,7 @@ Supported protocols
    * Configuration ROM for AV/C Devices 1.0 (Dec. 2000, 1394 Trade Association)
    * AV/C Digital Interface Command Set General Specification Version 4.2 (September 1, 2004. TA Document 2004006)
    * Audio and Music Data Transmission Protocol 2.3 (April 24, 2012. Document 2009013)
+   * AV/C Connection and Compatibility Management Specification 1.1 (March 19, 2003. TA Document 2002010)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ Supported protocols
 * IEEE 1212:2001 - IEEE Standard for a Control and Status Registers (CSR) Architecture for Microcomputer Buses https://ieeexplore.ieee.org/servlet/opac?punumber=8030
 * Protocols defined by 1394 Trading Association http://1394ta.org/specifications/
    * Configuration ROM for AV/C Devices 1.0 (Dec. 2000, 1394 Trade Association)
+   * AV/C Digital Interface Command Set General Specification Version 4.2 (September 1, 2004. TA Document 2004006)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/README.rst
+++ b/README.rst
@@ -113,6 +113,7 @@ Supported protocols
    * Audio and Music Data Transmission Protocol 2.3 (April 24, 2012. Document 2009013)
    * AV/C Connection and Compatibility Management Specification 1.1 (March 19, 2003. TA Document 2002010)
    * AV/C Audio Subunit Specification 1.0 (October 24, 2000. TA Document 1999008)
+   * AV/C Stream Format Information Specification 1.0 (May 24, 2002, TA Document 2001002)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,7 @@ Supported protocols
    * AV/C Connection and Compatibility Management Specification 1.1 (March 19, 2003. TA Document 2002010)
    * AV/C Audio Subunit Specification 1.0 (October 24, 2000. TA Document 1999008)
    * AV/C Stream Format Information Specification 1.0 (May 24, 2002, TA Document 2001002)
+   * AV/C Stream Format Information Specification 1.1 rev.5 (April 15, 2005. TA Document 2004008)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/README.rst
+++ b/README.rst
@@ -110,6 +110,7 @@ Supported protocols
 * Protocols defined by 1394 Trading Association http://1394ta.org/specifications/
    * Configuration ROM for AV/C Devices 1.0 (Dec. 2000, 1394 Trade Association)
    * AV/C Digital Interface Command Set General Specification Version 4.2 (September 1, 2004. TA Document 2004006)
+   * Audio and Music Data Transmission Protocol 2.3 (April 24, 2012. Document 2009013)
 * Vendor specific protocols
    * Protocol for Digi 002/003 family of Digidesign
    * Protocol for FireWire series of TASCAM (TEAC)

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -1,3 +1,107 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod config_rom;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AvcSubunitType {
+    Monitor,
+    Audio,
+    Printer,
+    Disc,
+    Tape,
+    Tuner,
+    Ca,
+    Camera,
+    Panel,
+    BulletinBoard,
+    CameraStorage,
+    Music,
+    VendorUnique,
+    Extended,
+    Reserved(u8),
+}
+
+impl AvcSubunitType {
+    const MONITOR: u8 = 0x00;
+    const AUDIO: u8 = 0x01;
+    const PRINTER: u8 = 0x02;
+    const DISC: u8 = 0x03;
+    const TAPE: u8 = 0x04;
+    const TUNER: u8 = 0x05;
+    const CA: u8 = 0x06;
+    const CAMERA: u8 = 0x07;
+    const PANEL: u8 = 0x09;
+    const BULLETIN_BOARD: u8 = 0x0a;
+    const CAMERA_STORAGE: u8 = 0x0b;
+    const MUSIC: u8 = 0x0c;
+    const VENDOR_UNIQUE: u8 = 0x1c;
+    const EXTENDED: u8 = 0x1e;
+}
+
+impl From<u8> for AvcSubunitType {
+    fn from(val: u8) -> Self {
+        match val {
+            AvcSubunitType::MONITOR => AvcSubunitType::Monitor,
+            AvcSubunitType::AUDIO => AvcSubunitType::Audio,
+            AvcSubunitType::PRINTER => AvcSubunitType::Printer,
+            AvcSubunitType::DISC => AvcSubunitType::Disc,
+            AvcSubunitType::TAPE => AvcSubunitType::Tape,
+            AvcSubunitType::TUNER => AvcSubunitType::Tuner,
+            AvcSubunitType::CA => AvcSubunitType::Ca,
+            AvcSubunitType::CAMERA => AvcSubunitType::Camera,
+            AvcSubunitType::PANEL => AvcSubunitType::Panel,
+            AvcSubunitType::BULLETIN_BOARD => AvcSubunitType::BulletinBoard,
+            AvcSubunitType::CAMERA_STORAGE => AvcSubunitType::CameraStorage,
+            AvcSubunitType::MUSIC => AvcSubunitType::Music,
+            AvcSubunitType::VENDOR_UNIQUE => AvcSubunitType::VendorUnique,
+            AvcSubunitType::EXTENDED => AvcSubunitType::Extended,
+            _ => AvcSubunitType::Reserved(val),
+        }
+    }
+}
+
+impl From<AvcSubunitType> for u8 {
+    fn from(subunit_type: AvcSubunitType) -> Self {
+        match subunit_type {
+            AvcSubunitType::Monitor => AvcSubunitType::MONITOR,
+            AvcSubunitType::Audio => AvcSubunitType::AUDIO,
+            AvcSubunitType::Printer => AvcSubunitType::PRINTER,
+            AvcSubunitType::Disc => AvcSubunitType::DISC,
+            AvcSubunitType::Tape => AvcSubunitType::TAPE,
+            AvcSubunitType::Tuner => AvcSubunitType::TUNER,
+            AvcSubunitType::Ca => AvcSubunitType::CA,
+            AvcSubunitType::Camera => AvcSubunitType::CAMERA,
+            AvcSubunitType::Panel => AvcSubunitType::PANEL,
+            AvcSubunitType::BulletinBoard => AvcSubunitType::BULLETIN_BOARD,
+            AvcSubunitType::CameraStorage => AvcSubunitType::CAMERA_STORAGE,
+            AvcSubunitType::Music => AvcSubunitType::MUSIC,
+            AvcSubunitType::VendorUnique => AvcSubunitType::VENDOR_UNIQUE,
+            AvcSubunitType::Extended => AvcSubunitType::EXTENDED,
+            AvcSubunitType::Reserved(value) => value,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::AvcSubunitType;
+
+    #[test]
+    fn avcsubunittype_from() {
+        assert_eq!(0x00, u8::from(AvcSubunitType::from(0x00)));
+        assert_eq!(0x01, u8::from(AvcSubunitType::from(0x01)));
+        assert_eq!(0x02, u8::from(AvcSubunitType::from(0x02)));
+        assert_eq!(0x03, u8::from(AvcSubunitType::from(0x03)));
+        assert_eq!(0x04, u8::from(AvcSubunitType::from(0x04)));
+        assert_eq!(0x05, u8::from(AvcSubunitType::from(0x05)));
+        assert_eq!(0x06, u8::from(AvcSubunitType::from(0x06)));
+        assert_eq!(0x07, u8::from(AvcSubunitType::from(0x07)));
+        assert_eq!(0x09, u8::from(AvcSubunitType::from(0x09)));
+        assert_eq!(0x0a, u8::from(AvcSubunitType::from(0x0a)));
+        assert_eq!(0x0b, u8::from(AvcSubunitType::from(0x0b)));
+        assert_eq!(0x0c, u8::from(AvcSubunitType::from(0x0c)));
+        assert_eq!(0x1c, u8::from(AvcSubunitType::from(0x1c)));
+        assert_eq!(0x1e, u8::from(AvcSubunitType::from(0x1e)));
+        assert_eq!(0xff, u8::from(AvcSubunitType::from(0xff)));
+    }
+}

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -144,9 +144,55 @@ impl From<AvcAddr> for u8 {
         }
     }
 }
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AvcCmdType {
+    Control,
+    Status,
+    SpecificInquiry,
+    Notify,
+    GeneralInquiry,
+    Reserved(u8),
+}
+
+impl AvcCmdType {
+    const CONTROL: u8 = 0x00;
+    const STATUS: u8 = 0x01;
+    const SPECIFIC_INQUIRY: u8 = 0x02;
+    const NOTIFY: u8 = 0x03;
+    const GENERAL_INQUIRY: u8 = 0x04;
+}
+
+impl From<u8> for AvcCmdType {
+    fn from(val: u8) -> Self {
+        match val {
+            AvcCmdType::CONTROL => AvcCmdType::Control,
+            AvcCmdType::STATUS => AvcCmdType::Status,
+            AvcCmdType::SPECIFIC_INQUIRY => AvcCmdType::SpecificInquiry,
+            AvcCmdType::NOTIFY => AvcCmdType::Notify,
+            AvcCmdType::GENERAL_INQUIRY => AvcCmdType::GeneralInquiry,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<AvcCmdType> for u8 {
+    fn from(code: AvcCmdType) -> Self {
+        match code {
+            AvcCmdType::Control => AvcCmdType::CONTROL,
+            AvcCmdType::Status => AvcCmdType::STATUS,
+            AvcCmdType::SpecificInquiry => AvcCmdType::SPECIFIC_INQUIRY,
+            AvcCmdType::Notify => AvcCmdType::NOTIFY,
+            AvcCmdType::GeneralInquiry => AvcCmdType::GENERAL_INQUIRY,
+            AvcCmdType::Reserved(val) => val,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{AvcSubunitType, AvcAddrSubunit, AvcAddr};
+    use super::AvcCmdType;
 
     #[test]
     fn avcsubunittype_from() {
@@ -188,5 +234,14 @@ mod test {
                    AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Music, 0x03)));
         assert_eq!(AvcAddr::from(0x87),
                    AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Reserved(0x10), 0x07)));
+    }
+
+    #[test]
+    fn avccmdtype_from() {
+        assert_eq!(0x00, u8::from(AvcCmdType::from(0x00)));
+        assert_eq!(0x01, u8::from(AvcCmdType::from(0x01)));
+        assert_eq!(0x02, u8::from(AvcCmdType::from(0x02)));
+        assert_eq!(0x03, u8::from(AvcCmdType::from(0x03)));
+        assert_eq!(0x04, u8::from(AvcCmdType::from(0x04)));
     }
 }

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -5,6 +5,7 @@ pub mod general;
 pub mod amdtp;
 pub mod ccm;
 pub mod audio;
+pub mod stream_format;
 
 use glib::{Error, error::ErrorDomain, Quark};
 

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod config_rom;
+pub mod general;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
@@ -93,10 +94,10 @@ pub struct AvcAddrSubunit {
 }
 
 impl AvcAddrSubunit {
-    const SUBUNIT_TYPE_SHIFT: usize = 3;
-    const SUBUNIT_TYPE_MASK: u8 = 0x1f;
-    const SUBUNIT_ID_SHIFT: usize = 0;
-    const SUBUNIT_ID_MASK: u8 = 0x07;
+    pub const SUBUNIT_TYPE_SHIFT: usize = 3;
+    pub const SUBUNIT_TYPE_MASK: u8 = 0x1f;
+    pub const SUBUNIT_ID_SHIFT: usize = 0;
+    pub const SUBUNIT_ID_MASK: u8 = 0x07;
 
     pub fn new(subunit_type: AvcSubunitType, mut subunit_id: u8) -> Self {
         subunit_id &= Self::SUBUNIT_ID_MASK;

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -89,6 +89,11 @@ impl From<AvcSubunitType> for u8 {
     }
 }
 
+pub const MUSIC_SUBUNIT_0: AvcAddrSubunit = AvcAddrSubunit{
+    subunit_type: AvcSubunitType::Music,
+    subunit_id: 0,
+};
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct AvcAddrSubunit {
     pub subunit_type: AvcSubunitType,

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -4,6 +4,7 @@ pub mod config_rom;
 pub mod general;
 pub mod amdtp;
 pub mod ccm;
+pub mod audio;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
@@ -91,6 +92,11 @@ impl From<AvcSubunitType> for u8 {
 
 pub const MUSIC_SUBUNIT_0: AvcAddrSubunit = AvcAddrSubunit{
     subunit_type: AvcSubunitType::Music,
+    subunit_id: 0,
+};
+
+pub const AUDIO_SUBUNIT_0: AvcAddrSubunit = AvcAddrSubunit{
+    subunit_type: AvcSubunitType::Audio,
     subunit_id: 0,
 };
 

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -3,6 +3,7 @@
 pub mod config_rom;
 pub mod general;
 pub mod amdtp;
+pub mod ccm;
 
 use glib::{Error, error::ErrorDomain, Quark};
 

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod config_rom;
 pub mod general;
+pub mod amdtp;
 
 use glib::{Error, error::ErrorDomain, Quark};
 

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -189,10 +189,62 @@ impl From<AvcCmdType> for u8 {
     }
 }
 
+#[derive(Debug, Eq, PartialEq)]
+pub enum AvcRespCode {
+    NotImplemented,
+    Accepted,
+    Rejected,
+    InTransition,
+    ImplementedStable,
+    Changed,
+    Interim,
+    Reserved(u8),
+}
+
+impl AvcRespCode {
+    const NOT_IMPLEMENTED: u8 = 0x08;
+    const ACCEPTED: u8 = 0x09;
+    const REJECTED: u8 = 0x0a;
+    const IN_TRANSITION: u8 = 0x0b;
+    const IMPLEMENTED_STABLE: u8 = 0x0c;
+    const CHANGED: u8 = 0x0d;
+    const INTERIM: u8 = 0x0f;
+}
+
+impl From<u8> for AvcRespCode {
+    fn from(val: u8) -> Self {
+        match val {
+            AvcRespCode::NOT_IMPLEMENTED => AvcRespCode::NotImplemented,
+            AvcRespCode::ACCEPTED => AvcRespCode::Accepted,
+            AvcRespCode::REJECTED => AvcRespCode::Rejected,
+            AvcRespCode::IN_TRANSITION => AvcRespCode::InTransition,
+            AvcRespCode::IMPLEMENTED_STABLE => AvcRespCode::ImplementedStable,
+            AvcRespCode::CHANGED => AvcRespCode::Changed,
+            AvcRespCode::INTERIM => AvcRespCode::Interim,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<AvcRespCode> for u8 {
+    fn from(resp: AvcRespCode) -> u8 {
+        match resp {
+            AvcRespCode::NotImplemented => AvcRespCode::NOT_IMPLEMENTED,
+            AvcRespCode::Accepted => AvcRespCode::ACCEPTED,
+            AvcRespCode::Rejected => AvcRespCode::REJECTED,
+            AvcRespCode::InTransition => AvcRespCode::IN_TRANSITION,
+            AvcRespCode::ImplementedStable => AvcRespCode::IMPLEMENTED_STABLE,
+            AvcRespCode::Changed => AvcRespCode::CHANGED,
+            AvcRespCode::Interim => AvcRespCode::INTERIM,
+            AvcRespCode::Reserved(val) => val,
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{AvcSubunitType, AvcAddrSubunit, AvcAddr};
-    use super::AvcCmdType;
+    use super::{AvcCmdType, AvcRespCode};
 
     #[test]
     fn avcsubunittype_from() {
@@ -243,5 +295,18 @@ mod test {
         assert_eq!(0x02, u8::from(AvcCmdType::from(0x02)));
         assert_eq!(0x03, u8::from(AvcCmdType::from(0x03)));
         assert_eq!(0x04, u8::from(AvcCmdType::from(0x04)));
+    }
+
+    #[test]
+    fn avcrespcode_from() {
+        assert_eq!(0x08, u8::from(AvcRespCode::from(0x08)));
+        assert_eq!(0x09, u8::from(AvcRespCode::from(0x09)));
+        assert_eq!(0x0a, u8::from(AvcRespCode::from(0x0a)));
+        assert_eq!(0x0b, u8::from(AvcRespCode::from(0x0b)));
+        assert_eq!(0x0c, u8::from(AvcRespCode::from(0x0c)));
+        assert_eq!(0x0d, u8::from(AvcRespCode::from(0x0d)));
+        assert_eq!(0x0e, u8::from(AvcRespCode::from(0x0e)));
+        assert_eq!(0x0f, u8::from(AvcRespCode::from(0x0f)));
+        assert_eq!(0xff, u8::from(AvcRespCode::from(0xff)));
     }
 }

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod config_rom;
 
+use glib::Error;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AvcSubunitType {
     Monitor,
@@ -239,6 +241,29 @@ impl From<AvcRespCode> for u8 {
             AvcRespCode::Reserved(val) => val,
         }
     }
+}
+
+pub trait AvcOp {
+    const OPCODE: u8;
+
+    fn opcode(&self) -> u8 {
+        Self::OPCODE
+    }
+}
+
+pub trait AvcControl {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;
+}
+
+pub trait AvcStatus {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;
+}
+
+pub trait AvcNotify {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;
 }
 
 #[cfg(test)]

--- a/src/ta1394.rs
+++ b/src/ta1394.rs
@@ -379,7 +379,7 @@ impl Ta1394Avc for hinawa::FwFcp {
         AvcControl::build_operands(op, addr, &mut operands)?;
         let opcode = op.opcode();
         let (rcode, operands) = self.trx(AvcCmdType::SpecificInquiry, addr, opcode, &mut operands, timeout_ms)?;
-        if rcode != AvcRespCode::ImplementedStable{
+        if rcode != AvcRespCode::ImplementedStable {
             let label = format!("Unexpected response code for specific inquiry opcode {}: {:?}", opcode, rcode);
             return Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label));
         }

--- a/src/ta1394/amdtp.rs
+++ b/src/ta1394/amdtp.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+pub const FMT_IS_AMDTP: u8 = 0x90;
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum AmdtpEventType{
+    Am824,
+    AudioPack,
+    FloatingPoint,
+    Reserved(u8),
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct AmdtpFdf{
+    pub ev_type: AmdtpEventType,
+    pub cmd_rate_ctl: bool,
+    pub freq: u32,
+}
+
+impl AmdtpFdf {
+    const EVT_MASK: u8 = 0x03;
+    const EVT_SHIFT: usize = 4;
+
+    const NFLAG_MASK: u8 = 0x01;
+    const NFLAG_SHIFT: usize = 3;
+
+    const SFC_MASK: u8 = 0x07;
+    const SFC_SHIFT: usize = 0;
+
+    const AM824: u8 = 0x00;
+    const AUDIOPACK: u8 = 0x01;
+    const FLOATINGPOINT: u8 = 0x02;
+
+    const SFC_32000: u8 = 0x00;
+    const SFC_44100: u8 = 0x01;
+    const SFC_48000: u8 = 0x02;
+    const SFC_88200: u8 = 0x03;
+    const SFC_96000: u8 = 0x04;
+    const SFC_176400: u8 = 0x05;
+    const SFC_192000: u8 = 0x06;
+    const SFC_RESERVED: u8 = 0x07;
+
+    pub fn new(ev_type: AmdtpEventType, cmd_rate_ctl: bool, freq: u32) -> Self {
+        AmdtpFdf{
+            ev_type,
+            cmd_rate_ctl,
+            freq,
+        }
+    }
+}
+
+impl From<&[u8]> for AmdtpFdf {
+    fn from(data: &[u8]) -> Self {
+        let ev_type = (data[0] >> Self::EVT_SHIFT) & Self::EVT_MASK;
+        let nflag = (data[0] >> Self::NFLAG_SHIFT) & Self::NFLAG_MASK;
+        let sfc = (data[0] >> Self::SFC_SHIFT) & Self::SFC_MASK;
+
+        let ev_type = match ev_type {
+            Self::AM824 => AmdtpEventType::Am824,
+            Self::AUDIOPACK => AmdtpEventType::AudioPack,
+            Self::FLOATINGPOINT => AmdtpEventType::FloatingPoint,
+            _ => AmdtpEventType::Reserved(data[0]),
+        };
+
+        let freq = match sfc {
+            Self::SFC_32000 => 32000,
+            Self::SFC_44100 => 44100,
+            Self::SFC_48000 => 48000,
+            Self::SFC_88200 => 88200,
+            Self::SFC_96000 => 96000,
+            Self::SFC_176400 => 176400,
+            Self::SFC_192000 => 192000,
+            _ => 0,
+        };
+
+        AmdtpFdf{
+            ev_type,
+            cmd_rate_ctl: nflag > 0,
+            freq,
+        }
+    }
+}
+
+impl From<AmdtpFdf> for [u8;3] {
+    fn from(fdf: AmdtpFdf) -> Self {
+        let mut data = [0xff;3];
+
+        let ev_type = match fdf.ev_type {
+            AmdtpEventType::Am824 => AmdtpFdf::AM824,
+            AmdtpEventType::AudioPack => AmdtpFdf::AUDIOPACK,
+            AmdtpEventType::FloatingPoint => AmdtpFdf::FLOATINGPOINT,
+            AmdtpEventType::Reserved(val) => val,
+        };
+
+        let nflag = fdf.cmd_rate_ctl;
+
+        let sfc = match fdf.freq {
+            32000 => AmdtpFdf::SFC_32000,
+            44100 => AmdtpFdf::SFC_44100,
+            48000 => AmdtpFdf::SFC_48000,
+            88200 => AmdtpFdf::SFC_88200,
+            96000 => AmdtpFdf::SFC_96000,
+            176400 => AmdtpFdf::SFC_176400,
+            192000 => AmdtpFdf::SFC_192000,
+            _ => AmdtpFdf::SFC_RESERVED,
+        };
+
+        data[0] = ((ev_type & AmdtpFdf::EVT_MASK) << AmdtpFdf::EVT_SHIFT) |
+                  ((nflag as u8 & AmdtpFdf::NFLAG_MASK) << AmdtpFdf::NFLAG_SHIFT) |
+                  ((sfc & AmdtpFdf::SFC_MASK) << AmdtpFdf::SFC_SHIFT);
+
+        data
+    }
+}

--- a/src/ta1394/audio.rs
+++ b/src/ta1394/audio.rs
@@ -1,0 +1,353 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use super::{AvcSubunitType, AUDIO_SUBUNIT_0, AvcAddr, Ta1394AvcError};
+use super::{AvcOp, AvcStatus, AvcControl};
+
+pub const AUDIO_SUBUNIT_0_ADDR: AvcAddr = AvcAddr::Subunit(AUDIO_SUBUNIT_0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AudioFuncBlkType {
+    Selector,
+    Feature,
+    Processing,
+    Reserved(u8),
+}
+
+impl From<u8> for AudioFuncBlkType {
+    fn from(val: u8) -> Self {
+        match val {
+            0x80 => AudioFuncBlkType::Selector,
+            0x81 => AudioFuncBlkType::Feature,
+            0x82 => AudioFuncBlkType::Processing,
+            _ => AudioFuncBlkType::Reserved(val),
+        }
+    }
+}
+
+impl From<AudioFuncBlkType> for u8 {
+    fn from(func_blk_type: AudioFuncBlkType) -> Self {
+        match func_blk_type {
+            AudioFuncBlkType::Selector => 0x80,
+            AudioFuncBlkType::Feature => 0x81,
+            AudioFuncBlkType::Processing => 0x82,
+            AudioFuncBlkType::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CtlAttr {
+    Resolution,
+    Minimum,
+    Maximum,
+    Default,
+    Duration,
+    Current,
+    Move,
+    Delta,
+    Reserved(u8),
+}
+
+impl From<u8> for CtlAttr {
+    fn from(val: u8) -> Self {
+        match val {
+            0x01 => Self::Resolution,
+            0x02 => Self::Minimum,
+            0x03 => Self::Maximum,
+            0x04 => Self::Default,
+            0x08 => Self::Duration,
+            0x10 => Self::Current,
+            0x18 => Self::Move,
+            0x19 => Self::Delta,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<CtlAttr> for u8 {
+    fn from(attr_type: CtlAttr) -> Self {
+        match attr_type {
+            CtlAttr::Resolution => 0x01,
+            CtlAttr::Minimum => 0x02,
+            CtlAttr::Maximum => 0x03,
+            CtlAttr::Default => 0x04,
+            CtlAttr::Duration => 0x08,
+            CtlAttr::Current => 0x10,
+            CtlAttr::Move => 0x18,
+            CtlAttr::Delta => 0x19,
+            CtlAttr::Reserved(val) => val,
+        }
+    }
+}
+
+impl std::fmt::Display for CtlAttr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            CtlAttr::Resolution => "resolution".to_owned(),
+            CtlAttr::Minimum => "minimum".to_owned(),
+            CtlAttr::Maximum => "maximum".to_owned(),
+            CtlAttr::Default => "default".to_owned(),
+            CtlAttr::Duration => "duration".to_owned(),
+            CtlAttr::Current => "current".to_owned(),
+            CtlAttr::Move => "move".to_owned(),
+            CtlAttr::Delta => "delta".to_owned(),
+            CtlAttr::Reserved(val) => format!("reserved: {}", val),
+        };
+        write!(f, "{}", &label)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AudioFuncBlkCtl {
+    selector: u8,
+    data: Vec<u8>,
+}
+
+impl AudioFuncBlkCtl {
+    fn new() -> Self {
+        AudioFuncBlkCtl{
+            selector: 0xff,
+            data: Vec::new(),
+        }
+    }
+
+    fn build_raw(&self, raw: &mut Vec<u8>) {
+        raw.push(self.selector);
+        if self.data.len() > 0 {
+            raw.push(self.data.len() as u8);
+            raw.extend_from_slice(&self.data);
+        }
+    }
+
+    fn parse_raw(&mut self, raw: &[u8]) {
+        self.selector = raw[0];
+        self.data.clear();
+        if raw.len() > 1 {
+            let length = raw[1] as usize;
+            if raw.len() >= 2 + length {
+                self.data.extend_from_slice(&raw[2..(2 + length)]);
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct AudioFuncBlk {
+    func_blk_type: AudioFuncBlkType,
+    func_blk_id: u8,
+    ctl_attr: CtlAttr,
+    audio_selector_data: Vec<u8>,
+    ctl: AudioFuncBlkCtl,
+}
+
+impl AudioFuncBlk {
+    fn new(func_blk_type: AudioFuncBlkType, func_blk_id: u8, ctl_attr: CtlAttr) -> Self {
+        AudioFuncBlk{
+            func_blk_type,
+            func_blk_id,
+            ctl_attr,
+            audio_selector_data: Vec::new(),
+            ctl: AudioFuncBlkCtl::new(),
+        }
+    }
+
+    fn build_operands(&self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        match addr {
+            AvcAddr::Unit => {
+                let label = "Unit address is not supported by AudioFuncBlk";
+                Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+            }
+            AvcAddr::Subunit(s) => {
+                if s.subunit_type == AvcSubunitType::Audio {
+                    operands.push(self.func_blk_type.into());
+                    operands.push(self.func_blk_id);
+                    operands.push(self.ctl_attr.into());
+                    operands.push(1 + self.audio_selector_data.len() as u8);
+                    operands.extend_from_slice(&self.audio_selector_data);
+                    self.ctl.build_raw(operands);
+                    Ok(())
+                } else {
+                    let label = "SubUnit address except for audio is not supported by AudioFuncBlk";
+                    Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+                }
+            }
+        }
+    }
+
+    fn parse_operands(&mut self, operands: &[u8]) -> Result<(), Error> {
+        if operands.len() < 4 {
+            let label = format!("Oprands too short for AudioFuncBlk; {}", operands.len());
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+        let func_blk_type = AudioFuncBlkType::from(operands[0]);
+        if func_blk_type != self.func_blk_type {
+            let label = format!("Unexpected function block type: {}", operands[0]);
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+        }
+
+        let func_blk_id = operands[1];
+        if func_blk_id != self.func_blk_id {
+            let label = format!("Unexpected function block ID: {} but {}",
+                                self.func_blk_id, func_blk_id);
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+        }
+
+        let ctl_attr = CtlAttr::from(operands[2]);
+        if ctl_attr != self.ctl_attr {
+            let label = format!("Unexpected control attribute: {} but {}",
+                                self.ctl_attr, ctl_attr);
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+        }
+
+        let mut audio_selector_length = operands[3] as usize;
+        if operands.len() < 3 + audio_selector_length {
+            let label = format!("Oprands too short for selector of AudioFuncBlk; {}", operands.len());
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        } else if audio_selector_length < 1 {
+            let label = "The length of audio selector is less thant 1:";
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+        }
+        audio_selector_length -= 1;
+        self.audio_selector_data = operands[4..(4 + audio_selector_length)].to_vec();
+
+        self.ctl.parse_raw(&operands[(4 + audio_selector_length)..]);
+
+        Ok(())
+    }
+}
+
+impl AvcOp for AudioFuncBlk {
+    const OPCODE: u8 = 0xb8;
+}
+
+impl AvcStatus for AudioFuncBlk {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        AudioFuncBlk::build_operands(self, addr, operands)
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AudioFuncBlk::parse_operands(self, operands)
+    }
+}
+
+impl AvcControl for AudioFuncBlk {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        AudioFuncBlk::build_operands(self, addr, operands)
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AudioFuncBlk::parse_operands(self, operands)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ta1394::AvcAddr;
+    use crate::ta1394::{AvcStatus, AvcControl};
+    use super::{AUDIO_SUBUNIT_0_ADDR, AudioFuncBlk, AudioFuncBlkType, CtlAttr};
+
+    #[test]
+    fn func_blk_operands() {
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Selector, 0xfe, CtlAttr::Resolution);
+        op.audio_selector_data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        op.ctl.selector = 0x11;
+        op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
+
+        let mut operands = Vec::new();
+        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x80, 0xfe, 0x01, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x11, 0x02, 0xbe, 0xef]);
+
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Selector);
+        assert_eq!(op.func_blk_id, 0xfe);
+        assert_eq!(op.ctl_attr, CtlAttr::Resolution);
+        assert_eq!(&op.audio_selector_data, &[0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(op.ctl.selector, 0x11);
+        assert_eq!(&op.ctl.data, &[0xbe, 0xef]);
+
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Selector, 0xfd, CtlAttr::Minimum);
+        op.audio_selector_data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        op.ctl.selector = 0x12;
+        op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
+
+        let mut operands = Vec::new();
+        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x80, 0xfd, 0x02, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x12, 0x02, 0xbe, 0xef]);
+
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Selector);
+        assert_eq!(op.func_blk_id, 0xfd);
+        assert_eq!(op.ctl_attr, CtlAttr::Minimum);
+        assert_eq!(&op.audio_selector_data, &[0xde, 0xad, 0xbe, 0xef]);
+        assert_eq!(op.ctl.selector, 0x12);
+        assert_eq!(&op.ctl.data, &[0xbe, 0xef]);
+
+        // For the case that audio_selector_data is empty.
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Feature, 0xfc, CtlAttr::Maximum);
+        op.ctl.selector = 0x13;
+        op.ctl.data.extend_from_slice(&[0xfe, 0xeb, 0xda, 0xed]);
+
+        let mut operands = Vec::new();
+        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x81, 0xfc, 0x03, 0x01, 0x13, 0x04, 0xfe, 0xeb, 0xda, 0xed]);
+
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Feature);
+        assert_eq!(op.func_blk_id, 0xfc);
+        assert_eq!(op.ctl_attr, CtlAttr::Maximum);
+        assert_eq!(&op.audio_selector_data, &[]);
+        assert_eq!(op.ctl.selector, 0x13);
+        assert_eq!(&op.ctl.data, &[0xfe, 0xeb, 0xda, 0xed]);
+
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Feature, 0xfb, CtlAttr::Default);
+        op.ctl.selector = 0x14;
+        op.ctl.data.extend_from_slice(&[0xfe, 0xeb, 0xda, 0xed]);
+
+        let mut operands = Vec::new();
+        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x81, 0xfb, 0x04, 0x01, 0x14, 0x04, 0xfe, 0xeb, 0xda, 0xed]);
+
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Feature);
+        assert_eq!(op.func_blk_id, 0xfb);
+        assert_eq!(op.ctl_attr, CtlAttr::Default);
+        assert_eq!(&op.audio_selector_data, &[]);
+        assert_eq!(op.ctl.selector, 0x14);
+        assert_eq!(&op.ctl.data, &[0xfe, 0xeb, 0xda, 0xed]);
+
+        // For the case that ctl_data is empty.
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Processing, 0xfa, CtlAttr::Duration);
+        op.audio_selector_data.extend_from_slice(&[0xda, 0xed]);
+        op.ctl.selector = 0x15;
+
+        let mut operands = Vec::new();
+        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x82, 0xfa, 0x08, 0x03, 0xda, 0xed, 0x15]);
+
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Processing);
+        assert_eq!(op.func_blk_id, 0xfa);
+        assert_eq!(op.ctl_attr, CtlAttr::Duration);
+        assert_eq!(&op.audio_selector_data, &[0xda, 0xed]);
+        assert_eq!(op.ctl.selector, 0x15);
+        assert_eq!(&op.ctl.data, &[]);
+
+        let mut op = AudioFuncBlk::new(AudioFuncBlkType::Processing, 0xf9, CtlAttr::Current);
+        op.audio_selector_data.extend_from_slice(&[0xda, 0xed]);
+        op.ctl.selector = 0x16;
+
+        let mut operands = Vec::new();
+        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x82, 0xf9, 0x10, 0x03, 0xda, 0xed, 0x16]);
+
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.func_blk_type, AudioFuncBlkType::Processing);
+        assert_eq!(op.func_blk_id, 0xf9);
+        assert_eq!(op.ctl_attr, CtlAttr::Current);
+        assert_eq!(&op.audio_selector_data, &[0xda, 0xed]);
+        assert_eq!(op.ctl.selector, 0x16);
+        assert_eq!(&op.ctl.data, &[]);
+    }
+}

--- a/src/ta1394/ccm.rs
+++ b/src/ta1394/ccm.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use super::{AvcSubunitType, AvcAddr, AvcAddrSubunit};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SignalUnitAddr {
+    Isoc(u8),
+    Ext(u8),
+}
+
+impl SignalUnitAddr {
+    const EXT_PLUG_FLAG: u8 = 0x80;
+    const PLUG_ID_MASK: u8 = 0x7f;
+}
+
+impl From<&[u8;2]> for SignalUnitAddr {
+    fn from(data: &[u8;2]) -> Self {
+        let plug_id = data[1] & Self::PLUG_ID_MASK;
+        if data[1] & Self::EXT_PLUG_FLAG > 0 {
+            Self::Ext(plug_id)
+        } else {
+            Self::Isoc(plug_id)
+        }
+    }
+}
+
+impl From<SignalUnitAddr> for [u8;2] {
+    fn from(addr: SignalUnitAddr) -> Self {
+        let mut data = [0;2];
+        data[0] = AvcAddr::UNIT_ADDR;
+        data[1] = match addr {
+            SignalUnitAddr::Isoc(val) => val,
+            SignalUnitAddr::Ext(val) => SignalUnitAddr::EXT_PLUG_FLAG | val,
+        };
+        data
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct SignalSubunitAddr {
+    pub subunit: AvcAddrSubunit,
+    pub plug_id: u8,
+}
+
+impl From<&[u8;2]> for SignalSubunitAddr {
+    fn from(data: &[u8;2]) -> Self {
+        let subunit = AvcAddrSubunit::from(data[0]);
+        let plug_id = data[1];
+        SignalSubunitAddr{subunit, plug_id}
+    }
+}
+
+impl From<SignalSubunitAddr> for [u8;2] {
+    fn from(addr: SignalSubunitAddr) -> Self {
+        let mut data = [0;2];
+        data[0] = u8::from(addr.subunit);
+        data[1] = addr.plug_id;
+        data
+    }
+}
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub enum SignalAddr {
+    Unit(SignalUnitAddr),
+    Subunit(SignalSubunitAddr),
+}
+
+impl SignalAddr {
+    pub fn new_for_isoc_unit(plug_id: u8) -> Self {
+        SignalAddr::Unit(SignalUnitAddr::Isoc(plug_id & SignalUnitAddr::PLUG_ID_MASK))
+    }
+
+    pub fn new_for_ext_unit(plug_id: u8) -> Self {
+        SignalAddr::Unit(SignalUnitAddr::Ext(plug_id & SignalUnitAddr::PLUG_ID_MASK))
+    }
+
+    pub fn new_for_subunit(subunit_type: AvcSubunitType, subunit_id: u8, plug_id: u8) -> Self {
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: AvcAddrSubunit{subunit_type, subunit_id},
+            plug_id,
+        })
+    }
+}
+
+impl From<&[u8;2]> for SignalAddr {
+    fn from(data: &[u8;2]) -> Self {
+        if data[0] == AvcAddr::UNIT_ADDR {
+            SignalAddr::Unit(data.into())
+        } else {
+            SignalAddr::Subunit(data.into())
+        }
+    }
+}
+
+impl From<SignalAddr> for [u8;2] {
+    fn from(addr: SignalAddr) -> Self {
+        match addr {
+            SignalAddr::Unit(a) => a.into(),
+            SignalAddr::Subunit(a) => a.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::SignalAddr;
+
+    #[test]
+    fn signaladdr_from() {
+        assert_eq!([0xff, 0x00], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x00])));
+        assert_eq!([0xff, 0x27], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x27])));
+        assert_eq!([0xff, 0x87], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x87])));
+        assert_eq!([0xff, 0xc7], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0xc7])));
+        assert_eq!([0x63, 0x07], Into::<[u8;2]>::into(SignalAddr::from(&[0x63, 0x07])));
+        assert_eq!([0x09, 0x11], Into::<[u8;2]>::into(SignalAddr::from(&[0x09, 0x11])));
+    }
+}

--- a/src/ta1394/general.rs
+++ b/src/ta1394/general.rs
@@ -370,12 +370,84 @@ impl AvcStatus for PlugInfo {
     }
 }
 
+//
+// AV/C INPUT PLUG SIGNAL FORMAT command.
+//
+#[derive(Debug)]
+pub struct InputPlugSignalFormat {
+    pub plug_id: u8,
+    pub fmt: u8,
+    pub fdf: [u8;3],
+}
+
+impl InputPlugSignalFormat {
+    pub fn new(plug_id: u8) -> Self {
+        InputPlugSignalFormat{
+            plug_id,
+            fmt: 0xff,
+            fdf: [0xff;3],
+        }
+    }
+
+    fn parse_operands(&mut self, operands: &[u8]) -> Result<(), Error> {
+        if operands.len() > 4 {
+            self.plug_id = operands[0];
+            self.fmt = operands[1];
+            self.fdf.copy_from_slice(&operands[2..5]);
+            Ok(())
+        } else {
+            let label = format!("Oprands too short for InputPlugSignalFormat; {}", operands.len());
+            Err(Error::new(Ta1394AvcError::TooShortResp, &label))
+        }
+    }
+}
+
+impl AvcOp for InputPlugSignalFormat {
+    const OPCODE: u8 = 0x19;
+}
+
+impl AvcControl for InputPlugSignalFormat {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        if *addr == AvcAddr::Unit {
+            operands.push(self.plug_id);
+            operands.push(self.fmt);
+            operands.extend_from_slice(&self.fdf);
+            Ok(())
+        } else {
+            let label = "Subunit address is not supported by InputPlugSignalFormat";
+            Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+        }
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        Self::parse_operands(self, operands)
+    }
+}
+
+impl AvcStatus for InputPlugSignalFormat {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        if *addr == AvcAddr::Unit {
+            operands.push(self.plug_id);
+            operands.extend_from_slice(&[0xff;4]);
+            Ok(())
+        } else {
+            let label = "Subunit address is not supported by InputPlugSignalFormat";
+            Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+        }
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        Self::parse_operands(self, operands)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::{AvcSubunitType, AvcAddr, AvcAddrSubunit};
     use super::{AvcStatus, AvcControl};
     use super::{UnitInfo, SubunitInfo, SubunitInfoEntry, VendorDependent};
     use super::{PlugInfo, PlugInfoUnitData};
+    use super::{InputPlugSignalFormat};
 
     #[test]
     fn unitinfo_operands() {
@@ -505,5 +577,29 @@ mod test {
         });
         AvcStatus::build_operands(&mut op, &addr, &mut target).unwrap();
         assert_eq!(&target, &[0x00, 0xff, 0xff, 0xff, 0xff]);
+    }
+
+    #[test]
+    fn inputplugsignalformat_from() {
+        let operands = [0x1e, 0xde, 0xad, 0xbe, 0xef];
+        let mut op = InputPlugSignalFormat::new(0x1e);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.plug_id, 0x1e);
+        assert_eq!(op.fmt, 0xde);
+        assert_eq!(op.fdf, [0xad, 0xbe, 0xef]);
+
+        let mut target = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut target).unwrap();
+        assert_eq!(target, &[0x1e, 0xff, 0xff, 0xff, 0xff]);
+
+        let mut target = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut target).unwrap();
+        assert_eq!(target, operands);
+
+        let mut op = InputPlugSignalFormat::new(0x1e);
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.plug_id, 0x1e);
+        assert_eq!(op.fmt, 0xde);
+        assert_eq!(op.fdf, [0xad, 0xbe, 0xef]);
     }
 }

--- a/src/ta1394/general.rs
+++ b/src/ta1394/general.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use super::{AvcAddr, AvcAddrSubunit, AvcSubunitType, Ta1394AvcError};
+use super::{AvcOp, AvcStatus};
+
+//
+// AV/C UNIT INFO command.
+//
+#[derive(Debug)]
+pub struct UnitInfo {
+    pub unit_type: AvcSubunitType,
+    pub unit_id: u8,
+    pub company_id: [u8;3],
+}
+
+impl UnitInfo {
+    const FIRST_OPERAND: u8 = 0x07;
+
+    pub fn new() -> Self {
+        UnitInfo{
+            unit_type: AvcSubunitType::Reserved(AvcAddrSubunit::SUBUNIT_TYPE_MASK),
+            unit_id: AvcAddrSubunit::SUBUNIT_ID_MASK,
+            company_id: [0xff;3],
+        }
+    }
+}
+
+impl AvcOp for UnitInfo {
+    const OPCODE: u8 = 0x30;
+}
+
+impl AvcStatus for UnitInfo {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        if let AvcAddr::Subunit(_) = addr {
+            let label = "Subunit address is not supported by UnitInfo";
+            Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+        } else {
+            operands.push(Self::FIRST_OPERAND);
+            operands.extend_from_slice(&[0xff;4]);
+            Ok(())
+        }
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        if operands.len() < 5 {
+            let label = format!("Oprands too short for UnitInfo; {}", operands.len());
+            Err(Error::new(Ta1394AvcError::TooShortResp, &label))
+        } else {
+            let unit_type = (operands[1] >> AvcAddrSubunit::SUBUNIT_TYPE_SHIFT) & AvcAddrSubunit::SUBUNIT_TYPE_MASK;
+            let unit_id = (operands[1] >> AvcAddrSubunit::SUBUNIT_ID_SHIFT) & AvcAddrSubunit::SUBUNIT_ID_MASK;
+
+            self.unit_type = AvcSubunitType::from(unit_type);
+            self.unit_id = unit_id;
+            self.company_id.copy_from_slice(&operands[2..5]);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{AvcSubunitType, AvcAddr};
+    use super::AvcStatus;
+    use super::UnitInfo;
+
+    #[test]
+    fn unitinfo_operands() {
+        let operands = [0x07, 0xde, 0xad, 0xbe, 0xef];
+        let mut op = UnitInfo::new();
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.unit_type, AvcSubunitType::Reserved(0x1b));
+        assert_eq!(op.unit_id, 0x06);
+        assert_eq!(op.company_id, [0xad, 0xbe, 0xef]);
+
+        let mut operands = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut operands).unwrap();
+        assert_eq!(&operands, &[0x07, 0xff, 0xff, 0xff, 0xff]);
+    }
+}

--- a/src/ta1394/stream_format.rs
+++ b/src/ta1394/stream_format.rs
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+//
+// AV/C STREAM FORMAT INFORMATION
+//
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Am824MultiBitAudioAttr {
+    pub freq: u32,
+    pub rate_ctl: bool,
+}
+
+impl Am824MultiBitAudioAttr {
+    const FREQ_CODE_22050: u8 = 0x00;
+    const FREQ_CODE_24000: u8 = 0x01;
+    const FREQ_CODE_32000: u8 = 0x02;
+    const FREQ_CODE_44100: u8 = 0x03;
+    const FREQ_CODE_48000: u8 = 0x04;
+    const FREQ_CODE_96000: u8 = 0x05;
+    const FREQ_CODE_176400: u8 = 0x06;
+    const FREQ_CODE_192000: u8 = 0x07;
+
+    const FREQ_CODE_MASK: u8 = 0x0f;
+    const FREQ_CODE_SHIFT: usize = 4;
+
+    const RATE_CTL_SUPPORTED: u8 = 0x00;
+    const RATE_CTL_DONT_CARE: u8 = 0x01;
+
+    const RATE_CTL_MASK: u8 = 0x01;
+    const RATE_CTL_SHIFT: usize = 0;
+}
+
+impl From<&[u8;2]> for Am824MultiBitAudioAttr {
+    fn from(raw: &[u8;2]) -> Self {
+        let freq_code =
+            (raw[0] >> Am824MultiBitAudioAttr::FREQ_CODE_SHIFT) & Am824MultiBitAudioAttr::FREQ_CODE_MASK;
+        let freq = match freq_code {
+            Am824MultiBitAudioAttr::FREQ_CODE_22050 => 22050,
+            Am824MultiBitAudioAttr::FREQ_CODE_24000 => 24000,
+            Am824MultiBitAudioAttr::FREQ_CODE_32000 => 32000,
+            Am824MultiBitAudioAttr::FREQ_CODE_44100 => 44100,
+            Am824MultiBitAudioAttr::FREQ_CODE_48000 => 48000,
+            Am824MultiBitAudioAttr::FREQ_CODE_96000 => 96000,
+            Am824MultiBitAudioAttr::FREQ_CODE_176400 => 176400,
+            Am824MultiBitAudioAttr::FREQ_CODE_192000 => 192000,
+            _ => 0xffffffff,
+        };
+
+        let rate_ctl_code =
+            (raw[0] >> Am824MultiBitAudioAttr::RATE_CTL_SHIFT) & Am824MultiBitAudioAttr::RATE_CTL_MASK;
+        let rate_ctl = rate_ctl_code == Am824MultiBitAudioAttr::RATE_CTL_SUPPORTED;
+
+        Am824MultiBitAudioAttr{
+            freq,
+            rate_ctl,
+        }
+    }
+}
+
+impl From<&Am824MultiBitAudioAttr> for [u8;2] {
+    fn from(data: &Am824MultiBitAudioAttr) -> Self {
+        let freq_code = match data.freq {
+            22050 => Am824MultiBitAudioAttr::FREQ_CODE_22050,
+            24000 => Am824MultiBitAudioAttr::FREQ_CODE_24000,
+            32000 => Am824MultiBitAudioAttr::FREQ_CODE_32000,
+            44100 => Am824MultiBitAudioAttr::FREQ_CODE_44100,
+            48000 => Am824MultiBitAudioAttr::FREQ_CODE_48000,
+            96000 => Am824MultiBitAudioAttr::FREQ_CODE_96000,
+            176400 => Am824MultiBitAudioAttr::FREQ_CODE_176400,
+            192000 => Am824MultiBitAudioAttr::FREQ_CODE_192000,
+            _ => 0x0f,
+        };
+
+        let rate_ctl_code = if data.rate_ctl {
+            Am824MultiBitAudioAttr::RATE_CTL_SUPPORTED
+        } else {
+            Am824MultiBitAudioAttr::RATE_CTL_DONT_CARE
+        };
+
+        let mut raw = [0xff;2];
+        raw[0] =
+            ((freq_code & Am824MultiBitAudioAttr::FREQ_CODE_MASK) << Am824MultiBitAudioAttr::FREQ_CODE_SHIFT) |
+            ((rate_ctl_code & Am824MultiBitAudioAttr::RATE_CTL_MASK) << Am824MultiBitAudioAttr::RATE_CTL_SHIFT);
+        raw
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Am824OneBitAudioAttr {
+    pub freq: u32,
+    pub rate_ctl: bool,
+}
+
+impl Am824OneBitAudioAttr {
+    const FREQ_CODE_2048000: u8 = 0x00;
+    const FREQ_CODE_2822400: u8 = 0x01;
+    const FREQ_CODE_3072000: u8 = 0x02;
+    const FREQ_CODE_5644800: u8 = 0x03;
+    const FREQ_CODE_6144000: u8 = 0x04;
+    const FREQ_CODE_11289600: u8 = 0x05;
+    const FREQ_CODE_12288000: u8 = 0x06;
+
+    const FREQ_CODE_MASK: u8 = 0x0f;
+    const FREQ_CODE_SHIFT: usize = 4;
+
+    const RATE_CTL_SUPPORTED: u8 = 0x00;
+    const RATE_CTL_DONT_CARE: u8 = 0x01;
+
+    const RATE_CTL_MASK: u8 = 0x01;
+    const RATE_CTL_SHIFT: usize = 0;
+}
+
+impl From<&[u8;2]> for Am824OneBitAudioAttr {
+    fn from(raw: &[u8;2]) -> Self {
+        let freq_code =
+            (raw[0] >> Am824OneBitAudioAttr::FREQ_CODE_SHIFT) & Am824OneBitAudioAttr::FREQ_CODE_MASK;
+        let freq = match freq_code {
+            Am824OneBitAudioAttr::FREQ_CODE_2048000 => 2048000,
+            Am824OneBitAudioAttr::FREQ_CODE_2822400 => 2822400,
+            Am824OneBitAudioAttr::FREQ_CODE_3072000 => 3072000,
+            Am824OneBitAudioAttr::FREQ_CODE_5644800 => 5644800,
+            Am824OneBitAudioAttr::FREQ_CODE_6144000 => 6144000,
+            Am824OneBitAudioAttr::FREQ_CODE_11289600 => 11289600,
+            Am824OneBitAudioAttr::FREQ_CODE_12288000 => 12288000,
+            _ => 0xffffffff,
+        };
+
+        let rate_ctl_code =
+            (raw[0] >> Am824OneBitAudioAttr::RATE_CTL_SHIFT) & Am824OneBitAudioAttr::RATE_CTL_MASK;
+        let rate_ctl = rate_ctl_code == Am824OneBitAudioAttr::RATE_CTL_SUPPORTED;
+
+        Am824OneBitAudioAttr{
+            freq,
+            rate_ctl,
+        }
+    }
+}
+
+impl From<&Am824OneBitAudioAttr> for [u8;2] {
+    fn from(data: &Am824OneBitAudioAttr) -> Self {
+        let freq_code = match data.freq {
+             2048000 => Am824OneBitAudioAttr::FREQ_CODE_2048000,
+             2822400 => Am824OneBitAudioAttr::FREQ_CODE_2822400,
+             3072000 => Am824OneBitAudioAttr::FREQ_CODE_3072000,
+             5644800 => Am824OneBitAudioAttr::FREQ_CODE_5644800,
+             6144000 => Am824OneBitAudioAttr::FREQ_CODE_6144000,
+             11289600 => Am824OneBitAudioAttr::FREQ_CODE_11289600,
+             12288000 => Am824OneBitAudioAttr::FREQ_CODE_12288000,
+            _ => 0x0f,
+        };
+
+        let rate_ctl_code = if data.rate_ctl {
+            Am824OneBitAudioAttr::RATE_CTL_SUPPORTED
+        } else {
+            Am824OneBitAudioAttr::RATE_CTL_DONT_CARE
+        };
+
+        let mut raw = [0xff;2];
+        raw[0] =
+            ((freq_code & Am824OneBitAudioAttr::FREQ_CODE_MASK) << Am824OneBitAudioAttr::FREQ_CODE_SHIFT) |
+            ((rate_ctl_code & Am824OneBitAudioAttr::RATE_CTL_MASK) << Am824OneBitAudioAttr::RATE_CTL_SHIFT);
+        raw
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Am824Stream {
+    Iec60958_3(Am824MultiBitAudioAttr),
+    Iec61937_3(Am824MultiBitAudioAttr),
+    Iec61937_4(Am824MultiBitAudioAttr),
+    Iec61937_5(Am824MultiBitAudioAttr),
+    Iec61937_6(Am824MultiBitAudioAttr),
+    Iec61937_7(Am824MultiBitAudioAttr),
+    MultiBitLinearAudioRaw(Am824MultiBitAudioAttr),
+    MultiBitLinearAudioDvd(Am824MultiBitAudioAttr),
+    OneBitAudioPlainRaw(Am824OneBitAudioAttr),
+    OneBitAudioPlainSacd(Am824OneBitAudioAttr),
+    OneBitAudioEncodedRaw(Am824OneBitAudioAttr),
+    OneBitAudioEncodedSacd(Am824OneBitAudioAttr),
+    HighPrecisionMultiBitLinearAudio(Am824MultiBitAudioAttr),
+    MidiConformant([u8;2]),
+    Reserved([u8;4]),
+}
+
+impl Am824Stream {
+    const IEC60958_3: u8 = 0x00;
+    const IEC61937_3: u8 = 0x01;
+    const IEC61937_4: u8 = 0x02;
+    const IEC61937_5: u8 = 0x03;
+    const IEC61937_6: u8 = 0x04;
+    const IEC61937_7: u8 = 0x05;
+    const MULTI_BIT_LINEAR_AUDIO_RAW: u8 = 0x06;
+    const MULTI_BIT_LINEAR_AUDIO_DVD: u8 = 0x07;
+    const ONE_BIT_AUDIO_PLAIN_RAW: u8 = 0x08;
+    const ONE_BIT_AUDIO_PLAIN_SACD: u8 = 0x09;
+    const ONE_BIT_AUDIO_ENCODED_RAW: u8 = 0x0a;
+    const ONE_BIT_AUDIO_ENCODED_SACD: u8 = 0x0b;
+    const HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO: u8 = 0x0c;
+    const MIDI_CONFORMANT: u8 = 0x0d;
+}
+
+impl From<&[u8;4]> for Am824Stream {
+    fn from(raw: &[u8;4]) -> Self {
+        match raw[0] {
+            Am824Stream::IEC60958_3 |
+            Am824Stream::IEC61937_3 |
+            Am824Stream::IEC61937_4 |
+            Am824Stream::IEC61937_5 |
+            Am824Stream::IEC61937_6 |
+            Am824Stream::IEC61937_7 |
+            Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW |
+            Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD |
+            Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                let mut r = [0;2];
+                r.copy_from_slice(&raw[2..4]);
+                let attrs = Am824MultiBitAudioAttr::from(&r);
+                match raw[0] {
+                    Am824Stream::IEC60958_3 => Am824Stream::Iec60958_3(attrs),
+                    Am824Stream::IEC61937_3 => Am824Stream::Iec61937_3(attrs),
+                    Am824Stream::IEC61937_4 => Am824Stream::Iec61937_4(attrs),
+                    Am824Stream::IEC61937_5 => Am824Stream::Iec61937_5(attrs),
+                    Am824Stream::IEC61937_6 => Am824Stream::Iec61937_6(attrs),
+                    Am824Stream::IEC61937_7 => Am824Stream::Iec61937_7(attrs),
+                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW =>
+                        Am824Stream::MultiBitLinearAudioRaw(attrs),
+                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD =>
+                        Am824Stream::MultiBitLinearAudioDvd(attrs),
+                    Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO =>
+                        Am824Stream::HighPrecisionMultiBitLinearAudio(attrs),
+                    _ => unreachable!(),
+                }
+            }
+            Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW |
+            Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD |
+            Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW |
+            Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
+                let mut r = [0;2];
+                r.copy_from_slice(&raw[2..4]);
+                let attrs = Am824OneBitAudioAttr::from(&r);
+                match raw[0] {
+                    Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW =>
+                        Am824Stream::OneBitAudioPlainRaw(attrs),
+                    Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD =>
+                        Am824Stream::OneBitAudioPlainSacd(attrs),
+                    Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW =>
+                        Am824Stream::OneBitAudioEncodedRaw(attrs),
+                    Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD =>
+                        Am824Stream::OneBitAudioEncodedSacd(attrs),
+                    _ => unreachable!(),
+                }
+            }
+            Am824Stream::MIDI_CONFORMANT => {
+                let mut r = [0;2];
+                r.copy_from_slice(&raw[2..4]);
+                Am824Stream::MidiConformant(r)
+            }
+            _ => Am824Stream::Reserved(*raw),
+        }
+    }
+}
+
+impl From<&Am824Stream> for [u8;4] {
+    fn from(format: &Am824Stream) -> Self {
+        let mut raw = [0xff;4];
+        match format {
+            Am824Stream::Iec60958_3(attrs) |
+            Am824Stream::Iec61937_3(attrs) |
+            Am824Stream::Iec61937_4(attrs) |
+            Am824Stream::Iec61937_5(attrs) |
+            Am824Stream::Iec61937_6(attrs) |
+            Am824Stream::Iec61937_7(attrs) |
+            Am824Stream::MultiBitLinearAudioRaw(attrs) |
+            Am824Stream::MultiBitLinearAudioDvd(attrs) |
+            Am824Stream::HighPrecisionMultiBitLinearAudio(attrs) => {
+                raw[0] = match format {
+                    Am824Stream::Iec60958_3(_) => Am824Stream::IEC60958_3,
+                    Am824Stream::Iec61937_3(_) => Am824Stream::IEC61937_3,
+                    Am824Stream::Iec61937_4(_) => Am824Stream::IEC61937_4,
+                    Am824Stream::Iec61937_5(_) => Am824Stream::IEC61937_5,
+                    Am824Stream::Iec61937_6(_) => Am824Stream::IEC61937_6,
+                    Am824Stream::Iec61937_7(_) => Am824Stream::IEC61937_7,
+                    Am824Stream::MultiBitLinearAudioRaw(_) =>
+                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW,
+                    Am824Stream::MultiBitLinearAudioDvd(_) =>
+                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD,
+                    Am824Stream::HighPrecisionMultiBitLinearAudio(_) =>
+                        Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+                    _ => unreachable!(),
+                };
+                let a = Into::<[u8;2]>::into(attrs);
+                raw[2..4].copy_from_slice(&a);
+                raw
+            }
+            Am824Stream::OneBitAudioPlainRaw(attrs) |
+            Am824Stream::OneBitAudioPlainSacd(attrs) |
+            Am824Stream::OneBitAudioEncodedRaw(attrs) |
+            Am824Stream::OneBitAudioEncodedSacd(attrs) => {
+                raw[0] = match format {
+                    Am824Stream::OneBitAudioPlainRaw(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW,
+                    Am824Stream::OneBitAudioPlainSacd(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD,
+                    Am824Stream::OneBitAudioEncodedRaw(_) => Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW,
+                    Am824Stream::OneBitAudioEncodedSacd(_) => Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD,
+                    _ => unreachable!(),
+                };
+                let a = Into::<[u8;2]>::into(attrs);
+                raw[2..4].copy_from_slice(&a);
+                raw
+            }
+            Am824Stream::MidiConformant(d) => {
+                let mut raw = [0xff;4];
+                raw[0] = Am824Stream::MIDI_CONFORMANT;
+                raw[2..4].copy_from_slice(d);
+                raw
+            }
+            Am824Stream::Reserved(raw) => *raw,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum AmStream{
+    Am824(Am824Stream),
+    AudioPack,
+    Fp32,
+    Reserved(Vec<u8>),
+}
+
+impl AmStream {
+    const HIER_LEVEL_1_AM824: u8 = 0x00;
+    const HIER_LEVEL_1_AUDIO_PACK: u8 = 0x01;
+    const HIER_LEVEL_1_FP32: u8 = 0x02;
+}
+
+impl From<&[u8]> for AmStream {
+    fn from(raw: &[u8]) -> Self {
+        match raw[0] {
+            AmStream::HIER_LEVEL_1_AM824 => {
+                let mut r = [0xff;4];
+                r.copy_from_slice(&raw[1..5]);
+                let format = Am824Stream::from(&r);
+                AmStream::Am824(format)
+            }
+            AmStream::HIER_LEVEL_1_AUDIO_PACK => AmStream::AudioPack,
+            AmStream::HIER_LEVEL_1_FP32 => AmStream::Fp32,
+            _ => AmStream::Reserved((*raw).to_vec()),
+        }
+    }
+}
+
+impl From<&AmStream> for Vec<u8> {
+    fn from(data: &AmStream) -> Self {
+        let mut raw = Vec::new();
+        match data {
+            AmStream::Am824(d) => {
+                raw.push(AmStream::HIER_LEVEL_1_AM824);
+                raw.extend_from_slice(&Into::<[u8;4]>::into(d));
+            }
+            AmStream::AudioPack => {
+                raw.push(AmStream::HIER_LEVEL_1_AUDIO_PACK);
+                raw.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+            }
+            AmStream::Fp32 => {
+                raw.push(AmStream::HIER_LEVEL_1_FP32);
+                raw.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+            }
+            AmStream::Reserved(d) => {
+                raw.copy_from_slice(d);
+            }
+        }
+        raw
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StreamFormat{
+    // Dvcr is not supported currently.
+    Am(AmStream),
+    Reserved(Vec<u8>),
+}
+
+impl StreamFormat {
+    const HIER_ROOT_AM: u8 = 0x90;
+
+    fn as_am_stream(&self) -> Result<&AmStream, Error> {
+        if let StreamFormat::Am(i) = self {
+            Ok(i)
+        } else {
+            let label = "Audio & Music format is not available for the unit";
+            Err(Error::new(FileError::Nxio, &label))
+        }
+    }
+
+    pub fn as_am824_stream(&self) -> Result<&Am824Stream, Error> {
+        if let AmStream::Am824(s) = self.as_am_stream()? {
+            Ok(s)
+        } else {
+            let label = "AM824 format is not available for the unit";
+            Err(Error::new(FileError::Nxio, &label))
+        }
+    }
+}
+
+impl From<&[u8]> for StreamFormat {
+    fn from(raw: &[u8]) -> Self {
+        match raw[0] {
+            Self::HIER_ROOT_AM => StreamFormat::Am(AmStream::from(&raw[1..])),
+            _ => StreamFormat::Reserved(raw.to_vec()),
+        }
+    }
+}
+
+impl From<&StreamFormat> for Vec<u8> {
+    fn from(data: &StreamFormat) -> Self {
+        let mut raw = Vec::new();
+        match data {
+            StreamFormat::Am(i) => {
+                raw.push(StreamFormat::HIER_ROOT_AM);
+                raw.append(&mut i.into());
+            }
+            StreamFormat::Reserved(d) => raw.extend_from_slice(d),
+        }
+        raw
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Am824MultiBitAudioAttr, Am824OneBitAudioAttr, Am824Stream};
+    use super::{AmStream, StreamFormat};
+
+    #[test]
+    fn am824multibitaudioattr_from() {
+        let raw = [0x31, 0xff];
+        let attr = Am824MultiBitAudioAttr::from(&raw);
+        assert_eq!(44100, attr.freq);
+        assert_eq!(false, attr.rate_ctl);
+        assert_eq!(raw, Into::<[u8;2]>::into(&attr));
+    }
+
+    #[test]
+    fn am824onebitaudioattr_from() {
+        let raw = [0x40, 0xff];
+        let attr = Am824OneBitAudioAttr::from(&raw);
+        assert_eq!(6144000, attr.freq);
+        assert_eq!(true, attr.rate_ctl);
+        assert_eq!(raw, Into::<[u8;2]>::into(&attr));
+    }
+
+    #[test]
+    fn am824stream_from() {
+        let raw = [0x06, 0xff, 0x20, 0xff];
+        let format = Am824Stream::from(&raw);
+        let attr = Am824MultiBitAudioAttr{
+            freq: 32000,
+            rate_ctl: true,
+        };
+        assert_eq!(format, Am824Stream::MultiBitLinearAudioRaw(attr));
+        assert_eq!(raw, Into::<[u8;4]>::into(&format));
+    }
+
+    #[test]
+    fn amstream_from() {
+        let raw: &[u8] = &[0x00, 0x08, 0xff, 0x40, 0xff];
+        let attr = Am824OneBitAudioAttr{
+            freq: 6144000,
+            rate_ctl: true,
+        };
+        let format = AmStream::from(raw);
+        assert_eq!(AmStream::Am824(Am824Stream::OneBitAudioPlainRaw(attr)), format);
+        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+
+        let raw: &[u8] = &[0x01, 0xff, 0xff, 0xff, 0xff];
+        let format = AmStream::from(raw);
+        assert_eq!(AmStream::AudioPack, format);
+        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+
+        let raw: &[u8] = &[0x02, 0xff, 0xff, 0xff, 0xff];
+        let format = AmStream::from(raw);
+        assert_eq!(AmStream::Fp32, format);
+        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+    }
+
+    #[test]
+    fn streamformat_from() {
+        let raw: &[u8] = &[0x90, 0x00, 0x08, 0xff, 0x40, 0xff];
+        let format = StreamFormat::from(raw);
+        if let StreamFormat::Am(i) = &format {
+            if let AmStream::Am824(s) = i {
+                if let Am824Stream::OneBitAudioPlainRaw(attr) = s {
+                    assert_eq!(6144000, attr.freq);
+                    assert_eq!(true, attr.rate_ctl);
+                } else {
+                    unreachable!();
+                }
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+    }
+}

--- a/src/ta1394/stream_format.rs
+++ b/src/ta1394/stream_format.rs
@@ -318,11 +318,240 @@ impl From<&Am824Stream> for [u8;4] {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum CompoundAm824StreamFormat{
+    Iec60958_3,
+    Iec61937_3,
+    Iec61937_4,
+    Iec61937_5,
+    Iec61937_6,
+    Iec61937_7,
+    MultiBitLinearAudioRaw,
+    MultiBitLinearAudioDvd,
+    HighPrecisionMultiBitLinearAudio,
+    MidiConformant,
+    SmpteTimeCodeConformant,
+    SampleCount,
+    AncillaryData,
+    SyncStream,
+    Reserved(u8),
+}
+
+impl CompoundAm824StreamFormat {
+    const IEC60958_3: u8 = 0x00;
+    const IEC61937_3: u8 = 0x01;
+    const IEC61937_4: u8 = 0x02;
+    const IEC61937_5: u8 = 0x03;
+    const IEC61937_6: u8 = 0x04;
+    const IEC61937_7: u8 = 0x05;
+    const MULTI_BIT_LINEAR_AUDIO_RAW: u8 = 0x06;
+    const MULTI_BIT_LINEAR_AUDIO_DVD: u8 = 0x07;
+    const HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO: u8 = 0x0c;
+    const MIDI_CONFORMANT: u8 = 0x0d;
+    const SMPTE_TIME_CODE_CONFORMANT: u8 = 0x0e;
+    const SAMPLE_COUNT: u8 = 0x0f;
+    const ANCILLARY_DATA: u8 = 0x10;
+    const SYNC_STREAM: u8 = 0x40;
+}
+
+impl From<u8> for CompoundAm824StreamFormat {
+    fn from(val: u8) -> Self {
+        match val {
+            CompoundAm824StreamFormat::IEC60958_3 => CompoundAm824StreamFormat::Iec60958_3,
+            CompoundAm824StreamFormat::IEC61937_3 => CompoundAm824StreamFormat::Iec61937_3,
+            CompoundAm824StreamFormat::IEC61937_4 => CompoundAm824StreamFormat::Iec61937_4,
+            CompoundAm824StreamFormat::IEC61937_5 => CompoundAm824StreamFormat::Iec61937_5,
+            CompoundAm824StreamFormat::IEC61937_6 => CompoundAm824StreamFormat::Iec61937_6,
+            CompoundAm824StreamFormat::IEC61937_7 => CompoundAm824StreamFormat::Iec61937_7,
+            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW => CompoundAm824StreamFormat::MultiBitLinearAudioRaw,
+            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD => CompoundAm824StreamFormat::MultiBitLinearAudioDvd,
+            CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio,
+            CompoundAm824StreamFormat::MIDI_CONFORMANT => CompoundAm824StreamFormat::MidiConformant,
+            CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT => CompoundAm824StreamFormat::SmpteTimeCodeConformant,
+            CompoundAm824StreamFormat::SAMPLE_COUNT => CompoundAm824StreamFormat::SampleCount,
+            CompoundAm824StreamFormat::ANCILLARY_DATA => CompoundAm824StreamFormat::AncillaryData,
+            CompoundAm824StreamFormat::SYNC_STREAM => CompoundAm824StreamFormat::SyncStream,
+            _ => CompoundAm824StreamFormat::Reserved(val),
+        }
+    }
+}
+
+impl From<CompoundAm824StreamFormat> for u8 {
+    fn from(fmt: CompoundAm824StreamFormat) -> Self {
+        match fmt {
+            CompoundAm824StreamFormat::Iec60958_3 => CompoundAm824StreamFormat::IEC60958_3,
+            CompoundAm824StreamFormat::Iec61937_3 => CompoundAm824StreamFormat::IEC61937_3,
+            CompoundAm824StreamFormat::Iec61937_4 => CompoundAm824StreamFormat::IEC61937_4,
+            CompoundAm824StreamFormat::Iec61937_5 => CompoundAm824StreamFormat::IEC61937_5,
+            CompoundAm824StreamFormat::Iec61937_6 => CompoundAm824StreamFormat::IEC61937_6,
+            CompoundAm824StreamFormat::Iec61937_7 => CompoundAm824StreamFormat::IEC61937_7,
+            CompoundAm824StreamFormat::MultiBitLinearAudioRaw => CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW,
+            CompoundAm824StreamFormat::MultiBitLinearAudioDvd => CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD,
+            CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio => CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+            CompoundAm824StreamFormat::MidiConformant => CompoundAm824StreamFormat::MIDI_CONFORMANT,
+            CompoundAm824StreamFormat::SmpteTimeCodeConformant => CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT,
+            CompoundAm824StreamFormat::SampleCount => CompoundAm824StreamFormat::SAMPLE_COUNT,
+            CompoundAm824StreamFormat::AncillaryData => CompoundAm824StreamFormat::ANCILLARY_DATA,
+            CompoundAm824StreamFormat::SyncStream => CompoundAm824StreamFormat::SYNC_STREAM,
+            CompoundAm824StreamFormat::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompoundAm824StreamEntry{
+    pub count: u8,
+    pub format: CompoundAm824StreamFormat,
+}
+
+impl From<&[u8;2]> for CompoundAm824StreamEntry {
+    fn from(raw: &[u8;2]) -> Self {
+        CompoundAm824StreamEntry{
+            count: raw[0],
+            format: CompoundAm824StreamFormat::from(raw[1]),
+        }
+    }
+}
+
+impl From<&CompoundAm824StreamEntry> for [u8;2] {
+    fn from(data: &CompoundAm824StreamEntry) -> Self {
+        [data.count, data.format.into()]
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RateCtl {
+    Supported,
+    DontCare,
+    NotSupported,
+    Reserved(u8),
+}
+
+impl RateCtl {
+    const SUPPORTED: u8 = 0x00;
+    const DONT_CARE: u8 = 0x01;
+    const NOT_SUPPORTED: u8 = 0x02;
+}
+
+impl From<RateCtl> for u8 {
+    fn from(rate_ctl: RateCtl) -> Self {
+        match rate_ctl {
+            RateCtl::Supported => RateCtl::SUPPORTED,
+            RateCtl::DontCare => RateCtl::DONT_CARE,
+            RateCtl::NotSupported => RateCtl::NOT_SUPPORTED,
+            RateCtl::Reserved(val) => val,
+        }
+    }
+}
+
+impl From<u8> for RateCtl {
+    fn from(val: u8) -> Self {
+        match val {
+            Self::SUPPORTED => Self::Supported,
+            Self::DONT_CARE => Self::DontCare,
+            Self::NOT_SUPPORTED => Self::NotSupported,
+            _ => RateCtl::Reserved(val),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompoundAm824Stream{
+    pub freq: u32,
+    pub sync_src: bool,
+    pub rate_ctl: RateCtl,
+    pub entries: Vec<CompoundAm824StreamEntry>,
+}
+
+impl CompoundAm824Stream {
+    const FREQ_CODE_22050: u8 = 0x00;
+    const FREQ_CODE_24000: u8 = 0x01;
+    const FREQ_CODE_32000: u8 = 0x02;
+    const FREQ_CODE_44100: u8 = 0x03;
+    const FREQ_CODE_48000: u8 = 0x04;
+    const FREQ_CODE_96000: u8 = 0x05;
+    const FREQ_CODE_176400: u8 = 0x06;
+    const FREQ_CODE_192000: u8 = 0x07;
+    const FREQ_CODE_88200: u8 = 0x0a;
+
+    const SYNC_SRC_MASK: u8 = 0x01;
+    const SYNC_SRC_SHIFT: usize = 2;
+
+    const RATE_CTL_MASK: u8 = 0x03;
+    const RATE_CTL_SHIFT: usize = 0;
+}
+
+impl From<&[u8]> for CompoundAm824Stream {
+    fn from(raw: &[u8]) -> Self {
+        let freq = match raw[0] {
+            CompoundAm824Stream::FREQ_CODE_22050 => 22050,
+            CompoundAm824Stream::FREQ_CODE_24000 => 24000,
+            CompoundAm824Stream::FREQ_CODE_32000 => 32000,
+            CompoundAm824Stream::FREQ_CODE_44100 => 44100,
+            CompoundAm824Stream::FREQ_CODE_48000 => 48000,
+            CompoundAm824Stream::FREQ_CODE_96000 => 96000,
+            CompoundAm824Stream::FREQ_CODE_176400 => 176400,
+            CompoundAm824Stream::FREQ_CODE_192000 => 192000,
+            CompoundAm824Stream::FREQ_CODE_88200 => 88200,
+            _ => u32::MAX,
+        };
+        let sync_src_code =
+            (raw[1] >> CompoundAm824Stream::SYNC_SRC_SHIFT) & CompoundAm824Stream::SYNC_SRC_MASK;
+        let sync_src = sync_src_code > 0;
+        let rate_ctl_code =
+            (raw[1] >> CompoundAm824Stream::RATE_CTL_SHIFT) & CompoundAm824Stream::RATE_CTL_MASK;
+        let rate_ctl = RateCtl::from(rate_ctl_code);
+        let entry_count = raw[2] as usize;
+        let entries = (0..entry_count).filter_map(|i| {
+            if 3 + i * 2 + 2 > raw.len() {
+                None
+            } else {
+                let mut doublet = [0;2];
+                doublet.copy_from_slice(&raw[(3 + i * 2)..(3 + i * 2 + 2)]);
+                Some(CompoundAm824StreamEntry::from(&doublet))
+            }
+        }).collect();
+        CompoundAm824Stream{freq, sync_src, rate_ctl, entries}
+    }
+}
+
+impl From<&CompoundAm824Stream> for Vec<u8> {
+    fn from(data: &CompoundAm824Stream) -> Self {
+        let mut raw = Vec::new();
+        let freq_code = match data.freq {
+            22050 => CompoundAm824Stream::FREQ_CODE_22050,
+            24000 => CompoundAm824Stream::FREQ_CODE_24000,
+            32000 => CompoundAm824Stream::FREQ_CODE_32000,
+            44100 => CompoundAm824Stream::FREQ_CODE_44100,
+            48000 => CompoundAm824Stream::FREQ_CODE_48000,
+            96000 => CompoundAm824Stream::FREQ_CODE_96000,
+            176400 => CompoundAm824Stream::FREQ_CODE_176400,
+            192000 => CompoundAm824Stream::FREQ_CODE_192000,
+            88200 => CompoundAm824Stream::FREQ_CODE_88200,
+            _ => u8::MAX,
+        };
+        raw.push(freq_code);
+
+        let sync_src_code = ((data.sync_src as u8) & CompoundAm824Stream::SYNC_SRC_MASK) <<
+                            CompoundAm824Stream::SYNC_SRC_SHIFT;
+        let rate_ctl_code = (u8::from(data.rate_ctl) & CompoundAm824Stream::RATE_CTL_MASK) <<
+                            CompoundAm824Stream::RATE_CTL_SHIFT;
+        raw.push(sync_src_code | rate_ctl_code);
+
+        raw.push(data.entries.len() as u8);
+        data.entries.iter().for_each(|entry|{
+            raw.extend_from_slice(&Into::<[u8;2]>::into(entry));
+        });
+        raw
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum AmStream{
     Am824(Am824Stream),
     AudioPack,
     Fp32,
+    CompoundAm824(CompoundAm824Stream),
     Reserved(Vec<u8>),
 }
 
@@ -330,6 +559,7 @@ impl AmStream {
     const HIER_LEVEL_1_AM824: u8 = 0x00;
     const HIER_LEVEL_1_AUDIO_PACK: u8 = 0x01;
     const HIER_LEVEL_1_FP32: u8 = 0x02;
+    const HIER_LEVEL_1_COMPOUND_AM824: u8 = 0x40;
 }
 
 impl From<&[u8]> for AmStream {
@@ -343,6 +573,10 @@ impl From<&[u8]> for AmStream {
             }
             AmStream::HIER_LEVEL_1_AUDIO_PACK => AmStream::AudioPack,
             AmStream::HIER_LEVEL_1_FP32 => AmStream::Fp32,
+            AmStream::HIER_LEVEL_1_COMPOUND_AM824 => {
+                let s = CompoundAm824Stream::from(&raw[1..]);
+                AmStream::CompoundAm824(s)
+            }
             _ => AmStream::Reserved((*raw).to_vec()),
         }
     }
@@ -363,6 +597,10 @@ impl From<&AmStream> for Vec<u8> {
             AmStream::Fp32 => {
                 raw.push(AmStream::HIER_LEVEL_1_FP32);
                 raw.extend_from_slice(&[0xff, 0xff, 0xff, 0xff]);
+            }
+            AmStream::CompoundAm824(s) => {
+                raw.push(AmStream::HIER_LEVEL_1_COMPOUND_AM824);
+                raw.append(&mut Into::<Vec<u8>>::into(s));
             }
             AmStream::Reserved(d) => {
                 raw.copy_from_slice(d);
@@ -399,6 +637,15 @@ impl StreamFormat {
             Err(Error::new(FileError::Nxio, &label))
         }
     }
+
+    pub fn as_compound_am824_stream(&self) -> Result<&CompoundAm824Stream, Error> {
+        if let AmStream::CompoundAm824(s) = self.as_am_stream()? {
+            Ok(s)
+        } else {
+            let label = "Compound AM824 stream is not available for the unit";
+            Err(Error::new(FileError::Nxio, &label))
+        }
+    }
 }
 
 impl From<&[u8]> for StreamFormat {
@@ -427,6 +674,7 @@ impl From<&StreamFormat> for Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::{Am824MultiBitAudioAttr, Am824OneBitAudioAttr, Am824Stream};
+    use super::{CompoundAm824Stream, CompoundAm824StreamEntry, CompoundAm824StreamFormat, RateCtl};
     use super::{AmStream, StreamFormat};
 
     #[test]
@@ -500,5 +748,74 @@ mod tests {
             unreachable!();
         }
         assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+
+        let mut raw = Vec::<u8>::new();
+        raw.extend_from_slice(&[0x90, 0x40, 0x04, 0x02, 0x01, 0x1c, 0x02]);
+        let stream_format = StreamFormat::from(raw.as_slice());
+        if let StreamFormat::Am(i) = &stream_format {
+            if let AmStream::CompoundAm824(s) = i {
+                assert_eq!(48000, s.freq);
+                assert_eq!(false, s.sync_src);
+                assert_eq!(RateCtl::NotSupported, s.rate_ctl);
+                assert_eq!(1, s.entries.len());
+                assert_eq!(0x1c, s.entries[0].count);
+                assert_eq!(CompoundAm824StreamFormat::Iec61937_4, s.entries[0].format);
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&stream_format));
+    }
+
+    #[test]
+    fn compoundam824streamformat_from() {
+        assert_eq!(0x00, u8::from(CompoundAm824StreamFormat::from(0x00)));
+        assert_eq!(0x01, u8::from(CompoundAm824StreamFormat::from(0x01)));
+        assert_eq!(0x02, u8::from(CompoundAm824StreamFormat::from(0x02)));
+        assert_eq!(0x03, u8::from(CompoundAm824StreamFormat::from(0x03)));
+        assert_eq!(0x04, u8::from(CompoundAm824StreamFormat::from(0x04)));
+        assert_eq!(0x05, u8::from(CompoundAm824StreamFormat::from(0x05)));
+        assert_eq!(0x06, u8::from(CompoundAm824StreamFormat::from(0x06)));
+        assert_eq!(0x07, u8::from(CompoundAm824StreamFormat::from(0x07)));
+        assert_eq!(0x0c, u8::from(CompoundAm824StreamFormat::from(0x0c)));
+        assert_eq!(0x0d, u8::from(CompoundAm824StreamFormat::from(0x0d)));
+        assert_eq!(0x0e, u8::from(CompoundAm824StreamFormat::from(0x0e)));
+        assert_eq!(0x0f, u8::from(CompoundAm824StreamFormat::from(0x0f)));
+        assert_eq!(0x10, u8::from(CompoundAm824StreamFormat::from(0x10)));
+        assert_eq!(0x40, u8::from(CompoundAm824StreamFormat::from(0x40)));
+        assert_eq!(0xff, u8::from(CompoundAm824StreamFormat::from(0xff)));
+    }
+
+    #[test]
+    fn compoundam824streamentry_from() {
+        assert_eq!([0x02, 0x04], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x02, 0x04])));
+        assert_eq!([0x19, 0x03], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x19, 0x03])));
+        assert_eq!([0x37, 0x00], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x37, 0x00])));
+    }
+
+    #[test]
+    fn ratectl_from() {
+        assert_eq!(0x00, u8::from(RateCtl::from(0x00)));
+        assert_eq!(0x01, u8::from(RateCtl::from(0x01)));
+        assert_eq!(0x02, u8::from(RateCtl::from(0x02)));
+        assert_eq!(0xff, u8::from(RateCtl::from(0xff)));
+    }
+
+    #[test]
+    fn compoundam824stream_from() {
+        let mut raw = Vec::<u8>::new();
+        raw.extend_from_slice(&[0x03, 0x02, 0x02, 0xee, 0x03, 0x37, 0x0d]);
+        let s = CompoundAm824Stream::from(raw.as_slice());
+        assert_eq!(44100, s.freq);
+        assert_eq!(false, s.sync_src);
+        assert_eq!(RateCtl::NotSupported, s.rate_ctl);
+        assert_eq!(2, s.entries.len());
+        assert_eq!(0xee, s.entries[0].count);
+        assert_eq!(CompoundAm824StreamFormat::Iec61937_5, s.entries[0].format);
+        assert_eq!(0x37, s.entries[1].count);
+        assert_eq!(CompoundAm824StreamFormat::MidiConformant, s.entries[1].format);
+        assert_eq!(raw, Into::<Vec<u8>>::into(&CompoundAm824Stream::from(raw.as_slice())));
     }
 }


### PR DESCRIPTION
1394 Trading Association defines AV/C transaction based on Function Control Protocol defined in IEC 61883-1. The association also defined many kind of command/response on the transaction. The series of specification is public in its [website](http://1394ta.org/specifications/).

This patchset adds support for the AV/C transaction and a part of command/response for devices supported by ALSA firewire stack, referring to below documents:

 * AV/C Digital Interface Command Set General Specification Version 4.2 (September 1, 2004. TA Document 2004006)
 * Audio and Music Data Transmission Protocol 2.3 (April 24, 2012. Document 2009013)
 * AV/C Connection and Compatibility Management Specification 1.1 (March 19, 2003. TA Document 2002010)
 * AV/C Audio Subunit Specification 1.0 (October 24, 2000. TA Document 1999008)
 * AV/C Stream Format Information Specification 1.0 (May 24, 2002, TA Document 2001002)
 * AV/C Stream Format Information Specification 1.1 rev.5 (April 15, 2005. TA Document 2004008)

Hinawa.FwFcp is used for the implementation of FCP in IEC 61883-1.