### PR TITLE
core: add ElemValueAccessor trait and implementation for each type of element value

### DIFF
--- a/libs/core/src/elem_value_accessor.rs
+++ b/libs/core/src/elem_value_accessor.rs
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+use glib::IsA;
+
+use alsactl::{ElemValueExt, ElemValueExtManual};
+
+pub trait ElemValueAccessor<T> : IsA<alsactl::ElemValue>
+    where T: Copy + Clone + Default + Eq + PartialEq
+{
+    fn set(&self, vals: &[T]);
+    fn get(&self, vals: &mut [T]);
+
+    fn set_vals<F>(&self, len: usize, mut cb: F)
+        -> Result<(), Error>
+        where F: FnMut(usize) -> Result<T, Error>
+    {
+        let mut vals = vec![Default::default();len];
+        vals.iter_mut().enumerate().try_for_each(|(ch, v)| {
+            *v = cb(ch)?;
+            Ok(())
+        })?;
+        self.set(&vals);
+        Ok(())
+    }
+
+    fn get_vals<F>(&self, old: &Self, len: usize, mut cb: F)
+        -> Result<(), Error>
+        where F: FnMut(usize, T) -> Result<(), Error>
+    {
+        let mut vals = vec![Default::default();len];
+        self.get(&mut vals[..len]);
+        old.get(&mut vals[len..]);
+        vals[..len].iter().zip(vals[len..].iter()).enumerate()
+            .filter(|(_, (n, o))| *n != *o)
+            .try_for_each(|(ch, (v, _))| {
+                cb(ch, *v)?;
+                Ok(())
+            })?;
+        Ok(())
+    }
+
+    fn set_val<F>(&self, mut cb: F) -> Result<(), Error>
+        where F: FnMut() -> Result<T, Error>
+    {
+        let mut vals = [Default::default()];
+        vals[0] = cb()?;
+        self.set(&vals);
+        Ok(())
+    }
+
+    fn get_val<F>(&self, mut cb: F) -> Result<(), Error>
+        where F: FnMut(T) -> Result<(), Error>
+    {
+        let mut vals = [Default::default()];
+        self.get(&mut vals);
+        cb(vals[0])
+    }
+}
+
+impl ElemValueAccessor<bool> for alsactl::ElemValue {
+    fn set(&self, vals: &[bool]) {
+        self.set_bool(vals);
+    }
+
+    fn get(&self, vals: &mut [bool]) {
+        self.get_bool(vals);
+    }
+}
+
+impl ElemValueAccessor<u8> for alsactl::ElemValue {
+    fn set(&self, vals: &[u8]) {
+        self.set_bytes(vals);
+    }
+
+    fn get(&self, vals: &mut [u8]) {
+        self.get_bytes(vals);
+    }
+}
+
+impl ElemValueAccessor<i32> for alsactl::ElemValue {
+    fn set(&self, vals: &[i32]) {
+        self.set_int(vals);
+    }
+
+    fn get(&self, vals: &mut [i32]) {
+        self.get_int(vals);
+    }
+}
+
+impl ElemValueAccessor<u32> for alsactl::ElemValue {
+    fn set(&self, vals: &[u32]) {
+        self.set_enum(vals);
+    }
+
+    fn get(&self, vals: &mut [u32]) {
+        self.get_enum(vals);
+    }
+}
+
+impl ElemValueAccessor<i64> for alsactl::ElemValue {
+    fn set(&self, vals: &[i64]) {
+        self.set_int64(vals);
+    }
+
+    fn get(&self, vals: &mut [i64]) {
+        self.get_int64(vals);
+    }
+}

--- a/libs/core/src/lib.rs
+++ b/libs/core/src/lib.rs
@@ -2,3 +2,4 @@
 // Copyright (c) 2020 Takashi Sakamoto
 pub mod dispatcher;
 pub mod card_cntr;
+pub mod elem_value_accessor;

--- a/libs/dg00x/src/common_ctl.rs
+++ b/libs/dg00x/src/common_ctl.rs
@@ -4,9 +4,8 @@ use glib::Error;
 
 use hinawa::SndUnitExt;
 
-use alsactl::{ElemValueExt, ElemValueExtManual};
-
 use core::card_cntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::protocol::CommonProtocol;
 
@@ -105,28 +104,38 @@ impl<'a> CommonCtl {
 
         match elem_id.get_name().as_str() {
             Self::CLK_SRC_NAME => {
-                let val = req.read_quadlet(&node, Self::CLK_SRC_OFFSET)?;
-                elem_value.set_enum(&[val]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.read_quadlet(&node, Self::CLK_SRC_OFFSET)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             Self::CLK_LOCAL_RATE_NAME => {
-                let val = req.read_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET)?;
-                elem_value.set_enum(&[val]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.read_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             Self::CLK_EXT_RATE_NAME => {
-                let val = req.read_quadlet(&node, Self::CLK_EXT_RATE_OFFSET)?;
-                elem_value.set_enum(&[val]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.read_quadlet(&node, Self::CLK_EXT_RATE_OFFSET)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             Self::OPT_IFACE_NAME => {
-                let val = req.read_quadlet(&node, Self::OPT_IFACE_OFFSET)?;
-                elem_value.set_enum(&[val]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.read_quadlet(&node, Self::OPT_IFACE_OFFSET)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             Self::CLK_EXT_DETECT_NAME => {
-                let val = req.read_quadlet(&node, Self::CLK_EXT_DETECT_OFFSET)?;
-                elem_value.set_enum(&[val]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.read_quadlet(&node, Self::CLK_EXT_DETECT_OFFSET)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -145,37 +154,31 @@ impl<'a> CommonCtl {
 
         match elem_id.get_name().as_str() {
             Self::CLK_SRC_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.write_quadlet(&node, Self::CLK_SRC_OFFSET, vals[0]);
-                let _ = unit.unlock();
-                match res {
-                    Err(err) => Err(err),
-                    Ok(()) => Ok(true),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = req.write_quadlet(&node, Self::CLK_SRC_OFFSET, val);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
             }
             Self::CLK_LOCAL_RATE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.write_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET, vals[0]);
-                let _ = unit.unlock();
-                match res {
-                    Err(err) => Err(err),
-                    Ok(()) => Ok(true),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = req.write_quadlet(&node, Self::CLK_LOCAL_RATE_OFFSET, val);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
             }
             Self::OPT_IFACE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.write_quadlet(&node, Self::OPT_IFACE_OFFSET, vals[0]);
-                let _ = unit.unlock();
-                match res {
-                    Err(err) => Err(err),
-                    Ok(()) => Ok(true),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = req.write_quadlet(&node, Self::OPT_IFACE_OFFSET, val);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
             }
             _ => Ok(false),
         }

--- a/libs/efw/src/guitar_ctl.rs
+++ b/libs/efw/src/guitar_ctl.rs
@@ -2,9 +2,8 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
-use alsactl::{ElemValueExt, ElemValueExtManual};
-
 use core::card_cntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::transactions::{HwInfo, HwCap, EfwGuitar};
 
@@ -54,18 +53,24 @@ impl<'a> GuitarCtl {
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             Self::MANUAL_CHARGE_NAME => {
-                let state = EfwGuitar::get_charge_state(unit)?;
-                elem_value.set_bool(&[state.manual_charge]);
+                ElemValueAccessor::<bool>::set_val(elem_value, || {
+                    let state = EfwGuitar::get_charge_state(unit)?;
+                    Ok(state.manual_charge)
+                })?;
                 Ok(true)
             }
             Self::AUTO_CHARGE_NAME => {
-                let state = EfwGuitar::get_charge_state(unit)?;
-                elem_value.set_bool(&[state.auto_charge]);
+                ElemValueAccessor::<bool>::set_val(elem_value, || {
+                    let state = EfwGuitar::get_charge_state(unit)?;
+                    Ok(state.auto_charge)
+                })?;
                 Ok(true)
             }
             Self::SUSPEND_TO_CHARGE => {
-                let state = EfwGuitar::get_charge_state(unit)?;
-                elem_value.set_int(&[state.suspend_to_charge as i32]);
+                ElemValueAccessor::<i32>::set_val(elem_value, || {
+                    let state = EfwGuitar::get_charge_state(unit)?;
+                    Ok(state.suspend_to_charge as i32)
+                })?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -81,27 +86,27 @@ impl<'a> GuitarCtl {
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             Self::MANUAL_CHARGE_NAME => {
-                let mut vals = [false];
-                new.get_bool(&mut vals);
-                let mut state = EfwGuitar::get_charge_state(unit)?;
-                state.manual_charge = vals[0];
-                EfwGuitar::set_charge_state(unit, &state)?;
+                ElemValueAccessor::<bool>::get_val(new, |val| {
+                    let mut state = EfwGuitar::get_charge_state(unit)?;
+                    state.manual_charge = val;
+                    EfwGuitar::set_charge_state(unit, &state)
+                })?;
                 Ok(true)
             }
             Self::AUTO_CHARGE_NAME => {
-                let mut vals = [false];
-                new.get_bool(&mut vals);
-                let mut state = EfwGuitar::get_charge_state(unit)?;
-                state.auto_charge = vals[0];
-                EfwGuitar::set_charge_state(unit, &state)?;
+                ElemValueAccessor::<bool>::get_val(new, |val| {
+                    let mut state = EfwGuitar::get_charge_state(unit)?;
+                    state.auto_charge = val;
+                    EfwGuitar::set_charge_state(unit, &state)
+                })?;
                 Ok(true)
             }
             Self::SUSPEND_TO_CHARGE => {
-                let mut vals = [0];
-                new.get_int(&mut vals);
-                let mut state = EfwGuitar::get_charge_state(unit)?;
-                state.suspend_to_charge = vals[0] as u32;
-                EfwGuitar::set_charge_state(unit, &state)?;
+                ElemValueAccessor::<i32>::get_val(new, |val| {
+                    let mut state = EfwGuitar::get_charge_state(unit)?;
+                    state.suspend_to_charge = val as u32;
+                    EfwGuitar::set_charge_state(unit, &state)
+                })?;
                 Ok(true)
             }
             _ => Ok(false),

--- a/libs/efw/src/meter_ctl.rs
+++ b/libs/efw/src/meter_ctl.rs
@@ -136,10 +136,7 @@ impl<'a> MeterCtl {
             }
             Self::MIDI_IN_DETECT => {
                 if let Some(meters) = &self.meters {
-                    let vals: Vec<bool> = (0..self.midi_inputs)
-                        .map(|i| meters.detected_midi_inputs[i])
-                        .collect();
-                    elem_value.set_bool(&vals);
+                    elem_value.set_bool(&meters.detected_midi_inputs[..self.midi_inputs]);
                     Ok(true)
                 } else {
                     Ok(false)
@@ -147,10 +144,7 @@ impl<'a> MeterCtl {
             }
             Self::MIDI_OUT_DETECT => {
                 if let Some(meters) = &self.meters {
-                    let vals: Vec<bool> = (0..self.midi_outputs)
-                        .map(|i| meters.detected_midi_inputs[i])
-                        .collect();
-                    elem_value.set_bool(&vals);
+                    elem_value.set_bool(&meters.detected_midi_outputs[..self.midi_outputs]);
                     Ok(true)
                 } else {
                     Ok(false)

--- a/libs/motu/src/v2_clk_ctls.rs
+++ b/libs/motu/src/v2_clk_ctls.rs
@@ -3,9 +3,9 @@
 use glib::Error;
 
 use hinawa::{SndUnitExt, SndMotu};
-use alsactl::{ElemValueExt, ElemValueExtManual};
 
 use core::card_cntr::CardCntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::common_proto::CommonProto;
 use super::v2_proto::V2Proto;
@@ -47,16 +47,20 @@ impl<'a> V2ClkCtl<'a> {
     {
         match elem_id.get_name().as_str() {
             Self::RATE_NAME => {
-                let val = req.get_clk_rate(unit, &self.rate_vals)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_clk_rate(unit, &self.rate_vals)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             Self::SRC_NAME => {
-                let val = req.get_clk_src(unit, &self.src_vals)?;
-                if self.has_lcd {
-                    req.update_clk_disaplay(unit, &self.src_labels[val])?;
-                }
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_clk_src(unit, &self.src_vals)?;
+                    if self.has_lcd {
+                        req.update_clk_disaplay(unit, &self.src_labels[val])?;
+                    }
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -69,33 +73,29 @@ impl<'a> V2ClkCtl<'a> {
     {
         match elem_id.get_name().as_str() {
             Self::RATE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.set_clk_rate(unit, &self.rate_vals, vals[0] as usize);
-                let _ = unit.unlock();
-                match res {
-                    Err(err) => Err(err),
-                    Ok(()) => Ok(true),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val|{
+                    unit.lock()?;
+                    let res = req.set_clk_rate(unit, &self.rate_vals, val as usize);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
             }
             Self::SRC_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                let prev_src = req.get_clk_src(unit, &self.src_vals)?;
-                unit.lock()?;
-                let mut res = req.set_clk_src(unit, &self.src_vals, vals[0] as usize);
-                if res.is_ok() && self.has_lcd {
-                    res = req.update_clk_disaplay(unit, self.src_labels[vals[0] as usize]);
-                    if res.is_err() {
-                        let _ = req.set_clk_src(unit, &self.src_vals, prev_src);
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    let prev_src = req.get_clk_src(unit, &self.src_vals)?;
+                    unit.lock()?;
+                    let mut res = req.set_clk_src(unit, &self.src_vals, val as usize);
+                    if res.is_ok() && self.has_lcd {
+                        res = req.update_clk_disaplay(unit, self.src_labels[val as usize]);
+                        if res.is_err() {
+                            let _ = req.set_clk_src(unit, &self.src_vals, prev_src);
+                        }
                     }
-                }
-                let _ = unit.unlock();
-                match res {
-                    Err(err) => Err(err),
-                    Ok(()) => Ok(true),
-                }
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
             }
             _ => Ok(false),
         }

--- a/libs/motu/src/v2_port_ctls.rs
+++ b/libs/motu/src/v2_port_ctls.rs
@@ -3,9 +3,9 @@
 use glib::Error;
 
 use hinawa::{SndUnitExt, SndMotu};
-use alsactl::{ElemValueExt, ElemValueExtManual};
 
 use core::card_cntr::CardCntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::common_proto::CommonProto;
 use super::v2_proto::V2Proto;
@@ -110,28 +110,38 @@ impl<'a> V2PortCtl<'a> {
     {
         match elem_id.get_name().as_str() {
             Self::PHONE_ASSIGN_NAME => {
-                let val = req.get_phone_assign(unit, &self.phone_assign_vals)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_phone_assign(unit, &self.phone_assign_vals)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             Self::MAIN_VOL_TARGET_NAME => {
-                let val = req.get_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             Self::WORD_OUT_MODE_NAME => {
-                let val = req.get_word_out(unit, &Self::WORD_OUT_MODE_VALS)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_word_out(unit, &Self::WORD_OUT_MODE_VALS)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             Self::OPT_IN_IFACE_MODE_NAME => {
-                let val = req.get_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             Self::OPT_OUT_IFACE_MODE_NAME => {
-                let val = req.get_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
-                elem_value.set_enum(&[val as u32]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let val = req.get_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS)?;
+                    Ok(val as u32)
+                })?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -144,44 +154,40 @@ impl<'a> V2PortCtl<'a> {
     {
         match elem_id.get_name().as_str() {
             Self::PHONE_ASSIGN_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                req.set_phone_assign(unit, &self.phone_assign_vals, vals[0] as usize)?;
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    req.set_phone_assign(unit, &self.phone_assign_vals, val as usize)
+                })?;
                 Ok(true)
             }
             Self::MAIN_VOL_TARGET_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                req.set_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS, vals[0] as usize)?;
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    req.set_main_vol_assign(unit, &Self::MAIN_VOL_TARGET_VALS, val as usize)
+                })?;
                 Ok(true)
             }
             Self::WORD_OUT_MODE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                req.set_word_out(unit, &Self::WORD_OUT_MODE_VALS, vals[0] as usize)?;
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    req.set_word_out(unit, &Self::WORD_OUT_MODE_VALS, val as usize)
+                })?;
                 Ok(true)
             }
             Self::OPT_IN_IFACE_MODE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.set_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, vals[0] as usize);
-                unit.unlock()?;
-                match res {
-                    Ok(()) => Ok(true),
-                    Err(err) => Err(err),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = req.set_opt_in_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, val as usize);
+                    unit.unlock()?;
+                    res
+                })?;
+                Ok(true)
             }
             Self::OPT_OUT_IFACE_MODE_NAME => {
-                let mut vals = [0];
-                new.get_enum(&mut vals);
-                unit.lock()?;
-                let res = req.set_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, vals[0] as usize);
-                unit.unlock()?;
-                match res {
-                    Ok(()) => Ok(true),
-                    Err(err) => Err(err),
-                }
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = req.set_opt_out_iface_mode(unit, &Self::OPT_IFACE_MODE_VALS, val as usize);
+                    unit.unlock()?;
+                    res
+                })?;
+                Ok(true)
             }
             _ => Ok(false),
         }

--- a/libs/oxfw/src/tascam_model.rs
+++ b/libs/oxfw/src/tascam_model.rs
@@ -4,9 +4,8 @@ use glib::Error;
 
 use hinawa::{FwFcpExt, SndUnitExt};
 
-use alsactl::{ElemValueExtManual, ElemValueExt};
-
 use core::card_cntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use ta1394::{Ta1394Avc, AvcAddr};
 use ta1394::general::UnitInfo;
@@ -84,27 +83,35 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
         } else {
             match elem_id.get_name().as_str() {
                 Self::DISPLAY_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::DisplayMode);
-                    self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
-                    elem_value.set_enum(&[op.val as u32]);
+                    ElemValueAccessor::<u32>::set_val(elem_value, || {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::DisplayMode);
+                        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                        Ok(op.val as u32)
+                    })?;
                     Ok(true)
                 }
                 Self::MESSAGE_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::MessageMode);
-                    self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
-                    elem_value.set_enum(&[op.val as u32]);
+                    ElemValueAccessor::<u32>::set_val(elem_value, || {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::MessageMode);
+                        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                        Ok(op.val as u32)
+                    })?;
                     Ok(true)
                 }
                 Self::INPUT_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::InputMode);
-                    self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
-                    elem_value.set_enum(&[op.val as u32]);
+                    ElemValueAccessor::<u32>::set_val(elem_value, || {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::InputMode);
+                        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                        Ok(op.val as u32)
+                    })?;
                     Ok(true)
                 }
                 Self::FIRMWARE_VERSION_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::FirmwareVersion);
-                    self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
-                    elem_value.set_bytes(&[op.val as u8]);
+                    ElemValueAccessor::<u8>::set_val(elem_value, || {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::FirmwareVersion);
+                        self.avc.status(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                        Ok(op.val as u8)
+                    })?;
                     Ok(true)
                 }
                 _ => Ok(false),
@@ -118,26 +125,29 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {
             return Ok(true);
         } else {
-            let mut vals = [0];
-            new.get_enum(&mut vals);
-
             match elem_id.get_name().as_str() {
                 Self::DISPLAY_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::DisplayMode);
-                    op.val = vals[0] as u8;
-                    self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::DisplayMode);
+                        op.val = val as u8;
+                        self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)
+                    })?;
                     Ok(true)
                 }
                 Self::MESSAGE_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::MessageMode);
-                    op.val = vals[0] as u8;
-                    self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::MessageMode);
+                        op.val = val as u8;
+                        self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)
+                    })?;
                     Ok(true)
                 }
                 Self::INPUT_MODE_NAME => {
-                    let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::InputMode);
-                    op.val = vals[0] as u8;
-                    self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)?;
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        let mut op = TascamProto::new(&self.avc.company_id, VendorCmd::InputMode);
+                        op.val = val as u8;
+                        self.avc.control(&AvcAddr::Unit, &mut op, Self::FCP_TIMEOUT_MS)
+                    })?;
                     Ok(true)
                 }
                 _ => Ok(false),

--- a/libs/tascam/src/console_ctl.rs
+++ b/libs/tascam/src/console_ctl.rs
@@ -4,9 +4,8 @@ use glib::Error;
 
 use hinawa::SndUnitExt;
 
-use alsactl::ElemValueExtManual;
-
 use core::card_cntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::protocol::ConsoleProtocol;
 
@@ -75,12 +74,14 @@ impl<'a> ConsoleCtl {
 
         match elem_id.get_name().as_str() {
             Self::MASTER_FADER_ASSIGN_NAME => {
-                let val = req.get_master_fader_assign(&node)?;
-                elem_value.set_bool(&[val]);
+                ElemValueAccessor::<bool>::set_val(elem_value, || {
+                    let val = req.get_master_fader_assign(&node)?;
+                    Ok(val)
+                })?;
                 Ok(true)
             }
             Self::HOST_MODE_NAME => {
-                elem_value.set_bool(&[self.host_mode]);
+                ElemValueAccessor::<bool>::set_val(elem_value, || Ok(self.host_mode))?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -99,9 +100,7 @@ impl<'a> ConsoleCtl {
 
         match elem_id.get_name().as_str() {
             Self::MASTER_FADER_ASSIGN_NAME => {
-                let mut vals = [false];
-                new.get_bool(&mut vals);
-                req.set_master_fader_assign(&node, vals[0])?;
+                ElemValueAccessor::<bool>::get_val(new, |val| req.set_master_fader_assign(&node, val))?;
                 Ok(true)
             }
             _ => Ok(false),

--- a/libs/tascam/src/meter_ctl.rs
+++ b/libs/tascam/src/meter_ctl.rs
@@ -5,6 +5,7 @@ use glib::Error;
 use alsactl::ElemValueExt;
 
 use core::card_cntr;
+use core::elem_value_accessor::ElemValueAccessor;
 
 use super::common_ctl::CommonCtl;
 
@@ -289,11 +290,11 @@ impl<'a> MeterCtl<'a> {
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             Self::MONITOR_ROTARY_NAME => {
-                elem_value.set_int(&[self.monitor]);
+                ElemValueAccessor::<i32>::set_val(elem_value, || Ok(self.monitor))?;
                 Ok(true)
             }
             Self::SOLO_ROTARY_NAME => {
-                elem_value.set_int(&[self.solo]);
+                ElemValueAccessor::<i32>::set_val(elem_value, || Ok(self.solo))?;
                 Ok(true)
             }
             Self::INPUT_METER_NAME => {
@@ -329,11 +330,11 @@ impl<'a> MeterCtl<'a> {
                 Ok(true)
             }
             Self::DETECTED_CLK_SRC_NAME => {
-                elem_value.set_enum(&[self.src]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.src))?;
                 Ok(true)
             }
             Self::DETECTED_CLK_RATE_NAME => {
-                elem_value.set_enum(&[self.rate]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.rate))?;
                 Ok(true)
             }
             Self::MONITOR_METER_NAME => {
@@ -345,7 +346,7 @@ impl<'a> MeterCtl<'a> {
                 Ok(true)
             }
             Self::MONITOR_MODE_NAME => {
-                elem_value.set_enum(&[self.monitor_mode]);
+                ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.monitor_mode))?;
                 Ok(true)
             }
             _ => Ok(false),


### PR DESCRIPTION
At present, element value is processed by each crate without any common code. This brings duplicated codes.

This commit adds ElemValueAccessor trait and implements it for each type of element value, to replace the duplicated codes with the implementation.