### PR TITLE
bebob: add service program for devices based on DM1000/DM1100/DM1500 ASICs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,7 @@ path = "src/bin/snd-firewire-motu-ctl-service.rs"
 [[bin]]
 name = "snd-oxfw-ctl-service"
 path = "src/bin/snd-oxfw-ctl-service.rs"
+
+[[bin]]
+name = "snd-bebob-ctl-service"
+path = "src/bin/snd-bebob-ctl-service.rs"

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,7 @@ your device, please contact to developer.
   * Apogee Ensemble
   * M-Audio Ozonic
   * M-Audio FireWire Solo
+  * M-Audio FireWire Audiophile
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -124,6 +124,7 @@ your device, please contact to developer.
   * M-Audio ProFire LightBridge
   * M-Audio FireWire 1814
   * M-Audio ProjectMix I/O
+  * Behringer FIREPOWER FCA610
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -125,6 +125,7 @@ your device, please contact to developer.
   * M-Audio FireWire 1814
   * M-Audio ProjectMix I/O
   * Behringer FIREPOWER FCA610
+  * Stanton ScratchAmp in Final Scratch version 2
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -108,10 +108,15 @@ your device, please contact to developer.
   * MOTU AudioExpress
 
 * snd-oxfw-ctl-service
+
   * Tascam FireOne
   * Apogee Duet FireWire
   * Griffin FireWave
   * Lacie FireWire Speakers
+
+* snd-bebob-ctl-service
+
+  * Apogee Ensemble
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,8 @@ snd-firewire-motu-ctl-service
    For sound card bound to ALSA firewire-motu driver (snd-firewire-motu)
 snd-oxfw-ctl-service
    For sound card bound to ALSA oxfw driver (snd-oxfw)
+snd-bebob-ctl-service
+   For sound card bound to ALSA bebob driver (snd-bebob)
 
 License
 =======
@@ -129,6 +131,7 @@ Supported protocols
    * Protocol for Fireworks board module of Echo Digital Audio
    * Protocol for Mark of the Unicorn (MOTU) FireWire series
    * Protocol for Oxford Semiconductor OXFW970/OXFW971 ASIC
+   * Protocol for DM1000/DM1100/DM1500 ASIC in BridgeCo. Enhanced BreakOut Box (BeBoB)
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -122,6 +122,8 @@ your device, please contact to developer.
   * M-Audio FireWire Audiophile
   * M-Audio FireWire 410
   * M-Audio ProFire LightBridge
+  * M-Audio FireWire 1814
+  * M-Audio ProjectMix I/O
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,7 @@ your device, please contact to developer.
   * M-Audio FireWire Solo
   * M-Audio FireWire Audiophile
   * M-Audio FireWire 410
+  * M-Audio ProFire LightBridge
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -117,6 +117,7 @@ your device, please contact to developer.
 * snd-bebob-ctl-service
 
   * Apogee Ensemble
+  * M-Audio Ozonic
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -120,6 +120,7 @@ your device, please contact to developer.
   * M-Audio Ozonic
   * M-Audio FireWire Solo
   * M-Audio FireWire Audiophile
+  * M-Audio FireWire 410
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -118,6 +118,7 @@ your device, please contact to developer.
 
   * Apogee Ensemble
   * M-Audio Ozonic
+  * M-Audio FireWire Solo
 
 Supported protocols
 ===================

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub mod unit;

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -10,6 +10,7 @@ mod model;
 mod apogee;
 mod maudio;
 mod behringer;
+mod stanton;
 
 
 use glib::Error;

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -8,6 +8,7 @@ mod common_ctls;
 mod model;
 
 mod apogee;
+mod maudio;
 
 
 use glib::Error;

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -3,7 +3,73 @@
 pub mod unit;
 
 mod extensions;
+mod common_ctls;
 
 mod model;
 
 mod apogee;
+
+
+use glib::Error;
+use crate::ta1394::{Ta1394Avc, Ta1394AvcError, AvcCmdType, AvcAddr, AvcRespCode};
+use crate::ta1394::{AvcOp, AvcStatus, AvcControl, AvcNotify};
+use crate::ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat};
+use crate::ta1394::ccm::SignalSource;
+
+pub struct BebobAvc{
+    pub fcp: hinawa::FwFcp,
+    pub company_id: [u8;3],
+}
+
+impl BebobAvc {
+    pub fn new() -> Self {
+        BebobAvc{
+            fcp: hinawa::FwFcp::new(),
+            company_id: [0;3],
+        }
+    }
+}
+
+impl AsRef<hinawa::FwFcp> for BebobAvc {
+    fn as_ref(&self) -> &hinawa::FwFcp {
+        &self.fcp
+    }
+}
+
+impl Ta1394Avc for BebobAvc {
+    fn control<O: AvcOp + AvcControl>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        let mut operands = Vec::new();
+        AvcControl::build_operands(op, addr, &mut operands)?;
+        let opcode = op.opcode();
+        let (rcode, operands) = self.trx(AvcCmdType::Control, addr, opcode, &mut operands, timeout_ms)?;
+        let unexpected = match opcode {
+            InputPlugSignalFormat::OPCODE |
+            OutputPlugSignalFormat::OPCODE |
+            SignalSource::OPCODE => {
+                // NOTE: quirk.
+                rcode == AvcRespCode::Accepted || rcode == AvcRespCode::Reserved(0x00)
+            }
+            _ => {
+                rcode == AvcRespCode::Accepted
+            }
+        };
+        if !unexpected {
+            let label = format!("Unexpected response code for control opcode {}: {:?}", opcode, rcode);
+            Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+        } else {
+            AvcControl::parse_operands(op, addr, &operands)
+        }
+    }
+
+    fn status<O: AvcOp + AvcStatus>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.status(addr, op, timeout_ms)
+    }
+
+    fn specific_inquiry<O: AvcOp + AvcControl>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.specific_inquiry(addr, op, timeout_ms)
+    }
+
+    fn notify<O: AvcOp + AvcNotify>(&self, addr: &AvcAddr, op: &mut O, timeout_ms: u32) -> Result<(), Error> {
+        self.fcp.notify(addr, op, timeout_ms)
+    }
+}

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -2,4 +2,6 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod unit;
 
+mod extensions;
+
 mod model;

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod unit;
+
+mod model;

--- a/src/bebob.rs
+++ b/src/bebob.rs
@@ -9,6 +9,7 @@ mod model;
 
 mod apogee;
 mod maudio;
+mod behringer;
 
 
 use glib::Error;

--- a/src/bebob/apogee.rs
+++ b/src/bebob/apogee.rs
@@ -1,9 +1,3 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-pub mod unit;
-
-mod extensions;
-
-mod model;
-
-mod apogee;
+pub mod apogee_model;

--- a/src/bebob/apogee.rs
+++ b/src/bebob/apogee.rs
@@ -2,4 +2,6 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod apogee_model;
 
+mod apogee_ctls;
+
 mod apogee_proto;

--- a/src/bebob/apogee.rs
+++ b/src/bebob/apogee.rs
@@ -1,3 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod apogee_model;
+
+mod apogee_proto;

--- a/src/bebob/apogee/apogee_ctls.rs
+++ b/src/bebob/apogee/apogee_ctls.rs
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndUnitExt;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+
+use crate::bebob::BebobAvc;
+use crate::bebob::extensions::{BcoPlugAddr, BcoPlugDirection, BcoPlugAddrUnitType};
+use crate::bebob::extensions::BcoCompoundAm824StreamFormat;
+use crate::bebob::extensions::ExtendedStreamFormatSingle;
+use super::apogee_proto::{ApogeeCmd, VendorCmd, HwCmdOp};
+
+pub struct HwCtl{
+    stream: u32,
+    cd: bool,
+    spdif_out_bypass: u32,
+}
+
+impl<'a> HwCtl {
+    const STREAM_MODE_NAME: &'a str = "stream-mode";
+    const CD_MODE_NAME: &'a str = "cd-mode";
+    const SPDIF_OUT_BYPASS_NAME: &'a str = "S/PDIF-out-bypass";
+
+    const STREAM_MODE_LABELS: &'a [&'a str] = &["16x16", "10x10", "8x8"];
+
+    const SPDIF_OUT_BYPASS_LABELS: &'a [&'a str] = &[
+        "none",
+        "analog-in-1/2",
+        "analog-in-3/4",
+        "analog-in-5/6",
+        "analog-in-7/8",
+        "spdif-opt-in-1/2",
+        "spdif-coax-in-1/2",
+        "spdif-coax-out-1/2",
+        "spdif-opt-out-1/2",
+    ];
+
+    pub fn new() -> Self {
+        HwCtl {
+            stream: 0,
+            cd: false,
+            spdif_out_bypass: 0,
+        }
+    }
+
+    pub fn load(&mut self, avc: &BebobAvc, card_cntr: &mut card_cntr::CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let plug_addr = BcoPlugAddr::new_for_unit(BcoPlugDirection::Output, BcoPlugAddrUnitType::Isoc,
+                                                  0);
+        let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
+        avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+        let info = op.stream_format.as_bco_compound_am824_stream()?;
+        let count = info.entries.iter()
+            .filter(|entry| entry.format == BcoCompoundAm824StreamFormat::MultiBitLinearAudioRaw)
+            .fold(0, |count, entry| count + entry.count as usize);
+        self.stream = match count {
+            18 => 0,
+            10 => 1,
+            _ => 2,
+        };
+
+        // Transfer initialized data.
+        let mut op = ApogeeCmd::new(&avc.company_id, VendorCmd::Hw(HwCmdOp::CdMode),
+                                    &[self.cd as u8]);
+        avc.control(&AvcAddr::Unit, &mut op, timeout_ms)?;
+
+        let mut op = ApogeeCmd::new(&avc.company_id, VendorCmd::Downgrade, &[self.cd as u8]);
+        avc.control(&AvcAddr::Unit, &mut op, timeout_ms)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::STREAM_MODE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::STREAM_MODE_LABELS, None, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::CD_MODE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                   0, 0, Self::SPDIF_OUT_BYPASS_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::SPDIF_OUT_BYPASS_LABELS, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::STREAM_MODE_NAME => {
+                elem_value.set_enum(&[self.stream]);
+                Ok(true)
+            }
+            Self::CD_MODE_NAME => {
+                elem_value.set_bool(&[self.cd]);
+                Ok(true)
+            }
+            Self::SPDIF_OUT_BYPASS_NAME => {
+                elem_value.set_enum(&[self.spdif_out_bypass]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &hinawa::SndUnit, avc: &BebobAvc, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::STREAM_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let mut op = ApogeeCmd::new(&avc.company_id, VendorCmd::Hw(HwCmdOp::StreamMode),
+                                            &[vals[0] as u8]);
+                unit.lock()?;
+                let res = avc.control(&AvcAddr::Unit, &mut op, timeout_ms);
+                unit.unlock()?;
+                res.and(Ok(true))
+            }
+            Self::CD_MODE_NAME => {
+                let mut vals = [false];
+                new.get_bool(&mut vals);
+                let mut op = ApogeeCmd::new(&avc.company_id, VendorCmd::Hw(HwCmdOp::CdMode),
+                                            &[vals[0] as u8]);
+                avc.control(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                self.cd = vals[0];
+                Ok(true)
+            }
+            Self::SPDIF_OUT_BYPASS_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let mut op = ApogeeCmd::new(&avc.company_id, VendorCmd::Downgrade,
+                                            &[vals[0] as u8]);
+                avc.control(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                self.spdif_out_bypass = vals[0] as u32;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -2,32 +2,87 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
+use hinawa::{FwFcpExt, SndUnitExt};
+
 use crate::card_cntr;
 
-pub struct EnsembleModel;
+use crate::ta1394::{Ta1394Avc, AvcAddr, MUSIC_SUBUNIT_0};
+use crate::ta1394::general::UnitInfo;
+use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
-impl EnsembleModel {
+use crate::bebob::BebobAvc;
+use crate::bebob::common_ctls::ClkCtl;
+
+pub struct EnsembleModel<'a>{
+    avc: BebobAvc,
+    clk_ctls: ClkCtl<'a>,
+}
+
+impl<'a> EnsembleModel<'a> {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 7,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 7,
+        }),
+        SignalAddr::Unit(SignalUnitAddr::Ext(4)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(5)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(6)),
+    ];
+
+    const CLK_SRC_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF coax",
+        "Optical",
+        "Word Clock",
+    ];
+
     pub fn new() -> Self {
-        EnsembleModel{}
+        EnsembleModel{
+            avc: BebobAvc::new(),
+            clk_ctls: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_SRC_LABELS),
+        }
     }
 }
 
-impl card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel {
-    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+        self.avc.company_id = op.company_id;
+
+        self.clk_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctls.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(true)
+        if self.clk_ctls.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,7 +12,7 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl, MixerCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
@@ -22,6 +22,7 @@ pub struct EnsembleModel<'a>{
     opt_iface_ctls: OpticalCtl,
     input_ctls: InputCtl,
     out_ctls: OutputCtl,
+    mixer_ctls: MixerCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -57,6 +58,7 @@ impl<'a> EnsembleModel<'a> {
             opt_iface_ctls: OpticalCtl::new(),
             input_ctls: InputCtl::new(),
             out_ctls: OutputCtl::new(),
+            mixer_ctls: MixerCtl::new(),
         }
     }
 }
@@ -77,6 +79,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.opt_iface_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.input_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.out_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.mixer_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -95,6 +98,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.input_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -116,6 +121,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.input_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.out_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.mixer_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,7 +12,7 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
@@ -20,6 +20,7 @@ pub struct EnsembleModel<'a>{
     hw_ctls: HwCtl,
     display_ctls: DisplayCtl,
     opt_iface_ctls: OpticalCtl,
+    input_ctls: InputCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -53,6 +54,7 @@ impl<'a> EnsembleModel<'a> {
             hw_ctls: HwCtl::new(),
             display_ctls: DisplayCtl::new(),
             opt_iface_ctls: OpticalCtl::new(),
+            input_ctls: InputCtl::new(),
         }
     }
 }
@@ -71,6 +73,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.hw_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.display_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.opt_iface_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.input_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -85,6 +88,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.display_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.opt_iface_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -102,6 +107,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.display_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.opt_iface_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.input_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -166,3 +166,20 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.meter_ctls.measure_elem(elem_id, elem_value)
     }
 }
+
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for EnsembleModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctls.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctls.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+pub struct EnsembleModel;
+
+impl EnsembleModel {
+    pub fn new() -> Self {
+        EnsembleModel{}
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel {
+    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(true)
+    }
+}

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,7 +12,7 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl, MixerCtl, RouteCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl, MixerCtl, RouteCtl, ResamplerCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
@@ -24,6 +24,7 @@ pub struct EnsembleModel<'a>{
     out_ctls: OutputCtl,
     mixer_ctls: MixerCtl,
     route_ctls: RouteCtl,
+    resampler_ctls: ResamplerCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -61,6 +62,7 @@ impl<'a> EnsembleModel<'a> {
             out_ctls: OutputCtl::new(),
             mixer_ctls: MixerCtl::new(),
             route_ctls: RouteCtl::new(),
+            resampler_ctls: ResamplerCtl::new(),
         }
     }
 }
@@ -83,6 +85,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.out_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.mixer_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.route_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.resampler_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -105,6 +108,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.mixer_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.route_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.resampler_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -130,6 +135,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.mixer_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.route_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.resampler_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,7 +12,7 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl, MixerCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl, MixerCtl, RouteCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
@@ -23,6 +23,7 @@ pub struct EnsembleModel<'a>{
     input_ctls: InputCtl,
     out_ctls: OutputCtl,
     mixer_ctls: MixerCtl,
+    route_ctls: RouteCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -59,6 +60,7 @@ impl<'a> EnsembleModel<'a> {
             input_ctls: InputCtl::new(),
             out_ctls: OutputCtl::new(),
             mixer_ctls: MixerCtl::new(),
+            route_ctls: RouteCtl::new(),
         }
     }
 }
@@ -80,6 +82,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.input_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.out_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.mixer_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.route_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -100,6 +103,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.out_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.route_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -123,6 +128,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.out_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.mixer_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.route_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,13 +12,14 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
     clk_ctls: ClkCtl<'a>,
     hw_ctls: HwCtl,
     display_ctls: DisplayCtl,
+    opt_iface_ctls: OpticalCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -51,6 +52,7 @@ impl<'a> EnsembleModel<'a> {
             clk_ctls: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_SRC_LABELS),
             hw_ctls: HwCtl::new(),
             display_ctls: DisplayCtl::new(),
+            opt_iface_ctls: OpticalCtl::new(),
         }
     }
 }
@@ -68,6 +70,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.clk_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.hw_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.display_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.opt_iface_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -80,6 +83,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.hw_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.display_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.opt_iface_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -95,6 +100,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.hw_ctls.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.display_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.opt_iface_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,7 +12,7 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl};
+use super::apogee_ctls::{HwCtl, DisplayCtl, OpticalCtl, InputCtl, OutputCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
@@ -21,6 +21,7 @@ pub struct EnsembleModel<'a>{
     display_ctls: DisplayCtl,
     opt_iface_ctls: OpticalCtl,
     input_ctls: InputCtl,
+    out_ctls: OutputCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -55,6 +56,7 @@ impl<'a> EnsembleModel<'a> {
             display_ctls: DisplayCtl::new(),
             opt_iface_ctls: OpticalCtl::new(),
             input_ctls: InputCtl::new(),
+            out_ctls: OutputCtl::new(),
         }
     }
 }
@@ -74,6 +76,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         self.display_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.opt_iface_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.input_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.out_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -90,6 +93,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.opt_iface_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.out_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -109,6 +114,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         } else if self.opt_iface_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.input_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_model.rs
+++ b/src/bebob/apogee/apogee_model.rs
@@ -12,12 +12,13 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
-use super::apogee_ctls::HwCtl;
+use super::apogee_ctls::{HwCtl, DisplayCtl};
 
 pub struct EnsembleModel<'a>{
     avc: BebobAvc,
     clk_ctls: ClkCtl<'a>,
     hw_ctls: HwCtl,
+    display_ctls: DisplayCtl,
 }
 
 impl<'a> EnsembleModel<'a> {
@@ -49,6 +50,7 @@ impl<'a> EnsembleModel<'a> {
             avc: BebobAvc::new(),
             clk_ctls: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_SRC_LABELS),
             hw_ctls: HwCtl::new(),
+            display_ctls: DisplayCtl::new(),
         }
     }
 }
@@ -65,6 +67,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
 
         self.clk_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.hw_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.display_ctls.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -75,6 +78,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         if self.clk_ctls.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.hw_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.display_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -88,6 +93,8 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         if self.clk_ctls.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.hw_ctls.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.display_ctls.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(true)

--- a/src/bebob/apogee/apogee_proto.rs
+++ b/src/bebob/apogee/apogee_proto.rs
@@ -1,0 +1,330 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::ta1394::AvcAddr;
+use crate::ta1394::{AvcOp, AvcControl};
+use crate::ta1394::general::VendorDependent;
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum VendorCmd {
+    InputLimit(u8),     // index, state
+    MicPower(u8),       // index, state
+    IoAttr(u8, u8),     // index, direction, state
+    IoRouting(u8),      // destination, source
+    Hw(HwCmdOp),
+    HpSrc(u8),          // destination, source
+    MixerSrc0(u8),      // mixer_pair, [u8;36]
+    MixerSrc1(u8),
+    MixerSrc2(u8),
+    MixerSrc3(u8),
+    MicGain(u8),        // 1/2/3/4, dB(10-75), also available as knob control
+    OptIfaceMode(u8),   // direction, mode
+    Downgrade,          // on/off
+    SpdifResample,      // on/off, iface, direction, rate
+    MicPolarity(u8),    // index, state
+    OutVol(u8),         // main/hp0/hp1, dB(127-0), also available as knob control
+    HwStatus(bool),     // [u8;17] or [u8;56]
+    Reserved(Vec<u8>),
+}
+
+impl VendorCmd {
+    const INPUT_LIMIT: u8 = 0xe4;
+    const MIC_POWER: u8 = 0xe5;
+    const IO_ATTR: u8 = 0xe8;
+    const IO_ROUTING: u8 = 0xef;
+    const HW: u8 = 0xeb;
+    const HP_SRC: u8 = 0xab;
+    const MIXER_SRC0: u8 = 0xb0;
+    const MIXER_SRC1: u8 = 0xb1;
+    const MIXER_SRC2: u8 = 0xb2;
+    const MIXER_SRC3: u8 = 0xb3;
+    const IN_VOL: u8 = 0xe6;
+    const OPT_IFACE_MODE: u8 = 0xf1;
+    const DOWNGRADE: u8 = 0xf2;
+    const SPDIF_RESAMPLE: u8 = 0xf3;
+    const MIC_POLARITY: u8 = 0xf5;
+    const OUT_VOL: u8 = 0xf6;
+    const HW_STATUS: u8 = 0xff;
+}
+
+impl From<&VendorCmd> for Vec<u8> {
+    fn from(cmd: &VendorCmd) -> Self {
+        let mut raw = Vec::new();
+
+        match cmd {
+            VendorCmd::InputLimit(ch) => {
+                raw.push(VendorCmd::INPUT_LIMIT);
+                raw.push(*ch);
+            }
+            VendorCmd::MicPower(ch) => {
+                raw.push(VendorCmd::MIC_POWER);
+                raw.push(*ch);
+            }
+            VendorCmd::IoAttr(ch, direction) => {
+                raw.push(VendorCmd::IO_ATTR);
+                raw.push(*ch);
+                raw.push(*direction);
+            }
+            VendorCmd::IoRouting(dst) => {
+                raw.push(VendorCmd::IO_ROUTING);
+                raw.push(*dst);
+            }
+            VendorCmd::Hw(op) => {
+                raw.push(VendorCmd::HW);
+                raw.push(u8::from(*op));
+            }
+            VendorCmd::HpSrc(dst) => {
+                raw.push(VendorCmd::HP_SRC);
+                raw.push((*dst + 1) % 2);
+            }
+            VendorCmd::MixerSrc0(pair) => {
+                raw.push(VendorCmd::MIXER_SRC0);
+                raw.push(*pair);
+            }
+            VendorCmd::MixerSrc1(pair) => {
+                raw.push(VendorCmd::MIXER_SRC1);
+                raw.push(*pair);
+            }
+            VendorCmd::MixerSrc2(pair) => {
+                raw.push(VendorCmd::MIXER_SRC2);
+                raw.push(*pair);
+            }
+            VendorCmd::MixerSrc3(pair) => {
+                raw.push(VendorCmd::MIXER_SRC3);
+                raw.push(*pair);
+            }
+            VendorCmd::MicGain(target) => {
+                raw.push(VendorCmd::IN_VOL);
+                raw.push(*target);
+            }
+            VendorCmd::OptIfaceMode(direction) => {
+                raw.push(VendorCmd::OPT_IFACE_MODE);
+                raw.push(*direction);
+            }
+            VendorCmd::Downgrade => {
+                raw.push(VendorCmd::DOWNGRADE);
+            }
+            VendorCmd::SpdifResample => {
+                raw.push(VendorCmd::SPDIF_RESAMPLE);
+            }
+            VendorCmd::MicPolarity(ch) => {
+                raw.push(VendorCmd::MIC_POLARITY);
+                raw.push(*ch);
+            }
+            VendorCmd::OutVol(target) => {
+                raw.push(VendorCmd::OUT_VOL);
+                raw.push(*target);
+            }
+            VendorCmd::HwStatus(is_long) => {
+                raw.push(VendorCmd::HW_STATUS);
+                raw.push(*is_long as u8);
+            }
+            VendorCmd::Reserved(r) => raw.extend_from_slice(&r),
+        }
+
+        raw
+    }
+}
+
+impl From<&[u8]> for VendorCmd {
+    fn from(raw: &[u8]) -> VendorCmd {
+        match raw[0] {
+            VendorCmd::INPUT_LIMIT => VendorCmd::InputLimit(raw[1]),
+            VendorCmd::MIC_POWER => VendorCmd::MicPower(raw[1]),
+            VendorCmd::IO_ATTR => VendorCmd::IoAttr(raw[1], raw[2]),
+            VendorCmd::IO_ROUTING => VendorCmd::IoRouting(raw[1]),
+            VendorCmd::HW => VendorCmd::Hw(HwCmdOp::from(raw[1])),
+            VendorCmd::HP_SRC => VendorCmd::HpSrc((raw[1] + 1) % 2),
+            VendorCmd::MIXER_SRC0 => VendorCmd::MixerSrc0(raw[1]),
+            VendorCmd::MIXER_SRC1 => VendorCmd::MixerSrc1(raw[1]),
+            VendorCmd::MIXER_SRC2 => VendorCmd::MixerSrc2(raw[1]),
+            VendorCmd::MIXER_SRC3 => VendorCmd::MixerSrc3(raw[1]),
+            VendorCmd::OPT_IFACE_MODE => VendorCmd::OptIfaceMode(raw[1]),
+            VendorCmd::DOWNGRADE => VendorCmd::Downgrade,
+            VendorCmd::SPDIF_RESAMPLE => VendorCmd::SpdifResample,
+            VendorCmd::MIC_POLARITY => VendorCmd::MicPolarity(raw[1]),
+            VendorCmd::OUT_VOL => VendorCmd::OutVol(raw[1]),
+            VendorCmd::HW_STATUS => VendorCmd::HwStatus(raw[1] > 0),
+            _ => VendorCmd::Reserved(raw.to_vec()),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HwCmdOp {
+    StreamMode,
+    DisplayIlluminate,
+    DisplayMode,
+    DisplayTarget,
+    DisplayOverhold,
+    MeterReset,
+    CdMode,
+    Reserved(u8),
+}
+
+impl HwCmdOp {
+    // NOTE: STREAM_MODE command generates bus reset to change available stream formats.
+    const STREAM_MODE: u8 = 0x06;
+    const DISPLAY_ILLUMINATE: u8 = 0x08;
+    const DISPLAY_MODE: u8 = 0x09;
+    const DISPLAY_TARGET: u8 = 0x0a;
+    const DISPLAY_OVERHOLD: u8 = 0x0e;
+    const METER_RESET: u8 = 0x0f;
+    const CD_MODE: u8 = 0xf5;
+}
+
+impl From<HwCmdOp> for u8 {
+    fn from(op: HwCmdOp) -> Self {
+        match op {
+            HwCmdOp::StreamMode => HwCmdOp::STREAM_MODE,
+            HwCmdOp::DisplayIlluminate => HwCmdOp::DISPLAY_ILLUMINATE,
+            HwCmdOp::DisplayMode => HwCmdOp::DISPLAY_MODE,
+            HwCmdOp::DisplayTarget => HwCmdOp::DISPLAY_TARGET,
+            HwCmdOp::DisplayOverhold => HwCmdOp::DISPLAY_OVERHOLD,
+            HwCmdOp::MeterReset => HwCmdOp::METER_RESET,
+            HwCmdOp::CdMode => HwCmdOp::CD_MODE,
+            HwCmdOp::Reserved(val) => val,
+        }
+    }
+}
+
+impl From<u8> for HwCmdOp {
+    fn from(val: u8) -> HwCmdOp {
+        match val {
+            HwCmdOp::STREAM_MODE => HwCmdOp::StreamMode,
+            HwCmdOp::DISPLAY_ILLUMINATE => HwCmdOp::DisplayIlluminate,
+            HwCmdOp::DISPLAY_MODE => HwCmdOp::DisplayMode,
+            HwCmdOp::DISPLAY_TARGET => HwCmdOp::DisplayTarget,
+            HwCmdOp::DISPLAY_OVERHOLD => HwCmdOp::DisplayOverhold,
+            HwCmdOp::METER_RESET => HwCmdOp::MeterReset,
+            HwCmdOp::CD_MODE => HwCmdOp::CdMode,
+            _ => HwCmdOp::Reserved(val),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct ApogeeCmd{
+    pub cmd: VendorCmd,
+    pub params: Vec<u8>,
+    op: VendorDependent,
+}
+
+impl ApogeeCmd {
+    pub fn new(company_id: &[u8;3], cmd: VendorCmd, params: &[u8]) -> Self {
+        ApogeeCmd{
+            cmd,
+            params: params.to_vec(),
+            op: VendorDependent::new(company_id),
+        }
+    }
+}
+
+impl AvcOp for ApogeeCmd {
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+impl AvcControl for ApogeeCmd {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        self.op.data.clear();
+        self.op.data.append(&mut Into::<Vec<u8>>::into(&self.cmd));
+        self.op.data.append(&mut self.params.clone());
+
+        // At least, 6 bytes should be required to align to 3 quadlets. Unless, the target unit is freezed.
+        while self.op.data.len() < 6 {
+            self.op.data.push(0xff);
+        }
+
+        AvcControl::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)?;
+
+        // NOTE: parameters are retrieved by HwStatus command only.
+        let cmd = VendorCmd::from(self.op.data.as_slice());
+        if let VendorCmd::HwStatus(_) = cmd {
+            self.params = self.op.data[Into::<Vec<u8>>::into(&cmd).len()..].to_vec();
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{VendorCmd, HwCmdOp, ApogeeCmd};
+    use crate::ta1394::AvcAddr;
+    use crate::ta1394::AvcControl;
+
+    #[test]
+    fn vendorcmd_from() {
+        let cmd = VendorCmd::InputLimit(1);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MicPower(1);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::IoAttr(1, 0);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::IoRouting(1);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::Hw(HwCmdOp::StreamMode);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::HpSrc(1);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MixerSrc0(3);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MixerSrc1(2);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MixerSrc2(1);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MixerSrc3(0);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::OptIfaceMode(0);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::Downgrade;
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::SpdifResample;
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::MicPolarity(0);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::OutVol(0);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+
+        let cmd = VendorCmd::HwStatus(true);
+        assert_eq!(cmd, VendorCmd::from(Into::<Vec<u8>>::into(&cmd).as_slice()));
+    }
+
+    #[test]
+    fn apogeecmd_operands() {
+        let operands = vec![0xde, 0xad, 0xbe, 0xef, 0x03, 0x02];
+        let mut op = ApogeeCmd::new(&[0xc0, 0xfe, 0xe1], VendorCmd::IoRouting(0x03), &[0x02]);
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.params, vec![0x02]);
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(&o[..6], operands.as_slice());
+
+        let operands = vec![0xde, 0xad, 0xbe, 0xf3, 0x01, 0x02, 0x03, 0x04];
+        let mut op = ApogeeCmd::new(&[0xde, 0xad, 0xbe], VendorCmd::SpdifResample, &[0x01, 0x02, 0x03, 0x04]);
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.params, vec![0x01, 0x02, 0x03, 0x04]);
+        let mut o = Vec::new();
+        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        assert_eq!(&o[..8], operands.as_slice());
+    }
+}

--- a/src/bebob/behringer.rs
+++ b/src/bebob/behringer.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub mod firepower_model;

--- a/src/bebob/behringer/firepower_model.rs
+++ b/src/bebob/behringer/firepower_model.rs
@@ -74,3 +74,20 @@ impl<'a> CtlModel<hinawa::SndUnit> for FirepowerModel<'a> {
         }
     }
 }
+
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for FirepowerModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/bebob/behringer/firepower_model.rs
+++ b/src/bebob/behringer/firepower_model.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+use card_cntr::CtlModel;
+
+pub struct FirepowerModel;
+
+impl FirepowerModel {
+    pub fn new() -> Self {
+        FirepowerModel{}
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for FirepowerModel {
+    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/common_ctls.rs
+++ b/src/bebob/common_ctls.rs
@@ -1,0 +1,177 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndUnitExt;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr::CardCntr;
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat};
+use crate::ta1394::amdtp::{AmdtpEventType, AmdtpFdf, FMT_IS_AMDTP};
+use crate::ta1394::ccm::{SignalSource, SignalAddr};
+
+use super::extensions::{BcoPlugDirection, BcoPlugAddr, BcoPlugAddrUnitType};
+use super::extensions::{ExtendedStreamFormatSingle, ExtendedStreamFormatList};
+
+use super::model::{CLK_RATE_NAME, CLK_SRC_NAME};
+
+pub struct ClkCtl<'a> {
+    supported_clk_rates: Vec<u32>,
+    clk_dst: &'a SignalAddr,
+    clk_srcs: &'a [SignalAddr],
+    clk_src_labels: &'a [&'a str],
+}
+
+impl<'a> ClkCtl<'a> {
+    pub fn new(clk_dst: &'a SignalAddr, clk_srcs: &'a [SignalAddr], clk_src_labels: &'a [&'a str]) -> Self {
+        ClkCtl{
+            supported_clk_rates: Vec::new(),
+            clk_dst,
+            clk_srcs,
+            clk_src_labels,
+        }
+    }
+
+    pub fn load<O>(&mut self, avc: &O, card_cntr: &mut CardCntr, timeout_ms: u32) -> Result<(), Error>
+        where O: Ta1394Avc
+    {
+        let mut input_formats = Vec::new();
+        let mut output_formats = Vec::new();
+
+        // Detect stream formats for input/output direction.
+        [BcoPlugDirection::Input, BcoPlugDirection::Output].iter().try_for_each(|direction| {
+            let entries = match *direction {
+                BcoPlugDirection::Input => &mut input_formats,
+                BcoPlugDirection::Output => &mut output_formats,
+                BcoPlugDirection::Reserved(_) => unreachable!(),
+            };
+            let plug_addr = BcoPlugAddr::new_for_unit(*direction, BcoPlugAddrUnitType::Isoc, 0);
+            let _ = (0..0xff).try_for_each(|index| {
+                let mut op = ExtendedStreamFormatList::new(&plug_addr, index);
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                let format = op.stream_format.as_bco_compound_am824_stream()?;
+                entries.push(format.clone());
+                Ok::<(), Error>(())
+            });
+            Ok(())
+        })?;
+
+        // Scan available sampling frequencies.
+        input_formats.iter().for_each(|entry| {
+            if self.supported_clk_rates.iter().position(|r| entry.freq == *r).is_none() {
+                self.supported_clk_rates.push(entry.freq);
+            }
+        });
+        output_formats.iter().for_each(|entry| {
+            if self.supported_clk_rates.iter().position(|r| entry.freq == *r).is_none() {
+                self.supported_clk_rates.push(entry.freq);
+            }
+        });
+
+        // Create labels.
+        let labels = self.supported_clk_rates.iter().map(|r| r.to_string()).collect::<Vec<String>>();
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, CLK_RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        if self.clk_srcs.len() > 1 {
+            // NOTE: all of bebob models support "SignalAddr::Unit(SignalUnitAddr::Isoc(0x00))"
+            // named as "PCR Compound Input" and "SignalAddr::Unit(SignalUnitAddr::Isoc(0x01))"
+            // named as "PCR Sync Input" for source of sampling clock. They are available to be
+            // synchronized to the series of syt field in incoming packets from the other unit on
+            // IEEE 1394 bus. However, the most of models doesn't work with it actually even if
+            // configured, therefore useless.
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, CLK_SRC_NAME, 0);
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.clk_src_labels, None, true)?;
+        }
+
+        Ok(())
+    }
+
+    pub fn read<O>(&mut self, avc: &O, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue,
+                   timeout_ms: u32)
+        -> Result<bool, Error>
+        where O: Ta1394Avc
+    {
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                let plug_addr = BcoPlugAddr::new_for_unit(BcoPlugDirection::Output, BcoPlugAddrUnitType::Isoc, 0);
+                let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                let format = op.stream_format.as_bco_compound_am824_stream()?;
+                match self.supported_clk_rates.iter().position(|r| *r == format.freq) {
+                    Some(idx) => {
+                        elem_value.set_enum(&[idx as u32]);
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
+            }
+            CLK_SRC_NAME => {
+                let mut op = SignalSource::new(self.clk_dst);
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
+                match self.clk_srcs.iter().position(|s| *s == op.src) {
+                    Some(idx) => {
+                        elem_value.set_enum(&[idx as u32]);
+                        Ok(true)
+                    }
+                    None => Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write<O>(&mut self, unit: &hinawa::SndUnit, avc: &O, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue, mut timeout_ms: u32)
+        -> Result<bool, Error>
+        where O: Ta1394Avc
+    {
+        // NOTE: Interim at first, then Accepted or Implemented/Stable.
+        timeout_ms *= 2;
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let freq = self.supported_clk_rates[vals[0] as usize];
+                let fdf = AmdtpFdf::new(AmdtpEventType::Am824, false, freq);
+                unit.lock()?;
+                let mut op = InputPlugSignalFormat{
+                    plug_id: 0,
+                    fmt: FMT_IS_AMDTP,
+                    fdf: fdf.into(),
+                };
+                let mut res = avc.control(&AvcAddr::Unit, &mut op, timeout_ms);
+                if res.is_ok() {
+                    let mut op = OutputPlugSignalFormat{
+                        plug_id: 0,
+                        fmt: FMT_IS_AMDTP,
+                        fdf: fdf.into(),
+                    };
+                    res = avc.control(&AvcAddr::Unit, &mut op, timeout_ms);
+                }
+                let _ = unit.unlock();
+                res.and(Ok(true))
+            }
+            CLK_SRC_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                match self.clk_srcs.iter().nth(vals[0] as usize) {
+                    Some(src) => {
+                        let mut op = SignalSource::new(self.clk_dst);
+                        op.src = *src;
+                        unit.lock()?;
+                        let res = avc.control(&AvcAddr::Unit, &mut op, timeout_ms);
+                        let _ = unit.unlock();
+                        res.and(Ok(true))
+                    }
+                    None => Ok(false),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/bebob/common_ctls.rs
+++ b/src/bebob/common_ctls.rs
@@ -23,6 +23,7 @@ pub struct ClkCtl<'a> {
     clk_dst: &'a SignalAddr,
     clk_srcs: &'a [SignalAddr],
     clk_src_labels: &'a [&'a str],
+    pub notified_elem_list: Vec<alsactl::ElemId>,
 }
 
 impl<'a> ClkCtl<'a> {
@@ -32,6 +33,7 @@ impl<'a> ClkCtl<'a> {
             clk_dst,
             clk_srcs,
             clk_src_labels,
+            notified_elem_list: Vec::new(),
         }
     }
 
@@ -75,7 +77,8 @@ impl<'a> ClkCtl<'a> {
         let labels = self.supported_clk_rates.iter().map(|r| r.to_string()).collect::<Vec<String>>();
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, CLK_RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        self.notified_elem_list.append(&mut elem_id_list);
 
         if self.clk_srcs.len() > 1 {
             // NOTE: all of bebob models support "SignalAddr::Unit(SignalUnitAddr::Isoc(0x00))"
@@ -85,7 +88,8 @@ impl<'a> ClkCtl<'a> {
             // IEEE 1394 bus. However, the most of models doesn't work with it actually even if
             // configured, therefore useless.
             let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, CLK_SRC_NAME, 0);
-            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.clk_src_labels, None, true)?;
+            let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &self.clk_src_labels, None, true)?;
+            self.notified_elem_list.append(&mut elem_id_list);
         }
 
         Ok(())

--- a/src/bebob/extensions.rs
+++ b/src/bebob/extensions.rs
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//
+// Bco Extended Plug Info command
+//
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoPlugAddrUnitType {
+    Isoc,
+    Ext,
+    Async,
+    Reserved(u8),
+}
+
+impl BcoPlugAddrUnitType {
+    const ISOC: u8 = 0x00;
+    const EXT: u8 = 0x01;
+    const ASYNC: u8 = 0x02;
+}
+
+impl From<u8> for BcoPlugAddrUnitType {
+    fn from(val: u8) -> Self {
+        match val {
+            BcoPlugAddrUnitType::ISOC => BcoPlugAddrUnitType::Isoc,
+            BcoPlugAddrUnitType::EXT => BcoPlugAddrUnitType::Ext,
+            BcoPlugAddrUnitType::ASYNC => BcoPlugAddrUnitType::Async,
+            _ => BcoPlugAddrUnitType::Reserved(val),
+        }
+    }
+}
+
+impl From<BcoPlugAddrUnitType> for u8 {
+    fn from(unit_type: BcoPlugAddrUnitType) -> u8 {
+        match unit_type {
+            BcoPlugAddrUnitType::Isoc => BcoPlugAddrUnitType::ISOC,
+            BcoPlugAddrUnitType::Ext => BcoPlugAddrUnitType::EXT,
+            BcoPlugAddrUnitType::Async => BcoPlugAddrUnitType::ASYNC,
+            BcoPlugAddrUnitType::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoPlugAddrUnit{
+    pub plug_type: BcoPlugAddrUnitType,
+    pub plug_id: u8,
+}
+
+impl From<&[u8;3]> for BcoPlugAddrUnit {
+    fn from(raw: &[u8;3]) -> Self {
+        BcoPlugAddrUnit{
+            plug_type: BcoPlugAddrUnitType::from(raw[0]),
+            plug_id: raw[1],
+        }
+    }
+}
+
+impl From<&BcoPlugAddrUnit> for [u8;3] {
+    fn from(data: &BcoPlugAddrUnit) -> Self {
+        [data.plug_type.into(), data.plug_id.into(), 0xff]
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoPlugAddrSubunit{
+    pub plug_id: u8,
+}
+
+impl From<&[u8;3]> for BcoPlugAddrSubunit {
+    fn from(raw: &[u8;3]) -> Self {
+        BcoPlugAddrSubunit{
+            plug_id: raw[0],
+        }
+    }
+}
+
+impl From<&BcoPlugAddrSubunit> for [u8;3] {
+    fn from(data: &BcoPlugAddrSubunit) -> Self {
+        [data.plug_id, 0xff, 0xff]
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoPlugAddrFuncBlk{
+    pub func_blk_type: u8,
+    pub func_blk_id: u8,
+    pub plug_id: u8,
+}
+
+impl From<&[u8;3]> for BcoPlugAddrFuncBlk {
+    fn from(raw: &[u8;3]) -> Self {
+        BcoPlugAddrFuncBlk{
+            func_blk_type: raw[0],
+            func_blk_id: raw[1],
+            plug_id: raw[2],
+        }
+    }
+}
+
+impl From<&BcoPlugAddrFuncBlk> for [u8;3] {
+    fn from(data: &BcoPlugAddrFuncBlk) -> Self {
+        [data.func_blk_type, data.func_blk_id, data.plug_id]
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoPlugAddrMode {
+    Unit(BcoPlugAddrUnit),
+    Subunit(BcoPlugAddrSubunit),
+    FuncBlk(BcoPlugAddrFuncBlk),
+    Reserved([u8;4]),
+}
+
+impl BcoPlugAddrMode {
+    const UNIT: u8 = 0x00;
+    const SUBUNIT: u8 = 0x01;
+    const FUNCBLK: u8 = 0x02;
+}
+
+impl From<&[u8;4]> for BcoPlugAddrMode {
+    fn from(raw: &[u8;4]) -> Self {
+        let mut r = [0;3];
+        r.copy_from_slice(&raw[1..]);
+        match raw[0] {
+            BcoPlugAddrMode::UNIT => BcoPlugAddrMode::Unit(BcoPlugAddrUnit::from(&r)),
+            BcoPlugAddrMode::SUBUNIT => BcoPlugAddrMode::Subunit(BcoPlugAddrSubunit::from(&r)),
+            BcoPlugAddrMode::FUNCBLK => BcoPlugAddrMode::FuncBlk(BcoPlugAddrFuncBlk::from(&r)),
+            _ => BcoPlugAddrMode::Reserved(*raw),
+        }
+    }
+}
+
+impl From<&BcoPlugAddrMode> for [u8;4] {
+    fn from(data: &BcoPlugAddrMode) -> Self {
+        let mut raw = [0;4];
+        match data {
+            BcoPlugAddrMode::Unit(d) => {
+                raw[0] = BcoPlugAddrMode::UNIT;
+                raw[1..].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoPlugAddrMode::Subunit(d) => {
+                raw[0] = BcoPlugAddrMode::SUBUNIT;
+                raw[1..].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoPlugAddrMode::FuncBlk(d) => {
+                raw[0] = BcoPlugAddrMode::FUNCBLK;
+                raw[1..].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoPlugAddrMode::Reserved(d) => {
+                raw.copy_from_slice(d);
+            }
+        }
+        raw
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoPlugDirection {
+    Input,
+    Output,
+    Reserved(u8),
+}
+
+impl BcoPlugDirection {
+    const INPUT: u8 = 0x00;
+    const OUTPUT: u8 = 0x01;
+}
+
+impl From<u8> for BcoPlugDirection {
+    fn from(val: u8) -> Self {
+        match val {
+            BcoPlugDirection::INPUT => BcoPlugDirection::Input,
+            BcoPlugDirection::OUTPUT => BcoPlugDirection::Output,
+            _ => BcoPlugDirection::Reserved(val),
+        }
+    }
+}
+
+impl From<BcoPlugDirection> for u8 {
+    fn from(direction: BcoPlugDirection) -> u8 {
+        match direction {
+            BcoPlugDirection::Input => BcoPlugDirection::INPUT,
+            BcoPlugDirection::Output => BcoPlugDirection::OUTPUT,
+            BcoPlugDirection::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoPlugAddr{
+    pub direction: BcoPlugDirection,
+    pub mode: BcoPlugAddrMode,
+}
+
+impl BcoPlugAddr {
+    pub fn new_for_unit(direction: BcoPlugDirection, plug_type: BcoPlugAddrUnitType,
+                        plug_id: u8) -> Self {
+        BcoPlugAddr{
+            direction,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type,
+                plug_id,
+            }),
+        }
+    }
+
+    pub fn new_for_subunit(direction: BcoPlugDirection, plug_id: u8) -> Self {
+        BcoPlugAddr{
+            direction,
+            mode: BcoPlugAddrMode::Subunit(BcoPlugAddrSubunit{
+                plug_id,
+            }),
+        }
+    }
+
+    pub fn new_for_func_blk(direction: BcoPlugDirection, func_blk_type: u8,
+                            func_blk_id: u8, plug_id: u8) -> Self {
+        BcoPlugAddr{
+            direction,
+            mode: BcoPlugAddrMode::FuncBlk(BcoPlugAddrFuncBlk{
+                func_blk_type,
+                func_blk_id,
+                plug_id,
+            }),
+        }
+    }
+}
+
+impl From<&[u8;5]> for BcoPlugAddr {
+    fn from(raw: &[u8;5]) -> Self {
+        let mut r = [0;4];
+        r.copy_from_slice(&raw[1..]);
+        BcoPlugAddr{
+            direction: BcoPlugDirection::from(raw[0]),
+            mode: BcoPlugAddrMode::from(&r),
+        }
+    }
+}
+
+impl From<&BcoPlugAddr> for [u8;5] {
+    fn from(data: &BcoPlugAddr) -> [u8;5] {
+        let mut raw = [0;5];
+        raw[0] = data.direction.into();
+        raw[1..].copy_from_slice(&Into::<[u8;4]>::into(&data.mode));
+        raw
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{BcoPlugAddr, BcoPlugAddrMode, BcoPlugDirection};
+    use super::BcoPlugAddrUnitType;
+
+    #[test]
+    fn bcoplugaddr_from() {
+        // Input plug for Unit.
+        let raw = [0x00, 0x00, 0x00, 0x03, 0xff];
+        let addr = BcoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Input);
+        if let BcoPlugAddrMode::Unit(d) = &addr.mode {
+            assert_eq!(d.plug_type, BcoPlugAddrUnitType::Isoc);
+            assert_eq!(d.plug_id, 0x03);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;5]>::into(&addr));
+
+        // Output plug for Subunit.
+        let raw = [0x01, 0x01, 0x04, 0xff, 0xff];
+        let addr = BcoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Output);
+        if let BcoPlugAddrMode::Subunit(d) = &addr.mode {
+            assert_eq!(d.plug_id, 0x04);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;5]>::into(&addr));
+
+        // Input plug for function block.
+        let raw = [0x02, 0x02, 0x06, 0x03, 0x02];
+        let addr = BcoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Reserved(0x02));
+        if let BcoPlugAddrMode::FuncBlk(d) = &addr.mode {
+            assert_eq!(d.func_blk_type, 0x06);
+            assert_eq!(d.func_blk_id, 0x03);
+            assert_eq!(d.plug_id, 0x02);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;5]>::into(&addr));
+    }
+}

--- a/src/bebob/extensions.rs
+++ b/src/bebob/extensions.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+use crate::ta1394::{AvcAddr, AvcAddrSubunit, AvcSubunitType, Ta1394AvcError};
+use crate::ta1394::{AvcOp, AvcStatus};
+use crate::ta1394::general::PlugInfo;
 
 //
 // Bco Extended Plug Info command
@@ -246,10 +250,618 @@ impl From<&BcoPlugAddr> for [u8;5] {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoIoPlugAddrMode {
+    Unit(BcoPlugAddrUnit),
+    Subunit(AvcAddrSubunit, BcoPlugAddrSubunit),
+    FuncBlk(AvcAddrSubunit, BcoPlugAddrFuncBlk),
+    Reserved([u8;6]),
+}
+
+impl From<&[u8;6]> for BcoIoPlugAddrMode {
+    fn from(raw: &[u8;6]) -> Self {
+        let mut r = [0;3];
+        match raw[0] {
+            BcoPlugAddrMode::UNIT => {
+                r.copy_from_slice(&raw[1..4]);
+                BcoIoPlugAddrMode::Unit(BcoPlugAddrUnit::from(&r))
+            }
+            BcoPlugAddrMode::SUBUNIT => {
+                let subunit = AvcAddrSubunit{
+                    subunit_type: AvcSubunitType::from(raw[1]),
+                    subunit_id: raw[2],
+                };
+                r.copy_from_slice(&raw[3..6]);
+                BcoIoPlugAddrMode::Subunit(subunit, BcoPlugAddrSubunit::from(&r))
+            }
+            BcoPlugAddrMode::FUNCBLK => {
+                let subunit = AvcAddrSubunit{
+                    subunit_type: AvcSubunitType::from(raw[1]),
+                    subunit_id: raw[2],
+                };
+                r.copy_from_slice(&raw[3..6]);
+                BcoIoPlugAddrMode::FuncBlk(subunit, BcoPlugAddrFuncBlk::from(&r))
+            }
+            _ => BcoIoPlugAddrMode::Reserved(*raw),
+        }
+    }
+}
+
+impl From<&BcoIoPlugAddrMode> for [u8;6] {
+    fn from(data: &BcoIoPlugAddrMode) -> Self {
+        let mut raw = [0xff;6];
+        match data {
+            BcoIoPlugAddrMode::Unit(d) => {
+                raw[0] = BcoPlugAddrMode::UNIT;
+                raw[1..4].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoIoPlugAddrMode::Subunit(s, d) => {
+                raw[0] = BcoPlugAddrMode::SUBUNIT;
+                raw[1] = s.subunit_type.into();
+                raw[2] = s.subunit_id;
+                raw[3..6].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoIoPlugAddrMode::FuncBlk(s, d) => {
+                raw[0] = BcoPlugAddrMode::FUNCBLK;
+                raw[1] = s.subunit_type.into();
+                raw[2] = s.subunit_id;
+                raw[3..6].copy_from_slice(&Into::<[u8;3]>::into(d));
+            }
+            BcoIoPlugAddrMode::Reserved(d) => {
+                raw.copy_from_slice(d);
+            }
+        }
+        raw
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoIoPlugAddr{
+    pub direction: BcoPlugDirection,
+    pub mode: BcoIoPlugAddrMode,
+}
+
+impl From<&[u8;7]> for BcoIoPlugAddr {
+    fn from(raw: &[u8;7]) -> Self {
+        let mut r = [0;6];
+        r.copy_from_slice(&raw[1..]);
+        BcoIoPlugAddr{
+            direction: BcoPlugDirection::from(raw[0]),
+            mode: BcoIoPlugAddrMode::from(&r),
+        }
+    }
+}
+
+impl From<&BcoIoPlugAddr> for [u8;7] {
+    fn from(data: &BcoIoPlugAddr) -> [u8;7] {
+        let mut raw = [0;7];
+        raw[0] = data.direction.into();
+        raw[1..].copy_from_slice(&Into::<[u8;6]>::into(&data.mode));
+        raw
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoPlugType {
+    Isoc,
+    Async,
+    Midi,
+    Sync,
+    Analog,
+    Digital,
+    Reserved(u8),
+}
+
+impl BcoPlugType {
+    const ISOC_STREAM: u8 = 0x00;
+    const ASYNC_STREAM: u8 = 0x01;
+    const MIDI: u8 = 0x02;
+    const SYNC: u8 = 0x03;
+    const ANALOG: u8 = 0x04;
+    const DIGITAL: u8 = 0x05;
+}
+
+impl From<u8> for BcoPlugType {
+    fn from(val: u8) -> Self {
+        match val {
+            BcoPlugType::ISOC_STREAM => BcoPlugType::Isoc,
+            BcoPlugType::ASYNC_STREAM => BcoPlugType::Async,
+            BcoPlugType::MIDI => BcoPlugType::Midi,
+            BcoPlugType::SYNC => BcoPlugType::Sync,
+            BcoPlugType::ANALOG => BcoPlugType::Analog,
+            BcoPlugType::DIGITAL => BcoPlugType::Digital,
+            _ => BcoPlugType::Reserved(val),
+        }
+    }
+}
+
+impl From<BcoPlugType> for u8 {
+    fn from(plug_type: BcoPlugType) -> u8 {
+        match plug_type {
+            BcoPlugType::Isoc => BcoPlugType::ISOC_STREAM,
+            BcoPlugType::Async => BcoPlugType::ASYNC_STREAM,
+            BcoPlugType::Midi => BcoPlugType::MIDI,
+            BcoPlugType::Sync => BcoPlugType::SYNC,
+            BcoPlugType::Analog => BcoPlugType::ANALOG,
+            BcoPlugType::Digital => BcoPlugType::DIGITAL,
+            BcoPlugType::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoLocation{
+    LeftFront,
+    RightFront,
+    Center,
+    LowFrequencyEffect,
+    LeftSurround,
+    RightSurround,
+    LeftCenter,
+    RightCenter,
+    Surround,
+    SideLeft,
+    SideRight,
+    Top,
+    Bottom,
+    LeftFrontEffect,
+    RightFrontEffect,
+    Reserved(u8),
+}
+
+impl BcoLocation {
+    const L: u8 = 0x01;
+    const R: u8 = 0x02;
+    const C: u8 = 0x03;
+    const LFE: u8 = 0x04;
+    const LS: u8 = 0x05;
+    const RS: u8 = 0x06;
+    const LC: u8 = 0x07;
+    const RC: u8 = 0x08;
+    const S: u8 = 0x09;
+    const SL: u8 = 0x0a;
+    const SR: u8 = 0x0b;
+    const T: u8 = 0x0c;
+    const B: u8 = 0x0d;
+    const FEL: u8 = 0x0e;
+    const FER: u8 = 0x0f;
+}
+
+impl From<u8> for BcoLocation {
+    fn from(val: u8) -> Self {
+        match val {
+            BcoLocation::L => BcoLocation::LeftFront,
+            BcoLocation::R => BcoLocation::RightFront,
+            BcoLocation::C => BcoLocation::Center,
+            BcoLocation::LFE => BcoLocation::LowFrequencyEffect,
+            BcoLocation::LS => BcoLocation::LeftSurround,
+            BcoLocation::RS => BcoLocation::RightSurround,
+            BcoLocation::LC => BcoLocation::LeftCenter,
+            BcoLocation::RC => BcoLocation::RightCenter,
+            BcoLocation::S => BcoLocation::Surround,
+            BcoLocation::SL => BcoLocation::SideLeft,
+            BcoLocation::SR => BcoLocation::SideRight,
+            BcoLocation::T => BcoLocation::Top,
+            BcoLocation::B => BcoLocation::Bottom,
+            BcoLocation::FEL => BcoLocation::LeftFrontEffect,
+            BcoLocation::FER => BcoLocation::RightFrontEffect,
+            _ => BcoLocation::Reserved(val),
+        }
+    }
+}
+
+impl From<BcoLocation> for u8 {
+    fn from(loc: BcoLocation) -> Self {
+        match loc {
+            BcoLocation::LeftFront => BcoLocation::L,
+            BcoLocation::RightFront => BcoLocation::R,
+            BcoLocation::Center => BcoLocation::C,
+            BcoLocation::LowFrequencyEffect => BcoLocation::LFE,
+            BcoLocation::LeftSurround => BcoLocation::LS,
+            BcoLocation::RightSurround => BcoLocation::RS,
+            BcoLocation::LeftCenter => BcoLocation::LC,
+            BcoLocation::RightCenter => BcoLocation::RC,
+            BcoLocation::Surround => BcoLocation::S,
+            BcoLocation::SideLeft => BcoLocation::SL,
+            BcoLocation::SideRight => BcoLocation::SR,
+            BcoLocation::Top => BcoLocation::T,
+            BcoLocation::Bottom => BcoLocation::B,
+            BcoLocation::LeftFrontEffect => BcoLocation::FEL,
+            BcoLocation::RightFrontEffect => BcoLocation::FER,
+            BcoLocation::Reserved(val) => val,
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct BcoChannelInfo{
+    pos: u8,
+    loc: BcoLocation,
+}
+
+impl From<&BcoChannelInfo> for [u8;2] {
+    fn from(data: &BcoChannelInfo) -> Self {
+        let mut raw = [0;2];
+        raw[0] = data.pos;
+        raw[1] = data.loc.into();
+        raw
+    }
+}
+
+impl From<&[u8;2]> for BcoChannelInfo {
+    fn from(raw: &[u8;2]) -> Self {
+        BcoChannelInfo{
+            pos: raw[0],
+            loc: BcoLocation::from(raw[1])
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BcoCluster{
+    entries: Vec<BcoChannelInfo>,
+}
+
+impl From<&[u8]> for BcoCluster{
+    fn from(raw: &[u8]) -> Self {
+        let count = raw[0] as usize;
+        BcoCluster{
+            entries: (0..count).map(|i| {
+                let mut r = [0;2];
+                let pos = 1 + i * 2;
+                r.copy_from_slice(&raw[pos..(pos + 2)]);
+                BcoChannelInfo::from(&r)
+            }).collect(),
+        }
+    }
+}
+
+impl From<&BcoCluster> for Vec<u8> {
+    fn from(data: &BcoCluster) -> Self {
+        let mut raw = Vec::new();
+        raw.push(data.entries.len() as u8);
+        data.entries.iter().fold(raw, |mut raw, entry| {
+            raw.extend_from_slice(&Into::<[u8;2]>::into(entry));
+            raw
+        })
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BcoChannelName{
+    pub ch: u8,
+    pub name: String,
+}
+
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum BcoPortType {
+    Speaker,
+    Headphone,
+    Microphone,
+    Line,
+    Spdif,
+    Adat,
+    Tdif,
+    Madi,
+    Analog,
+    Digital,
+    Midi,
+    Reserved(u8),
+}
+
+impl BcoPortType {
+    const SPEAKER: u8 = 0x00;
+    const HEADPHONE: u8 = 0x01;
+    const MICROPHONE: u8 = 0x02;
+    const LINE: u8 = 0x03;
+    const SPDIF: u8 = 0x04;
+    const ADAT: u8 = 0x05;
+    const TDIF: u8 = 0x06;
+    const MADI: u8 = 0x07;
+    const ANALOG: u8 = 0x08;
+    const DIGITAL: u8 = 0x09;
+    const MIDI: u8 = 0x0a;
+}
+
+impl From<BcoPortType> for u8 {
+    fn from(port_type: BcoPortType) -> Self {
+        match port_type {
+            BcoPortType::Speaker => BcoPortType::SPEAKER,
+            BcoPortType::Headphone => BcoPortType::HEADPHONE,
+            BcoPortType::Microphone => BcoPortType::MICROPHONE,
+            BcoPortType::Line => BcoPortType::LINE,
+            BcoPortType::Spdif => BcoPortType::SPDIF,
+            BcoPortType::Adat => BcoPortType::ADAT,
+            BcoPortType::Tdif => BcoPortType::TDIF,
+            BcoPortType::Madi => BcoPortType::MADI,
+            BcoPortType::Analog => BcoPortType::ANALOG,
+            BcoPortType::Digital => BcoPortType::DIGITAL,
+            BcoPortType::Midi => BcoPortType::MIDI,
+            BcoPortType::Reserved(val) => val,
+        }
+    }
+}
+
+impl From<u8> for BcoPortType {
+    fn from(val: u8) -> Self {
+        match val {
+            BcoPortType::SPEAKER => BcoPortType::Speaker,
+            BcoPortType::HEADPHONE => BcoPortType::Headphone,
+            BcoPortType::MICROPHONE => BcoPortType::Microphone,
+            BcoPortType::LINE => BcoPortType::Line,
+            BcoPortType::SPDIF => BcoPortType::Spdif,
+            BcoPortType::ADAT => BcoPortType::Adat,
+            BcoPortType::TDIF => BcoPortType::Tdif,
+            BcoPortType::MADI => BcoPortType::Madi,
+            BcoPortType::ANALOG => BcoPortType::Analog,
+            BcoPortType::DIGITAL => BcoPortType::Digital,
+            BcoPortType::MIDI => BcoPortType::Midi,
+            _ => BcoPortType::Reserved(val),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct BcoClusterInfo{
+    pub index: u8,
+    pub port_type: BcoPortType,
+    pub name: String,
+}
+
+impl From<&[u8]> for BcoClusterInfo {
+    fn from(raw: &[u8]) -> Self {
+        let pos = 3 + raw[2] as usize;
+        let name = if pos > raw.len() {
+            "".to_string()
+        } else {
+            String::from_utf8(raw[3..pos].to_vec()).unwrap_or("".to_string())
+        };
+        BcoClusterInfo{
+            index: raw[0],
+            port_type: BcoPortType::from(raw[1]),
+            name,
+        }
+    }
+}
+
+impl From<&BcoClusterInfo> for Vec<u8> {
+    fn from(data: &BcoClusterInfo) -> Vec<u8> {
+        let mut raw = Vec::new();
+        raw.push(data.index);
+        raw.push(data.port_type.into());
+        raw.push(data.name.len() as u8);
+        raw.append(&mut data.name.clone().into_bytes());
+        raw
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum BcoPlugInfo {
+    Type(BcoPlugType),
+    Name(String),
+    ChCount(u8),
+    ChPositions(Vec<BcoCluster>),
+    ChName(BcoChannelName),
+    Input(BcoIoPlugAddr),
+    Outputs(Vec<BcoIoPlugAddr>),
+    ClusterInfo(BcoClusterInfo),
+    Reserved(Vec<u8>),
+}
+
+impl BcoPlugInfo {
+    const TYPE: u8 = 0x00;
+    const NAME: u8 = 0x01;
+    const CH_COUNT: u8 = 0x02;
+    const CH_POSITIONS: u8 = 0x03;
+    const CH_NAME: u8 = 0x04;
+    const INPUT: u8 = 0x05;
+    const OUTPUTS: u8 = 0x06;
+    const CLUSTER_INFO: u8 = 0x07;
+}
+
+impl From<&BcoPlugInfo> for Vec<u8> {
+    fn from(data: &BcoPlugInfo) -> Self {
+        let mut raw = Vec::new();
+        match data {
+            BcoPlugInfo::Type(plug_type) => {
+                raw.push(BcoPlugInfo::TYPE);
+                raw.push(u8::from(*plug_type));
+            }
+            BcoPlugInfo::Name(n) => {
+                raw.push(BcoPlugInfo::NAME);
+                raw.push(n.len() as u8);
+                raw.append(&mut n.clone().into_bytes());
+            }
+            BcoPlugInfo::ChCount(c) => {
+                raw.push(BcoPlugInfo::CH_COUNT);
+                raw.push(*c);
+            }
+            BcoPlugInfo::ChPositions(entries) => {
+                raw.push(BcoPlugInfo::CH_POSITIONS);
+                raw.push(entries.len() as u8);
+                entries.iter().for_each(|entry| raw.append(&mut entry.into()));
+            }
+            BcoPlugInfo::ChName(d) => {
+                raw.push(BcoPlugInfo::CH_NAME);
+                raw.push(d.ch);
+                raw.push(d.name.len() as u8);
+                raw.append(&mut d.name.clone().into_bytes());
+            }
+            BcoPlugInfo::Input(plug_addr) => {
+                raw.push(BcoPlugInfo::INPUT);
+                raw.extend_from_slice(&mut Into::<[u8;7]>::into(plug_addr));
+            }
+            BcoPlugInfo::Outputs(plug_addrs) => {
+                raw.push(BcoPlugInfo::OUTPUTS);
+                raw.push(plug_addrs.len() as u8);
+                plug_addrs.iter().for_each(|plug_addr| raw.extend_from_slice(&Into::<[u8;7]>::into(plug_addr)));
+            }
+            BcoPlugInfo::ClusterInfo(d) => {
+                raw.push(BcoPlugInfo::CLUSTER_INFO);
+                raw.append(&mut d.into());
+            }
+            BcoPlugInfo::Reserved(d) => raw.extend_from_slice(&d),
+        }
+        raw
+    }
+}
+
+impl From<&[u8]> for BcoPlugInfo{
+    fn from(raw: &[u8]) -> Self {
+        match raw[0] {
+            BcoPlugInfo::TYPE => {
+                BcoPlugInfo::Type(BcoPlugType::from(raw[1]))
+            }
+            BcoPlugInfo::NAME => {
+                let pos = 2 + raw[1] as usize;
+                let name = if pos > raw.len() {
+                    "".to_string()
+                } else {
+                    String::from_utf8(raw[2..pos].to_vec()).unwrap_or("".to_string())
+                };
+                BcoPlugInfo::Name(name)
+            }
+            BcoPlugInfo::CH_COUNT => {
+                BcoPlugInfo::ChCount(raw[1])
+            }
+            BcoPlugInfo::CH_POSITIONS => {
+                let count = raw[1] as usize;
+                let mut entries = Vec::with_capacity(count);
+                let mut pos = 2;
+                while pos < raw.len() && entries.len() < count {
+                    let c = raw[pos] as usize;
+                    let size = 1 + 2 * c;
+                    entries.push(BcoCluster::from(&raw[pos..(pos + size)]));
+                    pos += size;
+                }
+                BcoPlugInfo::ChPositions(entries)
+            }
+            BcoPlugInfo::CH_NAME => {
+                let ch = raw[1] as u8;
+                let pos = 3 + raw[2] as usize;
+                let name = if pos > raw.len() {
+                    "".to_string()
+                } else {
+                    String::from_utf8(raw[3..pos].to_vec()).unwrap_or("".to_string())
+                };
+                BcoPlugInfo::ChName(BcoChannelName{ch, name})
+            }
+            BcoPlugInfo::INPUT => {
+                let mut r = [0;7];
+                r.copy_from_slice(&raw[1..8]);
+                BcoPlugInfo::Input(BcoIoPlugAddr::from(&r))
+            }
+            BcoPlugInfo::OUTPUTS => {
+                let count = raw[1] as usize;
+                let mut pos = 2;
+                let mut entries = Vec::new();
+                while pos < raw.len() && entries.len() < count {
+                    let mut r = [0;7];
+                    r.copy_from_slice(&raw[pos..(pos + 7)]);
+                    entries.push(BcoIoPlugAddr::from(&r));
+                    pos += 7;
+                }
+                BcoPlugInfo::Outputs(entries)
+            }
+            BcoPlugInfo::CLUSTER_INFO => {
+                BcoPlugInfo::ClusterInfo(BcoClusterInfo::from(&raw[1..]))
+            }
+            _ => BcoPlugInfo::Reserved(raw.to_vec()),
+        }
+    }
+}
+
+pub struct ExtendedPlugInfo{
+    pub addr: BcoPlugAddr,
+    pub info: BcoPlugInfo,
+}
+
+impl ExtendedPlugInfo {
+    const SUBFUNC: u8 = 0xc0;
+
+    #[allow(dead_code)]
+    pub fn new(addr: &BcoPlugAddr, info: BcoPlugInfo) -> Self {
+        ExtendedPlugInfo{
+            addr: *addr,
+            info,
+        }
+    }
+}
+
+impl AvcOp for ExtendedPlugInfo {
+    const OPCODE: u8 = PlugInfo::OPCODE;
+}
+
+impl AvcStatus for ExtendedPlugInfo {
+    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        operands.push(Self::SUBFUNC);
+        operands.extend_from_slice(&Into::<[u8;5]>::into(&self.addr));
+        operands.append(&mut Into::<Vec<u8>>::into(&self.info));
+        Ok(())
+    }
+
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        if operands.len() < 8 {
+            let label = format!("Oprands too short for ExtendedPlugInfo; {}", operands.len());
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+
+        if operands[0] != Self::SUBFUNC {
+            let label = format!("Unexpected subfunction for ExtendedPlugInfo; {}", operands[0]);
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+
+        let mut a = [0;5];
+        a.copy_from_slice(&operands[1..6]);
+        let addr = BcoPlugAddr::from(&a);
+        if addr != self.addr {
+            let label = format!("Unexpected address for ExtendedPlugInfo; {:?}", addr);
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+
+        let info_type = match &self.info {
+            BcoPlugInfo::Type(_) => BcoPlugInfo::TYPE,
+            BcoPlugInfo::Name(_) => BcoPlugInfo::NAME,
+            BcoPlugInfo::ChCount(_) => BcoPlugInfo::CH_COUNT,
+            BcoPlugInfo::ChPositions(_) => BcoPlugInfo::CH_POSITIONS,
+            BcoPlugInfo::ChName(_) => BcoPlugInfo::CH_NAME,
+            BcoPlugInfo::Input(_) => BcoPlugInfo::INPUT,
+            BcoPlugInfo::Outputs(_) => BcoPlugInfo::OUTPUTS,
+            BcoPlugInfo::ClusterInfo(_) => BcoPlugInfo::CLUSTER_INFO,
+            BcoPlugInfo::Reserved(d) => d[0],
+        };
+        if info_type != operands[6] {
+            let label = format!("Unexpected type of information for ExtendedPlugInfo; {}", operands[6]);
+            return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+        }
+
+        let info = BcoPlugInfo::from(&operands[6..]);
+        if let BcoPlugInfo::Input(d) = &info {
+            if let BcoPlugDirection::Reserved(val) = &d.direction {
+                let label = format!("Unexpected value for direction of ExtendedPlugInfo: {}", val);
+                return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
+            }
+        }
+
+        self.info = info;
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crate::ta1394::{AvcSubunitType, AvcAddr};
+    use crate::ta1394::AvcStatus;
     use super::{BcoPlugAddr, BcoPlugAddrMode, BcoPlugDirection};
-    use super::BcoPlugAddrUnitType;
+    use super::{BcoPlugAddrUnit, BcoPlugAddrUnitType, BcoPlugAddrSubunit, BcoPlugAddrFuncBlk};
+    use super::BcoPlugType;
+    use super::{BcoLocation, BcoChannelInfo};
+    use super::BcoChannelName;
+    use super::{BcoClusterInfo, BcoPortType, BcoCluster};
+    use super::{BcoIoPlugAddr, BcoIoPlugAddrMode};
+    use super::BcoPlugInfo;
+    use super::ExtendedPlugInfo;
 
     #[test]
     fn bcoplugaddr_from() {
@@ -288,5 +900,450 @@ mod test {
             unreachable!();
         }
         assert_eq!(raw, Into::<[u8;5]>::into(&addr));
+    }
+
+    #[test]
+    fn bcochannelinfo_from() {
+        let raw = [0x02, 0x0d];
+        assert_eq!(raw, Into::<[u8;2]>::into(&BcoChannelInfo::from(&raw)));
+        let raw = [0x3e, 0x0c];
+        assert_eq!(raw, Into::<[u8;2]>::into(&BcoChannelInfo::from(&raw)));
+    }
+
+    #[test]
+    fn bcocluster_from() {
+        let raw: Vec<u8> = vec![0x03, 0x03, 0x0b, 0x09, 0x03, 0x2c, 0x01];
+        assert_eq!(raw, Into::<Vec<u8>>::into(&BcoCluster::from(raw.as_slice())));
+
+        let raw: Vec<u8> = vec![0x05, 0x03, 0x0b, 0x09, 0x03, 0x2c, 0x01, 0x02, 0x0d, 0x3e, 0x0c];
+        assert_eq!(raw, Into::<Vec<u8>>::into(&BcoCluster::from(raw.as_slice())));
+    }
+
+    #[test]
+    fn bcoclusterinfo_from() {
+        let raw: Vec<u8> = vec![0x03, 0x0a, 0x03, 0x4c, 0x51, 0x33];
+        assert_eq!(raw, Into::<Vec<u8>>::into(&BcoClusterInfo::from(raw.as_slice())));
+    }
+
+    #[test]
+    fn bcoioplugaddr_from() {
+        // Unit.
+        let raw: [u8;7] = [0x00, 0x00, 0x02, 0x05, 0xff, 0xff, 0xff];
+        let addr = BcoIoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Input);
+        if let BcoIoPlugAddrMode::Unit(d) = &addr.mode {
+            assert_eq!(d.plug_type, BcoPlugAddrUnitType::Async);
+            assert_eq!(d.plug_id, 0x05);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;7]>::into(&addr));
+
+        // Subunit.
+        let raw: [u8;7] = [0x01, 0x01, 0x06, 0x05, 0x02, 0xff, 0xff];
+        let addr = BcoIoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Output);
+        if let BcoIoPlugAddrMode::Subunit(s, d) = &addr.mode {
+            assert_eq!(s.subunit_type, AvcSubunitType::Ca);
+            assert_eq!(s.subunit_id, 0x05);
+            assert_eq!(d.plug_id, 0x02);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;7]>::into(&addr));
+
+        // Function block.
+        let raw: [u8;7] = [0x00, 0x02, 0x04, 0x09, 0x80, 0x12, 0x23];
+        let addr = BcoIoPlugAddr::from(&raw);
+        assert_eq!(addr.direction, BcoPlugDirection::Input);
+        if let BcoIoPlugAddrMode::FuncBlk(s, d) = &addr.mode {
+            assert_eq!(s.subunit_type, AvcSubunitType::Tape);
+            assert_eq!(s.subunit_id, 0x09);
+            assert_eq!(d.func_blk_type, 0x80);
+            assert_eq!(d.func_blk_id, 0x12);
+            assert_eq!(d.plug_id, 0x23);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<[u8;7]>::into(&addr));
+    }
+
+    #[test]
+    fn bcopluginfo_type_from() {
+        let raw: Vec<u8> = vec![0x00, 0x03];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::Type(t) = &info {
+            assert_eq!(*t, BcoPlugType::Sync);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+
+    }
+
+    #[test]
+    fn bcopluginfo_name_from() {
+        let raw: Vec<u8> = vec![0x01, 0x03, 0x31, 0x32, 0x33];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::Name(n) = &info {
+            assert_eq!(n, "123");
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+
+    }
+
+    #[test]
+    fn bcopluginfo_chcount_from() {
+        let raw: Vec<u8> = vec![0x02, 0xc3];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::ChCount(c) = &info {
+            assert_eq!(*c, 0xc3);
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn bcopluginfo_chpositions_from() {
+        let raw: Vec<u8> = vec![0x03, 0x04,
+                                0x01, 0x00, 0x04,
+                                0x02, 0x03, 0x08, 0x00, 0x09,
+                                0x03, 0x04, 0x08, 0x06, 0x08, 0x05, 0x07,
+                                0x01, 0x09, 0xb];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::ChPositions(clusters) = &info {
+            assert_eq!(clusters.len(), 4);
+            let m = &clusters[0];
+            assert_eq!(m.entries.len(), 1);
+            assert_eq!(m.entries[0], BcoChannelInfo{pos: 0x00, loc: BcoLocation::LowFrequencyEffect});
+            let m = &clusters[1];
+            assert_eq!(m.entries.len(), 2);
+            assert_eq!(m.entries[0], BcoChannelInfo{pos: 0x03, loc: BcoLocation::RightCenter});
+            assert_eq!(m.entries[1], BcoChannelInfo{pos: 0x00, loc: BcoLocation::Surround});
+            let m = &clusters[2];
+            assert_eq!(m.entries.len(), 3);
+            assert_eq!(m.entries[0], BcoChannelInfo{pos: 0x04, loc: BcoLocation::RightCenter});
+            assert_eq!(m.entries[1], BcoChannelInfo{pos: 0x06, loc: BcoLocation::RightCenter});
+            assert_eq!(m.entries[2], BcoChannelInfo{pos: 0x05, loc: BcoLocation::LeftCenter});
+            let m = &clusters[3];
+            assert_eq!(m.entries.len(), 1);
+            assert_eq!(m.entries[0], BcoChannelInfo{pos: 0x09, loc: BcoLocation::SideRight});
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn bcopluginfo_chname_from() {
+        let raw: Vec<u8> = vec![0x04, 0x9a, 0x01, 0x39];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::ChName(d) = &info {
+            assert_eq!(d.ch, 0x9a);
+            assert_eq!(d.name, "9");
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn bcopluginfo_input_from() {
+        let raw: Vec<u8> = vec![0x05, 0xa9, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::Input(plug_addr) = &info {
+            assert_eq!(plug_addr.direction, BcoPlugDirection::Reserved(0xa9));
+            if let BcoIoPlugAddrMode::Subunit(s, d) = &plug_addr.mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::CameraStorage);
+                assert_eq!(s.subunit_id, 0x07);
+                assert_eq!(d.plug_id, 0x42);
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn bcopluginfo_outputs_from() {
+        let raw: Vec<u8> = vec![0x06, 0x02,
+                                0xa9, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff,
+                                0xa9, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::Outputs(plug_addrs) = &info {
+            let plug_addr = plug_addrs[0];
+            assert_eq!(plug_addr.direction, BcoPlugDirection::Reserved(0xa9));
+            if let BcoIoPlugAddrMode::Subunit(s, d) = &plug_addr.mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::CameraStorage);
+                assert_eq!(s.subunit_id, 0x07);
+                assert_eq!(d.plug_id, 0x42);
+            } else {
+                unreachable!();
+            }
+            let plug_addr = plug_addrs[1];
+            assert_eq!(plug_addr.direction, BcoPlugDirection::Reserved(0xa9));
+            if let BcoIoPlugAddrMode::Subunit(s, d) = &plug_addr.mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::CameraStorage);
+                assert_eq!(s.subunit_id, 0x07);
+                assert_eq!(d.plug_id, 0x42);
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn bcopluginfo_clusterinfo_from() {
+        let raw: Vec<u8> = vec![0x07, 0x01, 0x09, 0x05, 0x41, 0x42, 0x43, 0x44, 0x45];
+        let info = BcoPlugInfo::from(raw.as_slice());
+        if let BcoPlugInfo::ClusterInfo(d) = &info {
+            assert_eq!(d.index, 0x01);
+            assert_eq!(d.port_type, BcoPortType::Digital);
+            assert_eq!(d.name, "ABCDE");
+        } else {
+            unreachable!();
+        }
+        assert_eq!(raw, Into::<Vec<u8>>::into(&info));
+    }
+
+    #[test]
+    fn extendedpluginfo_type_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x01, 0x00, 0x00, 0x03, 0xff,
+                                0x00, 0x00];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Output,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type: BcoPlugAddrUnitType::Isoc,
+                plug_id: 0x03,
+            }),
+        };
+        let info = BcoPlugInfo::Type(BcoPlugType::Reserved(0xff));
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::Type(plug_type) = &op.info {
+            assert_eq!(plug_type, &BcoPlugType::Isoc);
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_name_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x00, 0x01, 0x17, 0xff, 0xff,
+                                0x01, 0x05, 0x39, 0x38, 0x52, 0x36, 0x35];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Input,
+            mode: BcoPlugAddrMode::Subunit(BcoPlugAddrSubunit{
+                plug_id: 0x17,
+            }),
+        };
+        let info = BcoPlugInfo::Name("".to_string());
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::Name(n) = &op.info {
+            assert_eq!(&n, &"98R65");
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_chcount_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x01, 0x02, 0x3e, 0x9a, 0x77,
+                                0x02, 0xe4];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Output,
+            mode: BcoPlugAddrMode::FuncBlk(BcoPlugAddrFuncBlk{
+                func_blk_type: 0x3e,
+                func_blk_id: 0x9a,
+                plug_id: 0x77,
+            }),
+        };
+        let info = BcoPlugInfo::ChCount(0xff);
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::ChCount(c) = &op.info {
+            assert_eq!(*c, 0xe4);
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_chpositions_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x00, 0x00, 0x01, 0x5c, 0xff,
+                                0x03, 0x03,
+                                0x01, 0x00, 0x0a,
+                                0x02, 0x03, 0x04, 0x02, 0x07,
+                                0x03, 0x01, 0x0f, 0x04, 0x01, 0x05, 0x03];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Input,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type: BcoPlugAddrUnitType::Ext,
+                plug_id: 0x5c,
+            }),
+        };
+        let info = BcoPlugInfo::ChPositions(Vec::new());
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::ChPositions(entries) = &op.info {
+            assert_eq!(entries.len(), 3);
+            let e = &entries[0].entries;
+            assert_eq!(e.len(), 1);
+            assert_eq!(e[0], BcoChannelInfo{pos: 0x00, loc: BcoLocation::SideLeft});
+            let e = &entries[1].entries;
+            assert_eq!(e.len(), 2);
+            assert_eq!(e[0], BcoChannelInfo{pos: 0x03, loc: BcoLocation::LowFrequencyEffect});
+            assert_eq!(e[1], BcoChannelInfo{pos: 0x02, loc: BcoLocation::LeftCenter});
+            let e = &entries[2].entries;
+            assert_eq!(e.len(), 3);
+            assert_eq!(e[0], BcoChannelInfo{pos: 0x01, loc: BcoLocation::RightFrontEffect});
+            assert_eq!(e[1], BcoChannelInfo{pos: 0x04, loc: BcoLocation::LeftFront});
+            assert_eq!(e[2], BcoChannelInfo{pos: 0x05, loc: BcoLocation::Center});
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_chname_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x00, 0x00, 0x02, 0x97, 0xff,
+                                0x04, 0x9d, 0x02, 0x46, 0x54];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Input,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type: BcoPlugAddrUnitType::Async,
+                plug_id: 0x97,
+            }),
+        };
+        let info = BcoPlugInfo::ChName(BcoChannelName{
+            ch: 0x9d,
+            name: "".to_string(),
+        });
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::ChName(d) = &op.info {
+            assert_eq!(d.ch, 0x9d);
+            assert_eq!(&d.name, &"FT");
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_input_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x01, 0x01, 0x5d, 0xff, 0xff,
+                                0x05, 0x00, 0x02, 0x0c, 0x12, 0x80, 0xd9, 0x04];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Output,
+            mode: BcoPlugAddrMode::Subunit(BcoPlugAddrSubunit{
+                plug_id: 0x5d
+            }),
+        };
+        let info = BcoPlugInfo::Input(BcoIoPlugAddr{
+            direction: BcoPlugDirection::Reserved(0xff),
+            mode: BcoIoPlugAddrMode::Reserved([0;6]),
+        });
+        let mut op = ExtendedPlugInfo::new(&addr, info);
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::Input(plug_addr) = op.info {
+            assert_eq!(plug_addr.direction, BcoPlugDirection::Input);
+            if let BcoIoPlugAddrMode::FuncBlk(s, d) = &plug_addr.mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::Music);
+                assert_eq!(s.subunit_id, 0x12);
+                assert_eq!(d.func_blk_type, 0x80);
+                assert_eq!(d.func_blk_id, 0xd9);
+                assert_eq!(d.plug_id, 0x04);
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_outputs_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x01, 0x00, 0x00, 0x11, 0xff,
+                                0x06, 0x02,
+                                0x00, 0x02, 0x0c, 0x12, 0x80, 0xd9, 0x04,
+                                0x00, 0x01, 0x0c, 0x03, 0x31, 0xff, 0xff];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Output,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type: BcoPlugAddrUnitType::Isoc,
+                plug_id: 0x11,
+            }),
+        };
+        let mut op = ExtendedPlugInfo::new(&addr, BcoPlugInfo::Outputs(Vec::new()));
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::Outputs(plug_addrs) = op.info {
+            assert_eq!(plug_addrs.len(), 2);
+
+            assert_eq!(plug_addrs[0].direction, BcoPlugDirection::Input);
+            if let BcoIoPlugAddrMode::FuncBlk(s, d) = &plug_addrs[0].mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::Music);
+                assert_eq!(s.subunit_id, 0x12);
+                assert_eq!(d.func_blk_type, 0x80);
+                assert_eq!(d.func_blk_id, 0xd9);
+                assert_eq!(d.plug_id, 0x04);
+            } else {
+                unreachable!();
+            }
+
+            assert_eq!(plug_addrs[1].direction, BcoPlugDirection::Input);
+            if let BcoIoPlugAddrMode::Subunit(s, d) = &plug_addrs[1].mode {
+                assert_eq!(s.subunit_type, AvcSubunitType::Music);
+                assert_eq!(s.subunit_id, 0x03);
+                assert_eq!(d.plug_id, 0x31);
+            } else {
+                unreachable!();
+            }
+        } else {
+            unreachable!();
+        }
+    }
+
+    #[test]
+    fn extendedpluginfo_clusterinfo_operands() {
+        let raw: Vec<u8> = vec![0xc0, 0x01, 0x00, 0x01, 0x1e, 0xff,
+                                0x07, 0x02, 0x05, 0x03, 0x60, 0x50, 0x70];
+        let addr = BcoPlugAddr{
+            direction: BcoPlugDirection::Output,
+            mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit{
+                plug_type: BcoPlugAddrUnitType::Ext,
+                plug_id: 0x1e,
+            }),
+        };
+        let info = BcoClusterInfo{
+            index: 0x02,
+            port_type: BcoPortType::Reserved(0xff),
+            name: "".to_string(),
+        };
+        let mut op = ExtendedPlugInfo::new(&addr, BcoPlugInfo::ClusterInfo(info));
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &raw).unwrap();
+        assert_eq!(op.addr, addr);
+        if let BcoPlugInfo::ClusterInfo(i) = &op.info {
+            assert_eq!(i.index, 0x02);
+            assert_eq!(i.port_type, BcoPortType::Adat);
+            assert_eq!(&i.name, &"`Pp");
+        } else {
+            unreachable!();
+        }
     }
 }

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -5,4 +5,6 @@ pub mod solo_model;
 pub mod audiophile_model;
 pub mod fw410_model;
 
+mod normal_ctls;
+
 mod common_proto;

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -5,6 +5,7 @@ pub mod solo_model;
 pub mod audiophile_model;
 pub mod fw410_model;
 pub mod profirelightbridge_model;
+pub mod special_model;
 
 mod normal_ctls;
 

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -8,5 +8,6 @@ pub mod profirelightbridge_model;
 pub mod special_model;
 
 mod normal_ctls;
+mod special_ctls;
 
 mod common_proto;

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub mod ozonic_model;
+
+mod common_proto;

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -2,5 +2,6 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod ozonic_model;
 pub mod solo_model;
+pub mod audiophile_model;
 
 mod common_proto;

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod ozonic_model;
+pub mod solo_model;
 
 mod common_proto;

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -4,6 +4,7 @@ pub mod ozonic_model;
 pub mod solo_model;
 pub mod audiophile_model;
 pub mod fw410_model;
+pub mod profirelightbridge_model;
 
 mod normal_ctls;
 

--- a/src/bebob/maudio.rs
+++ b/src/bebob/maudio.rs
@@ -3,5 +3,6 @@
 pub mod ozonic_model;
 pub mod solo_model;
 pub mod audiophile_model;
+pub mod fw410_model;
 
 mod common_proto;

--- a/src/bebob/maudio/audiophile_model.rs
+++ b/src/bebob/maudio/audiophile_model.rs
@@ -16,7 +16,7 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl, OutputCtl};
+use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl, OutputCtl, HpCtl};
 
 pub struct AudiophileModel<'a>{
     avc: BebobAvc,
@@ -27,6 +27,7 @@ pub struct AudiophileModel<'a>{
     input_ctl: InputCtl<'a>,
     aux_ctl: AuxCtl<'a>,
     output_ctl: OutputCtl<'a>,
+    hp_ctl: HpCtl<'a>,
 }
 
 impl<'a> AudiophileModel<'a> {
@@ -58,6 +59,7 @@ impl<'a> AudiophileModel<'a> {
     const PHYS_IN_LABELS: &'a [&'a str] = &["analog-1/2", "digital-1/2"];
     const MIXER_STREAM_SRC_FB_IDS: &'a [u8] = &[0x00, 0x01, 0x02];
     const STREAM_IN_LABELS: &'a [&'a str] = &["stream-1/2", "stream-3/4", "stream-5/6"];
+    const HP_SRC_LABELS: &'a [&'a str] = &["mixer-1/2", "mixer-3/4", "mixer-5/6", "aux-1/2"];
 
     const PHYS_IN_FB_IDS: &'a [u8] = &[0x04, 0x05];
     const STREAM_IN_FB_IDS: &'a [u8] = &[0x01, 0x02, 0x03];
@@ -69,6 +71,9 @@ impl<'a> AudiophileModel<'a> {
     const PHYS_OUT_LABELS: &'a [&'a str] = &["analog-1/2", "analog-3/4", "digital-1/2"];
     const PHYS_OUT_FB_IDS: &'a [u8] = &[0x0c, 0x0d, 0x0e];
     const PHYS_OUT_SRC_FB_IDS: &'a [u8] = &[0x01, 0x02, 0x03];
+
+    const HP_SRC_FB_ID: u8 = 0x04;
+    const HP_OUT_FB_ID: u8 = 0x0f;
 
     pub fn new() -> Self {
         AudiophileModel{
@@ -94,6 +99,7 @@ impl<'a> AudiophileModel<'a> {
                 Self::PHYS_OUT_FB_IDS,
                 Self::PHYS_OUT_SRC_FB_IDS,
             ),
+            hp_ctl: HpCtl::new(Self::HP_OUT_FB_ID, Self::HP_SRC_FB_ID, Self::HP_SRC_LABELS),
         }
     }
 }
@@ -112,6 +118,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         self.input_ctl.load(&self.avc, card_cntr)?;
         self.aux_ctl.load(&self.avc, card_cntr)?;
         self.output_ctl.load(&self.avc, card_cntr)?;
+        self.hp_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -130,6 +137,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         } else if self.aux_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.hp_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -151,6 +160,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         } else if self.aux_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else if self.output_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.hp_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/audiophile_model.rs
+++ b/src/bebob/maudio/audiophile_model.rs
@@ -16,10 +16,13 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
+use super::normal_ctls::MeterCtl;
 
 pub struct AudiophileModel<'a>{
     avc: BebobAvc,
+    req: hinawa::FwReq,
     clk_ctl: ClkCtl<'a>,
+    meter_ctl: MeterCtl<'a>,
 }
 
 impl<'a> AudiophileModel<'a> {
@@ -36,10 +39,21 @@ impl<'a> AudiophileModel<'a> {
     ];
     const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
 
+    const IN_METER_LABELS: &'a [&'a str] = &[
+        "analog-in-1", "analog-in-2", "digital-in-1", "digital-in-2",
+    ];
+
+    const OUT_METER_LABELS: &'a [&'a str] = &[
+        "analog-out-1", "analog-out-2", "analog-out-3", "analog-out-4",
+        "digital-out-1", "digital-out-2",
+    ];
+
     pub fn new() -> Self {
         AudiophileModel{
             avc: BebobAvc::new(),
+            req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
+            meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, &[], Self::OUT_METER_LABELS, true, 2, true),
         }
     }
 }
@@ -53,6 +67,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         self.avc.company_id = op.company_id;
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+        self.meter_ctl.load(unit, &self.avc, &self.req, card_cntr)?;
 
         Ok(())
     }
@@ -61,6 +76,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -73,6 +90,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
     {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
             Ok(true)
+        } else if self.meter_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -80,17 +99,18 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
 }
 
 impl<'a> MeasureModel<hinawa::SndUnit> for AudiophileModel<'a> {
-    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
-        Ok(())
+    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+        self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 
-    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.meter_ctl.measure_elem(elem_id, elem_value)
     }
 }
 

--- a/src/bebob/maudio/audiophile_model.rs
+++ b/src/bebob/maudio/audiophile_model.rs
@@ -16,7 +16,7 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl};
+use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl, OutputCtl};
 
 pub struct AudiophileModel<'a>{
     avc: BebobAvc,
@@ -26,6 +26,7 @@ pub struct AudiophileModel<'a>{
     mixer_ctl: MixerCtl<'a>,
     input_ctl: InputCtl<'a>,
     aux_ctl: AuxCtl<'a>,
+    output_ctl: OutputCtl<'a>,
 }
 
 impl<'a> AudiophileModel<'a> {
@@ -65,6 +66,10 @@ impl<'a> AudiophileModel<'a> {
     const AUX_PHYS_SRC_FB_IDS: &'a [u8] = &[0x09, 0x0a];
     const AUX_STREAM_SRC_FB_IDS: &'a [u8] = &[0x06, 0x07, 0x08];
 
+    const PHYS_OUT_LABELS: &'a [&'a str] = &["analog-1/2", "analog-3/4", "digital-1/2"];
+    const PHYS_OUT_FB_IDS: &'a [u8] = &[0x0c, 0x0d, 0x0e];
+    const PHYS_OUT_SRC_FB_IDS: &'a [u8] = &[0x01, 0x02, 0x03];
+
     pub fn new() -> Self {
         AudiophileModel{
             avc: BebobAvc::new(),
@@ -84,6 +89,11 @@ impl<'a> AudiophileModel<'a> {
                 Self::AUX_PHYS_SRC_FB_IDS, Self::PHYS_IN_LABELS,
                 Self::AUX_STREAM_SRC_FB_IDS, Self::STREAM_IN_LABELS,
             ),
+            output_ctl: OutputCtl::new(
+                Self::PHYS_OUT_LABELS,
+                Self::PHYS_OUT_FB_IDS,
+                Self::PHYS_OUT_SRC_FB_IDS,
+            ),
         }
     }
 }
@@ -101,6 +111,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         self.mixer_ctl.load(&self.avc, card_cntr)?;
         self.input_ctl.load(&self.avc, card_cntr)?;
         self.aux_ctl.load(&self.avc, card_cntr)?;
+        self.output_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -117,6 +128,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         } else if self.input_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else if self.aux_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -136,6 +149,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         } else if self.input_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else if self.aux_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.output_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/audiophile_model.rs
+++ b/src/bebob/maudio/audiophile_model.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+use card_cntr::{CtlModel, MeasureModel};
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::UnitInfo;
+
+use crate::bebob::BebobAvc;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct AudiophileModel{
+    avc: BebobAvc,
+}
+
+impl AudiophileModel {
+    pub fn new() -> Self {
+        AudiophileModel{
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for AudiophileModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+        self.avc.company_id = op.company_id;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<hinawa::SndUnit> for AudiophileModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for AudiophileModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/audiophile_model.rs
+++ b/src/bebob/maudio/audiophile_model.rs
@@ -7,50 +7,79 @@ use hinawa::{FwFcpExt, SndUnitExt};
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
-use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::{AvcAddr, MUSIC_SUBUNIT_0, Ta1394Avc};
 use crate::ta1394::general::UnitInfo;
+use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr, SignalUnitAddr};
+
+use crate::bebob::common_ctls::ClkCtl;
 
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
 
-pub struct AudiophileModel{
+pub struct AudiophileModel<'a>{
     avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
 }
 
-impl AudiophileModel {
+impl<'a> AudiophileModel<'a> {
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x01,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x01,
+        }),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x02)),
+    ];
+    const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
+
     pub fn new() -> Self {
         AudiophileModel{
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for AudiophileModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
         self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
         self.avc.company_id = op.company_id;
 
+        self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl MeasureModel<hinawa::SndUnit> for AudiophileModel {
+impl<'a> MeasureModel<hinawa::SndUnit> for AudiophileModel<'a> {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -65,17 +94,19 @@ impl MeasureModel<hinawa::SndUnit> for AudiophileModel {
     }
 }
 
-impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for AudiophileModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for AudiophileModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
     }
 }

--- a/src/bebob/maudio/common_proto.rs
+++ b/src/bebob/maudio/common_proto.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+pub const FCP_TIMEOUT_MS: u32 = 100;

--- a/src/bebob/maudio/common_proto.rs
+++ b/src/bebob/maudio/common_proto.rs
@@ -1,3 +1,24 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwReqExtManual, SndUnitExt};
+
 pub const FCP_TIMEOUT_MS: u32 = 100;
+
+pub trait CommonProto: FwReqExtManual {
+    const BASE_ADDR: u64 = 0xffc700700000;
+    const METER_ADDR: u64 = 0xffc700600000;
+
+    const TIMEOUT: u32 = 100;
+
+    fn read_meters(&self, unit: &hinawa::SndUnit, frames: &mut [u8]) -> Result<(), Error> {
+        self.transaction_sync(&unit.get_node(), hinawa::FwTcode::ReadBlockRequest,
+                              Self::METER_ADDR, frames.len(), frames, Self::TIMEOUT)
+    }
+
+    fn write_block(&self, unit: &hinawa::SndUnit, offset: u64, frames: &mut [u8]) -> Result<(), Error> {
+        self.transaction_sync(&unit.get_node(), hinawa::FwTcode::WriteBlockRequest,
+                              Self::BASE_ADDR + offset, frames.len(), frames, Self::TIMEOUT)
+    }
+}

--- a/src/bebob/maudio/fw410_model.rs
+++ b/src/bebob/maudio/fw410_model.rs
@@ -16,7 +16,7 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::{MeterCtl, MixerCtl};
+use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl};
 
 pub struct Fw410Model<'a>{
     avc: BebobAvc,
@@ -24,6 +24,7 @@ pub struct Fw410Model<'a>{
     clk_ctl: ClkCtl<'a>,
     meter_ctl: MeterCtl<'a>,
     mixer_ctl: MixerCtl<'a>,
+    input_ctl: InputCtl<'a>,
 }
 
 impl<'a> Fw410Model<'a> {
@@ -63,6 +64,9 @@ impl<'a> Fw410Model<'a> {
         "stream-9/10",
     ];
 
+    const PHYS_IN_FB_IDS: &'a [u8] = &[0x03, 0x04];
+    const STREAM_IN_FB_IDS: &'a [u8] = &[0x01, 0x01, 0x01, 0x01, 0x02];
+
     pub fn new() -> Self {
         Fw410Model{
             avc: BebobAvc::new(),
@@ -73,6 +77,10 @@ impl<'a> Fw410Model<'a> {
                 Self::MIXER_DST_FB_IDS, Self::MIXER_LABELS,
                 Self::MIXER_PHYS_SRC_FB_IDS, Self::PHYS_IN_LABELS,
                 Self::MIXER_STREAM_SRC_FB_IDS, Self::STREAM_IN_LABELS,
+            ),
+            input_ctl: InputCtl::new(
+                Self::PHYS_IN_FB_IDS, Self::PHYS_IN_LABELS,
+                Self::STREAM_IN_FB_IDS, Self::STREAM_IN_LABELS,
             ),
         }
     }
@@ -89,6 +97,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
         self.meter_ctl.load(unit, &self.avc, &self.req, card_cntr)?;
         self.mixer_ctl.load(&self.avc, card_cntr)?;
+        self.input_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -101,6 +110,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -116,6 +127,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         } else if self.meter_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else if self.mixer_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.input_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/fw410_model.rs
+++ b/src/bebob/maudio/fw410_model.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+use card_cntr::{CtlModel, MeasureModel};
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::UnitInfo;
+
+use crate::bebob::BebobAvc;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct Fw410Model{
+    avc: BebobAvc,
+}
+
+impl Fw410Model {
+    pub fn new() -> Self {
+        Fw410Model{
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for Fw410Model {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+        self.avc.company_id = op.company_id;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<hinawa::SndUnit> for Fw410Model {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for Fw410Model {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/fw410_model.rs
+++ b/src/bebob/maudio/fw410_model.rs
@@ -16,7 +16,7 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl};
+use super::normal_ctls::{MeterCtl, MixerCtl, InputCtl, AuxCtl, OutputCtl};
 
 pub struct Fw410Model<'a>{
     avc: BebobAvc,
@@ -26,6 +26,7 @@ pub struct Fw410Model<'a>{
     mixer_ctl: MixerCtl<'a>,
     input_ctl: InputCtl<'a>,
     aux_ctl: AuxCtl<'a>,
+    output_ctl: OutputCtl<'a>,
 }
 
 impl<'a> Fw410Model<'a> {
@@ -72,6 +73,13 @@ impl<'a> Fw410Model<'a> {
     const AUX_PHYS_SRC_FB_IDS: &'a [u8] = &[0x07, 0x08];
     const AUX_STREAM_SRC_FB_IDS: &'a [u8] = &[0x05, 0x05, 0x05, 0x05, 0x06];
 
+    const PHYS_OUT_LABELS: &'a [&'a str] = &[
+        "analog-1/2", "analog-3/4", "analog-5/6", "analog-7/8",
+        "digital-1/2",
+    ];
+    const PHYS_OUT_FB_IDS: &'a [u8] = &[0x0a, 0x0b, 0x0c, 0x0d, 0x0e];
+    const PHYS_OUT_SRC_FB_IDS: &'a [u8] = &[0x02, 0x03, 0x04, 0x05, 0x06];
+
     pub fn new() -> Self {
         Fw410Model{
             avc: BebobAvc::new(),
@@ -91,6 +99,11 @@ impl<'a> Fw410Model<'a> {
                 Self::AUX_PHYS_SRC_FB_IDS, Self::PHYS_IN_LABELS,
                 Self::AUX_STREAM_SRC_FB_IDS, Self::STREAM_IN_LABELS,
             ),
+            output_ctl: OutputCtl::new(
+                Self::PHYS_OUT_LABELS,
+                Self::PHYS_OUT_FB_IDS,
+                Self::PHYS_OUT_SRC_FB_IDS,
+            ),
         }
     }
 }
@@ -108,6 +121,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         self.mixer_ctl.load(&self.avc, card_cntr)?;
         self.input_ctl.load(&self.avc, card_cntr)?;
         self.aux_ctl.load(&self.avc, card_cntr)?;
+        self.output_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -124,6 +138,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         } else if self.input_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else if self.aux_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -143,6 +159,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         } else if self.input_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else if self.aux_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.output_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/fw410_model.rs
+++ b/src/bebob/maudio/fw410_model.rs
@@ -7,50 +7,79 @@ use hinawa::{FwFcpExt, SndUnitExt};
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
-use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::{AvcAddr, MUSIC_SUBUNIT_0, Ta1394Avc};
 use crate::ta1394::general::UnitInfo;
+use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr, SignalUnitAddr};
+
+use crate::bebob::common_ctls::ClkCtl;
 
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
 
-pub struct Fw410Model{
+pub struct Fw410Model<'a>{
     avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
 }
 
-impl Fw410Model {
+impl<'a> Fw410Model<'a> {
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x01,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x01,
+        }),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x02)),
+    ];
+    const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
+
     pub fn new() -> Self {
         Fw410Model{
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for Fw410Model {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
         self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
         self.avc.company_id = op.company_id;
 
+        self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl MeasureModel<hinawa::SndUnit> for Fw410Model {
+impl<'a> MeasureModel<hinawa::SndUnit> for Fw410Model<'a> {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -65,17 +94,19 @@ impl MeasureModel<hinawa::SndUnit> for Fw410Model {
     }
 }
 
-impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for Fw410Model {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for Fw410Model<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
     }
 }

--- a/src/bebob/maudio/fw410_model.rs
+++ b/src/bebob/maudio/fw410_model.rs
@@ -16,13 +16,14 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::MeterCtl;
+use super::normal_ctls::{MeterCtl, MixerCtl};
 
 pub struct Fw410Model<'a>{
     avc: BebobAvc,
     req: hinawa::FwReq,
     clk_ctl: ClkCtl<'a>,
     meter_ctl: MeterCtl<'a>,
+    mixer_ctl: MixerCtl<'a>,
 }
 
 impl<'a> Fw410Model<'a> {
@@ -49,12 +50,30 @@ impl<'a> Fw410Model<'a> {
         "digital-out-1", "digital-out-2",
     ];
 
+    const MIXER_DST_FB_IDS: &'a [u8] = &[0x01, 0x01, 0x01, 0x01, 0x01];
+    const MIXER_LABELS: &'a [&'a str] = &[
+        "mixer-1/2", "mixer-3/4", "mixer-5/6", "mixer-7/8",
+        "mixer-9/10",
+    ];
+    const MIXER_PHYS_SRC_FB_IDS: &'a [u8] = &[0x02, 0x03];
+    const PHYS_IN_LABELS: &'a [&'a str] = &["analog-1/2", "digital-1/2"];
+    const MIXER_STREAM_SRC_FB_IDS: &'a [u8] = &[0x01, 0x00, 0x00, 0x00, 0x00];
+    const STREAM_IN_LABELS: &'a [&'a str] = &[
+        "stream-1/2", "stream-3/4", "stream-5/6", "stream-7/8",
+        "stream-9/10",
+    ];
+
     pub fn new() -> Self {
         Fw410Model{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, &[], Self::OUT_METER_LABELS, false, 1, true),
+            mixer_ctl: MixerCtl::new(
+                Self::MIXER_DST_FB_IDS, Self::MIXER_LABELS,
+                Self::MIXER_PHYS_SRC_FB_IDS, Self::PHYS_IN_LABELS,
+                Self::MIXER_STREAM_SRC_FB_IDS, Self::STREAM_IN_LABELS,
+            ),
         }
     }
 }
@@ -69,6 +88,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
         self.meter_ctl.load(unit, &self.avc, &self.req, card_cntr)?;
+        self.mixer_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -79,6 +99,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -92,6 +114,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.meter_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/normal_ctls.rs
+++ b/src/bebob/maudio/normal_ctls.rs
@@ -1,0 +1,391 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::{AvcOp, AvcControl};
+use crate::ta1394::general::VendorDependent;
+
+use crate::bebob::BebobAvc;
+use crate::bebob::model::{IN_METER_NAME, OUT_METER_NAME};
+
+use super::common_proto::CommonProto;
+
+impl CommonProto for hinawa::FwReq {}
+
+pub const FCP_TIMEOUT_MS: u32 = 100;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SwitchState {
+    Off,
+    A,
+    B,
+}
+
+impl From<SwitchState> for u8 {
+    fn from(state: SwitchState) -> Self {
+        match state {
+            SwitchState::Off => 0x00,
+            SwitchState::A => 0x01,
+            SwitchState::B => 0x02,
+        }
+    }
+}
+
+impl From<u8> for SwitchState {
+    fn from(val: u8) -> Self {
+        match val {
+            0x01 => SwitchState::A,
+            0x02 => SwitchState::B,
+            _ => SwitchState::Off,
+        }
+    }
+}
+
+struct LedSwitch{
+    state: SwitchState,
+    op: VendorDependent,
+}
+
+impl LedSwitch {
+    pub fn new(company_id: &[u8;3], state: SwitchState) -> Self {
+        LedSwitch{
+            state,
+            op: VendorDependent{
+                company_id: *company_id,
+                data: Vec::new(),
+            },
+        }
+    }
+}
+
+impl AvcOp for LedSwitch {
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+impl AvcControl for LedSwitch {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        self.op.data.extend_from_slice(&[0x02, 0x00, 0x01, self.state.into(), 0xff, 0xff]);
+        AvcControl::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)
+    }
+}
+
+pub struct MeterCtl<'a> {
+    pub measure_elems: Vec<alsactl::ElemId>,
+
+    in_meter_labels: &'a [&'a str],
+    stream_meter_labels: &'a [&'a str],
+    out_meter_labels: &'a [&'a str],
+
+    cache: Vec<u8>,
+    switch: Option<SwitchState>,
+    rotary0: Option<i32>,
+    rotary1: Option<i32>,
+    sync_status: Option<bool>,
+}
+
+impl<'a> MeterCtl<'a> {
+    const HP_OUT_LABELS: &'a [&'a str] = &["headphone-1", "headphone-2"];
+    const AUX_OUT_LABELS: &'a [&'a str] = &["aux-1", "aux-2"];
+
+    const STREAM_METER_NAME: &'a str = "stream-meters";
+    const HP_OUT_METER_NAME: &'a str = "headphone-meters";
+    const AUX_OUT_METER_NAME: &'a str = "aux-meters";
+
+    const SWITCH_NAME: &'a str = "Switch";
+    const ROTARY0_NAME: &'a str = "Rotary0";
+    const ROTARY1_NAME: &'a str = "Rotary1";
+    const SYNC_STATUS_NAME: &'a str = "Sync status";
+
+    const SWITCH_LABELS: &'a [&'a str] = &["Off", "A", "B"];
+
+    const ROTARY_MIN: i32 = i16::MIN as i32;
+    const ROTARY_MAX: i32 = 0;
+    const ROTARY_STEP: i32 = 256;
+
+    const METER_MIN: i32 = 0;
+    const METER_MAX: i32 = i32::MAX;
+    const METER_STEP: i32 = 256;
+    const METER_TLV: &'a [i32] = &[5, 8, -14400, 0];
+
+    pub fn new(in_meter_labels: &'a [&'a str], stream_meter_labels: &'a [&'a str], out_meter_labels: &'a [&'a str],
+               has_switch: bool, rotary_count: usize, has_sync_status: bool)
+        -> Self
+    {
+        let mut len = in_meter_labels.len() + out_meter_labels.len();
+        if stream_meter_labels.len() > 0 {
+            len += stream_meter_labels.len();
+        } else {
+            // Plus headphone-1 and -2, aux-1 and -2.
+            len += 4;
+        }
+        if has_switch || rotary_count > 0 || has_sync_status {
+            len += 1;
+        }
+        len *= std::mem::size_of::<i32>();
+        let cache = vec![0;len];
+
+        let switch = if has_switch { Some(SwitchState::Off) } else { None };
+        let rotary0 = if rotary_count == 1 { Some(0) } else { None };
+        let rotary1 = if rotary_count == 2 { Some(0) } else { None };
+        let sync_status = if has_sync_status { Some(false) } else { None };
+
+        MeterCtl {
+            in_meter_labels,
+            stream_meter_labels,
+            out_meter_labels,
+            cache: cache,
+            switch,
+            rotary0,
+            rotary1,
+            sync_status,
+            measure_elems: Vec::new(),
+        }
+    }
+
+    fn add_meter_elem(&mut self, card_cntr: &mut card_cntr::CardCntr, name: &str, labels: &[&str])
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, name, 0);
+        let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1, Self::METER_MIN, Self::METER_MAX, Self::METER_STEP,
+                                                       labels.len(), Some(Self::METER_TLV), false)?;
+        self.measure_elems.append(&mut elem_id_list);
+        Ok(())
+    }
+
+    pub fn load(&mut self, unit: &hinawa::SndUnit, avc: &BebobAvc, req: &hinawa::FwReq,
+                card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        self.measure_states(unit, avc, req)?;
+
+        // For metering.
+        self.add_meter_elem(card_cntr, IN_METER_NAME, self.in_meter_labels)?;
+        self.add_meter_elem(card_cntr, OUT_METER_NAME, self.out_meter_labels)?;
+
+        if self.stream_meter_labels.len() > 0 {
+            self.add_meter_elem(card_cntr, Self::STREAM_METER_NAME, self.stream_meter_labels)?;
+        } else {
+            self.add_meter_elem(card_cntr, Self::HP_OUT_METER_NAME, Self::HP_OUT_LABELS)?;
+            self.add_meter_elem(card_cntr, Self::AUX_OUT_METER_NAME, Self::AUX_OUT_LABELS)?;
+        }
+
+        // For switch button.
+        if self.switch.is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::SWITCH_NAME, 0);
+            let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::SWITCH_LABELS, None, true)?;
+            self.measure_elems.append(&mut elem_id_list);
+        }
+
+        // For rotary knob.
+        if self.rotary0.is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::ROTARY0_NAME, 0);
+            let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+                                                Self::ROTARY_MIN, Self::ROTARY_MAX, Self::ROTARY_STEP,
+                                                1, None, false)?;
+            self.measure_elems.append(&mut elem_id_list);
+        }
+
+        if self.rotary1.is_some() {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card,
+                                                       0, 0, Self::ROTARY1_NAME, 0);
+            let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+                                                Self::ROTARY_MIN, Self::ROTARY_MAX, Self::ROTARY_STEP,
+                                                1, None, false)?;
+            self.measure_elems.append(&mut elem_id_list);
+        }
+
+        // For sync status.
+        if self.sync_status.is_some() {
+            let elem_id = alsactl::ElemId::new_by_name( alsactl::ElemIfaceType::Card,
+                                                        0, 0, Self::SYNC_STATUS_NAME, 0);
+            let mut elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+            self.measure_elems.append(&mut elem_id_list);
+        }
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.measure_elem(elem_id, elem_value)
+    }
+
+    pub fn write(&mut self, avc: &BebobAvc, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::SWITCH_NAME => {
+                if let Some(s) = &mut self.switch {
+                    let mut val = [0];
+                    new.get_enum(&mut val);
+                    let switch = SwitchState::from(val[0] as u8);
+                    let mut op = LedSwitch::new(&avc.company_id, switch);
+                    avc.control(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+                    *s = switch;
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn measure_states(&mut self, unit: &hinawa::SndUnit, avc: &BebobAvc, req: &hinawa::FwReq)
+        -> Result<(), Error>
+    {
+        let mut frames = vec![0;self.cache.len()];
+        req.read_meters(unit, &mut frames)?;
+
+        if let Some(s) = &mut self.switch {
+            let pos = self.cache.len() - 4;
+
+            if (self.cache[pos] ^ frames[pos]) & 0xf0 > 0 {
+                if self.cache[pos] & 0xf0 > 0 {
+                    let switch = match s {
+                        SwitchState::Off => SwitchState::A,
+                        SwitchState::A => SwitchState::B,
+                        SwitchState::B => SwitchState::Off,
+                    };
+                    let mut op = LedSwitch::new(&avc.company_id, switch);
+                    avc.control(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+                    *s = switch;
+                }
+            }
+        }
+
+        if self.rotary0.is_some() || self.rotary1.is_some() {
+            let pos = self.cache.len() - 3;
+            let prev = self.cache[pos];
+            let curr = frames[pos];
+
+            if let Some(rotary0) = &mut self.rotary0 {
+                if (prev ^ curr) & 0x0f > 0 {
+                    if prev & 0x0f == 0x01 {
+                        if *rotary0 <= Self::ROTARY_MAX - Self::ROTARY_STEP {
+                            *rotary0 += Self::ROTARY_STEP;
+                        }
+                    } else if prev & 0x0f == 0x02 {
+                        if *rotary0 >= Self::ROTARY_MIN + Self::ROTARY_STEP {
+                            *rotary0 -= Self::ROTARY_STEP;
+                        }
+                    }
+                }
+            }
+
+            if let Some(rotary1) = &mut self.rotary1 {
+                if (prev ^ curr) & 0xf0 > 0 {
+                    if prev & 0xf0 == 0x10 {
+                        if *rotary1 <= Self::ROTARY_MAX - Self::ROTARY_STEP {
+                            *rotary1 += Self::ROTARY_STEP;
+                        }
+                    } else if prev & 0xf0 == 0x20 {
+                        if *rotary1 >= Self::ROTARY_MIN + Self::ROTARY_STEP {
+                            *rotary1 -= Self::ROTARY_STEP;
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(sync_status) = &mut self.sync_status {
+            let pos = self.cache.len() - 1;
+            if self.cache[pos] != frames[pos] {
+                *sync_status = frames[pos] > 0;
+            }
+        }
+
+        self.cache.copy_from_slice(&frames);
+
+        Ok(())
+    }
+
+    fn parse_meters(&self, elem_value: &mut alsactl::ElemValue, offset: usize, labels: &[&str]) {
+        let vals = (0..labels.len()).map(|i| {
+            let pos = (offset + i) * std::mem::size_of::<i32>();
+            let mut quadlet = [0;std::mem::size_of::<i32>()];
+            quadlet.copy_from_slice(&self.cache[pos..(pos + std::mem::size_of::<i32>())]);
+            i32::from_be_bytes(quadlet)
+        }).collect::<Vec<i32>>();
+        elem_value.set_int(&vals);
+    }
+
+    pub fn measure_elem(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            IN_METER_NAME => {
+                self.parse_meters(elem_value, 0, self.in_meter_labels);
+                Ok(true)
+            }
+            Self::STREAM_METER_NAME => {
+                let offset = self.in_meter_labels.len();
+                self.parse_meters(elem_value, offset, self.stream_meter_labels);
+                Ok(true)
+            }
+            OUT_METER_NAME => {
+                let offset = self.in_meter_labels.len() + self.stream_meter_labels.len();
+                self.parse_meters(elem_value, offset, self.out_meter_labels);
+                Ok(true)
+            }
+            Self::HP_OUT_METER_NAME => {
+                let offset = self.in_meter_labels.len() + self.stream_meter_labels.len() +
+                             self.out_meter_labels.len();
+                self.parse_meters(elem_value, offset, Self::HP_OUT_LABELS);
+                Ok(true)
+            }
+            Self::AUX_OUT_METER_NAME => {
+                let offset = self.in_meter_labels.len() + self.stream_meter_labels.len() +
+                             self.out_meter_labels.len() + 2;
+                self.parse_meters(elem_value, offset, Self::AUX_OUT_LABELS);
+                Ok(true)
+            }
+            Self::SWITCH_NAME => {
+                if let Some(s) = &self.switch {
+                    elem_value.set_enum(&[u8::from(*s) as u32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::ROTARY0_NAME => {
+                if let Some(rotary0) = &self.rotary0 {
+                    elem_value.set_int(&[*rotary0 as i32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::ROTARY1_NAME => {
+                if let Some(rotary1) = &self.rotary1 {
+                    elem_value.set_int(&[*rotary1 as i32]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::SYNC_STATUS_NAME => {
+                if let Some(sync_status) = &self.sync_status {
+                    elem_value.set_bool(&[*sync_status]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+}

--- a/src/bebob/maudio/ozonic_model.rs
+++ b/src/bebob/maudio/ozonic_model.rs
@@ -7,50 +7,76 @@ use hinawa::{FwFcpExt, SndUnitExt};
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
-use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::{AvcAddr, MUSIC_SUBUNIT_0, Ta1394Avc};
 use crate::ta1394::general::UnitInfo;
+use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
+use crate::bebob::common_ctls::ClkCtl;
 
 use super::common_proto::FCP_TIMEOUT_MS;
 
-pub struct OzonicModel{
+pub struct OzonicModel<'a>{
     avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
 }
 
-impl OzonicModel {
+impl<'a> OzonicModel<'a> {
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x05,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x05,
+        }),
+    ];
+    const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
     pub fn new() -> Self {
         OzonicModel{
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for OzonicModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for OzonicModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
         self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
         self.avc.company_id = op.company_id;
 
+        self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl MeasureModel<hinawa::SndUnit> for OzonicModel {
+impl<'a> MeasureModel<hinawa::SndUnit> for OzonicModel<'a> {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -65,17 +91,19 @@ impl MeasureModel<hinawa::SndUnit> for OzonicModel {
     }
 }
 
-impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for OzonicModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for OzonicModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
     }
 }

--- a/src/bebob/maudio/ozonic_model.rs
+++ b/src/bebob/maudio/ozonic_model.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+use card_cntr::{CtlModel, MeasureModel};
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::UnitInfo;
+
+use crate::bebob::BebobAvc;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct OzonicModel{
+    avc: BebobAvc,
+}
+
+impl OzonicModel {
+    pub fn new() -> Self {
+        OzonicModel{
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for OzonicModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+        self.avc.company_id = op.company_id;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<hinawa::SndUnit> for OzonicModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for OzonicModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/profirelightbridge_model.rs
+++ b/src/bebob/maudio/profirelightbridge_model.rs
@@ -7,41 +7,86 @@ use hinawa::{FwFcpExt, SndUnitExt};
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
-use crate::bebob::BebobAvc;
+use crate::ta1394::{MUSIC_SUBUNIT_0};
+use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
-pub struct ProfirelightbridgeModel {
+use crate::bebob::BebobAvc;
+use crate::bebob::common_ctls::ClkCtl;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct ProfirelightbridgeModel<'a> {
     avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
 }
 
-impl ProfirelightbridgeModel {
+impl<'a> ProfirelightbridgeModel<'a> {
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x07,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x08,
+        }),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x01)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x02)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x03)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x04)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x05)),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x06)),
+    ];
+    const CLK_LABELS: &'a [&'a str] = &[
+        "Internal",
+        "S/PDIF",
+        "ADAT-1",
+        "ADAT-2",
+        "ADAT-3",
+        "ADAT-4",
+        "Word-clock",
+    ];
+
     pub fn new() -> Self {
         ProfirelightbridgeModel {
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
+
+        self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel {
+impl<'a> MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -56,17 +101,19 @@ impl MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel {
     }
 }
 
-impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ProfirelightbridgeModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ProfirelightbridgeModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
     }
 }

--- a/src/bebob/maudio/profirelightbridge_model.rs
+++ b/src/bebob/maudio/profirelightbridge_model.rs
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+use card_cntr::{CtlModel, MeasureModel};
+
+use crate::bebob::BebobAvc;
+
+pub struct ProfirelightbridgeModel {
+    avc: BebobAvc,
+}
+
+impl ProfirelightbridgeModel {
+    pub fn new() -> Self {
+        ProfirelightbridgeModel {
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ProfirelightbridgeModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/profirelightbridge_model.rs
+++ b/src/bebob/maudio/profirelightbridge_model.rs
@@ -4,6 +4,8 @@ use glib::Error;
 
 use hinawa::{FwFcpExt, SndUnitExt};
 
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
@@ -12,12 +14,15 @@ use crate::ta1394::ccm::{SignalAddr, SignalUnitAddr, SignalSubunitAddr};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
+use crate::bebob::model::OUT_METER_NAME;
 
-use super::common_proto::FCP_TIMEOUT_MS;
+use super::common_proto::{FCP_TIMEOUT_MS, CommonProto};
 
 pub struct ProfirelightbridgeModel<'a> {
     avc: BebobAvc,
+    req: hinawa::FwReq,
     clk_ctl: ClkCtl<'a>,
+    meter_ctl: MeterCtl,
 }
 
 impl<'a> ProfirelightbridgeModel<'a> {
@@ -50,7 +55,9 @@ impl<'a> ProfirelightbridgeModel<'a> {
     pub fn new() -> Self {
         ProfirelightbridgeModel {
             avc: BebobAvc::new(),
+            req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
+            meter_ctl: MeterCtl::new(),
         }
     }
 }
@@ -60,6 +67,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+        self.meter_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -87,17 +95,106 @@ impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
 }
 
 impl<'a> MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
-    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+        self.meter_ctl.measure_states(unit, &self.req)
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.meter_ctl.measure_elem(elem_id, elem_value)
+    }
+}
+
+struct MeterCtl {
+    measure_elems: Vec<alsactl::ElemId>,
+    cache: [u8;Self::FRAME_COUNT],
+}
+
+impl<'a> MeterCtl {
+    const FRAME_COUNT: usize = 56;
+
+    const DETECTED_RATE_NAME: &'a str = "Detected rate";
+    const SYNC_STATUS_NAME: &'a str = "Sync status";
+
+    const METER_LABELS: &'a [&'a str] = &["analog-out-1", "analog-out-2"];
+    const RATE_LABELS: &'a [&'a str] = &["44100", "48000", "88200", "96000"];
+
+    const METER_MIN: i32 = 0;
+    const METER_MAX: i32 = 0x007fffff;
+    const METER_STEP: i32 = 256;
+    const METER_TLV: &'a [i32] = &[5, 8, -14400, 0];
+
+    fn new() -> Self {
+        MeterCtl {
+            measure_elems: Vec::new(),
+            cache: [0;Self::FRAME_COUNT],
+        }
+    }
+
+    fn load(&mut self, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        // For metering.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_METER_NAME, 0);
+        let elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+                                                   Self::METER_MIN, Self::METER_MAX, Self::METER_STEP,
+                                                   Self::METER_LABELS.len(), Some(Self::METER_TLV), false)?;
+        self.measure_elems.push(elem_id_list[0].clone());
+
+        // For detection of sampling clock frequency.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::DETECTED_RATE_NAME, 0);
+        let elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::RATE_LABELS, None, false)?;
+        self.measure_elems.push(elem_id_list[0].clone());
+
+        // For sync status.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::SYNC_STATUS_NAME, 0);
+        let elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+        self.measure_elems.push(elem_id_list[0].clone());
+
         Ok(())
     }
 
-    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
-        -> Result<bool, Error>
-    {
-        Ok(false)
+    pub fn measure_states(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq) -> Result<(), Error> {
+        req.read_meters(unit, &mut self.cache)
+    }
+
+    fn measure_elem(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            OUT_METER_NAME => {
+                let mut vals = [0;2];
+                vals.iter_mut().enumerate().for_each(|(i, v)| {
+                    let mut quadlet = [0;4];
+                    let pos = 4 + i * 4;
+                    quadlet.copy_from_slice(&self.cache[pos..(pos + 4)]);
+                    *v = i32::from_be_bytes(quadlet);
+                });
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::DETECTED_RATE_NAME => {
+                let mut quadlet = [0;4];
+                quadlet.copy_from_slice(&self.cache[0..4]);
+                let val = u32::from_be_bytes(quadlet);
+                if val > 0 && val <= Self::RATE_LABELS.len() as u32 {
+                    elem_value.set_enum(&[val - 1]);
+                    Ok(true)
+                } else {
+                    Ok(false)
+                }
+            }
+            Self::SYNC_STATUS_NAME => {
+                let mut quadlet = [0;4];
+                quadlet.copy_from_slice(&self.cache[20..24]);
+                elem_value.set_bool(&[u32::from_be_bytes(quadlet) != 2]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 }
 

--- a/src/bebob/maudio/solo_model.rs
+++ b/src/bebob/maudio/solo_model.rs
@@ -7,50 +7,79 @@ use hinawa::{FwFcpExt, SndUnitExt};
 use crate::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 
-use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::{AvcAddr, MUSIC_SUBUNIT_0, Ta1394Avc};
 use crate::ta1394::general::UnitInfo;
+use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr, SignalUnitAddr};
+
+use crate::bebob::common_ctls::ClkCtl;
 
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
 
-pub struct SoloModel{
+pub struct SoloModel<'a>{
     avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
 }
 
-impl SoloModel {
+impl<'a> SoloModel<'a> {
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x01,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x01,
+        }),
+        SignalAddr::Unit(SignalUnitAddr::Ext(0x01)),
+    ];
+    const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
+
     pub fn new() -> Self {
         SoloModel{
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for SoloModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
         self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
         self.avc.company_id = op.company_id;
 
+        self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl MeasureModel<hinawa::SndUnit> for SoloModel {
+impl<'a> MeasureModel<hinawa::SndUnit> for SoloModel<'a> {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -65,17 +94,19 @@ impl MeasureModel<hinawa::SndUnit> for SoloModel {
     }
 }
 
-impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for SoloModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for SoloModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
     }
 }

--- a/src/bebob/maudio/solo_model.rs
+++ b/src/bebob/maudio/solo_model.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+use card_cntr::{CtlModel, MeasureModel};
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::UnitInfo;
+
+use crate::bebob::BebobAvc;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct SoloModel{
+    avc: BebobAvc,
+}
+
+impl SoloModel {
+    pub fn new() -> Self {
+        SoloModel{
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for SoloModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        let mut op = UnitInfo::new();
+        self.avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+        self.avc.company_id = op.company_id;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<hinawa::SndUnit> for SoloModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for SoloModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/solo_model.rs
+++ b/src/bebob/maudio/solo_model.rs
@@ -16,10 +16,13 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
+use super::normal_ctls::MeterCtl;
 
 pub struct SoloModel<'a>{
     avc: BebobAvc,
     clk_ctl: ClkCtl<'a>,
+    req: hinawa::FwReq,
+    meter_ctl: MeterCtl<'a>,
 }
 
 impl<'a> SoloModel<'a> {
@@ -36,10 +39,25 @@ impl<'a> SoloModel<'a> {
     ];
     const CLK_LABELS: &'a [&'a str] = &["Internal", "S/PDIF"];
 
+    const IN_METER_LABELS: &'a [&'a str] = &[
+        "analog-in-1", "analog-in-2", "digital-in-1", "digital-in-2",
+    ];
+
+    const OUT_METER_LABELS: &'a [&'a str] = &[
+        "analog-out-1", "analog-out-2", "digital-out-1", "digital-out-2",
+    ];
+
+    const STREAM_METER_LABELS: &'a [&'a str] = &[
+        "stream-in-1", "stream-in-2", "stream-in-3", "stream-in-4",
+    ];
+
     pub fn new() -> Self {
         SoloModel{
             avc: BebobAvc::new(),
+            req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
+            meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, Self::STREAM_METER_LABELS, Self::OUT_METER_LABELS,
+                                     false, 0, true),
         }
     }
 }
@@ -53,6 +71,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         self.avc.company_id = op.company_id;
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
+        self.meter_ctl.load(unit, &self.avc, &self.req, card_cntr)?;
 
         Ok(())
     }
@@ -61,6 +80,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -73,6 +94,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
     {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
             Ok(true)
+        } else if self.meter_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -80,17 +103,18 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
 }
 
 impl<'a> MeasureModel<hinawa::SndUnit> for SoloModel<'a> {
-    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
-        Ok(())
+    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+        self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 
-    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.meter_ctl.measure_elem(elem_id, elem_value)
     }
 }
 

--- a/src/bebob/maudio/solo_model.rs
+++ b/src/bebob/maudio/solo_model.rs
@@ -16,13 +16,14 @@ use crate::bebob::common_ctls::ClkCtl;
 use crate::bebob::BebobAvc;
 
 use super::common_proto::FCP_TIMEOUT_MS;
-use super::normal_ctls::MeterCtl;
+use super::normal_ctls::{MeterCtl, MixerCtl};
 
 pub struct SoloModel<'a>{
     avc: BebobAvc,
     clk_ctl: ClkCtl<'a>,
     req: hinawa::FwReq,
     meter_ctl: MeterCtl<'a>,
+    mixer_ctl: MixerCtl<'a>,
 }
 
 impl<'a> SoloModel<'a> {
@@ -51,6 +52,13 @@ impl<'a> SoloModel<'a> {
         "stream-in-1", "stream-in-2", "stream-in-3", "stream-in-4",
     ];
 
+    const MIXER_DST_FB_IDS: &'a [u8] = &[0x01, 0x01];
+    const MIXER_LABELS: &'a [&'a str] = &["mixer-1/2", "mixer-3/4"];
+    const MIXER_PHYS_SRC_FB_IDS: &'a [u8] = &[0x00, 0x01];
+    const PHYS_IN_LABELS: &'a [&'a str] = &["analog-1/2", "digital-1/2"];
+    const MIXER_STREAM_SRC_FB_IDS: &'a [u8] = &[0x02, 0x03];
+    const STREAM_IN_LABELS: &'a [&'a str] = &["stream-1/2", "stream-1/2"];
+
     pub fn new() -> Self {
         SoloModel{
             avc: BebobAvc::new(),
@@ -58,6 +66,11 @@ impl<'a> SoloModel<'a> {
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, Self::STREAM_METER_LABELS, Self::OUT_METER_LABELS,
                                      false, 0, true),
+            mixer_ctl: MixerCtl::new(
+                Self::MIXER_DST_FB_IDS, Self::MIXER_LABELS,
+                Self::MIXER_PHYS_SRC_FB_IDS, Self::PHYS_IN_LABELS,
+                Self::MIXER_STREAM_SRC_FB_IDS, Self::STREAM_IN_LABELS,
+            ),
         }
     }
 }
@@ -72,6 +85,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
         self.meter_ctl.load(unit, &self.avc, &self.req, card_cntr)?;
+        self.mixer_ctl.load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -82,6 +96,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(&self.avc, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -95,6 +111,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, FCP_TIMEOUT_MS)? {
             Ok(true)
         } else if self.meter_ctl.write(&self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(&self.avc, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_ctls.rs
+++ b/src/bebob/maudio/special_ctls.rs
@@ -323,3 +323,33 @@ impl<'a> MeterCtl {
         }
     }
 }
+
+pub struct StateCache{
+    cache: [u8;Self::CACHE_SIZE],
+}
+
+impl StateCache {
+    const CACHE_SIZE: usize = 160;
+
+    pub fn new() -> Self {
+        StateCache{
+            cache: [0;Self::CACHE_SIZE],
+        }
+    }
+
+    pub fn upload(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq) -> Result<(), Error> {
+        (0..(Self::CACHE_SIZE / 4)).try_for_each(|pos| {
+            let offset = pos * 4;
+            req.write_quadlet(unit, offset, &mut self.cache)
+        })
+    }
+}
+
+trait SpecialProto : CommonProto {
+    fn write_quadlet(&self, unit: &hinawa::SndUnit, offset: usize, cache: &mut [u8]) -> Result<(), Error> {
+        self.transaction_sync(&unit.get_node(), hinawa::FwTcode::WriteQuadletRequest,
+                              Self::BASE_ADDR + offset as u64, 4, &mut cache[offset..(offset + 4)], Self::TIMEOUT)
+    }
+}
+
+impl SpecialProto for hinawa::FwReq {}

--- a/src/bebob/maudio/special_ctls.rs
+++ b/src/bebob/maudio/special_ctls.rs
@@ -9,13 +9,14 @@ use alsactl::{ElemValueExt, ElemValueExtManual};
 use crate::card_cntr;
 
 use crate::ta1394::{AvcAddr, Ta1394Avc};
-use crate::ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat};
+use crate::ta1394::{AvcOp, AvcControl};
+use crate::ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat, VendorDependent};
 use crate::ta1394::amdtp::{AmdtpEventType, AmdtpFdf, FMT_IS_AMDTP};
 
 use crate::bebob::BebobAvc;
-use crate::bebob::model::CLK_RATE_NAME;
+use crate::bebob::model::{CLK_RATE_NAME, IN_METER_NAME, OUT_METER_NAME};
 
-use super::common_proto::FCP_TIMEOUT_MS;
+use super::common_proto::{FCP_TIMEOUT_MS, CommonProto};
 
 pub struct ClkCtl{
     supported_clk_rates: Vec<u32>,
@@ -97,6 +98,226 @@ impl<'a> ClkCtl {
                 }
                 unit.unlock()?;
                 res.and(Ok(true))
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+struct LedSwitch{
+    state: bool,
+    op: VendorDependent,
+}
+
+impl LedSwitch {
+    // NOTE: Unknown OUI.
+    const OUI: [u8;3] = [0x03, 0x00, 0x01];
+
+    pub fn new(state: bool) -> Self {
+        LedSwitch{
+            state,
+            op: VendorDependent{
+                company_id: Self::OUI,
+                data: Vec::new(),
+            },
+        }
+    }
+}
+
+impl AvcOp for LedSwitch {
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+impl AvcControl for LedSwitch {
+    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+        self.op.data.extend_from_slice(&[self.state as u8, 0xff]);
+        AvcControl::build_operands(&mut self.op, addr, operands)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)
+    }
+}
+
+pub struct MeterCtl{
+    pub measure_elems: Vec<alsactl::ElemId>,
+    meters: [u8; Self::METER_FRAME_SIZE],
+    switch: bool,
+    rotaries: [i32;3],
+    sync_status: bool,
+}
+
+impl<'a> MeterCtl {
+    const ROTARY0_NAME: &'a str = "rotary0";
+    const ROTARY1_NAME: &'a str = "rotary1";
+    const ROTARY2_NAME: &'a str = "rotary2";
+    const SWITCH_NAME: &'a str = "switch";
+    const SYNC_STATUS_NAME: &'a str = "Sync Status";
+    const HP_OUT_METER_NAME: &'a str = "headhpone-meters";
+
+    const IN_METER_LABELS: &'a [&'a str] = &[
+        "analog-in-1", "analog-in-2", "analog-in-3", "analog-in-4",
+        "analog-in-5", "analog-in-6", "analog-in-7", "analog-in-8",
+        "spdif-in-1", "spdif-in-2",
+        "adat-in-1", "adat-in-2", "adat-in-3", "adat-in-4",
+        "adat-in-5", "adat-in-6", "adat-in-7", "adat-in-8",
+    ];
+
+    const OUT_METER_LABELS: &'a [&'a str] = &[
+        "analog-out-1", "analog-out-2", "analog-out-3", "analog-out-4",
+        "spdif-out-1", "spdif-out-2",
+        "adat-out-1", "adat-out-2", "adat-out-3", "adat-out-4",
+        "adat-out-5", "adat-out-6", "adat-out-7", "adat-out-8",
+    ];
+
+    const HP_OUT_METER_LABELS: &'a [&'a str] = &[
+        "headphone-out-1", "headphone-out-2", "headphone-out-3", "headphone-out-4",
+    ];
+
+    const VAL_MIN: i32 = 0;
+    const VAL_MAX: i32 = i16::MAX as i32;
+    const VAL_STEP: i32 = 256;
+    const VAL_TLV: &'a [i32; 4] = &[5, 8, -12800, 0];
+
+    const METER_FRAME_SIZE: usize = 84;
+
+    pub fn new() -> Self {
+        MeterCtl{
+            measure_elems: Vec::new(),
+            meters: [0;Self::METER_FRAME_SIZE],
+            switch: false,
+            rotaries: [0;3],
+            sync_status: false,
+        }
+    }
+
+    fn add_meter_elem(&mut self, card_cntr: &mut card_cntr::CardCntr, name: &str, labels: &[&str])
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, name, 0);
+        let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1, Self::VAL_MIN, Self::VAL_MAX, Self::VAL_STEP,
+                                                       labels.len(), Some(Self::VAL_TLV), false)?;
+        self.measure_elems.append(&mut elem_id_list);
+        Ok(())
+    }
+
+    pub fn load(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq, avc: &BebobAvc,
+                card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::ROTARY0_NAME, 0);
+        let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1, Self::VAL_MIN, Self::VAL_MAX, Self::VAL_STEP,
+                                                       1, None, false)?;
+        self.measure_elems.append(&mut elem_id_list);
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::ROTARY1_NAME, 0);
+        let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1, Self::VAL_MIN, Self::VAL_MAX, Self::VAL_STEP,
+                                                       1, None, false)?;
+        self.measure_elems.append(&mut elem_id_list);
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::ROTARY2_NAME, 0);
+        let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1, Self::VAL_MIN, Self::VAL_MAX, Self::VAL_STEP,
+                                                       1, None, false)?;
+        self.measure_elems.append(&mut elem_id_list);
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::SWITCH_NAME, 0);
+        let mut elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
+        self.measure_elems.append(&mut elem_id_list);
+
+        self.add_meter_elem(card_cntr, IN_METER_NAME, Self::IN_METER_LABELS)?;
+        self.add_meter_elem(card_cntr, OUT_METER_NAME, Self::OUT_METER_LABELS)?;
+        self.add_meter_elem(card_cntr, Self::HP_OUT_METER_NAME, Self::HP_OUT_METER_LABELS)?;
+
+        self.measure_states(unit, req, avc)?;
+
+        Ok(())
+    }
+
+    pub fn measure_states(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq, avc: &BebobAvc)
+        -> Result<(), Error>
+    {
+        let mut frames = [0;Self::METER_FRAME_SIZE];
+        req.read_meters(unit, &mut frames)?;
+
+        if self.meters[0] == 0x01 && frames[0] == 0x00 {
+            let mut op = LedSwitch::new(!self.switch);
+            avc.control(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+            self.switch = !self.switch;
+        }
+
+        let meters = &self.meters;
+        self.rotaries.iter_mut().enumerate().for_each(|(i, v)| {
+            if meters[i + 1] ^ frames[i + 1] > 0 {
+                let delta = match meters[i + 1] {
+                    0x01 => Self::VAL_STEP,
+                    0x02 => -Self::VAL_STEP,
+                    _ => 0,
+                };
+                if *v + delta < Self::VAL_MIN {
+                    *v = Self::VAL_MIN;
+                } else if *v + delta > Self::VAL_MAX {
+                    *v = Self::VAL_MAX;
+                } else {
+                    *v += delta;
+                }
+            }
+        });
+
+        if self.meters[83] != frames[83] {
+            self.sync_status = frames[83] != 0;
+        }
+
+        self.meters.copy_from_slice(&frames);
+        Ok(())
+    }
+
+    fn parse_meters(&self, elem_value: &mut alsactl::ElemValue, offset: usize, labels: &[&str]) {
+        let vals = (0..labels.len()).map(|i| {
+            let pos = (offset + i) * std::mem::size_of::<i16>();
+            let mut doublet = [0;std::mem::size_of::<i16>()];
+            doublet.copy_from_slice(&self.meters[pos..(pos + std::mem::size_of::<i16>())]);
+            i16::from_be_bytes(doublet) as i32
+        }).collect::<Vec<i32>>();
+        elem_value.set_int(&vals);
+    }
+
+    pub fn measure_elem(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::ROTARY0_NAME => {
+                elem_value.set_int(&[self.rotaries[0]]);
+                Ok(true)
+            }
+            Self::ROTARY1_NAME => {
+                elem_value.set_int(&[self.rotaries[1]]);
+                Ok(true)
+            }
+            Self::ROTARY2_NAME => {
+                elem_value.set_int(&[self.rotaries[2]]);
+                Ok(true)
+            }
+            Self::SWITCH_NAME => {
+                elem_value.set_bool(&[self.switch]);
+                Ok(true)
+            }
+            Self::SYNC_STATUS_NAME => {
+                elem_value.set_bool(&[self.sync_status]);
+                Ok(true)
+            }
+            IN_METER_NAME => {
+                self.parse_meters(elem_value, 0, Self::IN_METER_LABELS);
+                Ok(true)
+            }
+            OUT_METER_NAME => {
+                let offset = Self::IN_METER_LABELS.len();
+                self.parse_meters(elem_value, offset, Self::OUT_METER_LABELS);
+                Ok(true)
+            }
+            Self::HP_OUT_METER_NAME => {
+                let offset = Self::IN_METER_LABELS.len() + Self::OUT_METER_LABELS.len();
+                self.parse_meters(elem_value, offset, Self::HP_OUT_METER_LABELS);
+                Ok(true)
             }
             _ => Ok(false),
         }

--- a/src/bebob/maudio/special_ctls.rs
+++ b/src/bebob/maudio/special_ctls.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndUnitExt;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+use crate::card_cntr;
+
+use crate::ta1394::{AvcAddr, Ta1394Avc};
+use crate::ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat};
+use crate::ta1394::amdtp::{AmdtpEventType, AmdtpFdf, FMT_IS_AMDTP};
+
+use crate::bebob::BebobAvc;
+use crate::bebob::model::CLK_RATE_NAME;
+
+use super::common_proto::FCP_TIMEOUT_MS;
+
+pub struct ClkCtl{
+    supported_clk_rates: Vec<u32>,
+    pub notified_elem_list: Vec<alsactl::ElemId>,
+}
+
+impl<'a> ClkCtl {
+    pub fn new(is_fw1814: bool) -> Self {
+        let mut supported_clk_rates = Vec::new();
+        supported_clk_rates.extend_from_slice(&[32000, 44100, 48000, 88200, 96000]);
+        if is_fw1814 {
+            supported_clk_rates.extend_from_slice(&[176400, 192000]);
+        }
+        ClkCtl{
+            supported_clk_rates,
+            notified_elem_list: Vec::new(),
+        }
+    }
+
+    pub fn load(&mut self, card_cntr: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        let labels = self.supported_clk_rates.iter().map(|l| l.to_string()).collect::<Vec<String>>();
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, CLK_RATE_NAME, 0);
+        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        self.notified_elem_list.append(&mut elem_id_list);
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, avc: &BebobAvc, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                let mut op = InputPlugSignalFormat::new(0);
+                avc.status(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS)?;
+
+                let fdf = AmdtpFdf::from(op.fdf.as_ref());
+                match self.supported_clk_rates.iter().position(|r| *r == fdf.freq) {
+                    Some(p) => {
+                        elem_value.set_enum(&[p as u32]);
+                        Ok(true)
+                    }
+                    None => Ok(false),
+                }
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &hinawa::SndUnit, avc: &BebobAvc, elem_id: &alsactl::ElemId,
+                 _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+
+                let freq = self.supported_clk_rates[vals[0] as usize];
+                let fdf = AmdtpFdf::new(AmdtpEventType::Am824, false, freq);
+
+                unit.lock()?;
+                let mut op = OutputPlugSignalFormat{
+                    plug_id: 0,
+                    fmt: FMT_IS_AMDTP,
+                    fdf: fdf.into(),
+                };
+                let mut res = avc.control(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS * 2);
+                if res.is_ok() {
+                    let mut op = InputPlugSignalFormat{
+                        plug_id: 0,
+                        fmt: FMT_IS_AMDTP,
+                        fdf: fdf.into(),
+                    };
+                    res = avc.control(&AvcAddr::Unit, &mut op, FCP_TIMEOUT_MS * 2)
+                }
+                unit.unlock()?;
+                res.and(Ok(true))
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/bebob/maudio/special_ctls.rs
+++ b/src/bebob/maudio/special_ctls.rs
@@ -353,3 +353,174 @@ trait SpecialProto : CommonProto {
 }
 
 impl SpecialProto for hinawa::FwReq {}
+
+pub trait StateCacheAccessor {
+    fn get_u32(&self, pos: usize) -> u32;
+    fn set_u32(&mut self, pos: usize, val: u32);
+}
+
+impl StateCacheAccessor for StateCache {
+    fn get_u32(&self, pos: usize) -> u32 {
+        let mut quadlet = [0;std::mem::size_of::<u32>()];
+        quadlet.copy_from_slice(&self.cache[pos..(pos + std::mem::size_of::<u32>())]);
+        u32::from_be_bytes(quadlet)
+    }
+
+    fn set_u32(&mut self, pos: usize, val: u32) {
+        let quadlet = val.to_be_bytes();
+        self.cache[pos..(pos + std::mem::size_of::<u32>())].copy_from_slice(&quadlet);
+    }
+}
+
+const STREAM_SRC_PAIR_LABELS: &[&str] = &["stream-1/2", "stream-3/4"];
+const ANALOG_SRC_PAIR_LABELS: &[&str] = &["analog-1/2", "analog-3/4", "analog-5/6", "analog-7/8"];
+const SPDIF_SRC_PAIR_LABELS: &[&str] = &["spdif-1/2"];
+const ADAT_SRC_PAIR_LABELS: &[&str] = &["adat-1/2", "adat-3/4", "adat-5/6", "adat-7/8"];
+
+const MIXER_DST_PAIR_LABELS: &[&str] = &["mixer-1/2", "mixer-3/4"];
+
+const MIXER_PHYS_SRC_POS: usize = 0x90;
+const MIXER_STREAM_SRC_POS: usize = 0x94;
+
+const MIXER_ANALOG_SRC_TO_DST_01_SHIFT: [usize;2] = [0, 4];
+const MIXER_SPDIF_SRC_TO_DST_01_SHIFT: [usize;2] = [16, 20];
+const MIXER_ADAT_SRC_TO_DST_01_SHIFT: [usize;2] = [8, 12];
+const MIXER_STREAM_SRC_01_TO_DST_SHIFT: [usize;2] = [0, 2];
+
+const MIXER_SRC_NAME: &str = "mixer-source";
+
+pub trait MixerCtl : StateCacheAccessor {
+    fn load(&mut self, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error>;
+    fn read(&self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue) -> Result<bool, Error>;
+    fn write(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error>;
+}
+
+trait MixerSrcOperation {
+    fn parse_stream_src_flags(&self, target: usize, table: &[usize;2]) -> Vec<bool>;
+    fn parse_phys_src_flags(&self, count: usize, target: usize, table: &[usize;2]) -> Vec<bool>;
+    fn build_stream_src_flags(&self, vals: &[bool], target: usize, table: &[usize;2]) -> Self;
+    fn build_phys_src_flags(&self, vals: &[bool], target: usize, table: &[usize;2]) -> Self;
+}
+
+impl MixerSrcOperation for u32 {
+    fn parse_stream_src_flags(&self, target: usize, table: &[usize;2]) -> Vec<bool> {
+        table.iter().map(|shift| {
+            let flag = (1 << (shift + target)) as u32;
+            (flag & *self) > 0
+        }).collect::<Vec<bool>>()
+    }
+
+    fn parse_phys_src_flags(&self, count: usize, target: usize, table: &[usize;2]) -> Vec<bool> {
+        (0..count).map(|i| {
+            let flag = (1 << (table[target] + i)) as u32;
+            (flag & *self) > 0
+        }).collect::<Vec<bool>>()
+    }
+
+    fn build_stream_src_flags(&self, vals: &[bool], target: usize, table: &[usize;2]) -> Self {
+        vals.iter().zip(table.iter()).fold(*self, |mut flags, (v, shift)| {
+            let flag = (1 << shift + target) as u32;
+            flags &= !flag;
+            if *v {
+                flags |= flag;
+            }
+            flags
+        })
+    }
+
+    fn build_phys_src_flags(&self, vals: &[bool], target: usize, table: &[usize;2]) -> Self {
+        let shift = table[target];
+        vals.iter().enumerate().fold(*self, |mut flags, (i, v)| {
+            let flag = (1 << (shift + i)) as u32;
+            flags &= !flag;
+            if *v {
+                flags |= flag;
+            }
+            flags
+        })
+    }
+}
+
+impl MixerCtl for StateCache {
+    fn load(&mut self, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        // Source of mixers.
+        let mut flags = self.get_u32(MIXER_STREAM_SRC_POS);
+        flags = flags.build_stream_src_flags(&[true, false], 0, &MIXER_STREAM_SRC_01_TO_DST_SHIFT);
+        flags = flags.build_stream_src_flags(&[false, true], 1, &MIXER_STREAM_SRC_01_TO_DST_SHIFT);
+        self.set_u32(MIXER_STREAM_SRC_POS, flags);
+
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, MIXER_SRC_NAME, 0);
+        let in_count = STREAM_SRC_PAIR_LABELS.len() + ANALOG_SRC_PAIR_LABELS.len()
+                     + SPDIF_SRC_PAIR_LABELS.len() + ADAT_SRC_PAIR_LABELS.len();
+        let _ = card_cntr.add_bool_elems(&elem_id, MIXER_DST_PAIR_LABELS.len(), in_count, true)?;
+
+        Ok(())
+    }
+
+    fn read(&self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            MIXER_SRC_NAME => {
+                let target = elem_id.get_index() as usize;
+
+                let flags = self.get_u32(MIXER_STREAM_SRC_POS);
+                let mut vals = flags.parse_stream_src_flags(target, &MIXER_STREAM_SRC_01_TO_DST_SHIFT);
+
+                let flags = self.get_u32(MIXER_PHYS_SRC_POS);
+                vals.append(&mut flags.parse_phys_src_flags(ANALOG_SRC_PAIR_LABELS.len(), target,
+                                                            &MIXER_ANALOG_SRC_TO_DST_01_SHIFT));
+                vals.append(&mut flags.parse_phys_src_flags(SPDIF_SRC_PAIR_LABELS.len(), target,
+                                                            &MIXER_SPDIF_SRC_TO_DST_01_SHIFT));
+                vals.append(&mut flags.parse_phys_src_flags(ADAT_SRC_PAIR_LABELS.len(), target,
+                                                            &MIXER_ADAT_SRC_TO_DST_01_SHIFT));
+
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &hinawa::SndUnit, req: &hinawa::FwReq, elem_id: &alsactl::ElemId,
+             _: &alsactl::ElemValue, new: &alsactl::ElemValue)
+        -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            MIXER_SRC_NAME => {
+                let index = elem_id.get_index() as usize;
+                let in_count = STREAM_SRC_PAIR_LABELS.len() + ANALOG_SRC_PAIR_LABELS.len()
+                             + SPDIF_SRC_PAIR_LABELS.len() + ADAT_SRC_PAIR_LABELS.len();
+                let mut vals = vec![false;in_count];
+                new.get_bool(&mut vals);
+
+                let prev_flags = self.get_u32(MIXER_STREAM_SRC_POS);
+                let mut curr_flags = prev_flags;
+                curr_flags = curr_flags.build_stream_src_flags(&vals[..STREAM_SRC_PAIR_LABELS.len()], index,
+                                                               &MIXER_STREAM_SRC_01_TO_DST_SHIFT);
+                if prev_flags != curr_flags {
+                    self.set_u32(MIXER_STREAM_SRC_POS, curr_flags);
+                    req.write_quadlet(unit, MIXER_STREAM_SRC_POS, &mut self.cache)?;
+                }
+
+                let prev_flags = self.get_u32(MIXER_PHYS_SRC_POS);
+                let mut curr_flags = prev_flags;
+                let mut skip = STREAM_SRC_PAIR_LABELS.len();
+                curr_flags = curr_flags.build_phys_src_flags(&vals[skip..(skip + ANALOG_SRC_PAIR_LABELS.len())], index,
+                                                             &MIXER_ANALOG_SRC_TO_DST_01_SHIFT);
+                skip += ANALOG_SRC_PAIR_LABELS.len();
+                curr_flags = curr_flags.build_phys_src_flags(&vals[skip..(skip + SPDIF_SRC_PAIR_LABELS.len())], index,
+                                                             &MIXER_SPDIF_SRC_TO_DST_01_SHIFT);
+                skip += SPDIF_SRC_PAIR_LABELS.len();
+                curr_flags = curr_flags.build_phys_src_flags(&vals[skip..(skip + ADAT_SRC_PAIR_LABELS.len())], index,
+                                                             &MIXER_ADAT_SRC_TO_DST_01_SHIFT);
+                if prev_flags != curr_flags {
+                    self.set_u32(MIXER_PHYS_SRC_POS, curr_flags);
+                    req.write_quadlet(unit, MIXER_PHYS_SRC_POS, &mut self.cache)?;
+                }
+
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{FwFcpExt, SndUnitExt};
+
+use crate::card_cntr;
+
+use crate::bebob::BebobAvc;
+
+pub struct SpecialModel {
+    avc: BebobAvc,
+}
+
+impl<'a> SpecialModel {
+    pub fn new() -> Self {
+        SpecialModel {
+            avc: BebobAvc::new(),
+        }
+    }
+}
+
+impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
+    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl<'a> card_cntr::MeasureModel<hinawa::SndUnit> for SpecialModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for SpecialModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,7 +8,7 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl, StateCache};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl};
 
 pub struct SpecialModel {
     avc: BebobAvc,
@@ -37,6 +37,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         self.clk_ctl.load(card_cntr)?;
         self.meter_ctl.load(unit, &self.req, &self.avc, card_cntr)?;
 
+        MixerCtl::load(&mut self.cache, card_cntr)?;
+
         self.cache.upload(unit, &self.req)?;
 
         Ok(())
@@ -46,6 +48,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else if MixerCtl::read(&mut self.cache, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -57,6 +61,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         -> Result<bool, Error>
     {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else if MixerCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,7 +8,7 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl, OutputCtl};
 
 pub struct SpecialModel {
     avc: BebobAvc,
@@ -39,6 +39,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
 
         MixerCtl::load(&mut self.cache, card_cntr)?;
         InputCtl::load(&mut self.cache, card_cntr)?;
+        OutputCtl::load(&mut self.cache, card_cntr)?;
 
         self.cache.upload(unit, &self.req)?;
 
@@ -54,6 +55,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
             Ok(true)
         } else if InputCtl::read(&mut self.cache, elem_id, elem_value)? {
             Ok(true)
+        } else if OutputCtl::read(&mut self.cache, elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -68,6 +71,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         } else if MixerCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else if InputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if OutputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,7 +8,7 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl};
 
 pub struct SpecialModel {
     avc: BebobAvc,
@@ -38,6 +38,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         self.meter_ctl.load(unit, &self.req, &self.avc, card_cntr)?;
 
         MixerCtl::load(&mut self.cache, card_cntr)?;
+        InputCtl::load(&mut self.cache, card_cntr)?;
 
         self.cache.upload(unit, &self.req)?;
 
@@ -51,6 +52,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
             Ok(true)
         } else if MixerCtl::read(&mut self.cache, elem_id, elem_value)? {
             Ok(true)
+        } else if InputCtl::read(&mut self.cache, elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -63,6 +66,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new)? {
             Ok(true)
         } else if MixerCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if InputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,7 +8,7 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl, OutputCtl};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl, OutputCtl, AuxCtl};
 
 pub struct SpecialModel {
     avc: BebobAvc,
@@ -40,6 +40,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         MixerCtl::load(&mut self.cache, card_cntr)?;
         InputCtl::load(&mut self.cache, card_cntr)?;
         OutputCtl::load(&mut self.cache, card_cntr)?;
+        AuxCtl::load(&mut self.cache, card_cntr)?;
 
         self.cache.upload(unit, &self.req)?;
 
@@ -57,6 +58,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
             Ok(true)
         } else if OutputCtl::read(&mut self.cache, elem_id, elem_value)? {
             Ok(true)
+        } else if AuxCtl::read(&mut self.cache, elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -73,6 +76,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         } else if InputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else if OutputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if AuxCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,39 +8,54 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
+use super::special_ctls::ClkCtl;
+
 pub struct SpecialModel {
     avc: BebobAvc,
+    clk_ctl: ClkCtl,
 }
 
-impl<'a> SpecialModel {
-    pub fn new() -> Self {
+impl SpecialModel {
+    pub fn new(is_fw1814: bool) -> Self {
         SpecialModel {
             avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(is_fw1814),
         }
     }
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
+
+        self.clk_ctl.load(card_cntr)?;
 
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-impl<'a> card_cntr::MeasureModel<hinawa::SndUnit> for SpecialModel {
+impl card_cntr::MeasureModel<hinawa::SndUnit> for SpecialModel {
     fn get_measure_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
     }
 
@@ -56,16 +71,17 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndUnit> for SpecialModel {
 }
 
 impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for SpecialModel {
-    fn get_notified_elem_list(&mut self, _: &mut Vec<alsactl::ElemId>) {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
     fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 
-    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.clk_ctl.read(&self.avc, elem_id, elem_value)
     }
 }

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,7 +8,7 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl, OutputCtl, AuxCtl};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache, MixerCtl, InputCtl, OutputCtl, AuxCtl, HpCtl};
 
 pub struct SpecialModel {
     avc: BebobAvc,
@@ -41,6 +41,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         InputCtl::load(&mut self.cache, card_cntr)?;
         OutputCtl::load(&mut self.cache, card_cntr)?;
         AuxCtl::load(&mut self.cache, card_cntr)?;
+        HpCtl::load(&mut self.cache, card_cntr)?;
 
         self.cache.upload(unit, &self.req)?;
 
@@ -60,6 +61,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
             Ok(true)
         } else if AuxCtl::read(&mut self.cache, elem_id, elem_value)? {
             Ok(true)
+        } else if HpCtl::read(&mut self.cache, elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -78,6 +81,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         } else if OutputCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else if AuxCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
+            Ok(true)
+        } else if HpCtl::write(&mut self.cache, unit, &self.req, elem_id, old, new)? {
             Ok(true)
         } else {
             Ok(false)

--- a/src/bebob/maudio/special_model.rs
+++ b/src/bebob/maudio/special_model.rs
@@ -8,13 +8,14 @@ use crate::card_cntr;
 
 use crate::bebob::BebobAvc;
 
-use super::special_ctls::{ClkCtl, MeterCtl};
+use super::special_ctls::{ClkCtl, MeterCtl, StateCache};
 
 pub struct SpecialModel {
     avc: BebobAvc,
     req: hinawa::FwReq,
     clk_ctl: ClkCtl,
     meter_ctl: MeterCtl,
+    cache: StateCache,
 }
 
 impl SpecialModel {
@@ -24,6 +25,7 @@ impl SpecialModel {
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(is_fw1814),
             meter_ctl: MeterCtl::new(),
+            cache: StateCache::new(),
         }
     }
 }
@@ -34,6 +36,8 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
 
         self.clk_ctl.load(card_cntr)?;
         self.meter_ctl.load(unit, &self.req, &self.avc, card_cntr)?;
+
+        self.cache.upload(unit, &self.req)?;
 
         Ok(())
     }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -24,7 +24,7 @@ enum BebobCtlModel<'a> {
     MaudioSolo(SoloModel<'a>),
     MaudioAudiophile(AudiophileModel<'a>),
     MaudioFw410(Fw410Model<'a>),
-    MaudioPlb(ProfirelightbridgeModel),
+    MaudioPlb(ProfirelightbridgeModel<'a>),
 }
 
 impl<'a> BebobModel<'a> {

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -51,3 +51,7 @@ impl<'a> BebobModel<'a> {
 
 pub const CLK_RATE_NAME: &str = "clock-rate";
 pub const CLK_SRC_NAME: &str = "clock-source";
+
+pub const OUT_SRC_NAME: &str = "output-source";
+
+pub const HP_SRC_NAME: &str = "headphone-source";

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -19,10 +19,10 @@ pub struct BebobModel<'a>{
 
 enum BebobCtlModel<'a> {
     ApogeeEnsemble(EnsembleModel<'a>),
-    MaudioOzonic(OzonicModel),
-    MaudioSolo(SoloModel),
-    MaudioAudiophile(AudiophileModel),
-    MaudioFw410(Fw410Model),
+    MaudioOzonic(OzonicModel<'a>),
+    MaudioSolo(SoloModel<'a>),
+    MaudioAudiophile(AudiophileModel<'a>),
+    MaudioFw410(Fw410Model<'a>),
 }
 
 impl<'a> BebobModel<'a> {

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -95,7 +95,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::BehringerFirepower(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
-            _ => (),
+            BebobCtlModel::StantonScratchamp(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -145,7 +145,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
-            _ => Ok(()),
+            BebobCtlModel::StantonScratchamp(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -63,6 +63,12 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
+
+    pub fn dispatch_stream_lock(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr, _: bool)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
 }
 
 pub const CLK_RATE_NAME: &str = "clock-rate";

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -7,6 +7,7 @@ use card_cntr::{CtlModel, MeasureModel, NotifyModel};
 
 use super::apogee::apogee_model::EnsembleModel;
 use super::maudio::ozonic_model::OzonicModel;
+use super::maudio::solo_model::SoloModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -17,6 +18,7 @@ pub struct BebobModel<'a>{
 enum BebobCtlModel<'a> {
     ApogeeEnsemble(EnsembleModel<'a>),
     MaudioOzonic(OzonicModel),
+    MaudioSolo(SoloModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -24,6 +26,7 @@ impl<'a> BebobModel<'a> {
         let ctl_model = match (vendor_id, model_id) {
             (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(EnsembleModel::new()),
             (0x000d6c, 0x00000a) => BebobCtlModel::MaudioOzonic(OzonicModel::new()),
+            (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(SoloModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -44,16 +47,19 @@ impl<'a> BebobModel<'a> {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioOzonic(m) => m.load(unit, card_cntr),
+            BebobCtlModel::MaudioSolo(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioOzonic(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            BebobCtlModel::MaudioSolo(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
 
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioOzonic(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::MaudioSolo(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -66,6 +72,7 @@ impl<'a> BebobModel<'a> {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -75,6 +82,7 @@ impl<'a> BebobModel<'a> {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            BebobCtlModel::MaudioSolo(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 
@@ -84,6 +92,7 @@ impl<'a> BebobModel<'a> {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -11,6 +11,7 @@ use super::maudio::solo_model::SoloModel;
 use super::maudio::audiophile_model::AudiophileModel;
 use super::maudio::fw410_model::Fw410Model;
 use super::maudio::profirelightbridge_model::ProfirelightbridgeModel;
+use super::maudio::special_model::SpecialModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -25,6 +26,7 @@ enum BebobCtlModel<'a> {
     MaudioAudiophile(AudiophileModel<'a>),
     MaudioFw410(Fw410Model<'a>),
     MaudioPlb(ProfirelightbridgeModel<'a>),
+    MaudioSpecial(SpecialModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -36,6 +38,8 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
             (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Fw410Model::new()),
             (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(ProfirelightbridgeModel::new()),
+            (0x000d6c, 0x010071) |
+            (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -60,6 +64,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioFw410(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioPlb(m) => m.load(unit, card_cntr),
+            BebobCtlModel::MaudioSpecial(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -69,6 +74,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioFw410(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioPlb(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            BebobCtlModel::MaudioSpecial(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
 
         match &mut self.ctl_model {
@@ -78,6 +84,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioFw410(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -94,6 +101,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -107,6 +115,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            BebobCtlModel::MaudioSpecial(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 
@@ -120,6 +129,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -7,15 +7,15 @@ use card_cntr::CtlModel;
 
 use super::apogee::apogee_model::EnsembleModel;
 
-pub struct BebobModel{
-    ctl_model: BebobCtlModel,
+pub struct BebobModel<'a>{
+    ctl_model: BebobCtlModel<'a>,
 }
 
-enum BebobCtlModel {
-    ApogeeEnsemble(EnsembleModel),
+enum BebobCtlModel<'a> {
+    ApogeeEnsemble(EnsembleModel<'a>),
 }
 
-impl BebobModel {
+impl<'a> BebobModel<'a> {
     pub fn new(vendor_id: u32, model_id: u32) -> Result<Self, Error> {
         let ctl_model = match (vendor_id, model_id) {
             (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(EnsembleModel::new()),
@@ -48,3 +48,6 @@ impl BebobModel {
         }
     }
 }
+
+pub const CLK_RATE_NAME: &str = "clock-rate";
+pub const CLK_SRC_NAME: &str = "clock-source";

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -38,8 +38,8 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
             (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Fw410Model::new()),
             (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(ProfirelightbridgeModel::new()),
-            (0x000d6c, 0x010071) |
-            (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new()),
+            (0x000d6c, 0x010071) => BebobCtlModel::MaudioSpecial(SpecialModel::new(true)),
+            (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new(false)),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -1,26 +1,50 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
 use crate::card_cntr;
+use card_cntr::CtlModel;
 
-pub struct BebobModel;
+use super::apogee::apogee_model::EnsembleModel;
+
+pub struct BebobModel{
+    ctl_model: BebobCtlModel,
+}
+
+enum BebobCtlModel {
+    ApogeeEnsemble(EnsembleModel),
+}
 
 impl BebobModel {
-    pub fn new(_: u32, _: u32) -> Result<Self, Error> {
-        Ok(BebobModel{})
+    pub fn new(vendor_id: u32, model_id: u32) -> Result<Self, Error> {
+        let ctl_model = match (vendor_id, model_id) {
+            (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(EnsembleModel::new()),
+            _ => {
+                return Err(Error::new(FileError::Noent, "Not supported"));
+            }
+        };
+
+        let model = BebobModel{
+            ctl_model,
+        };
+
+        Ok(model)
     }
 
-    pub fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+    pub fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.ctl_model {
+            BebobCtlModel::ApogeeEnsemble(m) => m.load(unit, card_cntr),
+        }
     }
 
-    pub fn dispatch_elem_event(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr,
-                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
+                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.ctl_model {
+            BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+        }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -8,6 +8,7 @@ use card_cntr::{CtlModel, MeasureModel, NotifyModel};
 use super::apogee::apogee_model::EnsembleModel;
 use super::maudio::ozonic_model::OzonicModel;
 use super::maudio::solo_model::SoloModel;
+use super::maudio::audiophile_model::AudiophileModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -19,6 +20,7 @@ enum BebobCtlModel<'a> {
     ApogeeEnsemble(EnsembleModel<'a>),
     MaudioOzonic(OzonicModel),
     MaudioSolo(SoloModel),
+    MaudioAudiophile(AudiophileModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -27,6 +29,7 @@ impl<'a> BebobModel<'a> {
             (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(EnsembleModel::new()),
             (0x000d6c, 0x00000a) => BebobCtlModel::MaudioOzonic(OzonicModel::new()),
             (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(SoloModel::new()),
+            (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -48,18 +51,21 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::ApogeeEnsemble(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioOzonic(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioSolo(m) => m.load(unit, card_cntr),
+            BebobCtlModel::MaudioAudiophile(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioOzonic(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioSolo(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            BebobCtlModel::MaudioAudiophile(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
 
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioOzonic(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSolo(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::MaudioAudiophile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -73,6 +79,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -83,6 +90,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            BebobCtlModel::MaudioAudiophile(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 
@@ -93,6 +101,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -12,6 +12,7 @@ use super::maudio::audiophile_model::AudiophileModel;
 use super::maudio::fw410_model::Fw410Model;
 use super::maudio::profirelightbridge_model::ProfirelightbridgeModel;
 use super::maudio::special_model::SpecialModel;
+use super::behringer::firepower_model::FirepowerModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -27,6 +28,7 @@ enum BebobCtlModel<'a> {
     MaudioFw410(Fw410Model<'a>),
     MaudioPlb(ProfirelightbridgeModel<'a>),
     MaudioSpecial(SpecialModel),
+    BehringerFirepower(FirepowerModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -40,6 +42,7 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(ProfirelightbridgeModel::new()),
             (0x000d6c, 0x010071) => BebobCtlModel::MaudioSpecial(SpecialModel::new(true)),
             (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new(false)),
+            (0x001564, 0x000610) => BebobCtlModel::BehringerFirepower(FirepowerModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -65,6 +68,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioPlb(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioSpecial(m) => m.load(unit, card_cntr),
+            BebobCtlModel::BehringerFirepower(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -75,6 +79,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioPlb(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioSpecial(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            _ => (),
         }
 
         match &mut self.ctl_model {
@@ -85,6 +90,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            _ => (),
         }
 
         Ok(())
@@ -102,6 +108,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -116,6 +123,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            _ => Ok(()),
         }
     }
 
@@ -130,6 +138,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            _ => Ok(()),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -30,7 +30,7 @@ enum BebobCtlModel<'a> {
     MaudioPlb(ProfirelightbridgeModel<'a>),
     MaudioSpecial(SpecialModel),
     BehringerFirepower(FirepowerModel<'a>),
-    StantonScratchamp(ScratchampModel),
+    StantonScratchamp(ScratchampModel<'a>),
 }
 
 impl<'a> BebobModel<'a> {

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -3,7 +3,7 @@
 use glib::{Error, FileError};
 
 use crate::card_cntr;
-use card_cntr::CtlModel;
+use card_cntr::{CtlModel, MeasureModel};
 
 use super::apogee::apogee_model::EnsembleModel;
 
@@ -38,7 +38,13 @@ impl<'a> BebobModel<'a> {
     {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => m.load(unit, card_cntr),
+        }?;
+
+        match &mut self.ctl_model {
+            BebobCtlModel::ApogeeEnsemble(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
+
+        Ok(())
     }
 
     pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
@@ -50,11 +56,11 @@ impl<'a> BebobModel<'a> {
         }
     }
 
-    pub fn measure_elems(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+    pub fn measure_elems(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
-            _ => Ok(()),
+            BebobCtlModel::ApogeeEnsemble(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 }
@@ -63,5 +69,9 @@ pub const CLK_RATE_NAME: &str = "clock-rate";
 pub const CLK_SRC_NAME: &str = "clock-source";
 
 pub const OUT_SRC_NAME: &str = "output-source";
+pub const OUT_VOL_NAME: &str = "output-volume";
 
 pub const HP_SRC_NAME: &str = "headphone-source";
+
+pub const IN_METER_NAME: &str = "input-meters";
+pub const OUT_METER_NAME: &str = "output-meters";

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+
+pub struct BebobModel;
+
+impl BebobModel {
+    pub fn new(_: u32, _: u32) -> Result<Self, Error> {
+        Ok(BebobModel{})
+    }
+
+    pub fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+
+    pub fn dispatch_elem_event(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr,
+                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+}

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -28,7 +28,7 @@ enum BebobCtlModel<'a> {
     MaudioFw410(Fw410Model<'a>),
     MaudioPlb(ProfirelightbridgeModel<'a>),
     MaudioSpecial(SpecialModel),
-    BehringerFirepower(FirepowerModel),
+    BehringerFirepower(FirepowerModel<'a>),
 }
 
 impl<'a> BebobModel<'a> {

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -9,6 +9,7 @@ use super::apogee::apogee_model::EnsembleModel;
 use super::maudio::ozonic_model::OzonicModel;
 use super::maudio::solo_model::SoloModel;
 use super::maudio::audiophile_model::AudiophileModel;
+use super::maudio::fw410_model::Fw410Model;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -21,6 +22,7 @@ enum BebobCtlModel<'a> {
     MaudioOzonic(OzonicModel),
     MaudioSolo(SoloModel),
     MaudioAudiophile(AudiophileModel),
+    MaudioFw410(Fw410Model),
 }
 
 impl<'a> BebobModel<'a> {
@@ -30,6 +32,7 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x00000a) => BebobCtlModel::MaudioOzonic(OzonicModel::new()),
             (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(SoloModel::new()),
             (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
+            (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Fw410Model::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -52,6 +55,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioSolo(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioAudiophile(m) => m.load(unit, card_cntr),
+            BebobCtlModel::MaudioFw410(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -59,6 +63,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioSolo(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioAudiophile(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            BebobCtlModel::MaudioFw410(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
 
         match &mut self.ctl_model {
@@ -66,6 +71,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSolo(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioAudiophile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::MaudioFw410(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -80,6 +86,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -91,6 +98,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            BebobCtlModel::MaudioFw410(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 
@@ -102,6 +110,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioOzonic(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -13,6 +13,7 @@ use super::maudio::fw410_model::Fw410Model;
 use super::maudio::profirelightbridge_model::ProfirelightbridgeModel;
 use super::maudio::special_model::SpecialModel;
 use super::behringer::firepower_model::FirepowerModel;
+use super::stanton::ScratchampModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -29,6 +30,7 @@ enum BebobCtlModel<'a> {
     MaudioPlb(ProfirelightbridgeModel<'a>),
     MaudioSpecial(SpecialModel),
     BehringerFirepower(FirepowerModel<'a>),
+    StantonScratchamp(ScratchampModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -43,6 +45,7 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x010071) => BebobCtlModel::MaudioSpecial(SpecialModel::new(true)),
             (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new(false)),
             (0x001564, 0x000610) => BebobCtlModel::BehringerFirepower(FirepowerModel::new()),
+            (0x001260, 0x000001) => BebobCtlModel::StantonScratchamp(ScratchampModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -69,6 +72,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioSpecial(m) => m.load(unit, card_cntr),
             BebobCtlModel::BehringerFirepower(m) => m.load(unit, card_cntr),
+            BebobCtlModel::StantonScratchamp(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -91,6 +95,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::BehringerFirepower(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            _ => (),
         }
 
         Ok(())
@@ -109,6 +114,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::StantonScratchamp(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -139,6 +145,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            _ => Ok(()),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -90,7 +90,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
-            _ => (),
+            BebobCtlModel::BehringerFirepower(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -138,7 +138,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
-            _ => Ok(()),
+            BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -10,6 +10,7 @@ use super::maudio::ozonic_model::OzonicModel;
 use super::maudio::solo_model::SoloModel;
 use super::maudio::audiophile_model::AudiophileModel;
 use super::maudio::fw410_model::Fw410Model;
+use super::maudio::profirelightbridge_model::ProfirelightbridgeModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -23,6 +24,7 @@ enum BebobCtlModel<'a> {
     MaudioSolo(SoloModel<'a>),
     MaudioAudiophile(AudiophileModel<'a>),
     MaudioFw410(Fw410Model<'a>),
+    MaudioPlb(ProfirelightbridgeModel),
 }
 
 impl<'a> BebobModel<'a> {
@@ -33,6 +35,7 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(SoloModel::new()),
             (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
             (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Fw410Model::new()),
+            (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(ProfirelightbridgeModel::new()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -56,6 +59,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioAudiophile(m) => m.load(unit, card_cntr),
             BebobCtlModel::MaudioFw410(m) => m.load(unit, card_cntr),
+            BebobCtlModel::MaudioPlb(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -64,6 +68,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioAudiophile(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
             BebobCtlModel::MaudioFw410(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
+            BebobCtlModel::MaudioPlb(m) => m.get_measure_elem_list(&mut self.measure_elem_list),
         }
 
         match &mut self.ctl_model {
@@ -72,6 +77,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioAudiophile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::MaudioFw410(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::MaudioPlb(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -87,6 +93,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -99,6 +106,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
+            BebobCtlModel::MaudioPlb(m) => card_cntr.measure_elems(unit, &self.measure_elem_list, m),
         }
     }
 
@@ -111,6 +119,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSolo(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioAudiophile(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::MaudioFw410(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::MaudioPlb(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/src/bebob/model.rs
+++ b/src/bebob/model.rs
@@ -9,6 +9,7 @@ use super::apogee::apogee_model::EnsembleModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
+    pub measure_elem_list: Vec<alsactl::ElemId>,
 }
 
 enum BebobCtlModel<'a> {
@@ -26,6 +27,7 @@ impl<'a> BebobModel<'a> {
 
         let model = BebobModel{
             ctl_model,
+            measure_elem_list: Vec::new(),
         };
 
         Ok(model)
@@ -45,6 +47,14 @@ impl<'a> BebobModel<'a> {
     {
         match &mut self.ctl_model {
             BebobCtlModel::ApogeeEnsemble(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+        }
+    }
+
+    pub fn measure_elems(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr)
+        -> Result<(), Error>
+    {
+        match &mut self.ctl_model {
+            _ => Ok(()),
         }
     }
 }

--- a/src/bebob/stanton.rs
+++ b/src/bebob/stanton.rs
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use crate::card_cntr;
+use card_cntr::CtlModel;
+
+pub struct ScratchampModel;
+
+impl ScratchampModel {
+    pub fn new() -> Self {
+        ScratchampModel{}
+    }
+}
+
+impl CtlModel<hinawa::SndUnit> for ScratchampModel {
+    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/src/bebob/stanton.rs
+++ b/src/bebob/stanton.rs
@@ -3,15 +3,18 @@
 use glib::Error;
 
 use hinawa::{SndUnitExt, FwFcpExt};
+use alsactl::{ElemValueExt, ElemValueExtManual};
 
 use crate::card_cntr;
 use card_cntr::CtlModel;
 
-use crate::ta1394::MUSIC_SUBUNIT_0;
+use crate::ta1394::{MUSIC_SUBUNIT_0, Ta1394Avc};
 use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr};
+use crate::ta1394::audio::{AUDIO_SUBUNIT_0_ADDR, AudioFeature, FeatureCtl, CtlAttr, AudioCh};
 
 use crate::bebob::BebobAvc;
 use crate::bebob::common_ctls::ClkCtl;
+use crate::bebob::model::OUT_VOL_NAME;
 
 pub struct ScratchampModel<'a>{
     avc: BebobAvc,
@@ -49,6 +52,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        InputCtl::load(&self.avc, card_cntr)?;
 
         Ok(())
     }
@@ -57,6 +61,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if InputCtl::read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -68,6 +74,8 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         -> Result<bool, Error>
     {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if InputCtl::write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -91,3 +99,77 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ScratchampModel<'a> {
         self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
     }
 }
+
+const VOL_MIN: i32 = i16::MIN as i32;
+const VOL_MAX: i32 = 0x0000;
+const VOL_STEP: i32 = 0x0080;
+const VOL_TLV: &[i32;4] = &[4, 8, -12800, 0];
+
+const OUTPUT_LABELS: &[&str] = &[
+    "analog-1", "analog-2", "analog-3", "analog-4",
+    "headphone-1", "headphone-2",
+];
+
+const FB_IDS: [u8;3] = [1, 2, 3];
+
+trait InputCtl : Ta1394Avc {
+    fn load(&self, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        // For volume of outputs.
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_VOL_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1, VOL_MIN, VOL_MAX, VOL_STEP,
+                                        OUTPUT_LABELS.len(), Some(VOL_TLV), true)?;
+
+        Ok(())
+    }
+
+    fn read(&self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            OUT_VOL_NAME => {
+                let mut vals = vec![0;OUTPUT_LABELS.len()];
+                (0..OUTPUT_LABELS.len()).try_for_each(|i| {
+                    let func_blk_id = FB_IDS[i / 2];
+                    let audio_ch_num = AudioCh::Each((i % 2) as u8);
+                    let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                   FeatureCtl::Volume(vec![-1]));
+                    self.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
+                    if let FeatureCtl::Volume(data) = op.ctl {
+                        vals[i] = data[0] as i32;
+                        Ok(())
+                    } else {
+                        unreachable!();
+                    }
+                })?;
+                elem_value.set_int(&vals);
+                Ok(true)
+            },
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&self, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue, new: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            OUT_VOL_NAME => {
+                let mut vals = vec![0;OUTPUT_LABELS.len() * 2];
+                new.get_int(&mut vals[..OUTPUT_LABELS.len()]);
+                old.get_int(&mut vals[OUTPUT_LABELS.len()..]);
+                vals[..OUTPUT_LABELS.len()].iter().zip(vals[OUTPUT_LABELS.len()..].iter()).enumerate()
+                    .filter(|(_, (n, o))| *n != *o)
+                    .try_for_each(|(i, (v, _))| {
+                        let func_blk_id = FB_IDS[i / 2];
+                        let audio_ch_num = AudioCh::Each((i % 2) as u8);
+                        let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                       FeatureCtl::Volume(vec![*v as i16]));
+                        self.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+                    })?;
+                Ok(true)
+            },
+            _ => Ok(false),
+        }
+    }
+}
+
+impl InputCtl for BebobAvc {}

--- a/src/bebob/stanton.rs
+++ b/src/bebob/stanton.rs
@@ -2,31 +2,75 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
+use hinawa::{SndUnitExt, FwFcpExt};
+
 use crate::card_cntr;
 use card_cntr::CtlModel;
 
-pub struct ScratchampModel;
+use crate::ta1394::MUSIC_SUBUNIT_0;
+use crate::ta1394::ccm::{SignalAddr, SignalSubunitAddr};
 
-impl ScratchampModel {
+use crate::bebob::BebobAvc;
+use crate::bebob::common_ctls::ClkCtl;
+
+pub struct ScratchampModel<'a>{
+    avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
+}
+
+impl<'a> ScratchampModel<'a> {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x05,
+    });
+    const CLK_SRCS: &'a [SignalAddr] = &[
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x05,
+        }),
+    ];
+
+    const CLK_LABELS: &'a [&'a str] = &[
+        "Internal",
+    ];
+
     pub fn new() -> Self {
-        ScratchampModel{}
+        ScratchampModel{
+            avc: BebobAvc::new(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
+        }
     }
 }
 
-impl CtlModel<hinawa::SndUnit> for ScratchampModel {
-    fn load(&mut self, _: &hinawa::SndUnit, _: &mut card_cntr::CardCntr) -> Result<(), Error> {
+impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
+    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+
+        self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &hinawa::SndUnit, _: &alsactl::ElemId, _: &alsactl::ElemValue, _: &alsactl::ElemValue)
+    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+             new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }

--- a/src/bebob/stanton.rs
+++ b/src/bebob/stanton.rs
@@ -74,3 +74,20 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         }
     }
 }
+
+impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ScratchampModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+                          elem_value: &mut alsactl::ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/src/bebob/unit.rs
+++ b/src/bebob/unit.rs
@@ -192,7 +192,7 @@ impl<'a> BebobUnit<'a> {
                 }
                 Event::Elem(elem_id, events) => {
                     if elem_id.get_name() != Self::TIMER_NAME {
-                        let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                        let _= self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
                                                                &elem_id, &events);
                     } else {
                         let mut elem_value = alsactl::ElemValue::new();

--- a/src/bebob/unit.rs
+++ b/src/bebob/unit.rs
@@ -8,7 +8,7 @@ use std::sync::mpsc;
 
 use hinawa::{FwNodeExt, FwNodeExtManual, SndUnitExt, SndUnitExtManual};
 
-use alsactl::CardExt;
+use alsactl::{CardExt, CardExtManual, ElemValueExtManual};
 
 use crate::dispatcher;
 use crate::card_cntr;
@@ -21,6 +21,7 @@ enum Event {
     Disconnected,
     BusReset(u32),
     Elem(alsactl::ElemId, alsactl::ElemEventMask),
+    Timer,
 }
 
 pub struct BebobUnit<'a> {
@@ -30,6 +31,7 @@ pub struct BebobUnit<'a> {
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
+    timer: Option<dispatcher::Dispatcher>,
 }
 
 impl<'a> Drop for BebobUnit<'a> {
@@ -42,6 +44,10 @@ impl<'a> Drop for BebobUnit<'a> {
 impl<'a> BebobUnit<'a> {
     const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
     const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+
+    const TIMER_NAME: &'a str = "metering";
+    const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     pub fn new(card_id: u32) -> Result<Self, Error> {
         let unit = hinawa::SndUnit::new();
@@ -73,6 +79,7 @@ impl<'a> BebobUnit<'a> {
             rx,
             tx,
             dispatchers: Vec::new(),
+            timer: None,
         })
     }
 
@@ -128,7 +135,33 @@ impl<'a> BebobUnit<'a> {
 
         self.model.load(&self.unit, &mut self.card_cntr)?;
 
+        if self.model.measure_elem_list.len() > 0 {
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,
+                                                       Self::TIMER_NAME, 0);
+            let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        }
+
         Ok(())
+    }
+
+    fn start_interval_timer(&mut self) -> Result<(), Error> {
+        let mut dispatcher = dispatcher::Dispatcher::run(Self::TIMER_DISPATCHER_NAME.to_string())?;
+        let tx = self.tx.clone();
+        dispatcher.attach_interval_handler(Self::TIMER_INTERVAL, move || {
+            let _ = tx.send(Event::Timer);
+            source::Continue(true)
+        });
+
+        self.timer = Some(dispatcher);
+
+        Ok(())
+    }
+
+    fn stop_interval_timer(&mut self) {
+        if let Some(dispatcher) = &self.timer {
+            drop(dispatcher);
+            self.timer = None;
+        }
     }
 
     pub fn run(&mut self) {
@@ -145,7 +178,24 @@ impl<'a> BebobUnit<'a> {
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Elem(elem_id, events) => {
-                    let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr, &elem_id, &events);
+                    if elem_id.get_name() != Self::TIMER_NAME {
+                        let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                                                               &elem_id, &events);
+                    } else {
+                        let mut elem_value = alsactl::ElemValue::new();
+                        if self.card_cntr.card.read_elem_value(&elem_id, &mut elem_value).is_ok() {
+                            let mut vals = [false];
+                            elem_value.get_bool(&mut vals);
+                            if vals[0] {
+                                let _ = self.start_interval_timer();
+                            } else {
+                                self.stop_interval_timer();
+                            }
+                        }
+                    }
+                }
+                Event::Timer => {
+                    let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
                 }
             }
         }

--- a/src/bebob/unit.rs
+++ b/src/bebob/unit.rs
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use glib::source;
+use nix::sys::signal;
+use std::sync::mpsc;
+
+use hinawa::{FwNodeExt, SndUnitExt, SndUnitExtManual};
+
+use crate::dispatcher;
+
+enum Event {
+    Shutdown,
+    Disconnected,
+    BusReset(u32),
+}
+
+pub struct BebobUnit {
+    unit: hinawa::SndUnit,
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
+
+impl<'a> Drop for BebobUnit {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> BebobUnit {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    pub fn new(card_id: u32) -> Result<Self, Error> {
+        let unit = hinawa::SndUnit::new();
+        unit.open(&format!("/dev/snd/hwC{}D0", card_id))?;
+
+        if unit.get_property_type() != hinawa::SndUnitType::Bebob {
+            let label = "ALSA bebob driver is not bound to the unit.";
+            return Err(Error::new(FileError::Inval, label));
+        }
+
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        Ok(BebobUnit {
+            unit,
+            rx,
+            tx,
+            dispatchers: Vec::new(),
+        })
+    }
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_unit(&self.unit, move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_fw_node(&self.unit.get_node(), move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        self.unit.get_node().connect_bus_update(move |node| {
+            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    pub fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) {
+        loop {
+            let ev = match self.rx.recv() {
+                Ok(ev) => ev,
+                Err(_) => continue,
+            };
+
+            match ev {
+                Event::Shutdown => break,
+                Event::Disconnected => break,
+                Event::BusReset(generation) => {
+                    println!("IEEE 1394 bus is updated: {}", generation);
+                }
+            }
+        }
+    }
+}

--- a/src/bebob/unit.rs
+++ b/src/bebob/unit.rs
@@ -23,23 +23,23 @@ enum Event {
     Elem(alsactl::ElemId, alsactl::ElemEventMask),
 }
 
-pub struct BebobUnit {
+pub struct BebobUnit<'a> {
     unit: hinawa::SndUnit,
-    model: BebobModel,
+    model: BebobModel<'a>,
     card_cntr: card_cntr::CardCntr,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
 }
 
-impl<'a> Drop for BebobUnit {
+impl<'a> Drop for BebobUnit<'a> {
     fn drop(&mut self) {
         // Finish I/O threads.
         self.dispatchers.clear();
     }
 }
 
-impl<'a> BebobUnit {
+impl<'a> BebobUnit<'a> {
     const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
     const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
 

--- a/src/bin/snd-bebob-ctl-service.rs
+++ b/src/bin/snd-bebob-ctl-service.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use snd_fw_ctl_services::bebob;
+
+use std::env;
+
+fn main() {
+    // Check arguments in command line.
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        println!("At least, one argument is required for: ");
+        println!("  The numerical ID of sound card.");
+        std::process::exit(1);
+    }
+
+    let card_id = match args[1].parse::<u32>() {
+        Ok(card_id) => card_id,
+        Err(err) => {
+            println!("{:?}", err);
+            std::process::exit(1);
+        }
+    };
+
+    let err = match bebob::unit::BebobUnit::new(card_id) {
+        Err(err) => {
+            println!("The {} is not for BeBoB device: {}", card_id, err);
+            Err(err)
+        }
+        Ok(mut unit) => {
+            if let Err(err) = unit.listen() {
+                println!("Fail to listen events: {}", err);
+                Err(err)
+            } else {
+                unit.run();
+                Ok(())
+            }
+        }
+    };
+
+    if err.is_err() {
+        std::process::exit(1)
+    }
+
+    std::process::exit(0)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,4 @@ pub mod tascam;
 pub mod efw;
 pub mod motu;
 pub mod oxfw;
+pub mod bebob;

--- a/src/ta1394/stream_format.rs
+++ b/src/ta1394/stream_format.rs
@@ -562,7 +562,7 @@ impl AmStream {
     const HIER_LEVEL_1_AM824: u8 = 0x00;
     const HIER_LEVEL_1_AUDIO_PACK: u8 = 0x01;
     const HIER_LEVEL_1_FP32: u8 = 0x02;
-    const HIER_LEVEL_1_COMPOUND_AM824: u8 = 0x40;
+    pub const HIER_LEVEL_1_COMPOUND_AM824: u8 = 0x40;
 }
 
 impl From<&[u8]> for AmStream {
@@ -621,7 +621,7 @@ pub enum StreamFormat{
 }
 
 impl StreamFormat {
-    const HIER_ROOT_AM: u8 = 0x90;
+    pub const HIER_ROOT_AM: u8 = 0x90;
 
     fn as_am_stream(&self) -> Result<&AmStream, Error> {
         if let StreamFormat::Am(i) = self {


### PR DESCRIPTION
ArchWave AG (formerly known as BridgeCo AG) designs DM1000/DM1100/DM1500 ASICs for its solution to audio and music unit on IEEE 1394 bus, named as "BridgeCo Enhancement Break Out Box (BeBoB)". The ASICs are widely used for many models from hardware vendors.

ALSA bebob driver supports models with the ASIC for their isochronous packet stream functionality. Although the driver allows userspace applications to process PCM frames and MIDI messages in the packet streaming, it doesn't support the other functionalities such as volume control since it can be achieved by any usespace application.

This patchset adds service program to satisfy the demand to control the models. ALSA control applications can request the control by IPC to the service program. The service program works as proxy to execute actual control.

At present, below models are supported:
  * Apogee Ensemble
  * M-Audio Ozonic
  * M-Audio FireWire Solo
  * M-Audio FireWire Audiophile
  * M-Audio FireWire 410
  * M-Audio ProFire LightBridge
  * M-Audio FireWire 1814
  * M-Audio ProjectMix I/O
  * Behringer FIREPOWER FCA610
  * Stanton ScratchAmp in Final Scratch version 2
