### PR TITLE
oxfw: add service program for devices based on OXFW970/OXFW971 ASIC

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,7 @@ path = "src/bin/snd-fireworks-ctl-service.rs"
 [[bin]]
 name = "snd-firewire-motu-ctl-service"
 path = "src/bin/snd-firewire-motu-ctl-service.rs"
+
+[[bin]]
+name = "snd-oxfw-ctl-service"
+path = "src/bin/snd-oxfw-ctl-service.rs"

--- a/README.rst
+++ b/README.rst
@@ -108,6 +108,7 @@ your device, please contact to developer.
 * snd-oxfw-ctl-service
   * Tascam FireOne
   * Apogee Duet FireWire
+  * Griffin FireWave
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,7 @@ your device, please contact to developer.
 
 * snd-oxfw-ctl-service
   * Tascam FireOne
+  * Apogee Duet FireWire
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,9 @@ your device, please contact to developer.
   * MOTU 4pre
   * MOTU AudioExpress
 
+* snd-oxfw-ctl-service
+  * Tascam FireOne
+
 Supported protocols
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,8 @@ snd-fireworks-ctl-service
    For sound card bound to ALSA fireworks driver (snd-fireworks)
 snd-firewire-motu-ctl-service
    For sound card bound to ALSA firewire-motu driver (snd-firewire-motu)
+snd-oxfw-ctl-service
+   For sound card bound to ALSA oxfw driver (snd-oxfw)
 
 License
 =======
@@ -120,6 +122,7 @@ Supported protocols
    * Protocol for FireWire series of TASCAM (TEAC)
    * Protocol for Fireworks board module of Echo Digital Audio
    * Protocol for Mark of the Unicorn (MOTU) FireWire series
+   * Protocol for Oxford Semiconductor OXFW970/OXFW971 ASIC
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,7 @@ your device, please contact to developer.
   * Tascam FireOne
   * Apogee Duet FireWire
   * Griffin FireWave
+  * Lacie FireWire Speakers
 
 Supported protocols
 ===================

--- a/src/bin/snd-oxfw-ctl-service.rs
+++ b/src/bin/snd-oxfw-ctl-service.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use snd_fw_ctl_services::oxfw;
+
+use std::env;
+
+fn main() {
+    // Check arguments in command line.
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("At least, one argument is required for: ");
+        println!("  The numerical ID of sound card.");
+        std::process::exit(1);
+    }
+
+    let card_id = match args[1].parse::<u32>() {
+        Ok(card_id) => card_id,
+        Err(err) => {
+            println!("{:?}", err);
+            std::process::exit(1);
+        }
+    };
+
+    let err = match oxfw::unit::OxfwUnit::new(card_id) {
+        Err(err) => {
+            println!("The card {} is not for OXFW device: {}", card_id, err);
+            Err(err)
+        }
+        Ok(mut unit) => {
+            if let Err(err) = unit.listen() {
+                println!("Fail to listen events: {}", err);
+                Err(err)
+            } else {
+                unit.run();
+                Ok(())
+            }
+        }
+    };
+
+    if err.is_err() {
+        std::process::exit(1)
+    }
+
+    std::process::exit(0)
+}

--- a/src/card_cntr.rs
+++ b/src/card_cntr.rs
@@ -76,18 +76,22 @@ impl CardCntr {
         self.register_elems(&elem_id, elem_count, &elem_info, None, unlock)
     }
 
-    pub fn add_enum_elems(
+    pub fn add_enum_elems<O>(
         &mut self,
         elem_id: &alsactl::ElemId,
         elem_count: usize,
         value_count: usize,
-        labels: &[&str],
+        labels: &[O],
         tlv: Option<&[i32]>,
         unlock: bool,
-    ) -> Result<Vec<alsactl::ElemId>, Error> {
+    ) -> Result<Vec<alsactl::ElemId>, Error>
+        where O: AsRef<str>
+    {
+        let entries = labels.iter().map(|entry| entry.as_ref()).collect::<Vec<&str>>();
+
         let elem_info = alsactl::ElemInfo::new(ElemType::Enumerated)?;
         elem_info.set_property_value_count(value_count as u32);
-        elem_info.set_enum_data(&labels)?;
+        elem_info.set_enum_data(&entries)?;
 
         let access = alsactl::ElemAccessFlag::READ
             | alsactl::ElemAccessFlag::WRITE

--- a/src/efw/clk_ctl.rs
+++ b/src/efw/clk_ctl.rs
@@ -34,38 +34,17 @@ impl<'a> ClkCtl {
         self.srcs.extend_from_slice(&hwinfo.clk_srcs);
         self.rates.extend_from_slice(&hwinfo.clk_rates);
 
-        let labels: Vec<&str> = self
-            .srcs
-            .iter()
-            .map(|src| match *src {
-                ClkSrc::Internal => "Internal",
-                ClkSrc::WordClock => "WordClock",
-                ClkSrc::Spdif => "S/PDIF",
-                ClkSrc::Adat => "ADAT",
-                ClkSrc::Adat2 => "ADAT2",
-                ClkSrc::Continuous => "Continuous",
-                ClkSrc::Unknown(_) => "Unknown",
-            })
-            .collect();
+        let labels = self.srcs.iter()
+            .map(|src| src.to_string())
+            .collect::<Vec<String>>();
 
         let elem_id =
             alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let labels: Vec<&str> = hwinfo
-            .clk_rates
-            .iter()
-            .map(|rate| match *rate {
-                32000 => "32000",
-                44100 => "44100",
-                48000 => "48000",
-                88200 => "88200",
-                96000 => "96000",
-                176400 => "176400",
-                192000 => "192000",
-                _ => "Unknown",
-            })
-            .collect();
+        let labels = hwinfo.clk_rates.iter()
+            .map(|rate| rate.to_string())
+            .collect::<Vec<String>>();
 
         let elem_id =
             alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::RATE_NAME, 0);
@@ -143,5 +122,19 @@ impl<'a> ClkCtl {
             }
             _ => Ok(false),
         }
+    }
+}
+
+impl ToString for ClkSrc {
+    fn to_string(&self) -> String {
+        match self {
+            ClkSrc::Internal => "Internal",
+            ClkSrc::WordClock => "WordClock",
+            ClkSrc::Spdif => "S/PDIF",
+            ClkSrc::Adat => "ADAT",
+            ClkSrc::Adat2 => "ADAT2",
+            ClkSrc::Continuous => "Continuous",
+            ClkSrc::Unknown(_) => "Unknown",
+        }.to_string()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,3 +11,4 @@ pub mod dg00x;
 pub mod tascam;
 pub mod efw;
 pub mod motu;
+pub mod oxfw;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -6,3 +6,5 @@ mod model;
 mod tascam_model;
 
 mod tascam_proto;
+
+mod common_ctl;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub mod unit;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -3,3 +3,4 @@
 pub mod unit;
 
 mod model;
+mod tascam_model;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -4,6 +4,7 @@ pub mod unit;
 
 mod model;
 mod tascam_model;
+mod apogee_model;
 
 mod tascam_proto;
 

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -6,6 +6,7 @@ mod model;
 mod tascam_model;
 mod apogee_model;
 mod griffin_model;
+mod lacie_model;
 
 mod tascam_proto;
 mod apogee_proto;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -7,5 +7,6 @@ mod tascam_model;
 mod apogee_model;
 
 mod tascam_proto;
+mod apogee_proto;
 
 mod common_ctl;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -4,3 +4,5 @@ pub mod unit;
 
 mod model;
 mod tascam_model;
+
+mod tascam_proto;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -10,3 +10,4 @@ mod tascam_proto;
 mod apogee_proto;
 
 mod common_ctl;
+mod apogee_ctls;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -5,6 +5,7 @@ pub mod unit;
 mod model;
 mod tascam_model;
 mod apogee_model;
+mod griffin_model;
 
 mod tascam_proto;
 mod apogee_proto;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -7,6 +7,7 @@ mod tascam_model;
 mod apogee_model;
 mod griffin_model;
 mod lacie_model;
+mod common_model;
 
 mod tascam_proto;
 mod apogee_proto;

--- a/src/oxfw.rs
+++ b/src/oxfw.rs
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod unit;
+
+mod model;

--- a/src/oxfw/apogee_ctls.rs
+++ b/src/oxfw/apogee_ctls.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use super::apogee_proto::{VendorCmd, ApogeeCmd};
+
+const TIMEOUT_MS: u32 = 100;
+
+pub struct OutputCtl;
+
+impl<'a> OutputCtl {
+    const SRC_NAME: &'a str = "output-source";
+    const LEVEL_NAME: &'a str = "output-level";
+    const MUTE_FOR_LINE_OUT: &'a str = "mute-for-line-out";
+    const MUTE_FOR_HP_OUT: &'a str = "mute-for-hp-out";
+
+    const SRC_LABELS: &'a [&'a str] = &["stream-1/2", "mixer-1/2"];
+    const LEVEL_LABELS: &'a [&'a str] = &["instrument", "-10dB"];
+
+    const MUTE_LABELS: &'a [&'a str] = &[
+        "never",
+        "normal",
+        "swapped"
+    ];
+
+    pub fn new() -> Self {
+        OutputCtl {}
+    }
+
+    pub fn load(&mut self, _: &hinawa::FwFcp, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        // For source of analog outputs.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,
+                                                   Self::SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::SRC_LABELS, None, true)?;
+
+        // For level of analog outputs.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,
+                                                   Self::LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::LEVEL_LABELS, None, true)?;
+
+        // For association of mute state to line output.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::MUTE_FOR_LINE_OUT, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::MUTE_LABELS, None, true)?;
+
+        // For association of mute state to hp output.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::MUTE_FOR_HP_OUT, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::MUTE_LABELS, None, true)?;
+
+        Ok(())
+    }
+
+    fn parse_mute_mode(mute_mode: bool, unmute_mode: bool) -> u32 {
+        let mut idx = 0;
+        if !mute_mode {
+            idx |= 0x01;
+        }
+        if !unmute_mode {
+            idx |= 0x02;
+        }
+        if idx > 2 {
+            idx = 0
+        }
+        idx
+    }
+
+    pub fn read(&mut self, avc: &hinawa::FwFcp, company_id: &[u8;3], elem_id: &alsactl::ElemId,
+                elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::SRC_NAME => {
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::UseMixerOut);
+                avc.status(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+                elem_value.set_enum(&[op.get_enum()]);
+                Ok(true)
+            }
+            Self::LEVEL_NAME => {
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::OutAttr);
+                avc.status(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+                elem_value.set_enum(&[op.get_enum()]);
+                Ok(true)
+            }
+            Self::MUTE_FOR_LINE_OUT => {
+                let mut mute_op = ApogeeCmd::new(company_id, VendorCmd::MuteForLineOut);
+                avc.status(&AvcAddr::Unit, &mut mute_op, TIMEOUT_MS)?;
+                let mut unmute_op = ApogeeCmd::new(company_id, VendorCmd::UnmuteForLineOut);
+                avc.status(&AvcAddr::Unit, &mut unmute_op, TIMEOUT_MS)?;
+
+                let idx = Self::parse_mute_mode(mute_op.get_enum() > 0, unmute_op.get_enum() > 0);
+                elem_value.set_enum(&[idx]);
+                Ok(true)
+            }
+            Self::MUTE_FOR_HP_OUT => {
+                let mut mute_op = ApogeeCmd::new(company_id, VendorCmd::MuteForHpOut);
+                avc.status(&AvcAddr::Unit, &mut mute_op, TIMEOUT_MS)?;
+                let mut unmute_op = ApogeeCmd::new(company_id, VendorCmd::UnmuteForHpOut);
+                avc.status(&AvcAddr::Unit, &mut unmute_op, TIMEOUT_MS)?;
+
+                let idx = Self::parse_mute_mode(mute_op.get_enum() > 0, unmute_op.get_enum() > 0);
+                elem_value.set_enum(&[idx]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn build_mute_mode(idx: u32) -> (bool, bool) {
+        (idx & 0x01 == 0, idx & 0x02 == 0)
+    }
+
+    pub fn write(&mut self, avc: &hinawa::FwFcp, company_id: &[u8;3], elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::SRC_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::UseMixerOut);
+                op.put_enum(vals[0]);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+                Ok(true)
+            }
+            Self::LEVEL_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::OutAttr);
+                op.put_enum(vals[0]);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+                Ok(true)
+            }
+            Self::MUTE_FOR_LINE_OUT => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let (mute_mode, unmute_mode) = Self::build_mute_mode(vals[0]);
+
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::MuteForLineOut);
+                op.put_enum(mute_mode as u32);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::UnmuteForLineOut);
+                op.put_enum(unmute_mode as u32);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+
+                Ok(true)
+            }
+            Self::MUTE_FOR_HP_OUT => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let (mute_mode, unmute_mode) = Self::build_mute_mode(vals[0]);
+
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::MuteForHpOut);
+                op.put_enum(mute_mode as u32);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+
+                let mut op = ApogeeCmd::new(company_id, VendorCmd::UnmuteForHpOut);
+                op.put_enum(unmute_mode as u32);
+                avc.control(&AvcAddr::Unit, &mut op, TIMEOUT_MS)?;
+
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -6,11 +6,17 @@ use hinawa::{SndUnitExt, FwFcpExt};
 
 use crate::card_cntr;
 
+use crate::ta1394::{Ta1394Avc, AvcAddr, AvcSubunitType};
+use crate::ta1394::general::UnitInfo;
+
 use super::common_ctl::CommonCtl;
+use super::apogee_ctls::OutputCtl;
 
 pub struct ApogeeModel{
     avc: hinawa::FwFcp,
+    company_id: [u8; 3],
     common_ctl: CommonCtl,
+    output_ctl: OutputCtl,
 }
 
 impl<'a> ApogeeModel {
@@ -19,7 +25,9 @@ impl<'a> ApogeeModel {
     pub fn new() -> Self {
         ApogeeModel{
             avc: hinawa::FwFcp::new(),
+            company_id: [0xff;3],
             common_ctl: CommonCtl::new(),
+            output_ctl: OutputCtl::new(),
         }
     }
 }
@@ -28,7 +36,16 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
     fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
+        let mut op = UnitInfo{
+            unit_type: AvcSubunitType::Reserved(0xff),
+            unit_id: 0xff,
+            company_id: [0xff;3],
+        };
+        self.avc.status(&AvcAddr::Unit, &mut op, 100)?;
+        self.company_id.copy_from_slice(&op.company_id);
+
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.output_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -39,16 +56,20 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
     {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
+        } else if self.output_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.output_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -10,13 +10,14 @@ use crate::ta1394::{Ta1394Avc, AvcAddr, AvcSubunitType};
 use crate::ta1394::general::UnitInfo;
 
 use super::common_ctl::CommonCtl;
-use super::apogee_ctls::OutputCtl;
+use super::apogee_ctls::{OutputCtl, MixerCtl};
 
 pub struct ApogeeModel{
     avc: hinawa::FwFcp,
     company_id: [u8; 3],
     common_ctl: CommonCtl,
     output_ctl: OutputCtl,
+    mixer_ctl: MixerCtl,
 }
 
 impl<'a> ApogeeModel {
@@ -28,6 +29,7 @@ impl<'a> ApogeeModel {
             company_id: [0xff;3],
             common_ctl: CommonCtl::new(),
             output_ctl: OutputCtl::new(),
+            mixer_ctl: MixerCtl::new(),
         }
     }
 }
@@ -46,6 +48,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
 
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.output_ctl.load(&self.avc, card_cntr)?;
+        self.mixer_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -57,6 +60,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.output_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -70,6 +75,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.output_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -2,46 +2,72 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
+use hinawa::{SndUnitExt, FwFcpExt};
+
 use crate::card_cntr;
 
-pub struct ApogeeModel;
+use super::common_ctl::CommonCtl;
+
+pub struct ApogeeModel{
+    avc: hinawa::FwFcp,
+    common_ctl: CommonCtl,
+}
 
 impl<'a> ApogeeModel {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
     pub fn new() -> Self {
-        ApogeeModel{}
+        ApogeeModel{
+            avc: hinawa::FwFcp::new(),
+            common_ctl: CommonCtl::new(),
+        }
     }
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
-    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.bind(&unit.get_node())?;
+
+        self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue,
-             _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
 impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ApogeeModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
     }
 }

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+pub struct ApogeeModel;
+
+impl<'a> ApogeeModel {
+    pub fn new() -> Self {
+        ApogeeModel{}
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
+    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue,
+             _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ApogeeModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -10,7 +10,7 @@ use crate::ta1394::{Ta1394Avc, AvcAddr, AvcSubunitType};
 use crate::ta1394::general::UnitInfo;
 
 use super::common_ctl::CommonCtl;
-use super::apogee_ctls::{OutputCtl, MixerCtl};
+use super::apogee_ctls::{OutputCtl, MixerCtl, InputCtl};
 
 pub struct ApogeeModel{
     avc: hinawa::FwFcp,
@@ -18,6 +18,7 @@ pub struct ApogeeModel{
     common_ctl: CommonCtl,
     output_ctl: OutputCtl,
     mixer_ctl: MixerCtl,
+    input_ctl: InputCtl,
 }
 
 impl<'a> ApogeeModel {
@@ -30,6 +31,7 @@ impl<'a> ApogeeModel {
             common_ctl: CommonCtl::new(),
             output_ctl: OutputCtl::new(),
             mixer_ctl: MixerCtl::new(),
+            input_ctl: InputCtl::new(),
         }
     }
 }
@@ -49,6 +51,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.output_ctl.load(&self.avc, card_cntr)?;
         self.mixer_ctl.load(&self.avc, card_cntr)?;
+        self.input_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -62,6 +65,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         } else if self.output_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -77,6 +82,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         } else if self.output_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else if self.mixer_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
+            Ok(true)
+        } else if self.input_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -98,6 +98,22 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
     }
 }
 
+impl card_cntr::MeasureModel<hinawa::SndUnit> for ApogeeModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId,
+                    _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
 impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ApogeeModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);

--- a/src/oxfw/apogee_model.rs
+++ b/src/oxfw/apogee_model.rs
@@ -10,7 +10,7 @@ use crate::ta1394::{Ta1394Avc, AvcAddr, AvcSubunitType};
 use crate::ta1394::general::UnitInfo;
 
 use super::common_ctl::CommonCtl;
-use super::apogee_ctls::{OutputCtl, MixerCtl, InputCtl};
+use super::apogee_ctls::{OutputCtl, MixerCtl, InputCtl, DisplayCtl};
 
 pub struct ApogeeModel{
     avc: hinawa::FwFcp,
@@ -19,6 +19,7 @@ pub struct ApogeeModel{
     output_ctl: OutputCtl,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
+    display_ctl: DisplayCtl,
 }
 
 impl<'a> ApogeeModel {
@@ -32,6 +33,7 @@ impl<'a> ApogeeModel {
             output_ctl: OutputCtl::new(),
             mixer_ctl: MixerCtl::new(),
             input_ctl: InputCtl::new(),
+            display_ctl: DisplayCtl::new(),
         }
     }
 }
@@ -52,6 +54,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         self.output_ctl.load(&self.avc, card_cntr)?;
         self.mixer_ctl.load(&self.avc, card_cntr)?;
         self.input_ctl.load(&self.avc, card_cntr)?;
+        self.display_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -67,6 +70,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         } else if self.mixer_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.display_ctl.read(&self.avc, &self.company_id, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -84,6 +89,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         } else if self.mixer_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else if self.input_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
+            Ok(true)
+        } else if self.display_ctl.write(&self.avc, &self.company_id, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/oxfw/apogee_proto.rs
+++ b/src/oxfw/apogee_proto.rs
@@ -195,6 +195,20 @@ impl<'a> ApogeeCmd {
         assert!(self.vals.len() == 0, "Unexpected write operation as u16 argument.");
         self.vals.extend_from_slice(&val.to_be_bytes());
     }
+
+    pub fn get_u8(&self) -> u8 {
+        assert!(self.vals.len() > 0, "Unexpected read operation as u8 argument.");
+        self.vals[0]
+    }
+
+    pub fn put_u8(&mut self, val: u8) {
+        assert!(self.vals.len() == 0, "Unexpected write operation as u8 argument.");
+        self.vals.push(val);
+    }
+
+    pub fn copy_block(&self, data: &mut [u8;8]) {
+        data.copy_from_slice(&self.vals[..8]);
+    }
 }
 
 impl AvcOp for ApogeeCmd {

--- a/src/oxfw/apogee_proto.rs
+++ b/src/oxfw/apogee_proto.rs
@@ -183,6 +183,18 @@ impl<'a> ApogeeCmd {
         assert!(self.vals.len() == 0, "Unexpected write operation as bool argument.");
         self.vals.push(if val > 0 { Self::ON } else { Self::OFF })
     }
+
+    pub fn read_u16(&self) -> u16 {
+        assert!(self.vals.len() > 0, "Unexpected read operation as bool argument.");
+        let mut doublet = [0;2];
+        doublet.copy_from_slice(&self.vals[..2]);
+        u16::from_be_bytes(doublet)
+    }
+
+    pub fn write_u16(&mut self, val: u16) {
+        assert!(self.vals.len() == 0, "Unexpected write operation as u16 argument.");
+        self.vals.extend_from_slice(&val.to_be_bytes());
+    }
 }
 
 impl AvcOp for ApogeeCmd {

--- a/src/oxfw/apogee_proto.rs
+++ b/src/oxfw/apogee_proto.rs
@@ -65,6 +65,9 @@ impl<'a> ApogeeCmd {
     const IN_CLICKLESS: u8 = 0x1e;
     const DISPLAY_FOLLOW: u8 = 0x22;
 
+    const ON: u8 = 0x70;
+    const OFF: u8 = 0x60;
+
     pub fn new(company_id: &[u8;3], cmd: VendorCmd) -> Self {
         ApogeeCmd{
             cmd,
@@ -169,6 +172,16 @@ impl<'a> ApogeeCmd {
             self.vals = self.op.data.split_off(6);
             Ok(())
         }
+    }
+
+    pub fn get_enum(&self) -> u32 {
+        assert!(self.vals.len() > 0, "Unexpected read operation as bool argument.");
+        (self.vals[0] == Self::ON) as u32
+    }
+
+    pub fn put_enum(&mut self, val: u32) {
+        assert!(self.vals.len() == 0, "Unexpected write operation as bool argument.");
+        self.vals.push(if val > 0 { Self::ON } else { Self::OFF })
     }
 }
 

--- a/src/oxfw/apogee_proto.rs
+++ b/src/oxfw/apogee_proto.rs
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::FwReqExtManual;
+
+use crate::ta1394::{Ta1394AvcError, AvcAddr};
+use crate::ta1394::{AvcOp, AvcStatus, AvcControl};
+use crate::ta1394::general::VendorDependent;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+// Usually 5 params.
+pub enum VendorCmd {
+    MicPolarity(u8),
+    PhoneInLine(u8),
+    LineInLevel(u8),
+    MicPhantom(u8),
+    OutAttr,
+    InGain(u8),
+    HwState,        // 11 parameters.
+    OutMute,
+    MicIn(u8),
+    MixerSrc(u8, u8),       // 7 params (0x0a, 0x10)
+    UseMixerOut,
+    DisplayOverhold,
+    DisplayClear,
+    OutVolume,
+    MuteForLineOut,
+    MuteForHpOut,
+    UnmuteForLineOut,
+    UnmuteForHpOut,
+    DisplayInput,
+    InClickless,
+    DisplayFollow,
+}
+
+pub struct ApogeeCmd{
+    cmd: VendorCmd,
+    vals: Vec<u8>,
+    op: VendorDependent,
+}
+
+impl<'a> ApogeeCmd {
+    const APOGEE_PREFIX: &'a [u8] = &[0x50, 0x43, 0x4d];    // 'P', 'C', 'M'
+
+    const MIC_POLARITY: u8 = 0x00;
+    const PHONE_IN_LEVEL: u8 = 0x01;
+    const LINE_IN_LEVEL: u8 = 0x02;
+    const MIC_PHANTOM: u8 = 0x03;
+    const OUT_ATTR: u8 = 0x04;
+    const IN_GAIN: u8 = 0x05;
+    const HW_STATE: u8 = 0x07;
+    const OUT_MUTE: u8 = 0x09;
+    const USE_LINE_IN: u8 = 0x0c;
+    const MIXER_SRC: u8 = 0x10;
+    const USE_MIXER_OUT: u8 = 0x11;
+    const DISPLAY_OVERHOLD: u8 = 0x13;
+    const DISPLAY_CLEAR: u8 = 0x14;
+    const OUT_VOLUME: u8 = 0x15;
+    const MUTE_FOR_LINE_OUT: u8 = 0x16;
+    const MUTE_FOR_HP_OUT: u8 = 0x17;
+    const UNMUTE_FOR_LINE_OUT: u8 = 0x18;
+    const UNMUTE_FOR_HP_OUT: u8 = 0x19;
+    const DISPLAY_INPUT: u8 = 0x1b;
+    const IN_CLICKLESS: u8 = 0x1e;
+    const DISPLAY_FOLLOW: u8 = 0x22;
+
+    pub fn new(company_id: &[u8;3], cmd: VendorCmd) -> Self {
+        ApogeeCmd{
+            cmd,
+            vals: Vec::new(),
+            op: VendorDependent::new(company_id),
+        }
+    }
+
+    fn build_args(&self) -> Vec<u8> {
+        let mut args = Vec::with_capacity(6);
+        args.extend_from_slice(&Self::APOGEE_PREFIX);
+        args.extend_from_slice(&[0xff;3]);
+
+        match &self.cmd {
+            VendorCmd::MicPolarity(ch) => {
+                args[3] = Self::MIC_POLARITY;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::PhoneInLine(ch) => {
+                args[3] = Self::PHONE_IN_LEVEL;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::LineInLevel(ch) => {
+                args[3] = Self::LINE_IN_LEVEL;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::MicPhantom(ch) => {
+                args[3] = Self::MIC_PHANTOM;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::OutAttr => {
+                args[3] = Self::OUT_ATTR;
+                args[4] = 0x80;
+            }
+            VendorCmd::InGain(ch) => {
+                args[3] = Self::IN_GAIN;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::HwState => args[3] = Self::HW_STATE,
+            VendorCmd::OutMute => {
+                args[3] = Self::OUT_MUTE;
+                args[4] = 0x80;
+            }
+            VendorCmd::MicIn(ch) => {
+                args[3] = Self::USE_LINE_IN;
+                args[4] = 0x80;
+                args[5] = *ch;
+            }
+            VendorCmd::MixerSrc(src, dst) => {
+                args[3] = Self::MIXER_SRC;
+                args[4] = (((*src / 2) << 4) | (*src % 2)) as u8;
+                args[5] = *dst;
+            }
+            VendorCmd::UseMixerOut => args[3] = Self::USE_MIXER_OUT,
+            VendorCmd::DisplayOverhold => args[3] = Self::DISPLAY_OVERHOLD,
+            VendorCmd::DisplayClear => args[3] = Self::DISPLAY_CLEAR,
+            VendorCmd::OutVolume => {
+                args[3] = Self::OUT_VOLUME;
+                args[4] = 0x80;
+            }
+            VendorCmd::MuteForLineOut => {
+                args[3] = Self::MUTE_FOR_LINE_OUT;
+                args[4] = 0x80;
+            }
+            VendorCmd::MuteForHpOut => {
+                args[3] = Self::MUTE_FOR_HP_OUT;
+                args[4] = 0x80;
+            }
+            VendorCmd::UnmuteForLineOut => {
+                args[3] = Self::UNMUTE_FOR_LINE_OUT;
+                args[4] = 0x80;
+            }
+            VendorCmd::UnmuteForHpOut => {
+                args[3] = Self::UNMUTE_FOR_HP_OUT;
+                args[4] = 0x80;
+            }
+            VendorCmd::DisplayInput=> args[3] = Self::DISPLAY_INPUT,
+            VendorCmd::InClickless => args[3] = Self::IN_CLICKLESS,
+            VendorCmd::DisplayFollow => args[3] = Self::DISPLAY_FOLLOW,
+        }
+
+        args
+    }
+
+    fn build_data(&mut self) -> Result<(), Error> {
+        self.op.data = self.build_args();
+        self.op.data.extend_from_slice(&self.vals);
+        Ok(())
+    }
+
+    fn parse_data(&mut self) -> Result<(), Error> {
+        let args = self.build_args();
+        if self.op.data[..6] != args[..6] {
+            let label = format!("Unexpected arguments in response: {:?} but {:?}", args, self.op.data);
+            Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
+        } else {
+            self.vals = self.op.data.split_off(6);
+            Ok(())
+        }
+    }
+}
+
+impl AvcOp for ApogeeCmd {
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+impl AvcControl for ApogeeCmd {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        self.build_data()?;
+        AvcControl::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)?;
+        self.parse_data()
+    }
+}
+
+impl AvcStatus for ApogeeCmd {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        self.build_data()?;
+        AvcStatus::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcStatus::parse_operands(&mut self.op, addr, operands)?;
+        self.parse_data()
+    }
+}
+
+pub trait ApogeeMeterProtocol : hinawa::FwReqExtManual {
+    const ADDR_BASE: u64 = 0xfffff0080000;
+
+    const OFFSET_ANALOG_INPUT: u32 = 0x0004;
+    const ANALOG_INPUT_SIZE: usize = 8;
+
+    const OFFSET_MIXER_SRC: u32 = 0x0404;
+    const MIXER_SRC_SIZE: usize = 16;
+
+    fn read_meters(&self, node: &hinawa::FwNode, meters: &mut [u32;6]) -> Result<(), Error>;
+}
+
+impl ApogeeMeterProtocol for hinawa::FwReq {
+    fn read_meters(&self, node: &hinawa::FwNode, meters: &mut [u32;6]) -> Result<(), Error> {
+        let mut frame = [0;Self::ANALOG_INPUT_SIZE + Self::MIXER_SRC_SIZE];
+
+        let addr = Self::ADDR_BASE + Self::OFFSET_ANALOG_INPUT as u64;
+        self.transaction_sync(node, hinawa::FwTcode::ReadBlockRequest, addr, Self::ANALOG_INPUT_SIZE,
+                              &mut frame[..Self::ANALOG_INPUT_SIZE], 10)?;
+
+        let addr = Self::ADDR_BASE + Self::OFFSET_MIXER_SRC as u64;
+        self.transaction_sync(node, hinawa::FwTcode::ReadBlockRequest, addr, Self::MIXER_SRC_SIZE,
+            &mut frame[Self::ANALOG_INPUT_SIZE..(Self::ANALOG_INPUT_SIZE + Self::MIXER_SRC_SIZE)], 10)?;
+
+        meters.iter_mut().enumerate().for_each(|(i, meter)| {
+            let mut quadlet = [0;4];
+            quadlet.copy_from_slice(&frame[(i * 4)..(i * 4 + 4)]);
+            *meter = u32::from_be_bytes(quadlet);
+        });
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ta1394::AvcAddr;
+    use crate::ta1394::{AvcStatus, AvcControl};
+    use super::{ApogeeCmd, VendorCmd};
+
+    #[test]
+    fn apogee_cmd_proto_operands() {
+        // No argument command.
+        let mut op = ApogeeCmd::new(&[0x01, 0x23, 0x45], VendorCmd::UseMixerOut);
+        let operands = [0x01, 0x23, 0x45, 0x50, 0x43, 0x4d, 0x11, 0xff, 0xff, 0xe3];
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xe3]);
+
+        let mut o = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        let mut op = ApogeeCmd::new(&[0x54, 0x32, 0x10], VendorCmd::UseMixerOut);
+        let operands = [0x54, 0x32, 0x10, 0x50, 0x43, 0x4d, 0x11, 0xff, 0xff, 0xe3];
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xe3]);
+
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        // One argument command.
+        let mut op = ApogeeCmd::new(&[0x01, 0x23, 0x45], VendorCmd::LineInLevel(1));
+        let operands = [0x01, 0x23, 0x45, 0x50, 0x43, 0x4d, 0x02, 0x80, 0x01, 0xb9];
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xb9]);
+
+        let mut o = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        let mut op = ApogeeCmd::new(&[0x54, 0x32, 0x10], VendorCmd::LineInLevel(1));
+        let operands = [0x54, 0x32, 0x10, 0x50, 0x43, 0x4d, 0x02, 0x80, 0x01, 0xb9];
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xb9]);
+
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        // Two arguments command.
+        let mut op = ApogeeCmd::new(&[0x01, 0x23, 0x45], VendorCmd::MixerSrc(1, 0));
+        let operands = [0x01, 0x23, 0x45, 0x50, 0x43, 0x4d, 0x10, 0x01, 0x00, 0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef];
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef]);
+
+        let mut o = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        let mut op = ApogeeCmd::new(&[0x54, 0x32, 0x10], VendorCmd::MixerSrc(1, 0));
+        let operands = [0x54, 0x32, 0x10, 0x50, 0x43, 0x4d, 0x10, 0x01, 0x00, 0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef];
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef]);
+
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        // Command for block request.
+        let mut op = ApogeeCmd::new(&[0x01, 0x23, 0x45], VendorCmd::HwState);
+        let operands = [0x01, 0x23, 0x45, 0x50, 0x43, 0x4d, 0x07, 0xff, 0xff,
+                        0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef, 0xde, 0xad, 0xbe, 0xef];
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef, 0xde, 0xad, 0xbe, 0xef]);
+
+        let mut o = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        let mut op = ApogeeCmd::new(&[0x54, 0x32, 0x10], VendorCmd::HwState);
+        let operands = [0x54, 0x32, 0x10, 0x50, 0x43, 0x4d, 0x07, 0xff, 0xff,
+                        0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef, 0xde, 0xad, 0xbe, 0xef];
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.vals, &[0xde, 0x00, 0xad, 0x01, 0xbe, 0x02, 0xef, 0xde, 0xad, 0xbe, 0xef]);
+
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+    }
+}

--- a/src/oxfw/common_ctl.rs
+++ b/src/oxfw/common_ctl.rs
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use hinawa::SndUnitExt;
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::*;
+use crate::ta1394::general::*;
+use crate::ta1394::stream_format::*;
+use crate::ta1394::amdtp::*;
+
+pub struct CommonCtl{
+    output_fmt_entries: Vec<CompoundAm824Stream>,
+    input_fmt_entries: Vec<CompoundAm824Stream>,
+    supported_rates: Vec<u32>,
+    assumed: bool,
+}
+
+impl<'a> CommonCtl {
+    const CLK_RATE_NAME: &'a str = "sampling-rate";
+
+    const SUPPORTED_RATES: &'a [u32] = &[32000, 44100, 48000, 88200, 96000, 176400, 192000];
+
+    pub fn new() -> Self {
+        CommonCtl{
+            output_fmt_entries: Vec::new(),
+            input_fmt_entries: Vec::new(),
+            supported_rates: Vec::new(),
+            assumed: false,
+        }
+    }
+
+    pub fn load<O>(&mut self, avc: &O, card_cntr: &mut card_cntr::CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+        where O: Ta1394Avc
+    {
+        let mut op = PlugInfo::new_for_unit_isoc_ext_plugs();
+        avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+
+        let (isoc_input_plugs, isoc_output_plugs) = match op {
+            PlugInfo::Unit(u) => match u {
+                PlugInfoUnitData::IsocExt(d) => (d.isoc_input_plugs, d.isoc_output_plugs),
+                _ => unreachable!(),
+            }
+            _ => unreachable!(),
+        };
+
+        if isoc_output_plugs > 0 {
+            self.output_fmt_entries = self.detect_stream_formats(avc, PlugDirection::Output,
+                                                                 timeout_ms)?;
+        }
+
+        if isoc_input_plugs > 0 {
+            self.input_fmt_entries = self.detect_stream_formats(avc, PlugDirection::Input,
+                                                                timeout_ms)?;
+        }
+
+        let mut rates = Vec::new();
+        self.output_fmt_entries.iter().for_each(|entry| {
+            if rates.iter().find(|&rate| *rate == entry.freq).is_none() {
+                rates.push(entry.freq);
+            }
+        });
+        self.input_fmt_entries.iter().for_each(|entry| {
+            if rates.iter().find(|&rate| *rate == entry.freq).is_none() {
+                rates.push(entry.freq);
+            }
+        });
+        rates.sort();
+        self.supported_rates = rates;
+
+        let labels = self.supported_rates.iter().map(|rate| rate.to_string()).collect::<Vec<String>>();
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::CLK_RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    fn read_freq<O>(&self, avc: &O, timeout_ms: u32) -> Result<usize, Error>
+        where O: Ta1394Avc
+    {
+        // For playback direction.
+        let mut op = InputPlugSignalFormat::new(0);
+        avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+        let fdf = AmdtpFdf::from(op.fdf.as_ref());
+
+        if let Some(pos) = self.supported_rates.iter().position(|rate| *rate == fdf.freq) {
+            Ok(pos)
+        } else {
+            let label = format!("Unsupported sampling rate: {}", fdf.freq);
+            Err(Error::new(FileError::Io, &label))
+        }
+    }
+
+    pub fn read<O>(&mut self, avc: &O, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue,
+                   timeout_ms: u32)
+        -> Result<bool, Error>
+        where O: Ta1394Avc
+    {
+        match elem_id.get_name().as_str() {
+            Self::CLK_RATE_NAME => {
+                let idx = self.read_freq(avc, timeout_ms)?;
+                elem_value.set_enum(&[idx as u32]);
+                Ok(true)
+            },
+            _ => Ok(false),
+        }
+    }
+
+    fn write_freq_for_fallback_mode<O>(&self, avc: &O, freq: u32, direction: PlugDirection,
+                                       timeout_ms: u32)
+        -> Result<(), Error>
+        where O: Ta1394Avc
+    {
+        let fdf: [u8;3] = AmdtpFdf::new(AmdtpEventType::Am824, false, freq).into();
+
+        if direction == PlugDirection::Input {
+            let mut op = InputPlugSignalFormat{
+                plug_id: 0,
+                fmt: FMT_IS_AMDTP,
+                fdf: fdf.clone(),
+            };
+            avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
+        } else {
+            let mut op = OutputPlugSignalFormat{
+                plug_id: 0,
+                fmt: FMT_IS_AMDTP,
+                fdf: fdf.clone(),
+            };
+            avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
+        }
+    }
+
+    fn write_freq_for_enhanced_mode<O>(&self, avc: &O, freq: u32, direction: PlugDirection,
+                                       timeout_ms: u32)
+        -> Result<(), Error>
+        where O: Ta1394Avc
+    {
+        let entries = match direction {
+            PlugDirection::Input => &self.input_fmt_entries,
+            _ => &self.output_fmt_entries,
+        };
+
+        let plug_addr = PlugAddr{
+            direction,
+            mode: PlugAddrMode::Unit(UnitPlugData{
+                unit_type: UnitPlugType::Pcr,
+                plug_id: 0,
+            }),
+        };
+        let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
+        avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+
+        let stream_format = op.stream_format.as_compound_am824_stream()?;
+        let pos = entries.iter().position(|entry|{
+            entry.freq == freq && entry.entries == stream_format.entries
+        }).ok_or_else(||{
+            let label = "Stream format entry is not found";
+            Error::new(FileError::Nxio, &label)
+        })?;
+
+        op.stream_format= StreamFormat::Am(AmStream::CompoundAm824(entries[pos].clone()));
+        avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
+    }
+
+    fn write_freq<O>(&self, avc: &O, idx: usize, timeout_ms: u32) -> Result<(), Error>
+        where O: Ta1394Avc
+    {
+        if idx >= self.supported_rates.len() {
+            let label = format!("Invalid value for index of sampling rate: {}", idx);
+            return Err(Error::new(FileError::Io, &label));
+        }
+        let freq = self.supported_rates[idx];
+
+        // For fallback mode.
+        if self.assumed {
+            if self.output_fmt_entries.len() > 0 {
+                self.write_freq_for_fallback_mode(avc, freq, PlugDirection::Output, timeout_ms)?;
+            }
+            if self.input_fmt_entries.len() > 0 {
+                self.write_freq_for_fallback_mode(avc, freq, PlugDirection::Input, timeout_ms)?;
+            }
+        } else {
+            if self.output_fmt_entries.len() > 0 {
+                self.write_freq_for_enhanced_mode(avc, freq, PlugDirection::Output, timeout_ms)?;
+            }
+            if self.input_fmt_entries.len() > 0 {
+                self.write_freq_for_enhanced_mode(avc, freq, PlugDirection::Input, timeout_ms)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn write<O>(&mut self, unit: &hinawa::SndUnit, avc: &O, elem_id: &alsactl::ElemId,
+                 elem_value: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+        where O: Ta1394Avc
+    {
+        match elem_id.get_name().as_str() {
+            Self::CLK_RATE_NAME => {
+                let mut vals = [0];
+                elem_value.get_enum(&mut vals);
+                unit.lock()?;
+                let res = self.write_freq(avc, vals[0] as usize, timeout_ms);
+                let _ = unit.unlock();
+                match res {
+                    Ok(()) => Ok(true),
+                    Err(err) => Err(err),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn detect_stream_formats<O>(&mut self, avc: &O, direction: PlugDirection, timeout_ms: u32)
+        -> Result<Vec<CompoundAm824Stream>, Error>
+        where O: Ta1394Avc
+    {
+        let mut entries = Vec::new();
+
+        let plug_addr = PlugAddr{
+            direction,
+            mode: PlugAddrMode::Unit(UnitPlugData{
+                unit_type: UnitPlugType::Pcr,
+                plug_id: 0,
+            }),
+        };
+        let mut op = ExtendedStreamFormatList::new(&plug_addr, 0);
+
+        if avc.status(&AvcAddr::Unit, &mut op, timeout_ms).is_ok() {
+            let stream_format = op.stream_format.as_compound_am824_stream()?;
+            entries.push(stream_format.clone());
+
+            let _ = (1..10).try_for_each(|i| {
+                op.index = i as u8;
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                let stream_format = op.stream_format.as_compound_am824_stream()?;
+                entries.push(stream_format.clone());
+                Ok::<(), Error>(())
+            });
+        } else {
+            // Fallback. At first, retrieve current format information.
+            let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
+            avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+
+            let stream_format = op.stream_format.as_compound_am824_stream()?;
+
+            // Next, inquire supported sampling rates and make entries.
+            Self::SUPPORTED_RATES.iter().for_each(|&freq| {
+                let fdf: [u8;3] = AmdtpFdf::new(AmdtpEventType::Am824, false, freq).into();
+
+                if direction == PlugDirection::Input {
+                    let mut op = InputPlugSignalFormat{
+                        plug_id: 0,
+                        fmt: FMT_IS_AMDTP,
+                        fdf,
+                    };
+                    if avc.specific_inquiry(&AvcAddr::Unit, &mut op, timeout_ms).is_err() {
+                        return;
+                    }
+                } else {
+                    let mut op = OutputPlugSignalFormat{
+                        plug_id: 0,
+                        fmt: FMT_IS_AMDTP,
+                        fdf,
+                    };
+                    if avc.specific_inquiry(&AvcAddr::Unit, &mut op, timeout_ms).is_err() {
+                        return;
+                    }
+                }
+
+                let mut entry = stream_format.clone();
+                entry.freq = freq;
+                entries.push(entry);
+            });
+
+            self.assumed = true;
+        }
+
+        Ok(entries)
+    }
+}

--- a/src/oxfw/common_ctl.rs
+++ b/src/oxfw/common_ctl.rs
@@ -17,6 +17,7 @@ pub struct CommonCtl{
     input_fmt_entries: Vec<CompoundAm824Stream>,
     supported_rates: Vec<u32>,
     assumed: bool,
+    pub notified_elem_list: Vec<alsactl::ElemId>,
 }
 
 impl<'a> CommonCtl {
@@ -30,6 +31,7 @@ impl<'a> CommonCtl {
             input_fmt_entries: Vec::new(),
             supported_rates: Vec::new(),
             assumed: false,
+            notified_elem_list: Vec::new(),
         }
     }
 
@@ -75,7 +77,8 @@ impl<'a> CommonCtl {
         let labels = self.supported_rates.iter().map(|rate| rate.to_string()).collect::<Vec<String>>();
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::CLK_RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        self.notified_elem_list.append(&mut elem_id_list);
 
         Ok(())
     }

--- a/src/oxfw/common_model.rs
+++ b/src/oxfw/common_model.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, FwFcpExt};
+
+use crate::card_cntr;
+
+use super::common_ctl::CommonCtl;
+
+pub struct CommonModel {
+    avc: hinawa::FwFcp,
+    common_ctl: CommonCtl,
+}
+
+impl<'a> CommonModel {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    pub fn new() -> Self {
+        CommonModel{
+            avc: hinawa::FwFcp::new(),
+            common_ctl: CommonCtl::new(),
+        }
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for CommonModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.bind(&unit.get_node())?;
+
+        self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+             new: &alsactl::ElemValue) -> Result<bool, Error>
+    {
+        if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for CommonModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/oxfw/griffin_model.rs
+++ b/src/oxfw/griffin_model.rs
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, FwFcpExt};
+
+use alsactl::{CardExtManual, ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::Ta1394Avc;
+use crate::ta1394::audio::{AUDIO_SUBUNIT_0_ADDR, AudioFeature, CtlAttr, FeatureCtl, AudioCh};
+
+use super::common_ctl::CommonCtl;
+
+pub struct GriffinModel {
+    avc: hinawa::FwFcp,
+    common_ctl: CommonCtl,
+    voluntary: bool,
+}
+
+impl<'a> GriffinModel {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    const VOL_LABEL: &'a str = "PCM Playback Volume";
+    const MUTE_LABEL: &'a str = "PCM Playback Switch";
+
+    const CHANNEL_MAP: &'a [usize] = &[0, 1, 4, 5, 2, 3];
+    const VOL_FB_ID: u8 = 0x02;
+    const MUTE_FB_ID: u8 = 0x01;
+
+    pub fn new() -> Self {
+        GriffinModel{
+            avc: hinawa::FwFcp::new(),
+            common_ctl: CommonCtl::new(),
+            voluntary: false,
+        }
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for GriffinModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.bind(&unit.get_node())?;
+
+        self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
+        // NOTE: I have a plan to remove control functionality from ALSA oxfw driver for future.
+        let elem_id_list = card_cntr.card.get_elem_id_list()?;
+        self.voluntary = elem_id_list.iter().find(|elem_id| elem_id.get_name().as_str() == Self::VOL_LABEL).is_none();
+        if self.voluntary {
+            let mut op = AudioFeature::new(Self::VOL_FB_ID, CtlAttr::Minimum, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let min = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let mut op = AudioFeature::new(Self::VOL_FB_ID, CtlAttr::Maximum, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let max = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let mut op = AudioFeature::new(Self::VOL_FB_ID, CtlAttr::Resolution, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let step = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::VOL_LABEL, 0);
+            let _ = card_cntr.add_int_elems(&elem_id, 1, min as i32, max as i32, step as i32,
+                                            Self::CHANNEL_MAP.len(), None, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::MUTE_LABEL, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        }
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.voluntary {
+            match elem_id.get_name().as_str() {
+                Self::VOL_LABEL => {
+                    let mut vals = [0;Self::CHANNEL_MAP.len()];
+                    vals.iter_mut().zip(Self::CHANNEL_MAP.iter()).try_for_each(|(val, ch)|{
+                        let mut op = AudioFeature::new(Self::VOL_FB_ID, CtlAttr::Current,
+                                            AudioCh::Each(*ch as u8), FeatureCtl::Volume(vec![-1]));
+                        self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                        if let FeatureCtl::Volume(data) = op.ctl {
+                            *val = data[0] as i32;
+                        } else {
+                            unreachable!();
+                        }
+                        Ok(())
+                    })?;
+                    elem_value.set_int(&vals);
+                    Ok(true)
+                }
+                Self::MUTE_LABEL => {
+                    let mut op = AudioFeature::new(Self::MUTE_FB_ID, CtlAttr::Current,
+                                                   AudioCh::All, FeatureCtl::Mute(vec![false]));
+                    self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    if let FeatureCtl::Mute(data) = op.ctl {
+                        elem_value.set_bool(&data);
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
+                }
+                _ => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue) -> Result<bool, Error>
+    {
+        if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.voluntary {
+            match elem_id.get_name().as_str() {
+                Self::VOL_LABEL => {
+                    let mut vals = vec![0;Self::CHANNEL_MAP.len() * 2];
+                    new.get_int(&mut vals[..Self::CHANNEL_MAP.len()]);
+                    old.get_int(&mut vals[Self::CHANNEL_MAP.len()..]);
+
+                    (0..Self::CHANNEL_MAP.len()).enumerate().filter(|(i, _)| {
+                        vals[*i] == vals[Self::CHANNEL_MAP.len() + i]
+                    }).try_for_each(|(i, ch)| {
+                        let val = vals[i] as u16;
+                        let mut op = AudioFeature::new(Self::VOL_FB_ID, CtlAttr::Current,
+                                            AudioCh::Each(ch as u8), FeatureCtl::Volume(vec![val as i16]));
+                        self.avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)
+                    })?;
+                    Ok(true)
+                }
+                Self::MUTE_LABEL => {
+                    let mut vals = vec![false];
+                    new.get_bool(&mut vals);
+                    let mut op = AudioFeature::new(Self::MUTE_FB_ID, CtlAttr::Current,
+                                                   AudioCh::All, FeatureCtl::Mute(vals));
+                    self.avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for GriffinModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/oxfw/lacie_model.rs
+++ b/src/oxfw/lacie_model.rs
@@ -1,0 +1,167 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndUnitExt, FwFcpExt};
+
+use alsactl::{CardExtManual, ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::Ta1394Avc;
+use crate::ta1394::audio::{AUDIO_SUBUNIT_0_ADDR, AudioFeature, CtlAttr, FeatureCtl, AudioCh};
+
+use super::common_ctl::CommonCtl;
+
+pub struct LacieModel {
+    avc: hinawa::FwFcp,
+    common_ctl: CommonCtl,
+    voluntary: bool,
+}
+
+impl<'a> LacieModel {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    const VOL_LABEL: &'a str = "PCM Playback Volume";
+    const MUTE_LABEL: &'a str = "PCM Playback Switch";
+
+    const FB_ID: u8 = 0x01;
+
+    pub fn new() -> Self {
+        LacieModel{
+            avc: hinawa::FwFcp::new(),
+            common_ctl: CommonCtl::new(),
+            voluntary: false,
+        }
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for LacieModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.bind(&unit.get_node())?;
+
+        self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
+        // NOTE: I have a plan to remove control functionality from ALSA oxfw driver for future.
+        let elem_id_list = card_cntr.card.get_elem_id_list()?;
+        self.voluntary = elem_id_list.iter().find(|elem_id| elem_id.get_name().as_str() == Self::VOL_LABEL).is_none();
+        if self.voluntary {
+            let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Minimum, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let min = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Maximum, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let max = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Resolution, AudioCh::All,
+                                           FeatureCtl::Volume(vec![-1]));
+            self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+            let step = match op.ctl {
+                FeatureCtl::Volume(data) => data[0],
+                _ => unreachable!(),
+            };
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::VOL_LABEL, 0);
+            let _ = card_cntr.add_int_elems(&elem_id, 1, min as i32, max as i32, step as i32,
+                                            1, None, true)?;
+
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                       0, 0, Self::MUTE_LABEL, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        }
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.voluntary {
+            match elem_id.get_name().as_str() {
+                Self::VOL_LABEL => {
+                    let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Current, AudioCh::All,
+                                                   FeatureCtl::Volume(vec![-1]));
+                    self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    if let FeatureCtl::Volume(data) = op.ctl {
+                        elem_value.set_int(&[data[0] as i32]);
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
+                }
+                Self::MUTE_LABEL => {
+                    let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Current, AudioCh::All,
+                                                   FeatureCtl::Mute(vec![false]));
+                    self.avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    if let FeatureCtl::Mute(data) = op.ctl {
+                        elem_value.set_bool(&data);
+                        Ok(true)
+                    } else {
+                        Ok(false)
+                    }
+                }
+                _ => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+             new: &alsactl::ElemValue) -> Result<bool, Error>
+    {
+        if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.voluntary {
+            match elem_id.get_name().as_str() {
+                Self::VOL_LABEL => {
+                    let mut vals = [0];
+                    new.get_int(&mut vals);
+                    let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Current, AudioCh::All,
+                                                   FeatureCtl::Volume(vec![vals[0] as i16]));
+                    self.avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    Ok(true)
+                }
+                Self::MUTE_LABEL => {
+                    let mut vals = vec![false];
+                    new.get_bool(&mut vals);
+                    let mut op = AudioFeature::new(Self::FB_ID, CtlAttr::Current, AudioCh::All,
+                                                   FeatureCtl::Mute(vals));
+                    self.avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for LacieModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -36,7 +36,7 @@ impl OxfwModel {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.load(unit, card_cntr),
         }?;
-        
+
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -1,26 +1,46 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
 use crate::card_cntr;
+use crate::card_cntr::CtlModel;
 
-pub struct OxfwModel;
+use super::tascam_model::TascamModel;
+
+enum OxfwCtlModel {
+    Fireone(TascamModel),
+}
+
+pub struct OxfwModel{
+    ctl_model: OxfwCtlModel,
+}
 
 impl OxfwModel {
-    pub fn new(_: u32, _: u32) -> Result<Self, Error> {
-        Ok(OxfwModel{})
+    pub fn new(vendor_id: u32, model_id: u32) -> Result<Self, Error> {
+        let ctl_model = match (vendor_id, model_id) {
+            (0x00022e, 0x800007) => OxfwCtlModel::Fireone(TascamModel::new()),
+            _ => return Err(Error::new(FileError::Noent, "Not supported")),
+        };
+        let model = OxfwModel{
+            ctl_model,
+        };
+        Ok(model)
     }
 
-    pub fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+    pub fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.ctl_model {
+            OxfwCtlModel::Fireone(m) => m.load(unit, card_cntr),
+        }
     }
 
-    pub fn dispatch_elem_event(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr,
-                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
+                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.ctl_model {
+            OxfwCtlModel::Fireone(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+        }
     }
 }

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -7,10 +7,12 @@ use crate::card_cntr::{CtlModel, MeasureModel, NotifyModel};
 
 use super::tascam_model::TascamModel;
 use super::apogee_model::ApogeeModel;
+use super::griffin_model::GriffinModel;
 
 enum OxfwCtlModel {
     Fireone(TascamModel),
     Duet(ApogeeModel),
+    Firewave(GriffinModel),
 }
 
 pub struct OxfwModel{
@@ -25,6 +27,7 @@ impl OxfwModel {
         let ctl_model = match (vendor_id, model_id) {
             (0x00022e, 0x800007) => OxfwCtlModel::Fireone(TascamModel::new()),
             (0x0003db, 0x01dddd) => OxfwCtlModel::Duet(ApogeeModel::new()),
+            (0x001292, 0x00f970) => OxfwCtlModel::Firewave(GriffinModel::new()),
             _ => return Err(Error::new(FileError::Noent, "Not supported")),
         };
         let model = OxfwModel{
@@ -41,6 +44,7 @@ impl OxfwModel {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.load(unit, card_cntr),
             OxfwCtlModel::Duet(m) => m.load(unit, card_cntr),
+            OxfwCtlModel::Firewave(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -51,6 +55,7 @@ impl OxfwModel {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             OxfwCtlModel::Duet(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            OxfwCtlModel::Firewave(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -63,6 +68,7 @@ impl OxfwModel {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             OxfwCtlModel::Duet(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            OxfwCtlModel::Firewave(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }
 
@@ -81,6 +87,7 @@ impl OxfwModel {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
             OxfwCtlModel::Duet(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
+            OxfwCtlModel::Firewave(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -8,11 +8,13 @@ use crate::card_cntr::{CtlModel, MeasureModel, NotifyModel};
 use super::tascam_model::TascamModel;
 use super::apogee_model::ApogeeModel;
 use super::griffin_model::GriffinModel;
+use super::lacie_model::LacieModel;
 
 enum OxfwCtlModel {
     Fireone(TascamModel),
     Duet(ApogeeModel),
     Firewave(GriffinModel),
+    Speaker(LacieModel),
 }
 
 pub struct OxfwModel{
@@ -28,6 +30,7 @@ impl OxfwModel {
             (0x00022e, 0x800007) => OxfwCtlModel::Fireone(TascamModel::new()),
             (0x0003db, 0x01dddd) => OxfwCtlModel::Duet(ApogeeModel::new()),
             (0x001292, 0x00f970) => OxfwCtlModel::Firewave(GriffinModel::new()),
+            (0x00d04b, 0x00f970) => OxfwCtlModel::Speaker(LacieModel::new()),
             _ => return Err(Error::new(FileError::Noent, "Not supported")),
         };
         let model = OxfwModel{
@@ -45,6 +48,7 @@ impl OxfwModel {
             OxfwCtlModel::Fireone(m) => m.load(unit, card_cntr),
             OxfwCtlModel::Duet(m) => m.load(unit, card_cntr),
             OxfwCtlModel::Firewave(m) => m.load(unit, card_cntr),
+            OxfwCtlModel::Speaker(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -56,6 +60,7 @@ impl OxfwModel {
             OxfwCtlModel::Fireone(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             OxfwCtlModel::Duet(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             OxfwCtlModel::Firewave(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            OxfwCtlModel::Speaker(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -69,6 +74,7 @@ impl OxfwModel {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             OxfwCtlModel::Duet(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             OxfwCtlModel::Firewave(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            OxfwCtlModel::Speaker(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }
 
@@ -88,6 +94,7 @@ impl OxfwModel {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
             OxfwCtlModel::Duet(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
             OxfwCtlModel::Firewave(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
+            OxfwCtlModel::Speaker(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -66,10 +66,13 @@ impl OxfwModel {
         }
     }
 
-    pub fn measure_elems(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+    pub fn measure_elems(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.ctl_model {
+            OxfwCtlModel::Duet(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            _ => Ok(()),
+        }
     }
 
     pub fn dispatch_notification(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr, locked: bool)

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+pub struct OxfwModel;
+
+impl OxfwModel {
+    pub fn new(_: u32, _: u32) -> Result<Self, Error> {
+        Ok(OxfwModel{})
+    }
+
+    pub fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+
+    pub fn dispatch_elem_event(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr,
+                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+}

--- a/src/oxfw/model.rs
+++ b/src/oxfw/model.rs
@@ -6,9 +6,11 @@ use crate::card_cntr;
 use crate::card_cntr::{CtlModel, NotifyModel};
 
 use super::tascam_model::TascamModel;
+use super::apogee_model::ApogeeModel;
 
 enum OxfwCtlModel {
     Fireone(TascamModel),
+    Duet(ApogeeModel),
 }
 
 pub struct OxfwModel{
@@ -21,6 +23,7 @@ impl OxfwModel {
     pub fn new(vendor_id: u32, model_id: u32) -> Result<Self, Error> {
         let ctl_model = match (vendor_id, model_id) {
             (0x00022e, 0x800007) => OxfwCtlModel::Fireone(TascamModel::new()),
+            (0x0003db, 0x01dddd) => OxfwCtlModel::Duet(ApogeeModel::new()),
             _ => return Err(Error::new(FileError::Noent, "Not supported")),
         };
         let model = OxfwModel{
@@ -35,10 +38,12 @@ impl OxfwModel {
     {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.load(unit, card_cntr),
+            OxfwCtlModel::Duet(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            OxfwCtlModel::Duet(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -50,6 +55,7 @@ impl OxfwModel {
     {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            OxfwCtlModel::Duet(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
         }
     }
 
@@ -58,6 +64,7 @@ impl OxfwModel {
     {
         match &mut self.ctl_model {
             OxfwCtlModel::Fireone(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
+            OxfwCtlModel::Duet(m) => card_cntr.dispatch_notification(unit, &locked, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/oxfw/tascam_model.rs
+++ b/src/oxfw/tascam_model.rs
@@ -2,18 +2,37 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
+use hinawa::{FwFcpExt, SndUnitExt};
+
 use crate::card_cntr;
 
-pub struct TascamModel;
+use crate::ta1394::{Ta1394Avc, AvcAddr};
+use crate::ta1394::general::UnitInfo;
+
+use super::tascam_proto::TascamAvc;
+
+pub struct TascamModel{
+    avc: TascamAvc,
+}
 
 impl TascamModel {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
     pub fn new() -> Self {
-        TascamModel{}
+        TascamModel{
+            avc: TascamAvc::new(),
+        }
     }
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
-    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+        self.avc.company_id.copy_from_slice(&op.company_id);
+
         Ok(())
     }
 

--- a/src/oxfw/tascam_model.rs
+++ b/src/oxfw/tascam_model.rs
@@ -145,3 +145,18 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
         }
     }
 }
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for TascamModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/oxfw/tascam_model.rs
+++ b/src/oxfw/tascam_model.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+pub struct TascamModel;
+
+impl TascamModel {
+    pub fn new() -> Self {
+        TascamModel{}
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
+    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue,
+             _: &alsactl::ElemValue) -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/oxfw/tascam_model.rs
+++ b/src/oxfw/tascam_model.rs
@@ -147,16 +147,17 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
 }
 
 impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for TascamModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
     }
 }

--- a/src/oxfw/tascam_model.rs
+++ b/src/oxfw/tascam_model.rs
@@ -11,8 +11,11 @@ use crate::ta1394::general::UnitInfo;
 
 use super::tascam_proto::TascamAvc;
 
+use super::common_ctl::CommonCtl;
+
 pub struct TascamModel{
     avc: TascamAvc,
+    common_ctl: CommonCtl,
 }
 
 impl TascamModel {
@@ -21,30 +24,42 @@ impl TascamModel {
     pub fn new() -> Self {
         TascamModel{
             avc: TascamAvc::new(),
+            common_ctl: CommonCtl::new(),
         }
     }
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
         self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
         self.avc.company_id.copy_from_slice(&op.company_id);
 
+        self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+            elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            return Ok(true);
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue,
-             _: &alsactl::ElemValue) -> Result<bool, Error>
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+             new: &alsactl::ElemValue) -> Result<bool, Error>
     {
-        Ok(false)
+        if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
+            return Ok(true);
+        } else {
+            Ok(false)
+        }
     }
 }

--- a/src/oxfw/tascam_proto.rs
+++ b/src/oxfw/tascam_proto.rs
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::ta1394::{Ta1394Avc, Ta1394AvcError, AvcCmdType, AvcAddr, AvcRespCode};
+use crate::ta1394::{AvcOp, AvcControl, AvcStatus, AvcNotify};
+use crate::ta1394::general::VendorDependent;
+
+pub enum VendorCmd {
+    DisplayMode,
+    MessageMode,
+    InputMode,
+    FirmwareVersion,
+}
+
+impl VendorCmd {
+    const DISPLAY_MODE: u8 = 0x10;
+    const MESSAGE_MODE: u8 = 0x11;
+    const INPUT_MODE: u8 = 0x12;
+    const FIRMWARE_VERSION: u8 = 0x13;
+}
+
+impl From<&VendorCmd> for u8 {
+    fn from(cmd: &VendorCmd) -> u8 {
+        match cmd {
+            VendorCmd::DisplayMode => VendorCmd::DISPLAY_MODE,
+            VendorCmd::MessageMode => VendorCmd::MESSAGE_MODE,
+            VendorCmd::InputMode => VendorCmd::INPUT_MODE,
+            VendorCmd::FirmwareVersion => VendorCmd::FIRMWARE_VERSION,
+        }
+    }
+}
+
+pub struct TascamProto{
+    cmd: VendorCmd,
+    pub val: u8,
+    op: VendorDependent,
+}
+
+impl<'a> TascamProto {
+    const TASCAM_PREFIX: &'a [u8] = &[0x46, 0x49, 0x31];    // 'F', 'I', '1'
+
+    pub fn new(company_id: &[u8;3], cmd: VendorCmd) -> Self {
+        TascamProto{
+            cmd,
+            val: 0xff,
+            op: VendorDependent::new(company_id),
+        }
+    }
+
+    fn build_op(&mut self) -> Result<(), Error> {
+        self.op.data.clear();
+        self.op.data.extend_from_slice(&Self::TASCAM_PREFIX);
+        self.op.data.push(u8::from(&self.cmd));
+        self.op.data.push(self.val);
+        Ok(())
+    }
+
+    fn parse_op(&mut self) -> Result<(), Error> {
+        if self.op.data.len() < 5 {
+            let label = format!("Data too short for TascamProtocol; {}", self.op.data.len());
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+
+        if self.op.data[3] != u8::from(&self.cmd) {
+            let label = format!("Invalid command for TascamProto; {:?}", self.op.data[3]);
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+        }
+
+        self.val = self.op.data[4];
+
+        Ok(())
+    }
+}
+
+impl AvcOp for TascamProto{
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+impl AvcControl for TascamProto {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        Self::build_op(self)?;
+        AvcControl::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)?;
+        Self::parse_op(self)
+    }
+}
+
+impl AvcStatus for TascamProto {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        Self::build_op(self)?;
+        AvcStatus::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcStatus::parse_operands(&mut self.op, addr, operands)?;
+        Self::parse_op(self)
+    }
+}
+
+pub struct TascamAvc{
+    pub fcp: hinawa::FwFcp,
+    pub company_id: [u8;3],
+}
+
+impl TascamAvc {
+    pub fn new() -> Self {
+        TascamAvc {
+            fcp: hinawa::FwFcp::new(),
+            company_id: [0;3],
+        }
+    }
+}
+
+impl AsRef<hinawa::FwFcp> for TascamAvc {
+    fn as_ref(&self) -> &hinawa::FwFcp {
+        &self.fcp
+    }
+}
+
+impl Ta1394Avc for TascamAvc {
+    fn control<O: AvcOp + AvcControl>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        let mut operands = Vec::new();
+        AvcControl::build_operands(op, addr, &mut operands)?;
+        let opcode = op.opcode();
+        let (rcode, operands) = self.trx(AvcCmdType::Control, addr, opcode, &mut operands, timeout_ms)?;
+        let expected = if opcode != VendorDependent::OPCODE {
+            AvcRespCode::Accepted
+        } else {
+            // NOTE: quirk. Furthermore, company_id in response transaction is 0xffffff.
+            AvcRespCode::ImplementedStable
+        };
+        if rcode != expected {
+            let label = format!("Unexpected response code for TascamAvc control: {:?}", rcode);
+            return Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label));
+        }
+        AvcControl::parse_operands(op, addr, &operands)
+    }
+
+    fn status<O: AvcOp + AvcStatus>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.status(addr, op, timeout_ms)
+    }
+
+    fn specific_inquiry<O: AvcOp + AvcControl>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.specific_inquiry(addr, op, timeout_ms)
+    }
+
+    fn notify<O: AvcOp + AvcNotify>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.notify(addr, op, timeout_ms)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ta1394::{AvcAddr, AvcStatus, AvcControl};
+    use super::{TascamProto, VendorCmd};
+
+    #[test]
+    fn tascam_proto_operands() {
+        let mut op = TascamProto::new(&[0x01, 0x23, 0x45], VendorCmd::DisplayMode);
+        let operands = [0x01, 0x23, 0x45, 0x46, 0x49, 0x31, 0x10, 0x01];
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.val, 0x01);
+
+        let mut o = Vec::new();
+        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+        let mut op = TascamProto::new(&[0x54, 0x32, 0x10], VendorCmd::InputMode);
+        let operands = [0x54, 0x32, 0x10, 0x46, 0x49, 0x31, 0x12, 0x1c];
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.val, 0x1c);
+
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(o, operands);
+
+    }
+}

--- a/src/oxfw/unit.rs
+++ b/src/oxfw/unit.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+use glib::source;
+
+use nix::sys::signal;
+use std::sync::mpsc;
+
+use hinawa::{FwNodeExt, SndUnitExt, SndUnitExtManual};
+
+use crate::dispatcher;
+
+enum Event {
+    Shutdown,
+    Disconnected,
+    BusReset(u32),
+}
+
+pub struct OxfwUnit {
+    unit: hinawa::SndUnit,
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
+
+impl Drop for OxfwUnit {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> OxfwUnit {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    pub fn new(card_id: u32) -> Result<Self, Error> {
+        let unit = hinawa::SndUnit::new();
+        unit.open(&format!("/dev/snd/hwC{}D0", card_id))?;
+
+        if unit.get_property_type() != hinawa::SndUnitType::Oxfw {
+            let label = "ALSA oxfw driver is not bound to the unit.";
+            return Err(Error::new(FileError::Inval, label));
+        }
+
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        Ok(OxfwUnit {
+            unit,
+            rx,
+            tx,
+            dispatchers: Vec::new(),
+        })
+    }
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_unit(&self.unit, move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_fw_node(&self.unit.get_node(), move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        self.unit.get_node().connect_bus_update(move |node| {
+            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    pub fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) {
+        loop {
+            let ev = match self.rx.recv() {
+                Ok(ev) => ev,
+                Err(_) => continue,
+            };
+
+            match ev {
+                Event::Shutdown => break,
+                Event::Disconnected => break,
+                Event::BusReset(generation) => {
+                    println!("IEEE 1394 bus is updated: {}", generation);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Oxford Semiconductor designs OXFW970/OXFW971 ASIC for audio applications in IEEE 1394 bus. ALSA oxfw driver supports models with the ASIC for their isochronous packet stream functionality. Although the driver allows userspace applications to process PCM frames and MIDI messages in the packet streaming, it doesn't support the other functionalities such as volume control since it can be achieved by any usespace application.

This patchset adds service program to satisfy the demand to control the models. ALSA control applications can request the control by IPC to the service program. The service program works as proxy to execute actual control.