### PR TITLE
alsa-ctl-tlv-codec: add crate to encode/decode TLV data in  ALSA control interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "libs/alsa-ctl-tlv-codec",
     "libs/core",
     "libs/ieee1212",
     "libs/ta1394",

--- a/libs/alsa-ctl-tlv-codec/Cargo.toml
+++ b/libs/alsa-ctl-tlv-codec/Cargo.toml
@@ -9,3 +9,7 @@ description = """
 Encoder and Decoder for data of Type-Length-Value(TLV) style in ALSA control
 interface
 """
+
+[[bin]]
+name = "tlv-decode"
+doc = false

--- a/libs/alsa-ctl-tlv-codec/Cargo.toml
+++ b/libs/alsa-ctl-tlv-codec/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "alsa-ctl-tlv-codec"
+version = "0.0.1"
+authors = ["Takashi Sakamoto <o-takashi@sakamocchi.jp>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+homepage = "https://github.com/alsa-project/snd-firewire-ctl-services"
+description = """
+Encoder and Decoder for data of Type-Length-Value(TLV) style in ALSA control
+interface
+"""

--- a/libs/alsa-ctl-tlv-codec/Cargo.toml
+++ b/libs/alsa-ctl-tlv-codec/Cargo.toml
@@ -13,3 +13,7 @@ interface
 [[bin]]
 name = "tlv-decode"
 doc = false
+
+[[bin]]
+name = "db-calculate"
+doc = false

--- a/libs/alsa-ctl-tlv-codec/README.md
+++ b/libs/alsa-ctl-tlv-codec/README.md
@@ -1,0 +1,245 @@
+# alsa-ctl-tlv-codec - Encoder and Decoder for data of Type-Length-Value(TLV) style in ALSA control interface
+
+The crate is designed to process data represented by TLV (Type-Length-Value) style in
+ALSA control interface. The crate produces encoder and decoder for the u32 array of data
+of TLV style as well as structures and enumerations to represent the content.
+
+The data of TLV style is used for several purposes. As of Linux kernel 5.10, it includes
+information about dB representation as well as information about channel mapping in ALSA
+PCM substream. The definitions are under `include/uapi/sound/tlv.h` of source code of
+Linux kernel.
+
+## Structures and enumerations
+
+Linux kernel has the series of macro to build u32 array for data of TLV, instead of definitions
+of structure. This is convenient to embed binary data to object file, however not friendly to
+developers and users. The crate has some structures and enumerations to represent the data of
+TLV. The relationship between structures and macros is listed below:
+
+* `DbScale`
+    * `SNDRV_CTL_TLVT_DB_SCALE`
+* `DbInterval`
+    * `SNDRV_CTL_TLVT_DB_LINEAR`
+    * `SNDRV_CTL_TLVT_DB_MINMAX`
+    * `SNDRV_CTL_TLVT_DB_MINMAX_MUTE`
+* `Chmap` / `ChmapMode` / `ChmapEntry` / `ChmapPos` / `ChmapGenericPos`
+    * `SNDRV_CTL_TLVT_CHMAP_FIXED`
+    * `SNDRV_CTL_TLVT_CHMAP_VAR`
+    * `SNDRV_CTL_TLVT_CHMAP_PAIRED`
+* `DbRange` / `DbRangeEntry` / `DbRangeEntryData`
+    * `SNDRV_CTL_TLVT_DB_RANGE`
+* `Container`
+    * `SNDRV_CTL_TLVT_CONTAINER`
+
+The crate has `TlvItem` enumeration to dispatch data of TLV for the above structures.
+
+## Usage
+
+```rust
+use alsa_ctl_tlv_codec::TlvItem;
+use std::convert::TryFrom;
+
+// Prepare raw data of TLV as array of u32 elements.
+let raw = [2 as u32, 8, -100i32 as u32, 0]; // This is for SNDRV_CTL_TLVT_DB_LINEAR.
+
+match TlvItem::try_from(&raw[..]) {
+    Ok(data) => {
+        let raw_generated: Vec<u32> = match &data {
+          TlvItem::Container(d) => d.into(),
+          TlvItem::DbRange(d) => d.into(),
+          TlvItem::DbScale(d) => d.into(),
+          TlvItem::DbInterval(d) => d.into(),
+          TlvItem::Chmap(d) => d.into(),
+        };
+
+        assert_eq!(&raw[..], &raw_generated[..]);
+    }
+    Err(err) => println!("{}", err),
+}
+
+```
+
+`TlvItem` enumeration is a good start to use the crate. It implements `TryFrom<&[u32]>` to
+decode raw data of TLV which is array of u32 elements. The type of data is retrieved by a shape
+of Rust enumeration items. Each item has associated value. Both of enumeration itself and the
+structure of associated value implements `Into<Vec<u32>>` to generate raw data of TLV.
+
+The associated value can be instantiated directly, then raw data can be generated:
+
+```rust
+use alsa_ctl_tlv_codec::items;
+
+let scale = items::DbScale{
+    min: -100,
+    step: 10,
+    mute_avail: true,
+};
+
+let raw_generated: Vec<u32> = (&scale).into();
+
+let raw_expected = [1 as u32, 8, -100i32 as u32, 10 | 0x00010000];
+
+assert_eq!(&raw_generated[..], &raw_expected[..]);
+```
+
+Some of the associated value are container type, which aggregates the other items. In this
+case, `TlvItem` is used for the aggregation of `Container`.
+
+```rust
+use alsa_ctl_tlv_codec::{*, items::*, containers::*};
+
+let cntr = Container{
+    entries: vec![
+        TlvItem::Chmap(Chmap{
+            mode: ChmapMode::Fixed,
+            entries: vec![
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::LowFrequencyEffect), ..Default::default()},
+            ],
+        }),
+        TlvItem::Chmap(Chmap{
+            mode: ChmapMode::ArbitraryExchangeable,
+            entries: vec![
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+            ],
+        }),
+        TlvItem::Chmap(Chmap{
+            mode: ChmapMode::PairedExchangeable,
+            entries: vec![
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearLeft), ..Default::default()},
+                ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearRight), ..Default::default()},
+            ],
+        }),
+    ],
+};
+
+let raw_generated: Vec<u32> = (&cntr).into();
+
+let raw_expected = [0 as u32, 60,
+                    0x101, 12, 3, 4, 8,
+                    0x102, 8, 3, 4,
+                    0x103, 16, 3, 4, 5, 6];
+
+assert_eq!(&raw_generated[..], &raw_expected[..]);
+
+```
+
+## Utilities
+
+Some programs are available under `src/bin` directory.
+
+### src/bin/tlv-decode.rs
+
+This program decodes raw data of TLV from stdin, or numeric literals as arguments of command line,
+then print parsed structure.
+
+Without any command line argument, it prints help message and exit.
+
+```sh
+$ cargo run --bin tlv-decode
+Usage:
+  tlv-decode MODE DATA | "-"
+
+  where:
+    MODE:           The mode to process after parsing DATA:
+                        "structure":    prints data structures.
+                        "macro":        prints C macro representation
+                        "literal":      prints space-separated decimal array.
+                        "raw":          prints binary with host endian.
+    DATA:           space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+    "-":            use binary from STDIN to interpret DATA according to host endian.
+    DECIMAL:        decimal number. It can be signed if needed.
+    HEXADECIMAL:    hexadecimal number. It should have '0x' as prefix.
+```
+
+For data of TLV from arguments in command line:
+
+```sh
+$ cargo run --bin tlv-decode -- structure 5 8 0xfffffe00 128
+...
+DbInterval(DbInterval { min: -512, max: 128, linear: false, mute_avail: true })
+```
+
+For data of TLV from STDIN, in the case that the machine architecture is little endian:
+
+```sh
+$ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+    cargo run --bin tlv-decode -- structure -
+...
+DbInterval(DbInterval { min: -512, max: 128, linear: false, mute_avail: true })
+```
+
+The data of TLV can be printed in C language macro representation:
+
+```sh
+$ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+    cargo run --bin tlv-decode -- macro -
+...
+SNDRV_CTL_TLVD_ITEM ( SNDRV_CTL_TLVT_DB_MINMAX_MUTE, 0xfffffe00, 0x80 ) 
+```
+
+The data of TLV can be printed as both of u32 numeric literal array and u8 binary:
+
+```sh
+$ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+    cargo run --bin tlv-decode -- literal -
+...
+5 8 4294966784 128 
+
+$ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+    cargo run --bin tlv-decode -- raw -
+...
+```
+
+### src/bin/db-calculate.rs
+
+This program calculates between dB value and raw value for control element, based on data of
+TLV from STDIN or command line argument. It uses double precision floating point number for
+dB calculation internally. For linear type of dB calculation, it uses exponentiation and logarithm.
+
+Without any command line argument, it prints help message and exit.
+
+```sh
+$ cargo run --bin db-calculate
+Usage:
+  db-calculate "db" DECIMAL-FLOATING-POINT VALUE-RANGE DATA | "-"
+  db-calculate "value" DECIMAL | HEXADECIMAL VALUE-RANGE DATA | "-"
+
+  where:
+    "db":                   Use this program for db calculation.
+    "value":                Use this program for value calculation.
+    DECIMAL-FLOATING-POINT: decimal floating point number. It can be signed if needed.
+    DECIMAL:                decimal number. It can be signed if needed.
+    HEXADECIMAL:            hexadecimal number. It should have '0x' as prefix.
+    VALUE-RANGE:            space-separated triplet of MIN, MAX, and STEP comes from information of
+                            control element. All of them are DECIMAL or HEXADECIMAL.
+    DATA:                   space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+    "-":                    use STDIN to interpret DATA according to host endian.
+
+   When data of TLV has information to support mute, "-9999999" for value and "-inf" for db are
+   available.
+```
+
+For calculation from dB to value based on data of TLV from STDIN, in the case that the machine
+architecture is little endian:
+
+```sh
+$ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+    cargo run --bin db-calculate db 1.0    128 512 1    -
+  ...
+  495
+```
+
+For calculation to dB from value based on data of TLV from arguments of command line:
+
+```sh
+$ cargo run --bin db-calculate value 495    128 512 1    5 8 0xfffffe00 0
+  ...
+  0.996666666666667
+```
+
+The calculation has no validated numerics.

--- a/libs/alsa-ctl-tlv-codec/src/bin/db-calculate.rs
+++ b/libs/alsa-ctl-tlv-codec/src/bin/db-calculate.rs
@@ -1,0 +1,671 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use alsa_ctl_tlv_codec::{*, items::*, containers::*, range_utils::*};
+
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::io::Read;
+use std::convert::TryFrom;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ErrorTarget {
+    Container,
+    DbRange,
+    DbScale,
+    DbInterval,
+    Chmap,
+}
+
+impl From<&TlvItem> for ErrorTarget {
+    fn from(item: &TlvItem) -> Self {
+        match item {
+            TlvItem::Container(_) => ErrorTarget::Container,
+            TlvItem::DbRange(_) => ErrorTarget::DbRange,
+            TlvItem::DbScale(_) => ErrorTarget::DbScale,
+            TlvItem::DbInterval(_) => ErrorTarget::DbInterval,
+            TlvItem::Chmap(_) => ErrorTarget::Chmap,
+        }
+    }
+}
+
+impl std::fmt::Display for ErrorTarget {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            ErrorTarget::Container => "Container",
+            ErrorTarget::DbRange => "DbRange",
+            ErrorTarget::DbScale => "DbScale",
+            ErrorTarget::DbInterval => "DbInterval",
+            ErrorTarget::Chmap => "Chmap",
+        };
+        write!(f, "{}", label)
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum ErrorCause {
+    NoEntryAvail,
+    CalculationFailed,
+    ToDbInterval,
+    OutOfRange,
+}
+
+impl std::fmt::Display for ErrorCause {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            ErrorCause::NoEntryAvail => "No entry available",
+            ErrorCause::CalculationFailed => "Calculation failed",
+            ErrorCause::ToDbInterval => "dB information not found",
+            ErrorCause::OutOfRange => "Out of range",
+        };
+        write!(f, "{}", label)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LocalError{
+    target: ErrorTarget,
+    ctx: ErrorCause,
+    msg: String,
+}
+
+impl LocalError {
+    fn new(target: ErrorTarget, ctx: ErrorCause, msg: String) -> Self {
+        LocalError{target, ctx, msg}
+    }
+}
+
+impl std::fmt::Display for LocalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "target: {}, ctx: {}, msg: {}", self.target, self.ctx, self.msg)
+    }
+}
+
+// Unit conversion between raw dB and dB in data of TLV in ALSA control interface.
+trait DbUnitConvert {
+    const UNIT: f64 = DB_VALUE_MULTIPLIER as f64;
+    fn min_f(&self) -> f64;
+    fn max_f(&self) -> f64;
+}
+
+// Decibel calculation for SNDRV_CTL_TLVT_DB_LINEAR.
+trait LinearDbCalc {
+    const REFERENCE: f64 = 20.0;
+    fn val_to_linear_for_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError>;
+    fn val_from_linear_for_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError>;
+}
+
+// Common calculation methods between raw value and raw dB.
+trait DbCalc {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError>;
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError>;
+}
+
+// Extensions of DbScale implementation.
+impl DbCalc for DbScale {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        let interval = self.to_dbinterval(&range).unwrap();
+        interval.val_to_db(val, range)
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        let interval = self.to_dbinterval(&range).unwrap();
+        interval.val_from_db(db, range)
+    }
+}
+
+// Extensions of DbInterval implementation.
+impl DbUnitConvert for DbInterval {
+    fn min_f(&self) -> f64 {
+        (self.min as f64) / Self::UNIT
+    }
+
+    fn max_f(&self) -> f64 {
+        (self.max as f64) / Self::UNIT
+    }
+}
+
+impl LinearDbCalc for DbInterval {
+    fn val_to_linear_for_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        if val == CTL_VALUE_MUTE && self.mute_avail {
+            Ok(f64::NEG_INFINITY)
+        } else if !range.contains(val) {
+            let msg = format!("{} is not between {} and {}", val, range.min, range.max);
+            Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+        } else if val == range.min {
+            Ok(self.min_f())
+        } else if val == range.max {
+            Ok(self.max_f())
+        } else {
+            let linear_min = 10f64.powf(self.min_f() / Self::REFERENCE);
+            let linear_max = 10f64.powf(self.max_f() / Self::REFERENCE);
+            let linear_length = (linear_min - linear_max).abs();
+            let linear_val = linear_min + linear_length * ((val - range.min) as f64) / (range.length() as f64);
+            Ok(Self::REFERENCE * f64::log10(linear_val))
+        }
+    }
+
+    fn val_from_linear_for_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        if db == f64::NEG_INFINITY {
+            if self.mute_avail {
+                Ok(CTL_VALUE_MUTE)
+            } else {
+                let msg = format!("{} is not supported for mute", db);
+                Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+            }
+        } else {
+            let min = self.min_f();
+            let max = self.max_f();
+            if db < min || db > max {
+                let msg = format!("{} is not between {} and {}", db, min, max);
+                Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+            } else if db == min {
+                Ok(range.min)
+            } else if db >= max {
+                Ok(range.max)
+            } else {
+                let linear_val = 10f64.powf(db / Self::REFERENCE);
+                let linear_min = 10f64.powf(self.min_f() / Self::REFERENCE);
+                let linear_max = 10f64.powf(self.max_f() / Self::REFERENCE);
+                let linear_length = (linear_max - linear_min).abs();
+                Ok(((range.min as f64) + (range.length() as f64) * ((linear_val - linear_min) / linear_length)) as i32)
+            }
+        }
+    }
+}
+
+impl DbCalc for DbInterval {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        if self.linear {
+            self.val_to_linear_for_db(val, range)
+        } else {
+            if val == CTL_VALUE_MUTE && self.mute_avail {
+                Ok(f64::NEG_INFINITY)
+            } else if !range.contains(val) {
+                let msg = format!("{} is not between {} and {}", val, range.min, range.max);
+                Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+            } else if val == range.min {
+                Ok(self.min_f())
+            } else if val == range.max {
+                Ok(self.max_f())
+            } else {
+                let db_min = self.min_f();
+                let db_max = self.max_f();
+                let db_length = (db_max - db_min).abs();
+                Ok(db_min + db_length * ((val - range.min) as f64) / (range.length() as f64))
+            }
+        }
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        if self.linear {
+            self.val_from_linear_for_db(db, range)
+        } else {
+            if db == f64::NEG_INFINITY {
+                if self.mute_avail {
+                    Ok(CTL_VALUE_MUTE)
+                } else {
+                    let msg = format!("{} is not supported for mute", db);
+                    Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+                }
+            } else {
+                let min = self.min_f();
+                let max = self.max_f();
+                if db < min || db > max {
+                    let msg = format!("{} is not between {} and {}", db, min, max);
+                    Err(LocalError::new(ErrorTarget::DbInterval, ErrorCause::OutOfRange, msg))
+                } else if db == min {
+                    Ok(range.min)
+                } else if db == max {
+                    Ok(range.max)
+                } else {
+                    let db_min = self.min_f();
+                    let db_max = self.max_f();
+                    let db_length = (db_max - db_min).abs();
+                    let v = (range.min as f64) + (range.length() as f64) * (db - db_min) / db_length;
+                    Ok(v as i32)
+                }
+            }
+        }
+    }
+}
+
+// Extensions for DbRange implementation.
+impl DbCalc for DbRangeEntry {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        let r = self.to_valuerange(range).unwrap();
+        match &self.data {
+            DbRangeEntryData::DbScale(d) => d.val_to_db(val, &r),
+            DbRangeEntryData::DbInterval(d) => d.val_to_db(val, &r),
+            DbRangeEntryData::DbRange(d) => d.val_to_db(val, &r),
+        }
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        let r = self.to_valuerange(range).unwrap();
+        match &self.data {
+            DbRangeEntryData::DbScale(d) => d.val_from_db(db, &r),
+            DbRangeEntryData::DbInterval(d) => d.val_from_db(db, &r),
+            DbRangeEntryData::DbRange(d) => d.val_from_db(db, &r),
+        }
+    }
+}
+
+// Extensions for DbRange implementation.
+impl DbCalc for DbRange {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        (if val == CTL_VALUE_MUTE {
+            self.entries.iter()
+                .filter_map(|entry| {
+                    let r = entry.to_valuerange(&range).unwrap();
+                    entry.to_dbinterval(&r)
+                        .ok()
+                        .and_then(|i| Some((i.min, r, entry)))
+                })
+                .min_by(|r, l| r.0.cmp(&l.0))
+                .map(|(_, r, entry)| (r, entry))
+        } else {
+            self.entries.iter()
+                .find_map(|entry| {
+                    let r = entry.to_valuerange(&range).unwrap();
+                    if r.contains(val) { Some((r, entry)) } else { None }
+                })
+        })
+        .ok_or_else(|| {
+            let msg = format!("{:?}", self);
+            LocalError::new(ErrorTarget::DbRange, ErrorCause::NoEntryAvail, msg)
+        })
+        .and_then(|(r, entry)| {
+            entry.val_to_db(val, &r).or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, entry);
+                Err(LocalError::new(ErrorTarget::DbRange, ErrorCause::CalculationFailed, msg))
+            })
+        })
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        (if db == f64::NEG_INFINITY {
+            self.entries.iter()
+                .filter_map(|entry| {
+                    let r = entry.to_valuerange(&range).unwrap();
+                    entry.to_dbinterval(&range)
+                        .ok()
+                        .and_then(|i| Some((i.min, r, entry)))
+                })
+                .min_by(|r, l| r.0.cmp(&l.0))
+                .map(|(_, r, entry)| (r, entry))
+        } else {
+            let db_devaluated = (db * (DB_VALUE_MULTIPLIER as f64)) as i32;
+            self.entries.iter()
+                .find_map(|entry| {
+                    let r = entry.to_valuerange(&range).unwrap();
+                    entry.to_dbinterval(&r)
+                        .ok()
+                        .and_then(|i| if i.contains(db_devaluated) { Some((r, entry)) } else { None })
+                })
+        })
+        .ok_or_else(|| {
+            let msg = format!("{:?}", self);
+            LocalError::new(ErrorTarget::DbRange, ErrorCause::NoEntryAvail, msg)
+        })
+        .and_then(|(r, entry)| {
+            entry.val_from_db(db, &r).or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, entry);
+                Err(LocalError::new(ErrorTarget::DbRange, ErrorCause::CalculationFailed, msg))
+            })
+        })
+    }
+}
+
+// Extensions of Container implementation.
+impl DbCalc for Container {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        (if val == CTL_VALUE_MUTE {
+            self.entries.iter()
+                .filter_map(|entry| {
+                    entry.to_valuerange(&range)
+                        .and_then(|r| {
+                            entry.to_dbinterval(&r)
+                                .ok()
+                                .and_then(|i| Some((i.min, r, entry)))
+                        })
+                })
+                .min_by(|r, l| r.0.cmp(&l.0))
+                .and_then(|(_, r, entry)| Some((r, entry)))
+        } else {
+            self.entries.iter()
+                .find_map(|entry| {
+                    entry.to_valuerange(&range)
+                        .and_then(|r| if r.contains(val) { Some((r, entry)) } else { None })
+                })
+        })
+        .ok_or_else(|| {
+            let msg = format!("{:?}", self);
+            LocalError::new(ErrorTarget::DbRange, ErrorCause::NoEntryAvail, msg)
+        })
+        .and_then(|(r, entry)| {
+            entry.val_to_db(val, &r).or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, entry);
+                Err(LocalError::new(ErrorTarget::Container, ErrorCause::CalculationFailed, msg))
+            })
+        })
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        (if db == f64::NEG_INFINITY {
+            self.entries.iter()
+                .filter_map(|entry| {
+                    entry.to_valuerange(&range)
+                        .and_then(|r| {
+                            entry.to_dbinterval(&range)
+                                .ok()
+                                .and_then(|i| Some((i.min, r, entry)))
+                        })
+                })
+                .min_by(|r, l| r.0.cmp(&l.0))
+                .map(|(_, r, entry)| (r, entry))
+        } else {
+            let db_devaluated = (db * (DB_VALUE_MULTIPLIER as f64)) as i32;
+            self.entries.iter()
+                .find_map(|entry| {
+                    entry.to_valuerange(&range)
+                        .and_then(|r| {
+                            entry.to_dbinterval(&r)
+                                .ok()
+                                .and_then(|i| if i.contains(db_devaluated) { Some((r, entry)) } else { None })
+                        })
+                })
+        })
+        .ok_or_else(|| {
+            let msg = format!("{:?}", self);
+            LocalError::new(ErrorTarget::DbRange, ErrorCause::NoEntryAvail, msg)
+        })
+        .and_then(|(r, entry)| {
+            entry.val_from_db(db, &r).or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, entry);
+                Err(LocalError::new(ErrorTarget::DbRange, ErrorCause::CalculationFailed, msg))
+            })
+        })
+    }
+}
+
+// Extensions of TlvItem implementation.
+impl DbCalc for TlvItem {
+    fn val_to_db(&self, val: i32, range: &ValueRange) -> Result<f64, LocalError> {
+        self.to_dbinterval(&range)
+            .or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, self);
+                Err(LocalError::new(ErrorTarget::from(self), ErrorCause::ToDbInterval, msg))
+            })
+            .and_then(|i| i.val_to_db(val, range))
+    }
+
+    fn val_from_db(&self, db: f64, range: &ValueRange) -> Result<i32, LocalError> {
+        self.to_dbinterval(&range)
+            .or_else(|e| {
+                let msg = format!("{}: {:?}", e.msg, self);
+                Err(LocalError::new(ErrorTarget::from(self), ErrorCause::ToDbInterval, msg))
+            })
+            .and_then(|i| i.val_from_db(db, range))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+enum Mode {
+    Db(f64),
+    Value(i32),
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() < 6 {
+        print_help();
+        std::process::exit(0);
+    }
+
+    let mode = if args[0] == "db" {
+        let db = f64::from_str(&args[1]).unwrap_or_else(|_| {
+            eprintln!("Invalid argument for decimal floating point value: {}", args[1]);
+            std::process::exit(1);
+        });
+        Mode::Db(db)
+    } else if args[0] == "value" {
+        let val = interpret_i32(&args[1]).unwrap_or_else(|_| {
+            eprintln!("Invalid argument for decimal value: {}", args[1]);
+            std::process::exit(1);
+        });
+        Mode::Value(val)
+    } else {
+        eprintln!("Invalid argument for operation mode: {}", args[0]);
+        print_help();
+        std::process::exit(1);
+    };
+
+    let min = interpret_i32(&args[2]).unwrap_or_else(|_| {
+        eprintln!("Invalid argument for minimum value: {}", args[1]);
+        std::process::exit(1);
+    });
+    let max = interpret_i32(&args[3]).unwrap_or_else(|_| {
+        eprintln!("Invalid argument for minimum value: {}", args[1]);
+        std::process::exit(1);
+    });
+    let step = interpret_i32(&args[4]).unwrap_or_else(|_| {
+        eprintln!("Invalid argument for minimum value: {}", args[1]);
+        std::process::exit(1);
+    });
+    let range = ValueRange{min, max, step};
+
+    let raw = if args[5] == "-" {
+        interpret_tlv_data_from_stdin().unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            std::process::exit(1);
+        })
+    } else {
+        interpret_tlv_data_from_command_line(&args[5..]).unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            std::process::exit(1);
+        })
+    };
+
+    let data = TlvItem::try_from(&raw[..]).unwrap_or_else(|error| {
+        eprintln!("{}", error);
+        std::process::exit(1)
+    });
+
+    if let Err(e) = match mode {
+        Mode::Db(db) => {
+            data.val_from_db(db, &range)
+                .and_then(|val| {
+                    println!("{}", val);
+                    Ok(())
+                })
+        }
+        Mode::Value(val) => {
+            data.val_to_db(val, &range)
+                .and_then(|db| {
+                    println!("{}", db);
+                    Ok(())
+                })
+        }
+    } {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    } else {
+        std::process::exit(0);
+    }
+}
+
+fn print_help() {
+    print!(
+r###"
+Usage:
+  db-calculate "db" DECIMAL-FLOATING-POINT VALUE-RANGE DATA | "-"
+  db-calculate "value" DECIMAL | HEXADECIMAL VALUE-RANGE DATA | "-"
+
+  where:
+    "db":                   Use this program for db calculation.
+    "value":                Use this program for value calculation.
+    DECIMAL-FLOATING-POINT: decimal floating point number. It can be signed if needed.
+    DECIMAL:                decimal number. It can be signed if needed.
+    HEXADECIMAL:            hexadecimal number. It should have '0x' as prefix.
+    VALUE-RANGE:            space-separated triplet of MIN, MAX, and STEP comes from information of
+                            control element. All of them are DECIMAL or HEXADECIMAL.
+    DATA:                   space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+    "-":                    use STDIN to interpret DATA according to host endian.
+
+   When data of TLV has information to support mute, "-9999999" for value and "-inf" for db are
+   available.
+"###);
+}
+
+fn interpret_i32(arg: &str) -> Result<i32, ParseIntError> {
+    if arg.starts_with("0x") {
+        i32::from_str_radix(arg.trim_start_matches("0x"), 16)
+    } else if arg.find(&['A', 'B', 'C', 'D', 'E', 'F', 'a', 'b', 'c', 'd', 'e', 'f'][..]).is_some() {
+        i32::from_str_radix(arg, 16)
+    } else {
+        i32::from_str(arg)
+    }
+}
+
+fn interpret_tlv_data_from_stdin() -> Result<Vec<u32>, String> {
+    let mut raw = Vec::new();
+
+    let input = std::io::stdin();
+    let mut handle = input.lock();
+
+    let mut buf = Vec::new();
+    match handle.read_to_end(&mut buf) {
+        Ok(len) => {
+            if len == 0 {
+                return Err("Nothing available via standard input.".to_string());
+            } else if len % 4 > 0 {
+                return Err("The length of data via standard input is not multiples of 4.".to_string());
+            } else {
+                let mut quadlet = [0;4];
+                (0..(buf.len() / 4)).for_each(|i| {
+                    let pos = i * 4;
+                    quadlet.copy_from_slice(&buf[pos..(pos + 4)]);
+                    raw.push(u32::from_ne_bytes(quadlet));
+                });
+            }
+        }
+        Err(e) => return Err(e.to_string()),
+    };
+
+    Ok(raw)
+}
+
+fn interpret_tlv_data_from_command_line(args: &[String]) -> Result<Vec<u32>, String> {
+    let mut raw = Vec::new();
+
+    if let Err(e) = args.iter().try_for_each(|arg| {
+        let val = if arg.starts_with("0x") {
+            u32::from_str_radix(arg.trim_start_matches("0x"), 16)?
+        } else if arg.find(&['A', 'B', 'C', 'D', 'E', 'F', 'a', 'b', 'c', 'd', 'e', 'f'][..]).is_some() {
+            u32::from_str_radix(arg, 16)?
+        } else {
+            u32::from_str(arg)?
+        };
+        raw.push(val);
+        Ok::<(), ParseIntError>(())
+    }) {
+        return Err(e.to_string());
+    }
+
+    Ok(raw)
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn dbcalc_dbscale() {
+        let range = ValueRange{min: -10, max: 0, step: 1};
+        let scale = DbScale{min: 1, step: 100, mute_avail: false};
+
+        assert_eq!(scale.val_to_db(-10, &range).unwrap(), 0.01f64);
+        assert_eq!(scale.val_to_db(0, &range).unwrap(), 10.01f64);
+        assert_eq!(scale.val_to_db(-5, &range).unwrap(), 5.01f64);
+
+        assert_eq!(scale.val_from_db(0.01f64, &range).unwrap(), -10);
+        assert_eq!(scale.val_from_db(10.01f64, &range).unwrap(), 0);
+        assert_eq!(scale.val_from_db(5.01f64, &range).unwrap(), -5);
+    }
+
+    #[test]
+    fn dbconvert_dbinterval() {
+        let interval = DbInterval{min: 100, max: 1000, linear: false, mute_avail: true};
+        assert_eq!(interval.min_f(), 1f64);
+        assert_eq!(interval.max_f(), 10f64);
+    }
+
+    #[test]
+    fn lineardbcalc_dbinterval() {
+        let interval = DbInterval{min: 2000, max: 6000, linear: false, mute_avail: true};
+        let range = ValueRange{min: 33, max: 133, step: 1};
+
+        let value_midpoint = range.min + (range.max - range.min) / 2;
+        let linear_min = 10f64.powf((interval.min as f64) / 20f64 / 100f64);
+        let linear_max = 10f64.powf((interval.max as f64) / 20f64 / 100f64);
+        let linear_midpoint = linear_min + (linear_max - linear_min) / 2f64;
+        let db_midpoint = 20f64 * linear_midpoint.log10();
+
+        assert_eq!(interval.val_to_linear_for_db(CTL_VALUE_MUTE, &range).unwrap(), f64::NEG_INFINITY);
+        assert_eq!(interval.val_to_linear_for_db(33, &range).unwrap(), 20f64);
+        assert_eq!(interval.val_to_linear_for_db(133, &range).unwrap(), 60f64);
+        assert_eq!(interval.val_to_linear_for_db(value_midpoint, &range).unwrap(), db_midpoint);
+
+        assert_eq!(interval.val_from_linear_for_db(f64::NEG_INFINITY, &range).unwrap(), CTL_VALUE_MUTE);
+        assert_eq!(interval.val_from_linear_for_db(20f64, &range).unwrap(), 33);
+        assert_eq!(interval.val_from_linear_for_db(60f64, &range).unwrap(), 133);
+        assert_eq!(interval.val_from_linear_for_db(db_midpoint, &range).unwrap(), value_midpoint);
+    }
+
+    #[test]
+    fn dbcalc_dbinterval() {
+        let interval = DbInterval{min: 1, max: 1001, linear: false, mute_avail: false};
+        let range = ValueRange{min: -10, max: 0, step: 1};
+
+        assert_eq!(interval.val_to_db(-10, &range).unwrap(), 0.01f64);
+        assert_eq!(interval.val_to_db(0, &range).unwrap(), 10.01f64);
+        assert_eq!(interval.val_to_db(-5, &range).unwrap(), 5.01f64);
+
+        assert_eq!(interval.val_from_db(0.01f64, &range).unwrap(), -10);
+        assert_eq!(interval.val_from_db(10.01f64, &range).unwrap(), 0);
+        assert_eq!(interval.val_from_db(5.01f64, &range).unwrap(), -5);
+    }
+
+    #[test]
+    fn dbcalc_dbrange() {
+        let first_data = DbInterval{min: 1, max: 501, linear: false, mute_avail: true};
+        let second_data = DbInterval{min: 501, max: 1001, linear: false, mute_avail: false};
+
+        let db_range = DbRange{
+            entries: vec![
+                DbRangeEntry{
+                    min_val: -10,
+                    max_val: -5,
+                    data: DbRangeEntryData::DbInterval(first_data),
+                },
+                DbRangeEntry{
+                    min_val: -5,
+                    max_val: 0,
+                    data: DbRangeEntryData::DbInterval(second_data),
+                },
+            ],
+        };
+        let val_range = ValueRange{min: -10, max: 0, step: 1};
+
+        assert_eq!(db_range.val_to_db(CTL_VALUE_MUTE, &val_range).unwrap(), f64::NEG_INFINITY);
+        assert_eq!(db_range.val_to_db(-10, &val_range), Ok(0.01f64));
+        assert_eq!(db_range.val_to_db(-5, &val_range), Ok(5.01f64));
+        assert_eq!(db_range.val_to_db(0, &val_range), Ok(10.01f64));
+
+        assert_eq!(db_range.val_from_db(f64::NEG_INFINITY, &val_range).unwrap(), CTL_VALUE_MUTE);
+        assert_eq!(db_range.val_from_db(0.01f64, &val_range), Ok(-10));
+        assert_eq!(db_range.val_from_db(5.01f64, &val_range), Ok(-5));
+        assert_eq!(db_range.val_from_db(10.01f64, &val_range), Ok(0));
+    }
+}

--- a/libs/alsa-ctl-tlv-codec/src/bin/tlv-decode.rs
+++ b/libs/alsa-ctl-tlv-codec/src/bin/tlv-decode.rs
@@ -1,0 +1,308 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use alsa_ctl_tlv_codec::{*, items::*, containers::*};
+use std::convert::TryFrom;
+
+use std::io::{Read, Write};
+use std::str::FromStr;
+use std::num::ParseIntError;
+
+
+fn generate_indent(level: usize) -> String {
+    (0..(level * INDENTS_PER_LEVEL)).fold(String::new(), |mut l, _| {l.push(' '); l})
+}
+
+trait PrintAsMacro {
+    fn print_as_macro(&self, level: usize);
+}
+
+impl PrintAsMacro for DbScale {
+    fn print_as_macro(&self, _: usize) {
+        print!("SNDRV_CTL_TLVD_ITEM ( SNDRV_CTL_TLVT_DB_SCALE, 0x{:x}, 0x{:x}{} )",
+               self.min as u32, self.step,
+               if self.mute_avail { " | SNDRV_CTL_TLVD_DB_SCALE_MUTE" } else { "" });
+    }
+}
+
+impl PrintAsMacro for DbInterval {
+    fn print_as_macro(&self, _: usize) {
+        let label = if self.linear {
+            "SNDRV_CTL_TLVT_DB_LINEAR"
+        } else {
+            if self.mute_avail {
+                "SNDRV_CTL_TLVT_DB_MINMAX_MUTE"
+            } else {
+                "SNDRV_CTL_TLVT_DB_MINMAX"
+            }
+        };
+        print!("SNDRV_CTL_TLVD_ITEM ( {}, 0x{:x}, 0x{:x} )",
+               label, self.min as u32, self.max as u32);
+    }
+}
+
+impl PrintAsMacro for ChmapEntry {
+    fn print_as_macro(&self, _: usize) {
+        match self.pos {
+            ChmapPos::Generic(p) => {
+                let label = match p {
+                    ChmapGenericPos::Unknown => "SNDRV_CHMAP_UNKNOWN",
+                    ChmapGenericPos::NotAvailable => "SNDRV_CHMAP_NA",
+                    ChmapGenericPos::Monaural => "SNDRV_CHMAP_MONO",
+                    ChmapGenericPos::FrontLeft => "SNDRV_CHMAP_FL",
+                    ChmapGenericPos::FrontRight => "SNDRV_CHMAP_FR",
+                    ChmapGenericPos::RearLeft => "SNDRV_CHMAP_RL",
+                    ChmapGenericPos::RearRight => "SNDRV_CHMAP_RR",
+                    ChmapGenericPos::FrontCenter => "SNDRV_CHMAP_FC",
+                    ChmapGenericPos::LowFrequencyEffect => "SNDRV_CHMAP_LFE",
+                    ChmapGenericPos::SideLeft => "SNDRV_CHMAP_SL",
+                    ChmapGenericPos::SideRight => "SNDRV_CHMAP_SR",
+                    ChmapGenericPos::RearCenter => "SNDRV_CHMAP_RC",
+                    ChmapGenericPos::FrontLeftCenter => "SNDRV_CHMAP_FLC",
+                    ChmapGenericPos::FrontRightCenter => "SNDRV_CHMAP_FRC",
+                    ChmapGenericPos::RearLeftCenter => "SNDRV_CHMAP_RLC",
+                    ChmapGenericPos::RearRightCenter => "SNDRV_CHMAP_RRC",
+                    ChmapGenericPos::FrontLeftWide => "SNDRV_CHMAP_FLW",
+                    ChmapGenericPos::FrontRightWide => "SNDRV_CHMAP_FRW",
+                    ChmapGenericPos::FrontLeftHigh => "SNDRV_CHMAP_FLH",
+                    ChmapGenericPos::FrontCenterHigh => "SNDRV_CHMAP_FCH",
+                    ChmapGenericPos::FrontRightHigh => "SNDRV_CHMAP_FRH",
+                    ChmapGenericPos::TopCenter => "SNDRV_CHMAP_TC",
+                    ChmapGenericPos::TopFrontLeft => "SNDRV_CHMAP_TFL",
+                    ChmapGenericPos::TopFrontRight => "SNDRV_CHMAP_TFR",
+                    ChmapGenericPos::TopFrontCenter => "SNDRV_CHMAP_TFC",
+                    ChmapGenericPos::TopRearLeft => "SNDRV_CHMAP_TRL",
+                    ChmapGenericPos::TopRearRight => "SNDRV_CHMAP_TRR",
+                    ChmapGenericPos::TopRearCenter => "SNDRV_CHMAP_TRC",
+                    ChmapGenericPos::TopFrontLeftCenter => "SNDRV_CHMAP_TFLC",
+                    ChmapGenericPos::TopFrontRightCenter => "SNDRV_CHMAP_TFRC",
+                    ChmapGenericPos::TopSideLeft => "SNDRV_CHMAP_TSL",
+                    ChmapGenericPos::TopSideRight => "SNDRV_CHMAP_TSR",
+                    ChmapGenericPos::LeftLowFrequencyEffect => "SNDRV_CHMAP_LLFE",
+                    ChmapGenericPos::RightLowFrequencyEffect => "SNDRV_CHMAP_RLFE",
+                    ChmapGenericPos::BottomCenter => "SNDRV_CHMAP_BC",
+                    ChmapGenericPos::BottomLeftCenter => "SNDRV_CHMAP_BLC",
+                    ChmapGenericPos::BottomRightCenter => "SNDRV_CHMAP_BRC",
+                };
+                print!("{}", label);
+            }
+            ChmapPos::Specific(p) => {
+                print!("{} | SNDRV_CHMAP_DRIVER_SPEC", p)
+            }
+        };
+        if self.phase_inverse {
+            print!(" | SNDRV_CHMAP_PHASE_INVERSE");
+        }
+    }
+}
+
+impl PrintAsMacro for Chmap {
+    fn print_as_macro(&self, mut level: usize) {
+        level += 1;
+        let indent = generate_indent(level);
+
+        let label = match self.mode {
+            ChmapMode::Fixed => "SNDRV_CTL_TLVT_CHMAP_FIXED",
+            ChmapMode::ArbitraryExchangeable => "SNDRV_CTL_TLVT_CHMAP_VAR",
+            ChmapMode::PairedExchangeable => "SNDRV_CTL_TLVT_CHMAP_PAIRED",
+        };
+
+        println!("SNDRV_CTL_TLVD_ITEM ( {},", label);
+        self.entries.iter().for_each(|entry| {
+            print!("{}", indent);
+            entry.print_as_macro(level);
+            println!(",");
+        });
+    }
+}
+
+impl PrintAsMacro for DbRangeEntry {
+    fn print_as_macro(&self, mut level: usize) {
+        level += 1;
+
+        print!("{}, {}, ", self.min_val, self.max_val);
+
+        match &self.data {
+            DbRangeEntryData::DbScale(d) => d.print_as_macro(level),
+            DbRangeEntryData::DbInterval(d) => d.print_as_macro(level),
+            DbRangeEntryData::DbRange(d) => d.print_as_macro(level),
+        };
+    }
+}
+
+impl PrintAsMacro for DbRange {
+    fn print_as_macro(&self, mut level: usize) {
+        level += 1;
+        let indent =generate_indent(level);
+
+        println!("SNDRV_CTL_TLVD_ITEM ( SNDRV_CTL_TLVT_DB_RANGE,");
+        self.entries.iter().for_each(|entry| {
+            print!("{}", indent);
+            entry.print_as_macro(level);
+            println!(",");
+        });
+    }
+}
+
+const INDENTS_PER_LEVEL: usize = 4;
+
+impl PrintAsMacro for Container {
+    fn print_as_macro(&self, mut level: usize) {
+        level += 1;
+        let indent = generate_indent(level);
+
+        println!("SNDRV_CTL_TLVD_ITEM ( SNDRV_CTL_TLVT_CONTAINER, ");
+        self.entries.iter().for_each(|entry| {
+            print!("{}", indent);
+            entry.print_as_macro(level);
+            println!("{}),", indent)
+        });
+        print!(")");
+    }
+}
+
+impl PrintAsMacro for TlvItem {
+    fn print_as_macro(&self, level: usize) {
+        match self {
+            TlvItem::Container(d) => d.print_as_macro(level),
+            TlvItem::DbRange(d) => d.print_as_macro(level),
+            TlvItem::DbScale(d) => d.print_as_macro(level),
+            TlvItem::DbInterval(d) => d.print_as_macro(level),
+            TlvItem::Chmap(d) => d.print_as_macro(level),
+        }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum Mode {
+    Structure,
+    Literal,
+    Raw,
+    Macro,
+}
+
+fn main() {
+    let args = std::env::args().skip(1).collect::<Vec<_>>();
+    if args.len() < 2 {
+        print_help();
+        std::process::exit(0);
+    }
+
+    let mode = match args[0].as_str() {
+        "structure" => Mode::Structure,
+        "literal" => Mode::Literal,
+        "raw" => Mode::Raw,
+        "macro" => Mode::Macro,
+        _ => {
+            eprintln!("Invalid argument for mode: {}", args[0]);
+            std::process::exit(1);
+        }
+    };
+
+    let raw = if args[1] == "-" {
+        interpret_tlv_data_from_stdin().unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            std::process::exit(1);
+        })
+    } else {
+        interpret_tlv_data_from_command_line(&args[1..]).unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            std::process::exit(1);
+        })
+    };
+
+    let item = TlvItem::try_from(&raw[..]).unwrap_or_else(|msg| {
+        eprintln!("{}", msg);
+        std::process::exit(1);
+    });
+
+    if mode == Mode::Structure {
+        println!("{:?}", item);
+    } else if mode == Mode::Macro {
+        item.print_as_macro(0);
+        println!("");
+    } else {
+        let raw: Vec<u32> = match item {
+          TlvItem::Container(d) => d.into(),
+          TlvItem::DbRange(d) => d.into(),
+          TlvItem::DbScale(d) => d.into(),
+          TlvItem::DbInterval(d) => d.into(),
+          TlvItem::Chmap(d) => d.into(),
+        };
+
+        if mode == Mode::Literal {
+            raw.iter().for_each(|val| print!("{} ", val));
+            println!("")
+        } else {
+            let stdout = std::io::stdout();
+            let mut out = stdout.lock();
+            raw.iter().for_each(|val| out.write_all(&val.to_ne_bytes()).unwrap_or(()))
+        }
+    }
+}
+
+fn print_help() {
+    print!(
+r###"
+Usage:
+  tlv-decode MODE DATA | "-"
+
+  where:
+    MODE:           The mode to process after parsing DATA:
+                        "structure":    prints data structures.
+                        "macro":        prints C macro representation
+                        "literal":      prints space-separated decimal array.
+                        "raw":          prints binary with host endian.
+    DATA:           space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+    "-":            use binary from STDIN to interpret DATA according to host endian.
+    DECIMAL:        decimal number. It can be signed if needed.
+    HEXADECIMAL:    hexadecimal number. It should have '0x' as prefix.
+"###);
+}
+
+fn interpret_tlv_data_from_stdin() -> Result<Vec<u32>, String> {
+    let mut raw = Vec::new();
+
+    let input = std::io::stdin();
+    let mut handle = input.lock();
+
+    let mut buf = Vec::new();
+    match handle.read_to_end(&mut buf) {
+        Ok(len) => {
+            if len == 0 {
+                return Err("Nothing available via standard input.".to_string());
+            } else if len % 4 > 0 {
+                return Err("The length of data via standard input is not multiples of 4.".to_string());
+            } else {
+                let mut quadlet = [0;4];
+                (0..(buf.len() / 4)).for_each(|i| {
+                    let pos = i * 4;
+                    quadlet.copy_from_slice(&buf[pos..(pos + 4)]);
+                    raw.push(u32::from_ne_bytes(quadlet));
+                });
+            }
+        }
+        Err(e) => return Err(e.to_string()),
+    };
+
+    Ok(raw)
+}
+
+fn interpret_tlv_data_from_command_line(args: &[String]) -> Result<Vec<u32>, String> {
+    let mut raw = Vec::new();
+
+    if let Err(e) = args.iter().try_for_each(|arg| {
+        let val = if arg.starts_with("0x") {
+            u32::from_str_radix(arg.trim_start_matches("0x"), 16)?
+        } else if arg.find(&['A', 'B', 'C', 'D', 'E', 'F', 'a', 'b', 'c', 'd', 'e', 'f'][..]).is_some() {
+            u32::from_str_radix(arg, 16)?
+        } else {
+            u32::from_str(arg)?
+        };
+        raw.push(val);
+        Ok::<(), ParseIntError>(())
+    }) {
+        return Err(e.to_string());
+    }
+
+    Ok(raw)
+}

--- a/libs/alsa-ctl-tlv-codec/src/containers.rs
+++ b/libs/alsa-ctl-tlv-codec/src/containers.rs
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! A set of containers to aggregate items in TLV (Type-Length-Value) of ALSA control interface.
+
+use super::*;
+use super::uapi::*;
+use super::items::*;
+
+trait DataEntry<'a> : std::convert::TryFrom<&'a [u32]> {
+    fn raw_length(&self) -> usize;
+}
+
+/// The enumeration to dispatch each type of data for entry of dB range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DbRangeEntryData{
+    DbScale(DbScale),
+    DbInterval(DbInterval),
+    DbRange(DbRange),
+}
+
+/// The entry to represent information of each entry of dB range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbRangeEntry{
+    pub min_val: i32,
+    pub max_val: i32,
+    /// The data of dB representation for the minimum/maximum range in the state of control element.
+    pub data: DbRangeEntryData,
+}
+
+impl<'a> DataEntry<'a> for DbRangeEntry {
+    fn raw_length(&self) -> usize {
+        let data_value_length = match &self.data {
+            DbRangeEntryData::DbScale(d) => d.value_length(),
+            DbRangeEntryData::DbInterval(d) => d.value_length(),
+            DbRangeEntryData::DbRange(d) => d.value_length(),
+        };
+        let data_length = 2 + data_value_length;
+        2 + data_length
+    }
+}
+
+impl std::convert::TryFrom<&[u32]> for DbRangeEntry {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(raw: &[u32]) -> Result<Self, Self::Error> {
+        if raw.len() < 4 {
+            Err(InvalidTlvDataError::new("Invalid length of data for DbRangeEntry"))
+        } else {
+            let min_val = raw[0] as i32;
+            let max_val = raw[1] as i32;
+
+            let data_value_type = raw[2];
+            let data_value_length = (raw[3] as usize) / 4;
+            let data_raw = &raw[2..(4 + data_value_length)];
+
+            let data = match data_value_type {
+                SNDRV_CTL_TLVT_DB_SCALE => {
+                    let d = DbScale::try_from(data_raw)?;
+                    DbRangeEntryData::DbScale(d)
+                }
+                SNDRV_CTL_TLVT_DB_RANGE => {
+                    let d = DbRange::try_from(data_raw)?;
+                    DbRangeEntryData::DbRange(d)
+                }
+                SNDRV_CTL_TLVT_DB_LINEAR |
+                SNDRV_CTL_TLVT_DB_MINMAX |
+                SNDRV_CTL_TLVT_DB_MINMAX_MUTE => {
+                    let d = DbInterval::try_from(data_raw)?;
+                    DbRangeEntryData::DbInterval(d)
+                }
+                _ => {
+                    return Err(InvalidTlvDataError::new("Invalid type of data for DbRangeEntry"));
+                }
+            };
+
+            Ok(DbRangeEntry{min_val, max_val, data})
+        }
+    }
+}
+
+impl From<&DbRangeEntry> for Vec<u32> {
+    fn from(entry: &DbRangeEntry) -> Self {
+        let mut raw = Vec::new();
+        raw.push(entry.min_val as u32);
+        raw.push(entry.max_val as u32);
+        let mut data_raw = match &entry.data {
+            DbRangeEntryData::DbScale(d) => Into::<Vec<u32>>::into(d),
+            DbRangeEntryData::DbRange(d) => Into::<Vec<u32>>::into(d),
+            DbRangeEntryData::DbInterval(d) => Into::<Vec<u32>>::into(d),
+        };
+        raw.append(&mut data_raw);
+        raw
+    }
+}
+
+impl From<DbRangeEntry> for Vec<u32> {
+    fn from(entry: DbRangeEntry) -> Self {
+        (&entry).into()
+    }
+}
+
+/// The data to represent multiple ranges in the state of control element for dB representation.
+/// It has `SNDRV_CTL_TLVT_DB_RANGE` (=3) in its type field and has variable number of elements in
+/// value field.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DbRange{
+    /// The entries of ranges for dB representation.
+    pub entries: Vec<DbRangeEntry>,
+}
+
+impl<'a> TlvData<'a> for DbRange {
+    fn value_type(&self) -> u32 {
+        SNDRV_CTL_TLVT_DB_RANGE
+    }
+
+    fn value_length(&self) -> usize {
+        self.entries.iter().fold(0, |length, entry| length + entry.raw_length())
+    }
+
+    fn value(&self) -> Vec<u32> {
+        let mut raw = Vec::new();
+        self.entries.iter().for_each(|entry| {
+            let mut entry_raw = Into::<Vec<u32>>::into(entry);
+            raw.append(&mut entry_raw);
+        });
+        raw
+    }
+}
+
+impl std::convert::TryFrom<&[u32]> for DbRange {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(raw: &[u32]) -> Result<Self, Self::Error> {
+        if raw.len() < 6 {
+            let msg = "Invalid length of data for DbRange";
+            Err(InvalidTlvDataError::new(msg))
+        } else if raw[0] != SNDRV_CTL_TLVT_DB_RANGE {
+            let msg = "Invalid type of data for DbRange";
+            Err(InvalidTlvDataError::new(msg))
+        } else {
+            let cntr_value_length = (raw[1] as usize) / 4;
+            if raw[2..].len() < cntr_value_length {
+                let msg = "Truncated length of data for DbRange";
+                Err(InvalidTlvDataError::new(msg))
+            } else {
+                let mut cntr_value = &raw[2..(2 + cntr_value_length)];
+
+                let mut entries = Vec::new();
+                while cntr_value.len() > 4 {
+                    let data_value_length = (cntr_value[3] as usize) / 4;
+                    if cntr_value[4..].len() < data_value_length {
+                        let msg = "Invalid length of data for DbRangeEntry";
+                        return Err(InvalidTlvDataError::new(msg));
+                    }
+                    let data_raw = &cntr_value[..(4 + data_value_length)];
+                    let entry = DbRangeEntry::try_from(data_raw)?;
+                    entries.push(entry);
+                    cntr_value = &cntr_value[(4 + data_value_length)..];
+                }
+                Ok(DbRange{entries})
+            }
+        }
+    }
+}
+
+impl From<&DbRange> for Vec<u32> {
+    fn from(data: &DbRange) -> Self {
+        let mut raw = Vec::new();
+        raw.push(data.value_type());
+        raw.push(4 * data.value_length() as u32);
+        raw.append(&mut data.value());
+        raw
+    }
+}
+
+impl From<DbRange> for Vec<u32> {
+    fn from(data: DbRange) -> Self {
+        (&data).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+    use super::{DbScale, DbInterval};
+    use super::{DbRangeEntryData, DbRangeEntry, DbRange};
+
+    #[test]
+    fn test_dbrangeentry_dbscale() {
+        let raw = [-9i32 as u32, 100, 1, 8, 0, 10];
+        let entry = DbRangeEntry::try_from(&raw[..]).unwrap();
+        assert_eq!(entry.min_val, -9);
+        assert_eq!(entry.max_val, 100);
+        assert_eq!(entry.data, DbRangeEntryData::DbScale(DbScale{min: 0, step: 10, mute_avail: false}));
+        assert_eq!(&Into::<Vec<u32>>::into(entry)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbrangeentry_dbinterval_linear() {
+        let raw = [-9i32 as u32, 100, 2, 8, 0, 10];
+        let entry = DbRangeEntry::try_from(&raw[..]).unwrap();
+        assert_eq!(entry.min_val, -9);
+        assert_eq!(entry.max_val, 100);
+        assert_eq!(entry.data, DbRangeEntryData::DbInterval(DbInterval{min: 0, max: 10, linear: true, mute_avail: true}));
+        assert_eq!(&Into::<Vec<u32>>::into(entry)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbrange() {
+        let raw = [3u32, 72,
+                   0, 10, 2, 8, -110i32 as u32, 10,
+                   10, 20, 4, 8, -10i32 as u32, 0,
+                   20, 30, 5, 8, 0, 20,
+        ];
+        let range = DbRange::try_from(&raw[..]).unwrap();
+        assert_eq!(range.entries[0], DbRangeEntry{
+            min_val: 0,
+            max_val: 10,
+            data: DbRangeEntryData::DbInterval(DbInterval{min: -110, max: 10, linear: true, mute_avail: true}),
+        });
+        assert_eq!(range.entries[1], DbRangeEntry{
+            min_val: 10,
+            max_val: 20,
+            data: DbRangeEntryData::DbInterval(DbInterval{min: -10, max: 0, linear: false, mute_avail: false}),
+        });
+        assert_eq!(range.entries[2], DbRangeEntry{
+            min_val: 20,
+            max_val: 30,
+            data: DbRangeEntryData::DbInterval(DbInterval{min: 0, max: 20, linear: false, mute_avail: true}),
+        });
+        assert_eq!(&Into::<Vec<u32>>::into(range)[..], &raw[..]);
+    }
+}

--- a/libs/alsa-ctl-tlv-codec/src/items.rs
+++ b/libs/alsa-ctl-tlv-codec/src/items.rs
@@ -184,10 +184,316 @@ impl From<DbInterval> for Vec<u32> {
     }
 }
 
+/// The enumeration to represent generic channel position corresponding to physical port on real
+/// device. They are defined as `SNDRV_CHMAP_XXX` enumeration in UAPI of Linux kernel. 
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ChmapGenericPos {
+    Unknown,
+    NotAvailable,
+    Monaural,
+    FrontLeft,
+    FrontRight,
+    RearLeft,
+    RearRight,
+    FrontCenter,
+    LowFrequencyEffect,
+    SideLeft,
+    SideRight,
+    RearCenter,
+    FrontLeftCenter,
+    FrontRightCenter,
+    RearLeftCenter,
+    RearRightCenter,
+    FrontLeftWide,
+    FrontRightWide,
+    FrontLeftHigh,
+    FrontCenterHigh,
+    FrontRightHigh,
+    TopCenter,
+    TopFrontLeft,
+    TopFrontRight,
+    TopFrontCenter,
+    TopRearLeft,
+    TopRearRight,
+    TopRearCenter,
+    TopFrontLeftCenter,
+    TopFrontRightCenter,
+    TopSideLeft,
+    TopSideRight,
+    LeftLowFrequencyEffect,
+    RightLowFrequencyEffect,
+    BottomCenter,
+    BottomLeftCenter,
+    BottomRightCenter,
+}
+
+impl Default for ChmapGenericPos {
+    fn default() -> Self {
+        ChmapGenericPos::Unknown
+    }
+}
+
+impl std::convert::TryFrom<u16> for ChmapGenericPos {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(val: u16) -> Result<Self, Self::Error> {
+        let v = match val as u32 {
+            SNDRV_CHMAP_UNKNOWN => ChmapGenericPos::Unknown,
+            SNDRV_CHMAP_NA => ChmapGenericPos::NotAvailable,
+            SNDRV_CHMAP_MONO => ChmapGenericPos::Monaural,
+            SNDRV_CHMAP_FL => ChmapGenericPos::FrontLeft,
+            SNDRV_CHMAP_FR => ChmapGenericPos::FrontRight,
+            SNDRV_CHMAP_RL => ChmapGenericPos::RearLeft,
+            SNDRV_CHMAP_RR => ChmapGenericPos::RearRight,
+            SNDRV_CHMAP_FC => ChmapGenericPos::FrontCenter,
+            SNDRV_CHMAP_LFE => ChmapGenericPos::LowFrequencyEffect,
+            SNDRV_CHMAP_SL => ChmapGenericPos::SideLeft,
+            SNDRV_CHMAP_SR => ChmapGenericPos::SideRight,
+            SNDRV_CHMAP_RC => ChmapGenericPos::RearCenter,
+            SNDRV_CHMAP_FLC => ChmapGenericPos::FrontLeftCenter,
+            SNDRV_CHMAP_FRC => ChmapGenericPos::FrontRightCenter,
+            SNDRV_CHMAP_RLC => ChmapGenericPos::RearLeftCenter,
+            SNDRV_CHMAP_RRC => ChmapGenericPos::RearRightCenter,
+            SNDRV_CHMAP_FLW => ChmapGenericPos::FrontLeftWide,
+            SNDRV_CHMAP_FRW => ChmapGenericPos::FrontRightWide,
+            SNDRV_CHMAP_FLH => ChmapGenericPos::FrontLeftHigh,
+            SNDRV_CHMAP_FCH => ChmapGenericPos::FrontCenterHigh,
+            SNDRV_CHMAP_FRH => ChmapGenericPos::FrontRightHigh,
+            SNDRV_CHMAP_TC => ChmapGenericPos::TopCenter,
+            SNDRV_CHMAP_TFL => ChmapGenericPos::TopFrontLeft,
+            SNDRV_CHMAP_TFR => ChmapGenericPos::TopFrontRight,
+            SNDRV_CHMAP_TFC => ChmapGenericPos::TopFrontCenter,
+            SNDRV_CHMAP_TRL => ChmapGenericPos::TopRearLeft,
+            SNDRV_CHMAP_TRR => ChmapGenericPos::TopRearRight,
+            SNDRV_CHMAP_TRC => ChmapGenericPos::TopRearCenter,
+            SNDRV_CHMAP_TFLC => ChmapGenericPos::TopFrontLeftCenter,
+            SNDRV_CHMAP_TFRC => ChmapGenericPos::TopFrontRightCenter,
+            SNDRV_CHMAP_TSL => ChmapGenericPos::TopSideLeft,
+            SNDRV_CHMAP_TSR => ChmapGenericPos::TopSideRight,
+            SNDRV_CHMAP_LLFE => ChmapGenericPos::LeftLowFrequencyEffect,
+            SNDRV_CHMAP_RLFE => ChmapGenericPos::RightLowFrequencyEffect,
+            SNDRV_CHMAP_BC => ChmapGenericPos::BottomCenter,
+            SNDRV_CHMAP_BLC => ChmapGenericPos::BottomLeftCenter,
+            SNDRV_CHMAP_BRC => ChmapGenericPos::BottomRightCenter,
+            _ => {
+                return Err(InvalidTlvDataError::new("Invalid value for ChmapGenericPos"));
+            }
+        };
+        Ok(v)
+    }
+}
+
+impl From<ChmapGenericPos> for u16 {
+    fn from(code: ChmapGenericPos) -> Self {
+        (match code {
+            ChmapGenericPos::Unknown => SNDRV_CHMAP_UNKNOWN,
+            ChmapGenericPos::NotAvailable => SNDRV_CHMAP_NA,
+            ChmapGenericPos::Monaural => SNDRV_CHMAP_MONO,
+            ChmapGenericPos::FrontLeft => SNDRV_CHMAP_FL,
+            ChmapGenericPos::FrontRight => SNDRV_CHMAP_FR,
+            ChmapGenericPos::RearLeft => SNDRV_CHMAP_RL,
+            ChmapGenericPos::RearRight => SNDRV_CHMAP_RR,
+            ChmapGenericPos::FrontCenter => SNDRV_CHMAP_FC,
+            ChmapGenericPos::LowFrequencyEffect => SNDRV_CHMAP_LFE,
+            ChmapGenericPos::SideLeft => SNDRV_CHMAP_SL,
+            ChmapGenericPos::SideRight => SNDRV_CHMAP_SR,
+            ChmapGenericPos::RearCenter => SNDRV_CHMAP_RC,
+            ChmapGenericPos::FrontLeftCenter => SNDRV_CHMAP_FLC,
+            ChmapGenericPos::FrontRightCenter => SNDRV_CHMAP_FRC,
+            ChmapGenericPos::RearLeftCenter => SNDRV_CHMAP_RLC,
+            ChmapGenericPos::RearRightCenter => SNDRV_CHMAP_RRC,
+            ChmapGenericPos::FrontLeftWide => SNDRV_CHMAP_FLW,
+            ChmapGenericPos::FrontRightWide => SNDRV_CHMAP_FRW,
+            ChmapGenericPos::FrontLeftHigh => SNDRV_CHMAP_FLH,
+            ChmapGenericPos::FrontCenterHigh => SNDRV_CHMAP_FCH,
+            ChmapGenericPos::FrontRightHigh => SNDRV_CHMAP_FRH,
+            ChmapGenericPos::TopCenter => SNDRV_CHMAP_TC,
+            ChmapGenericPos::TopFrontLeft => SNDRV_CHMAP_TFL,
+            ChmapGenericPos::TopFrontRight => SNDRV_CHMAP_TFR,
+            ChmapGenericPos::TopFrontCenter => SNDRV_CHMAP_TFC,
+            ChmapGenericPos::TopRearLeft => SNDRV_CHMAP_TRL,
+            ChmapGenericPos::TopRearRight => SNDRV_CHMAP_TRR,
+            ChmapGenericPos::TopRearCenter => SNDRV_CHMAP_TRC,
+            ChmapGenericPos::TopFrontLeftCenter => SNDRV_CHMAP_TFLC,
+            ChmapGenericPos::TopFrontRightCenter => SNDRV_CHMAP_TFRC,
+            ChmapGenericPos::TopSideLeft => SNDRV_CHMAP_TSL,
+            ChmapGenericPos::TopSideRight => SNDRV_CHMAP_TSR,
+            ChmapGenericPos::LeftLowFrequencyEffect => SNDRV_CHMAP_LLFE,
+            ChmapGenericPos::RightLowFrequencyEffect => SNDRV_CHMAP_RLFE,
+            ChmapGenericPos::BottomCenter => SNDRV_CHMAP_BC,
+            ChmapGenericPos::BottomLeftCenter => SNDRV_CHMAP_BLC,
+            ChmapGenericPos::BottomRightCenter => SNDRV_CHMAP_BRC,
+        }) as u16
+    }
+}
+
+/// The enumeration to represent channel position.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ChmapPos {
+    /// The position of channel is generic. It's relevant to the series of `SNDRV_CHMAP_XXX` macro.
+    Generic(ChmapGenericPos),
+    /// The position of channel is specific, programmed by driver. It's relevant to
+    /// `SNDRV_CHMAP_DRIVER_SPEC` macro in UAPI of Linux kernel.
+    Specific(u16),
+}
+
+impl Default for ChmapPos {
+    fn default() -> Self {
+        ChmapPos::Generic(Default::default())
+    }
+}
+
+/// The entry to represent information of each channel in channel map.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ChmapEntry{
+    /// The position of channel.
+    pub pos: ChmapPos,
+    /// If true, phase is inverted (e.g. a microphone channel within multiple channels). It's
+    /// relevant to `SNDRV_CHMAP_PHASE_INVERSE` macro in UAPI of Linux kernel.
+    pub phase_inverse: bool,
+}
+
+impl std::convert::TryFrom<u32> for ChmapEntry {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(val: u32) -> Result<Self, Self::Error> {
+        let pos_val = (val & 0x0000ffff) as u16;
+        let phase_inverse = val & SNDRV_CHMAP_PHASE_INVERSE > 0;
+        let driver_spec = val & SNDRV_CHMAP_DRIVER_SPEC > 0;
+        let pos = if driver_spec {
+            ChmapPos::Specific(pos_val)
+        } else {
+            let p = ChmapGenericPos::try_from(pos_val)?;
+            ChmapPos::Generic(p)
+        };
+        Ok(ChmapEntry{pos, phase_inverse})
+    }
+}
+
+impl From<ChmapEntry> for u32 {
+    fn from(entry: ChmapEntry) -> Self {
+        let mut val = match entry.pos {
+            ChmapPos::Generic(p) => u16::from(p) as u32,
+            ChmapPos::Specific(p) => (p as u32) | SNDRV_CHMAP_DRIVER_SPEC,
+        };
+        if entry.phase_inverse {
+            val |= SNDRV_CHMAP_PHASE_INVERSE;
+        }
+        val
+    }
+}
+
+/// The mode for channel map.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum ChmapMode{
+    /// The map is fixed and no way to change. It's relevant to `SNDRV_CTL_TLVT_CHMAP_FIXED`.
+    Fixed,
+    /// Each entry in the map is exchangeable arbitrarily. It's relevant to
+    /// `SNDRV_CTL_TLVT_CHMAP_VAR`.
+    ArbitraryExchangeable,
+    /// The stereo pair of entries in the map is exchangeable. It's relevant to
+    /// `SNDRV_CTL_TLVT_CHMAP_PAIRED`.
+    PairedExchangeable,
+}
+
+impl Default for ChmapMode {
+    fn default() -> Self {
+        ChmapMode::Fixed
+    }
+}
+
+/// The data to represent channel map of PCM substream in TLV (Type-Length-Value) of ALSA control interface.
+///
+/// It has three variants below;
+///  * `SNDRV_CTL_TLVT_CHMAP_FIXED` (=0x101)
+///  * `SNDRV_CTL_TLVT_CHMAP_VAR` (=0x102)
+///  * `SNDRV_CTL_TLVT_CHMAP_PAIRED` (=0x103)
+///
+/// The length of value field is variable depending on the number of channels.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct Chmap{
+    /// The mode of map.
+    pub mode: ChmapMode,
+    /// The entries of map corresponding to each channel.
+    pub entries: Vec<ChmapEntry>,
+}
+
+impl<'a> TlvData<'a> for Chmap {
+    fn value_type(&self) -> u32 {
+        match self.mode {
+            ChmapMode::Fixed => SNDRV_CTL_TLVT_CHMAP_FIXED,
+            ChmapMode::ArbitraryExchangeable => SNDRV_CTL_TLVT_CHMAP_VAR,
+            ChmapMode::PairedExchangeable => SNDRV_CTL_TLVT_CHMAP_PAIRED,
+        }
+    }
+
+    fn value_length(&self) -> usize {
+        self.entries.len()
+    }
+
+    fn value(&self) -> Vec<u32> {
+        let mut raw = Vec::new();
+        self.entries.iter().for_each(|&entry| raw.push(u32::from(entry)));
+        raw
+    }
+}
+
+impl std::convert::TryFrom<&[u32]> for Chmap {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(raw: &[u32]) -> Result<Self, Self::Error> {
+        if raw.len() < 2 {
+            Err(InvalidTlvDataError::new("Invalid length of data for Chmap"))
+        } else if raw[0] != SNDRV_CTL_TLVT_CHMAP_FIXED &&
+                  raw[0] != SNDRV_CTL_TLVT_CHMAP_VAR &&
+                  raw[0] != SNDRV_CTL_TLVT_CHMAP_PAIRED {
+            Err(InvalidTlvDataError::new("Invalid type of data for Chmap"))
+        } else {
+            let mode = if raw[0] == SNDRV_CTL_TLVT_CHMAP_FIXED {
+                ChmapMode::Fixed
+            } else if raw[0] == SNDRV_CTL_TLVT_CHMAP_VAR {
+                ChmapMode::ArbitraryExchangeable
+            } else {
+                ChmapMode::PairedExchangeable
+            };
+
+            let value = &raw[2..];
+            if mode == ChmapMode::PairedExchangeable && value.len() % 2 > 0 {
+                Err(InvalidTlvDataError::new("Invalid type of data for PairedExchangeable mode of Chmap"))
+            } else {
+                let mut entries = Vec::new();
+                value.iter().try_for_each(|&val| {
+                    let entry = ChmapEntry::try_from(val)?;
+                    entries.push(entry);
+                    Ok(())
+                })?;
+                Ok(Chmap{mode, entries})
+            }
+        }
+    }
+}
+
+impl From<&Chmap> for Vec<u32> {
+    fn from(data: &Chmap) -> Self {
+        let mut raw = Vec::new();
+        raw.push(data.value_type());
+        raw.push(4 * data.value_length() as u32);
+        raw.append(&mut data.value());
+        raw
+    }
+}
+
+impl From<Chmap> for Vec<u32> {
+    fn from(data: Chmap) -> Self {
+        (&data).into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::convert::TryFrom;
     use super::{DbScale, DbInterval};
+    use super::{ChmapGenericPos, ChmapPos, ChmapEntry, ChmapMode, Chmap};
 
     #[test]
     fn test_dbitem() {
@@ -240,5 +546,79 @@ mod test {
         assert_eq!(item.linear, true);
         assert_eq!(item.mute_avail, true);
         assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_chmapgenericpos() {
+        (0..37).for_each(|val| {
+            let generic_pos = ChmapGenericPos::try_from(val as u16).unwrap();
+            assert_eq!(u16::from(generic_pos), val as u16);
+        });
+    }
+
+    #[test]
+    fn test_chmapgenericpos_invalid() {
+        (37..0xffff).for_each(|val| {
+            assert!(ChmapGenericPos::try_from(val as u16).is_err());
+        });
+    }
+
+    #[test]
+    fn test_chmapentry() {
+        (0..37).for_each(|val| {
+            let raw = val as u32;
+            let entry = ChmapEntry::try_from(raw).unwrap();
+            assert_eq!(entry.phase_inverse, false);
+            assert_eq!(u32::from(entry), raw);
+
+            let raw = 0x00010000u32 | (val as u32);
+            let entry = ChmapEntry::try_from(raw).unwrap();
+            assert_eq!(entry.phase_inverse, true);
+            assert_eq!(u32::from(entry), raw);
+
+            let raw = 0x00020000u32 | (val as u32);
+            let entry = ChmapEntry::try_from(raw).unwrap();
+            assert_eq!(entry.phase_inverse, false);
+            assert_eq!(u32::from(entry), raw);
+        });
+    }
+
+    #[test]
+    fn test_chmap_fixed() {
+        let raw = [0x101u32, 8, 3, 4];
+        let map = Chmap::try_from(&raw[..]).unwrap();
+        assert_eq!(map.mode, ChmapMode::Fixed);
+        assert_eq!(&map.entries[..], &[
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), phase_inverse: false},
+        ]);
+        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_chmap_arbitrary_exchangeable() {
+        let raw = [0x102u32, 12, 3, 4, 8];
+        let map = Chmap::try_from(&raw[..]).unwrap();
+        assert_eq!(map.mode, ChmapMode::ArbitraryExchangeable);
+        assert_eq!(&map.entries[..], &[
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::LowFrequencyEffect), phase_inverse: false},
+        ][..]);
+        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_chmap_paired_exchangeable() {
+        let raw = [0x103u32, 16, 3, 4, 5, 6];
+        let map = Chmap::try_from(&raw[..]).unwrap();
+        assert_eq!(map.mode, ChmapMode::PairedExchangeable);
+        assert_eq!(&map.entries[..], &[
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearLeft), phase_inverse: false},
+            ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearRight), phase_inverse: false},
+        ][..]);
+        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
     }
 }

--- a/libs/alsa-ctl-tlv-codec/src/items.rs
+++ b/libs/alsa-ctl-tlv-codec/src/items.rs
@@ -88,10 +88,106 @@ impl From<DbScale> for Vec<u32> {
     }
 }
 
+/// The data to represent dB interval in TLV (Type-Length-Value) of ALSA control interface.
+///
+/// It has three variants below;
+///  * SNDRV_CTL_TLVT_DB_LINEAR(=2)
+///  * SNDRV_CTL_TLVT_DB_MINMAX(=4)
+///  * SNDRV_CTL_TLVT_DB_MINMAX_MUTE(=5)
+///
+///  All of them have two elements in value field.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct DbInterval{
+    /// The minimum value by dB representation, in 0.1 dB unit. This corresponds to the minimum
+    /// value in the state of control element.
+    pub min: i32,
+    /// The maximum value by dB representation, 0.1 dB unit. This corresponds to the maximum value
+    /// in the state of control element.
+    pub max: i32,
+    /// If true, the value in the state of control element increases linearly, thus need calculation
+    /// to convert to the value by dB representation. The calculation shall be:
+    ///
+    /// 20 * log10( current_value / ( maximum_value - minimum_value ) ) (* 100 in 0.1dB unit)
+    ///
+    /// Else, the value in the state of control element corresponds to dB representation itself.
+    pub linear: bool,
+    /// If true, the value less than or equals to [`CTL_VALUE_MUTE`] (=-9999999) is available to
+    /// mute the control element explicitly.
+    pub mute_avail: bool,
+}
+
+impl DbInterval {
+    const VALUE_COUNT: usize = 2;
+}
+
+impl<'a> TlvData<'a> for DbInterval {
+    fn value_type(&self) -> u32 {
+        if self.linear {
+            SNDRV_CTL_TLVT_DB_LINEAR
+        } else if self.mute_avail {
+            SNDRV_CTL_TLVT_DB_MINMAX_MUTE
+        } else {
+            SNDRV_CTL_TLVT_DB_MINMAX
+        }
+    }
+
+    fn value_length(&self) -> usize {
+        Self::VALUE_COUNT
+    }
+
+    fn value(&self) -> Vec<u32> {
+        vec![self.min as u32, self.max as u32]
+    }
+}
+
+impl std::convert::TryFrom<&[u32]> for DbInterval {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(raw: &[u32]) -> Result<Self, Self::Error> {
+        if raw.len() != 4 || raw[1] != 4 * Self::VALUE_COUNT as u32 {
+            Err(InvalidTlvDataError::new("Invalid length of data for DbInterval"))
+        } else if raw[0] != SNDRV_CTL_TLVT_DB_LINEAR &&
+                  raw[0] != SNDRV_CTL_TLVT_DB_MINMAX &&
+                  raw[0] != SNDRV_CTL_TLVT_DB_MINMAX_MUTE {
+            Err(InvalidTlvDataError::new("Invalid type of data for DbInterval"))
+        } else {
+            let mut data = DbInterval{
+                min: raw[2] as i32,
+                max: raw[3] as i32,
+                linear: false,
+                mute_avail: false,
+            };
+            if raw[0] == SNDRV_CTL_TLVT_DB_LINEAR {
+                data.linear = true;
+                data.mute_avail = true;
+            } else if raw[0] == SNDRV_CTL_TLVT_DB_MINMAX_MUTE {
+                data.mute_avail = true;
+            }
+            Ok(data)
+        }
+    }
+}
+
+impl From<&DbInterval> for Vec<u32> {
+    fn from(data: &DbInterval) -> Self {
+        let mut raw = Vec::new();
+        raw.push(data.value_type());
+        raw.push(4 * data.value_length() as u32);
+        raw.append(&mut data.value());
+        raw
+    }
+}
+
+impl From<DbInterval> for Vec<u32> {
+    fn from(data: DbInterval) -> Self {
+        (&data).into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use std::convert::TryFrom;
-    use super::DbScale;
+    use super::{DbScale, DbInterval};
 
     #[test]
     fn test_dbitem() {
@@ -109,6 +205,39 @@ mod test {
         let item = DbScale::try_from(raw.as_ref()).unwrap();
         assert_eq!(item.min, 10);
         assert_eq!(item.step, 16);
+        assert_eq!(item.mute_avail, true);
+        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbinterval() {
+        let raw = [4u32, 8, -100i32 as u32, 100];
+        let item = DbInterval::try_from(&raw[..]).unwrap();
+        assert_eq!(item.min, -100);
+        assert_eq!(item.max, 100);
+        assert_eq!(item.linear, false);
+        assert_eq!(item.mute_avail, false);
+        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbinterval_mute() {
+        let raw = [5u32, 8, -100i32 as u32, 100];
+        let item = DbInterval::try_from(&raw[..]).unwrap();
+        assert_eq!(item.min, -100);
+        assert_eq!(item.max, 100);
+        assert_eq!(item.linear, false);
+        assert_eq!(item.mute_avail, true);
+        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbinterval_linear() {
+        let raw = [2u32, 8, -100i32 as u32, 100];
+        let item = DbInterval::try_from(&raw[..]).unwrap();
+        assert_eq!(item.min, -100);
+        assert_eq!(item.max, 100);
+        assert_eq!(item.linear, true);
         assert_eq!(item.mute_avail, true);
         assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
     }

--- a/libs/alsa-ctl-tlv-codec/src/items.rs
+++ b/libs/alsa-ctl-tlv-codec/src/items.rs
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! A set of minimum items in TLV (Type-Length-Value) of ALSA control interface.
+
+use super::*;
+use super::uapi::*;
+
+/// The data to represent dB scale in TLV (Type-Length-Value) of ALSA control interface.
+///
+/// It has `SNDRV_CTL_TLVT_DB_SCALE` (=1) in its type field and has two elements in value field.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct DbScale{
+    /// The minimum value by dB representation, in 0.1 dB unit. This corresponds to the minimum
+    /// value in the state of control element.
+    pub min: i32,
+    /// The step by dB representation, in 0.1 dB unit. This corresponds to one increase of the value
+    /// in the state of control element.
+    pub step: u16,
+    /// If true, the value less than or equals to [`CTL_VALUE_MUTE`] (=-9999999) is available to
+    /// mute the control element explicitly.
+    pub mute_avail: bool,
+}
+
+/// When information about dB includes mute_avail, the value is available to mute the control
+/// element. It's relevant to `SNDRV_CTL_TLVD_DB_GAIN_MUTE` macro in UAPI of Linux kernel.
+pub const CTL_VALUE_MUTE: i32 = SNDRV_CTL_TLVD_DB_GAIN_MUTE;
+
+/// The value of dB should be represented in 0.1 dB unit in data of TLV and crate structures.
+pub const DB_VALUE_MULTIPLIER: i32= 100;
+
+impl DbScale {
+    const VALUE_COUNT: usize = 2;
+}
+
+impl<'a> TlvData<'a> for DbScale {
+    fn value_type(&self) -> u32 {
+        SNDRV_CTL_TLVT_DB_SCALE
+    }
+
+    fn value_length(&self) -> usize {
+        Self::VALUE_COUNT
+    }
+
+    fn value(&self) -> Vec<u32> {
+        let mut raw = Vec::new();
+        raw.push(self.min as u32);
+        raw.push(self.step as u32);
+        if self.mute_avail {
+            raw[1] |= SNDRV_CTL_TLVD_DB_SCALE_MUTE;
+        }
+        raw
+    }
+}
+
+impl std::convert::TryFrom<&[u32]> for DbScale {
+    type Error = InvalidTlvDataError;
+
+    fn try_from(raw: &[u32]) -> Result<Self, Self::Error> {
+        if raw.len() != 4 || raw[1] != 4 * Self::VALUE_COUNT as u32 {
+            Err(InvalidTlvDataError::new("Invalid length of data for DbScale"))
+        } else if raw[0] != SNDRV_CTL_TLVT_DB_SCALE {
+            Err(InvalidTlvDataError::new("Invalid type of data for DbScale"))
+        } else {
+            let data = DbScale{
+                min: raw[2] as i32,
+                step: (raw[3] & SNDRV_CTL_TLVD_DB_SCALE_MASK) as u16,
+                mute_avail: raw[3] & SNDRV_CTL_TLVD_DB_SCALE_MUTE > 0,
+            };
+            Ok(data)
+        }
+    }
+}
+
+impl From<&DbScale> for Vec<u32> {
+    fn from(data: &DbScale) -> Self {
+        let mut raw = Vec::new();
+        raw.push(data.value_type());
+        raw.push(4 * data.value_length() as u32);
+        raw.append(&mut data.value());
+        raw
+    }
+}
+
+impl From<DbScale> for Vec<u32> {
+    fn from(data: DbScale) -> Self {
+        (&data).into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+    use super::DbScale;
+
+    #[test]
+    fn test_dbitem() {
+        let raw = [1u32, 8, -10i32 as u32, 0x00000010];
+        let item = DbScale::try_from(raw.as_ref()).unwrap();
+        assert_eq!(item.min, -10);
+        assert_eq!(item.step, 16);
+        assert_eq!(item.mute_avail, false);
+        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+
+    #[test]
+    fn test_dbitem_mute_avail() {
+        let raw = [1u32, 8, 10, 0x00010010];
+        let item = DbScale::try_from(raw.as_ref()).unwrap();
+        assert_eq!(item.min, 10);
+        assert_eq!(item.step, 16);
+        assert_eq!(item.mute_avail, true);
+        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+    }
+}

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -134,6 +134,7 @@ mod uapi;
 
 pub mod items;
 pub mod containers;
+pub mod range_utils;
 
 /// The error type at failure to convert from array of u32 elements to TLV data.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -11,3 +11,38 @@
 
 #[allow(dead_code)]
 mod uapi;
+
+/// The error type at failure to convert from array of u32 elements to TLV data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidTlvDataError{
+    msg: &'static str,
+}
+
+impl InvalidTlvDataError {
+    pub fn new(msg: &'static str) -> Self {
+        InvalidTlvDataError{msg}
+    }
+}
+
+impl std::fmt::Display for InvalidTlvDataError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+impl std::error::Error for InvalidTlvDataError {}
+
+/// The trait for common methods to data of TLV (Type-Length-Value) in ALSA control interface.
+/// The TryFrom supertrait should be implemented to parse the array of u32 elements and it
+/// can return InvalidTlvDataError at failure. The Into supertrait should be implemented as well
+/// to build the array of u32 element.
+pub trait TlvData<'a> : std::convert::TryFrom<&'a [u32]> + Into<Vec<u32>> {
+    /// Return the value of type field. It should come from UAPI of Linux kernel.
+    fn value_type(&self) -> u32;
+
+    /// Return the length of value field. It should be in byte unit and multiples of 4 as result.
+    fn value_length(&self) -> usize;
+
+    /// Generate vector with u32 element for raw data.
+    fn value(&self) -> Vec<u32>;
+}

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -195,6 +195,55 @@
 //!     cargo run --bin tlv-decode -- raw -
 //! ...
 //! ```
+//!
+//! ### src/bin/db-calculate.rs
+//!
+//! This program calculates between dB value and raw value for control element, based on data of
+//! TLV from STDIN or command line argument. It uses double precision floating point number for
+//! dB calculation internally. For linear type of dB calculation, it uses exponentiation and logarithm.
+//!
+//! Without any command line argument, it prints help message and exit.
+//!
+//! ```sh
+//! $ cargo run --bin db-calculate
+//! Usage:
+//!   db-calculate "db" DECIMAL-FLOATING-POINT VALUE-RANGE DATA | "-"
+//!   db-calculate "value" DECIMAL | HEXADECIMAL VALUE-RANGE DATA | "-"
+//!
+//!   where:
+//!     "db":                   Use this program for db calculation.
+//!     "value":                Use this program for value calculation.
+//!     DECIMAL-FLOATING-POINT: decimal floating point number. It can be signed if needed.
+//!     DECIMAL:                decimal number. It can be signed if needed.
+//!     HEXADECIMAL:            hexadecimal number. It should have '0x' as prefix.
+//!     VALUE-RANGE:            space-separated triplet of MIN, MAX, and STEP comes from information of
+//!                             control element. All of them are DECIMAL or HEXADECIMAL.
+//!     DATA:                   space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+//!     "-":                    use STDIN to interpret DATA according to host endian.
+//!
+//!    When data of TLV has information to support mute, "-9999999" for value and "-inf" for db are
+//!    available.
+//! ```
+//!
+//! For calculation from dB to value based on data of TLV from STDIN, in the case that the machine
+//! architecture is little endian:
+//!
+//! ```sh
+//! $ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+//!     cargo run --bin db-calculate db 1.0    128 512 1    -
+//!   ...
+//!   495
+//! ```
+//!
+//! For calculation to dB from value based on data of TLV from arguments of command line:
+//!
+//! ```sh
+//! $ cargo run --bin db-calculate value 495    128 512 1    5 8 0xfffffe00 0
+//!   ...
+//!   0.996666666666667
+//! ```
+//!
+//! The calculation has no validated numerics.
 
 #[allow(dead_code)]
 mod uapi;

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! The crate is designed to process data represented by TLV (Type-Length-Value) style in
+//! ALSA control interface. The crate produces encoder and decoder for the u32 array of data
+//! as well as structures and enumerations to represent the data.
+//!
+//! The data of TLV style is used for several purposes. As of Linux kernel 5.10, it includes
+//! information about dB representation as well as information about channel mapping in ALSA
+//! PCM substream.

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -3,11 +3,131 @@
 
 //! The crate is designed to process data represented by TLV (Type-Length-Value) style in
 //! ALSA control interface. The crate produces encoder and decoder for the u32 array of data
-//! as well as structures and enumerations to represent the data.
+//! of TLV style as well as structures and enumerations to represent the content.
 //!
 //! The data of TLV style is used for several purposes. As of Linux kernel 5.10, it includes
 //! information about dB representation as well as information about channel mapping in ALSA
-//! PCM substream.
+//! PCM substream. The definitions are under `include/uapi/sound/tlv.h` of source code of
+//! Linux kernel.
+//!
+//! ## Structures and enumerations
+//!
+//! Linux kernel has the series of macro to build u32 array for data of TLV, instead of definitions
+//! of structure. This is convenient to embed binary data to object file, however not friendly to
+//! developers and users. The crate has some structures and enumerations to represent the data of
+//! TLV. The relationship between structures and macros is listed below:
+//!
+//! * `DbScale`
+//!     * `SNDRV_CTL_TLVT_DB_SCALE`
+//! * `DbInterval`
+//!     * `SNDRV_CTL_TLVT_DB_LINEAR`
+//!     * `SNDRV_CTL_TLVT_DB_MINMAX`
+//!     * `SNDRV_CTL_TLVT_DB_MINMAX_MUTE`
+//! * `Chmap` / `ChmapMode` / `ChmapEntry` / `ChmapPos` / `ChmapGenericPos`
+//!     * `SNDRV_CTL_TLVT_CHMAP_FIXED`
+//!     * `SNDRV_CTL_TLVT_CHMAP_VAR`
+//!     * `SNDRV_CTL_TLVT_CHMAP_PAIRED`
+//! * `DbRange` / `DbRangeEntry` / `DbRangeEntryData`
+//!     * `SNDRV_CTL_TLVT_DB_RANGE`
+//! * `Container`
+//!     * `SNDRV_CTL_TLVT_CONTAINER`
+//!
+//! The crate has `TlvItem` enumeration to dispatch data of TLV for the above structures.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use alsa_ctl_tlv_codec::TlvItem;
+//! use std::convert::TryFrom;
+//!
+//! // Prepare raw data of TLV as array of u32 elements.
+//! let raw = [2 as u32, 8, -100i32 as u32, 0]; // This is for SNDRV_CTL_TLVT_DB_LINEAR.
+//!
+//! match TlvItem::try_from(&raw[..]) {
+//!     Ok(data) => {
+//!         let raw_generated: Vec<u32> = match data {
+//!           TlvItem::Container(d) => d.into(),
+//!           TlvItem::DbRange(d) => d.into(),
+//!           TlvItem::DbScale(d) => d.into(),
+//!           TlvItem::DbInterval(d) => d.into(),
+//!           TlvItem::Chmap(d) => d.into(),
+//!         };
+//!
+//!         assert_eq!(&raw[..], &raw_generated[..]);
+//!     }
+//!     Err(err) => println!("{}", err),
+//! }
+//!
+//! ```
+//!
+//! `TlvItem` enumeration is a good start to use the crate. It implements `TryFrom<&[u32]>` to
+//! decode raw data of TLV which is array of u32 elements. The type of data is retrieved by a shape
+//! of Rust enumeration items. Each item has associated value. Both of enumeration itself and the
+//! structure of associated value implements `Into<Vec<u32>>` to generate raw data of TLV.
+//!
+//! The associated value can be instantiated directly, then raw data can be generated:
+//!
+//! ```rust
+//! use alsa_ctl_tlv_codec::items;
+//!
+//! let scale = items::DbScale{
+//!     min: -100,
+//!     step: 10,
+//!     mute_avail: true,
+//! };
+//!
+//! let raw_generated: Vec<u32> = scale.into();
+//!
+//! let raw_expected = [1 as u32, 8, -100i32 as u32, 10 | 0x00010000];
+//!
+//! assert_eq!(&raw_generated[..], &raw_expected[..]);
+//! ```
+//!
+//! Some of the associated value are container type, which aggregates the other items. In this
+//! case, `TlvItem` is used for the aggregation of `Container`.
+//!
+//! ```rust
+//! use alsa_ctl_tlv_codec::{*, items::*, containers::*};
+//!
+//! let cntr = Container{
+//!     entries: vec![
+//!         TlvItem::Chmap(Chmap{
+//!             mode: ChmapMode::Fixed,
+//!             entries: vec![
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::LowFrequencyEffect), ..Default::default()},
+//!             ],
+//!         }),
+//!         TlvItem::Chmap(Chmap{
+//!             mode: ChmapMode::ArbitraryExchangeable,
+//!             entries: vec![
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+//!             ],
+//!         }),
+//!         TlvItem::Chmap(Chmap{
+//!             mode: ChmapMode::PairedExchangeable,
+//!             entries: vec![
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearLeft), ..Default::default()},
+//!                 ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearRight), ..Default::default()},
+//!             ],
+//!         }),
+//!     ],
+//! };
+//!
+//! let raw_generated: Vec<u32> = cntr.into();
+//!
+//! let raw_expected = [0 as u32, 60,
+//!                     0x101, 12, 3, 4, 8,
+//!                     0x102, 8, 3, 4,
+//!                     0x103, 16, 3, 4, 5, 6];
+//!
+//! assert_eq!(&raw_generated[..], &raw_expected[..]);
+//!
+//! ```
 
 #[allow(dead_code)]
 mod uapi;

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -8,3 +8,6 @@
 //! The data of TLV style is used for several purposes. As of Linux kernel 5.10, it includes
 //! information about dB representation as well as information about channel mapping in ALSA
 //! PCM substream.
+
+#[allow(dead_code)]
+mod uapi;

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -128,6 +128,73 @@
 //! assert_eq!(&raw_generated[..], &raw_expected[..]);
 //!
 //! ```
+//!
+//! ## Utilities
+//!
+//! Some programs are available under `src/bin` directory.
+//!
+//! ### src/bin/tlv-decode.rs
+//!
+//! This program decodes raw data of TLV from stdin, or numeric literals as arguments of command line,
+//! then print parsed structure.
+//!
+//! Without any command line argument, it prints help message and exit.
+//!
+//! ```sh
+//! $ cargo run --bin tlv-decode
+//! Usage:
+//!   tlv-decode MODE DATA | "-"
+//! 
+//!   where:
+//!     MODE:           The mode to process after parsing DATA:
+//!                         "structure":    prints data structures.
+//!                         "macro":        prints C macro representation
+//!                         "literal":      prints space-separated decimal array.
+//!                         "raw":          prints binary with host endian.
+//!     DATA:           space-separated DECIMAL and HEXADECIMAL array for the data of TLV.
+//!     "-":            use binary from STDIN to interpret DATA according to host endian.
+//!     DECIMAL:        decimal number. It can be signed if needed.
+//!     HEXADECIMAL:    hexadecimal number. It should have '0x' as prefix.
+//! ```
+//!
+//! For data of TLV from arguments in command line:
+//!
+//! ```sh
+//! $ cargo run --bin tlv-decode -- structure 5 8 0xfffffe00 128
+//! ...
+//! DbInterval(DbInterval { min: -512, max: 128, linear: false, mute_avail: true })
+//! ```
+//!
+//! For data of TLV from STDIN, in the case that the machine architecture is little endian:
+//!
+//! ```sh
+//! $ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+//!     cargo run --bin tlv-decode -- structure -
+//! ...
+//! DbInterval(DbInterval { min: -512, max: 128, linear: false, mute_avail: true })
+//! ```
+//!
+//! The data of TLV can be printed in C language macro representation:
+//!
+//! ```sh
+//! $ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+//!     cargo run --bin tlv-decode -- macro -
+//! ...
+//! SNDRV_CTL_TLVD_ITEM ( SNDRV_CTL_TLVT_DB_MINMAX_MUTE, 0xfffffe00, 0x80 ) 
+//! ```
+//!
+//! The data of TLV can be printed as both of u32 numeric literal array and u8 binary:
+//!
+//! ```sh
+//! $ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+//!     cargo run --bin tlv-decode -- literal -
+//! ...
+//! 5 8 4294966784 128 
+//!
+//! $ echo -en "\x05\x00\x00\x00\x08\x00\x00\x00\x00\xfe\xff\xff\x80\x00\x00\x00" | \
+//!     cargo run --bin tlv-decode -- raw -
+//! ...
+//! ```
 
 #[allow(dead_code)]
 mod uapi;

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -13,6 +13,7 @@
 mod uapi;
 
 pub mod items;
+pub mod containers;
 
 /// The error type at failure to convert from array of u32 elements to TLV data.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -12,6 +12,8 @@
 #[allow(dead_code)]
 mod uapi;
 
+pub mod items;
+
 /// The error type at failure to convert from array of u32 elements to TLV data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct InvalidTlvDataError{

--- a/libs/alsa-ctl-tlv-codec/src/range_utils.rs
+++ b/libs/alsa-ctl-tlv-codec/src/range_utils.rs
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+//! A set of trait and implementation to retrieve range of dB value and raw value from data of TLV.
+use super::{*, items::*, containers::*};
+
+/// The structure represents the range of available value in the state of control element with
+/// step to change it.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct ValueRange {
+    /// The minimum value in the state of control element.
+    pub min: i32,
+    /// The maximum value in the state of control element.
+    pub max: i32,
+    /// The step of value in the state of control element.
+    pub step: i32,
+}
+
+/// The trait for utilities about range information.
+pub trait RangeUtil<T> {
+    /// The length from the minimum to maximum.
+    fn length(&self) -> T;
+
+    /// Whether the val is between the minimum and maximum.
+    fn contains(&self, val: T) -> bool;
+}
+
+impl RangeUtil<i32> for ValueRange {
+    fn length(&self) -> i32 {
+        (self.max - self.min).abs()
+    }
+
+    fn contains(&self, val: i32) -> bool {
+        val >= self.min && val <= self.max
+    }
+}
+
+// NOTE: in 0.1 dB unit.
+impl RangeUtil<i32> for DbInterval {
+    fn length(&self) -> i32 {
+        (self.max - self.min).abs()
+    }
+
+    fn contains(&self, db: i32) -> bool {
+        db >= self.min && db <= self.max
+    }
+}
+
+/// The trait for conversion into range of raw value on control element.
+pub trait ToValueRange {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange>;
+}
+
+impl ToValueRange for DbScale {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        Some(*range)
+    }
+}
+
+impl ToValueRange for DbInterval {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        Some(*range)
+    }
+}
+
+impl ToValueRange for DbRangeEntry {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        Some(ValueRange{min: self.min_val, max: self.max_val, step: range.step})
+    }
+}
+
+impl ToValueRange for DbRange {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        let mut r = ValueRange{min: i32::MAX, max: i32::MIN, step: range.step};
+        self.entries.iter().for_each(|entry| {
+            if !r.contains(entry.min_val) {
+                r.min = entry.min_val;
+            }
+            if !r.contains(entry.max_val) {
+                r.max = entry.max_val;
+            }
+        });
+        if r.min != i32::MAX && r.max != i32::MIN {
+            Some(r)
+        } else {
+            None
+        }
+    }
+}
+
+impl ToValueRange for Container {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        let mut r = ValueRange{min: i32::MAX, max: i32::MIN, step: range.step};
+        self.entries.iter().for_each(|entry| {
+            if let Some(range) = entry.to_valuerange(&range) {
+                if !r.contains(range.min) {
+                    r.min = range.min;
+                }
+                if !r.contains(range.max) {
+                    r.max = range.max;
+                }
+            }
+        });
+        if r.min != i32::MAX && r.max != i32::MIN {
+            Some(r)
+        } else {
+            None
+        }
+    }
+}
+
+impl ToValueRange for TlvItem {
+    fn to_valuerange(&self, range: &ValueRange) -> Option<ValueRange> {
+        match self {
+            TlvItem::DbRange(d) => d.to_valuerange(&range),
+            TlvItem::Container(d) => d.to_valuerange(&range),
+            TlvItem::DbScale(_) |
+            TlvItem::DbInterval(_) => Some(*range),
+            _ => None,
+        }
+    }
+}
+
+/// The structure to represent conversin error into interval of dB
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ToDbIntervalError{
+    /// Arbitrary message for error cause.
+    pub msg: String,
+}
+
+impl ToDbIntervalError {
+    pub fn new(msg: String) -> Self {
+        ToDbIntervalError{msg}
+    }
+}
+
+impl std::fmt::Display for ToDbIntervalError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.msg)
+    }
+}
+
+/// The trait for conversion into interval of dB.
+pub trait ToDbInterval {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError>;
+}
+
+impl ToDbInterval for DbScale {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        Ok(DbInterval{
+            min: self.min,
+            max: self.min + range.length() * self.step as i32,
+            linear: false,
+            mute_avail: self.mute_avail,
+        })
+    }
+}
+
+impl ToDbInterval for DbInterval {
+    fn to_dbinterval(&self, _: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        Ok(*self)
+    }
+}
+
+impl ToDbInterval for DbRangeEntry {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        let r = ValueRange{min: self.min_val, max: self.max_val, step: range.step};
+        match &self.data {
+            DbRangeEntryData::DbScale(d) => d.to_dbinterval(&r),
+            DbRangeEntryData::DbInterval(d) => Ok(*d),
+            DbRangeEntryData::DbRange(d) => d.to_dbinterval(&r),
+        }
+    }
+}
+
+impl ToDbInterval for DbRange {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        let entries = self.entries.iter().map(|entry| {
+            if range.contains(entry.min_val) && range.contains(entry.max_val) {
+                let r = ValueRange{min: entry.min_val, max: entry.max_val, step: range.step};
+                entry.to_dbinterval(&r).and_then(|i| Ok((r, i)))
+            } else {
+                let msg = format!("DbRange includes entry in which value range is out of expectation:{}:{} but {}:{}",
+                                  entry.min_val, entry.max_val, range.min, range.max);
+                Err(ToDbIntervalError{msg})
+            }
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+        if entries.len() > 0 {
+            let mut interval = entries[0].1;
+            entries[1..].iter().try_for_each(|entry| {
+                let i = entry.1;
+                if i.linear != interval.linear {
+                    let msg = "DbRange includes entries for both of non-linear and linear value".to_string();
+                    Err(ToDbIntervalError{msg})
+                } else {
+                    if !interval.contains(i.min) {
+                        interval.min = i.min;
+                        interval.mute_avail = i.mute_avail;
+                    }
+                    if !interval.contains(i.max) {
+                        interval.max = i.max;
+                    }
+                    Ok(())
+                }
+            })?;
+            Ok(interval)
+        } else {
+            let msg = "DbRange includes no entry for dB information".to_string();
+            Err(ToDbIntervalError{msg})
+        }
+    }
+}
+
+impl ToDbInterval for Container {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        let intervals = self.entries.iter()
+            .map(|entry| entry.to_dbinterval(&range))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        if intervals.len() > 0 {
+            let mut interval = intervals[0];
+            intervals[1..].iter().try_for_each(|i| {
+                if i.linear != interval.linear {
+                    let msg = "Container includes entries for both of non-linear and linear value".to_string();
+                    Err(ToDbIntervalError{msg})
+                } else {
+                    if !interval.contains(i.min) {
+                        interval.min = i.min;
+                        interval.mute_avail = i.mute_avail;
+                    }
+                    if !interval.contains(i.max) {
+                        interval.max = i.max;
+                    }
+                    Ok(())
+                }
+            })?;
+            Ok(interval)
+        } else {
+            let msg = "Container includes no entry for dB information".to_string();
+            Err(ToDbIntervalError{msg})
+        }
+    }
+}
+
+impl ToDbInterval for TlvItem {
+    fn to_dbinterval(&self, range: &ValueRange) -> Result<DbInterval, ToDbIntervalError> {
+        match self {
+            TlvItem::Container(d) => d.to_dbinterval(&range),
+            TlvItem::DbRange(d) => d.to_dbinterval(&range),
+            TlvItem::DbScale(d) => d.to_dbinterval(&range),
+            TlvItem::DbInterval(d) => Ok(*d),
+            _ => {
+                let msg = "Container includes entry without dB information".to_string();
+                Err(ToDbIntervalError{msg})
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn to_dbinterval_dbscale() {
+        let scale = &DbScale{min: 100, step: 10, mute_avail: true};
+        let range = ValueRange{min: 33, max: 333, step: 1};
+        let interval = scale.to_dbinterval(&range).unwrap();
+        assert_eq!(interval, DbInterval{min: 100, max: 3100, linear: false, mute_avail: true});
+    }
+
+    #[test]
+    fn to_valuerange_dbrange() {
+        let first_data = DbInterval{min: 1, max: 5, linear: false, mute_avail: true};
+        let second_data = DbInterval{min: 5, max: 10, linear: false, mute_avail: false};
+        let third_data = DbInterval{min: 10, max: 20, linear: false, mute_avail: false};
+
+        let dbrange = DbRange{
+            entries: vec![
+                DbRangeEntry{
+                    min_val: 0,
+                    max_val: 10,
+                    data: DbRangeEntryData::DbInterval(first_data),
+                },
+                DbRangeEntry{
+                    min_val: 10,
+                    max_val: 20,
+                    data: DbRangeEntryData::DbInterval(second_data),
+                },
+                DbRangeEntry{
+                    min_val: 20,
+                    max_val: 40,
+                    data: DbRangeEntryData::DbInterval(third_data),
+                },
+            ],
+        };
+        let r = ValueRange{min: 0, max: 40, step: 1};
+        let range = dbrange.to_valuerange(&r).unwrap();
+        assert_eq!(range.min, 0);
+        assert_eq!(range.max, 40);
+        assert_eq!(range.step, 1);
+    }
+
+    #[test]
+    fn to_dbinterval_dbrange() {
+        let first_data = DbInterval{min: 1, max: 5, linear: false, mute_avail: true};
+        let second_data = DbInterval{min: 5, max: 10, linear: false, mute_avail: false};
+        let third_data = DbInterval{min: 10, max: 20, linear: false, mute_avail: false};
+        let range = DbRange{
+            entries: vec![
+                DbRangeEntry{
+                    min_val: 0,
+                    max_val: 10,
+                    data: DbRangeEntryData::DbInterval(first_data),
+                },
+                DbRangeEntry{
+                    min_val: 10,
+                    max_val: 20,
+                    data: DbRangeEntryData::DbInterval(second_data),
+                },
+                DbRangeEntry{
+                    min_val: 20,
+                    max_val: 40,
+                    data: DbRangeEntryData::DbInterval(third_data),
+                },
+            ],
+        };
+        let r = ValueRange{min: 0, max: 40, step: 1};
+        let interval = range.to_dbinterval(&r).unwrap();
+        assert_eq!(interval, DbInterval{min: 1, max: 20, linear: false, mute_avail: true});
+    }
+}

--- a/libs/alsa-ctl-tlv-codec/src/uapi.rs
+++ b/libs/alsa-ctl-tlv-codec/src/uapi.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+// The content comes from 'include/uapi/sound/tlv.h' of Linux kernel.
+pub const SNDRV_CTL_TLVT_CONTAINER: u32 = 0;
+pub const SNDRV_CTL_TLVT_DB_SCALE: u32 = 1;
+pub const SNDRV_CTL_TLVT_DB_LINEAR: u32 = 2;
+pub const SNDRV_CTL_TLVT_DB_RANGE: u32 = 3;
+pub const SNDRV_CTL_TLVT_DB_MINMAX: u32 = 4;
+pub const SNDRV_CTL_TLVT_DB_MINMAX_MUTE: u32 = 5;
+
+pub const SNDRV_CTL_TLVT_CHMAP_FIXED: u32 = 0x101;
+pub const SNDRV_CTL_TLVT_CHMAP_VAR: u32 = 0x102;
+pub const SNDRV_CTL_TLVT_CHMAP_PAIRED: u32 = 0x103;
+
+pub const SNDRV_CTL_TLVD_DB_SCALE_MASK: u32 = 0xffff;
+pub const SNDRV_CTL_TLVD_DB_SCALE_MUTE: u32 = 0x10000;
+
+pub const SNDRV_CTL_TLVO_DB_SCALE_MIN: u32 = 2;
+pub const SNDRV_CTL_TLVO_DB_SCALE_MUTE_AND_STEP: u32 = 3;
+
+pub const SNDRV_CTL_TLVO_DB_MINMAX_MIN: u32 = 2;
+pub const SNDRV_CTL_TLVO_DB_MINMAX_MAX: u32 = 3;
+
+pub const SNDRV_CTL_TLVO_DB_LINEAR_MIN: u32 = 2;
+pub const SNDRV_CTL_TLVO_DB_LINEAR_MAX: u32 = 3;
+
+pub const SNDRV_CTL_TLVD_DB_GAIN_MUTE: i32 = -9999999;
+
+// The content comes from 'include/uapi/sound/asound.h' of Linux kernel.
+pub const SNDRV_CHMAP_UNKNOWN: u32 = 0;
+pub const SNDRV_CHMAP_NA: u32 = 1;
+pub const SNDRV_CHMAP_MONO: u32 = 2;
+pub const SNDRV_CHMAP_FL: u32 = 3;
+pub const SNDRV_CHMAP_FR: u32 = 4;
+pub const SNDRV_CHMAP_RL: u32 = 5;
+pub const SNDRV_CHMAP_RR: u32 = 6;
+pub const SNDRV_CHMAP_FC: u32 = 7;
+pub const SNDRV_CHMAP_LFE: u32 = 8;
+pub const SNDRV_CHMAP_SL: u32 = 9;
+pub const SNDRV_CHMAP_SR: u32 = 10;
+pub const SNDRV_CHMAP_RC: u32 = 11;
+pub const SNDRV_CHMAP_FLC: u32 = 12;
+pub const SNDRV_CHMAP_FRC: u32 = 13;
+pub const SNDRV_CHMAP_RLC: u32 = 14;
+pub const SNDRV_CHMAP_RRC: u32 = 15;
+pub const SNDRV_CHMAP_FLW: u32 = 16;
+pub const SNDRV_CHMAP_FRW: u32 = 17;
+pub const SNDRV_CHMAP_FLH: u32 = 18;
+pub const SNDRV_CHMAP_FCH: u32 = 19;
+pub const SNDRV_CHMAP_FRH: u32 = 20;
+pub const SNDRV_CHMAP_TC: u32 = 21;
+pub const SNDRV_CHMAP_TFL: u32 = 22;
+pub const SNDRV_CHMAP_TFR: u32 = 23;
+pub const SNDRV_CHMAP_TFC: u32 = 24;
+pub const SNDRV_CHMAP_TRL: u32 = 25;
+pub const SNDRV_CHMAP_TRR: u32 = 26;
+pub const SNDRV_CHMAP_TRC: u32 = 27;
+pub const SNDRV_CHMAP_TFLC: u32 = 28;
+pub const SNDRV_CHMAP_TFRC: u32 = 29;
+pub const SNDRV_CHMAP_TSL: u32 = 30;
+pub const SNDRV_CHMAP_TSR: u32 = 31;
+pub const SNDRV_CHMAP_LLFE: u32 = 32;
+pub const SNDRV_CHMAP_RLFE: u32 = 33;
+pub const SNDRV_CHMAP_BC: u32 = 34;
+pub const SNDRV_CHMAP_BLC: u32 = 35;
+pub const SNDRV_CHMAP_BRC: u32 = 36;
+
+pub const SNDRV_CHMAP_POSITION_MASK: u32 = 0x0000ffff;
+pub const SNDRV_CHMAP_PHASE_INVERSE: u32 = 0x00010000;
+pub const SNDRV_CHMAP_DRIVER_SPEC: u32 = 0x00020000;

--- a/libs/bebob/Cargo.toml
+++ b/libs/bebob/Cargo.toml
@@ -15,5 +15,6 @@ nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ta1394 = { path = "../ta1394" }

--- a/libs/bebob/src/apogee/apogee_ctls.rs
+++ b/libs/bebob/src/apogee/apogee_ctls.rs
@@ -6,6 +6,8 @@ use hinawa::SndUnitExt;
 
 use alsactl::{ElemValueExt, ElemValueExtManual};
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use core::elem_value_accessor::ElemValueAccessor;
 
@@ -629,7 +631,7 @@ impl<'a> MixerCtl {
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 0x7fff;
     const GAIN_STEP: i32 = 0xff;
-    const GAIN_TLV: &'a [u32; 4] = &[5, 8, -4800i32 as u32, 0];
+    const GAIN_TLV: DbInterval = DbInterval{min: -4800, max: 0, linear: false, mute_avail: true};
 
     pub fn new() -> Self {
         let mut mixers = [[0; 36]; 4];
@@ -695,7 +697,8 @@ impl<'a> MixerCtl {
                                                    0, 0, Self::MIXER_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, Self::MIXER_LABELS.len(),
                                         Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
-                                        Self::MIXER_SRC_LABELS.len(), Some(Self::GAIN_TLV), true)?;
+                                        Self::MIXER_SRC_LABELS.len(),
+                                        Some(&Into::<Vec<u32>>::into(Self::GAIN_TLV)), true)?;
 
         Ok(())
     }
@@ -1107,13 +1110,13 @@ impl<'a> MeterCtl {
     const GAIN_MIN: i32 = 10;
     const GAIN_MAX: i32 = 75;
     const GAIN_STEP: i32 = 1;
-    const GAIN_TLV: &'a [u32;4] = &[4, 8, 1000, 7500];
+    const GAIN_TLV: DbInterval = DbInterval{min: 1000, max: 7500, linear: false, mute_avail: false};
 
     // NOTE: actually inverted value.
     const VOL_MIN: i32 = -127;
     const VOL_MAX: i32 = 0;
     const VOL_STEP: i32 = 1;
-    const VOL_TLV: &'a [u32;4] = &[4, 8, -12700i32 as u32, 0];
+    const VOL_TLV: DbInterval = DbInterval{min: -12700, max: 0, linear: false, mute_avail: false};
 
     const SELECT_POS: usize = 4;
     const IN_GAIN_POS: &'a [usize] = &[0, 1, 2, 3];
@@ -1124,7 +1127,7 @@ impl<'a> MeterCtl {
     const METER_MIN: i32 = 0x00;
     const METER_MAX: i32 = 0xff;
     const METER_STEP: i32 = 0x01;
-    const METER_TLV: &'a [u32;4] = &[4, 8, -4800i32 as u32, 0];
+    const METER_TLV: DbInterval = DbInterval{min: -4800, max: 0, linear: false, mute_avail: false};
 
     const FRAME_SIZE: usize = 56;
 
@@ -1150,7 +1153,8 @@ impl<'a> MeterCtl {
                                                    0, 0, Self::IN_GAIN_NAME, 0);
         let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
                                         Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
-                                        Self::IN_SELECT_LABELS.len(), Some(Self::GAIN_TLV), true)?;
+                                        Self::IN_SELECT_LABELS.len(),
+                                        Some(&Into::<Vec<u32>>::into(Self::GAIN_TLV)), true)?;
         self.measure_elem_list.append(&mut elem_id_list);
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
@@ -1162,19 +1166,22 @@ impl<'a> MeterCtl {
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_VOL_NAME, 0);
         let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
                                         Self::VOL_MIN, Self::VOL_MAX, Self::VOL_STEP,
-                                        Self::OUT_SELECT_LABELS.len(), Some(Self::VOL_TLV), true)?;
+                                        Self::OUT_SELECT_LABELS.len(),
+                                        Some(&Into::<Vec<u32>>::into(Self::VOL_TLV)), true)?;
         self.measure_elem_list.append(&mut elem_id_list);
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, IN_METER_NAME, 0);
         let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
                                                        Self::METER_MIN, Self::METER_MAX, Self::METER_STEP,
-                                                       Self::IN_METER_LABELS.len(), Some(Self::METER_TLV), false)?;
+                                                       Self::IN_METER_LABELS.len(),
+                                                       Some(&Into::<Vec<u32>>::into(Self::METER_TLV)), false)?;
         self.measure_elem_list.append(&mut elem_id_list);
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_METER_NAME, 0);
         let mut elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
                                                        Self::METER_MIN, Self::METER_MAX, Self::METER_STEP,
-                                                       Self::OUT_METER_LABELS.len(), Some(Self::VOL_TLV), false)?;
+                                                       Self::OUT_METER_LABELS.len(),
+                                                       Some(&Into::<Vec<u32>>::into(Self::VOL_TLV)), false)?;
         self.measure_elem_list.append(&mut elem_id_list);
 
 

--- a/libs/bebob/src/apogee/apogee_ctls.rs
+++ b/libs/bebob/src/apogee/apogee_ctls.rs
@@ -629,7 +629,7 @@ impl<'a> MixerCtl {
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 0x7fff;
     const GAIN_STEP: i32 = 0xff;
-    const GAIN_TLV: &'a [i32; 4] = &[5, 8, -4800, 0];
+    const GAIN_TLV: &'a [u32; 4] = &[5, 8, -4800i32 as u32, 0];
 
     pub fn new() -> Self {
         let mut mixers = [[0; 36]; 4];
@@ -1107,13 +1107,13 @@ impl<'a> MeterCtl {
     const GAIN_MIN: i32 = 10;
     const GAIN_MAX: i32 = 75;
     const GAIN_STEP: i32 = 1;
-    const GAIN_TLV: &'a [i32;4] = &[4, 8, 1000, 7500];
+    const GAIN_TLV: &'a [u32;4] = &[4, 8, 1000, 7500];
 
     // NOTE: actually inverted value.
     const VOL_MIN: i32 = -127;
     const VOL_MAX: i32 = 0;
     const VOL_STEP: i32 = 1;
-    const VOL_TLV: &'a [i32;4] = &[4, 8, -12700, 0];
+    const VOL_TLV: &'a [u32;4] = &[4, 8, -12700i32 as u32, 0];
 
     const SELECT_POS: usize = 4;
     const IN_GAIN_POS: &'a [usize] = &[0, 1, 2, 3];
@@ -1124,7 +1124,7 @@ impl<'a> MeterCtl {
     const METER_MIN: i32 = 0x00;
     const METER_MAX: i32 = 0xff;
     const METER_STEP: i32 = 0x01;
-    const METER_TLV: &'a [i32;4] = &[4, 8, -4800, 0];
+    const METER_TLV: &'a [u32;4] = &[4, 8, -4800i32 as u32, 0];
 
     const FRAME_SIZE: usize = 56;
 

--- a/libs/bebob/src/maudio/normal_ctls.rs
+++ b/libs/bebob/src/maudio/normal_ctls.rs
@@ -114,7 +114,7 @@ impl<'a> MeterCtl<'a> {
     const METER_MIN: i32 = 0;
     const METER_MAX: i32 = i32::MAX;
     const METER_STEP: i32 = 256;
-    const METER_TLV: &'a [i32] = &[5, 8, -14400, 0];
+    const METER_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 0];
 
     pub fn new(in_meter_labels: &'a [&'a str], stream_meter_labels: &'a [&'a str], out_meter_labels: &'a [&'a str],
                has_switch: bool, rotary_count: usize, has_sync_status: bool)
@@ -522,12 +522,12 @@ pub struct InputCtl<'a> {
 const GAIN_MIN: i32 = i16::MIN as i32;
 const GAIN_MAX: i32 = 0;
 const GAIN_STEP: i32 = 256;
-const GAIN_TLV: &[i32] = &[5, 8, -12800, 0];
+const GAIN_TLV: &[u32] = &[5, 8, -12800i32 as u32, 0];
 
 const PAN_MIN: i32 = i16::MIN as i32;
 const PAN_MAX: i32 = i16::MAX as i32;
 const PAN_STEP: i32 = 256;
-const PAN_TLV: &[i32] = &[5, 8, -12800, 12800];
+const PAN_TLV: &[u32] = &[5, 8, -12800i32 as u32, 12800];
 
 impl<'a> InputCtl<'a> {
     const PHYS_GAIN_NAME: &'a str = "phys-in-gain";
@@ -660,7 +660,7 @@ impl<'a> InputCtl<'a> {
 const VOL_MIN: i32 = i16::MIN as i32;
 const VOL_MAX: i32 = 0;
 const VOL_STEP: i32 = 256;
-const VOL_TLV: &[i32] = &[5, 8, -12800, 0];
+const VOL_TLV: &[u32] = &[5, 8, -12800i32 as u32, 0];
 
 pub struct AuxCtl<'a> {
     out_fb_id: u8,

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -135,7 +135,7 @@ impl<'a> MeterCtl {
     const METER_MIN: i32 = 0;
     const METER_MAX: i32 = 0x007fffff;
     const METER_STEP: i32 = 256;
-    const METER_TLV: DbInterval = DbInterval{min: -14400, max: 0, linear: false, mute_avail: true};
+    const METER_TLV: DbInterval = DbInterval{min: -14400, max: 0, linear: false, mute_avail: false};
 
     fn new() -> Self {
         MeterCtl {

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -133,7 +133,7 @@ impl<'a> MeterCtl {
     const METER_MIN: i32 = 0;
     const METER_MAX: i32 = 0x007fffff;
     const METER_STEP: i32 = 256;
-    const METER_TLV: &'a [i32] = &[5, 8, -14400, 0];
+    const METER_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 0];
 
     fn new() -> Self {
         MeterCtl {

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -4,6 +4,8 @@ use glib::Error;
 
 use hinawa::{FwFcpExt, SndUnitExt};
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use card_cntr::{CtlModel, MeasureModel};
 use core::elem_value_accessor::ElemValueAccessor;
@@ -133,7 +135,7 @@ impl<'a> MeterCtl {
     const METER_MIN: i32 = 0;
     const METER_MAX: i32 = 0x007fffff;
     const METER_STEP: i32 = 256;
-    const METER_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 0];
+    const METER_TLV: DbInterval = DbInterval{min: -14400, max: 0, linear: false, mute_avail: true};
 
     fn new() -> Self {
         MeterCtl {
@@ -147,7 +149,8 @@ impl<'a> MeterCtl {
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_METER_NAME, 0);
         let elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
                                                    Self::METER_MIN, Self::METER_MAX, Self::METER_STEP,
-                                                   Self::METER_LABELS.len(), Some(Self::METER_TLV), false)?;
+                                                   Self::METER_LABELS.len(),
+                                                   Some(&Into::<Vec<u32>>::into(Self::METER_TLV)), false)?;
         self.measure_elems.push(elem_id_list[0].clone());
 
         // For detection of sampling clock frequency.

--- a/libs/bebob/src/maudio/special_ctls.rs
+++ b/libs/bebob/src/maudio/special_ctls.rs
@@ -181,7 +181,7 @@ impl<'a> MeterCtl {
     const VAL_MIN: i32 = 0;
     const VAL_MAX: i32 = i16::MAX as i32;
     const VAL_STEP: i32 = 256;
-    const VAL_TLV: &'a [i32; 4] = &[5, 8, -12800, 0];
+    const VAL_TLV: &'a [u32; 4] = &[5, 8, -12800i32 as u32, 0];
 
     const METER_FRAME_SIZE: usize = 84;
 
@@ -580,7 +580,7 @@ const ADAT_IN_PAN_NAME: &str = "adat-in-balance";
 const GAIN_MIN: i32 = i16::MIN as i32;
 const GAIN_MAX: i32 = 0;
 const GAIN_STEP: i32 = 256;
-const GAIN_TLV: &[i32;4] = &[5, 8, -12800, 0];
+const GAIN_TLV: &[u32;4] = &[5, 8, -12800i32 as u32, 0];
 
 const PAN_MIN: i32 = i16::MIN as i32;
 const PAN_MAX: i32 = i16::MAX as i32;
@@ -796,7 +796,7 @@ const VOL_SIZE: usize = std::mem::size_of::<i16>();
 const VOL_MIN: i32 = i16::MIN as i32;
 const VOL_MAX: i32 = 0;
 const VOL_STEP: i32 = 256;
-const VOL_TLV: &[i32;4] = &[5, 8, -12800, 0];
+const VOL_TLV: &[u32;4] = &[5, 8, -12800i32 as u32, 0];
 
 trait OutputSrcOperation {
     fn parse_out_src_flags(&self) -> Vec<u32>;

--- a/libs/bebob/src/maudio/special_ctls.rs
+++ b/libs/bebob/src/maudio/special_ctls.rs
@@ -183,7 +183,7 @@ impl<'a> MeterCtl {
     const VAL_MIN: i32 = 0;
     const VAL_MAX: i32 = i16::MAX as i32;
     const VAL_STEP: i32 = 256;
-    const VAL_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: true};
+    const VAL_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: false};
 
     const METER_FRAME_SIZE: usize = 84;
 
@@ -583,7 +583,7 @@ const ADAT_IN_PAN_NAME: &str = "adat-in-balance";
 const GAIN_MIN: i32 = i16::MIN as i32;
 const GAIN_MAX: i32 = 0;
 const GAIN_STEP: i32 = 256;
-const GAIN_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: true};
+const GAIN_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: false};
 
 const PAN_MIN: i32 = i16::MIN as i32;
 const PAN_MAX: i32 = i16::MAX as i32;
@@ -800,7 +800,7 @@ const VOL_SIZE: usize = std::mem::size_of::<i16>();
 const VOL_MIN: i32 = i16::MIN as i32;
 const VOL_MAX: i32 = 0;
 const VOL_STEP: i32 = 256;
-const VOL_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: true};
+const VOL_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: false};
 
 trait OutputSrcOperation {
     fn parse_out_src_flags(&self) -> Vec<u32>;

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -103,7 +103,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ScratchampModel<'a> {
 const VOL_MIN: i32 = i16::MIN as i32;
 const VOL_MAX: i32 = 0x0000;
 const VOL_STEP: i32 = 0x0080;
-const VOL_TLV: &[i32;4] = &[4, 8, -12800, 0];
+const VOL_TLV: &[u32;4] = &[4, 8, -12800i32 as u32, 0];
 
 const OUTPUT_LABELS: &[&str] = &[
     "analog-1", "analog-2", "analog-3", "analog-4",

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -4,6 +4,8 @@ use glib::Error;
 
 use hinawa::{SndUnitExt, FwFcpExt};
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use card_cntr::CtlModel;
 use core::elem_value_accessor::ElemValueAccessor;
@@ -103,7 +105,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ScratchampModel<'a> {
 const VOL_MIN: i32 = i16::MIN as i32;
 const VOL_MAX: i32 = 0x0000;
 const VOL_STEP: i32 = 0x0080;
-const VOL_TLV: &[u32;4] = &[4, 8, -12800i32 as u32, 0];
+const VOL_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: true};
 
 const OUTPUT_LABELS: &[&str] = &[
     "analog-1", "analog-2", "analog-3", "analog-4",
@@ -117,7 +119,8 @@ trait InputCtl : Ta1394Avc {
         // For volume of outputs.
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, OUT_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, VOL_MIN, VOL_MAX, VOL_STEP,
-                                        OUTPUT_LABELS.len(), Some(VOL_TLV), true)?;
+                                        OUTPUT_LABELS.len(),
+                                        Some(&Into::<Vec<u32>>::into(VOL_TLV)), true)?;
 
         Ok(())
     }

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -82,7 +82,7 @@ impl CardCntr {
         elem_count: usize,
         value_count: usize,
         labels: &[O],
-        tlv: Option<&[i32]>,
+        tlv: Option<&[u32]>,
         unlock: bool,
     ) -> Result<Vec<alsactl::ElemId>, Error>
         where O: AsRef<str>
@@ -106,7 +106,7 @@ impl CardCntr {
         elem_id: &alsactl::ElemId,
         elem_count: usize,
         value_count: usize,
-        tlv: Option<&[i32]>,
+        tlv: Option<&[u32]>,
         unlock: bool,
     ) -> Result<Vec<alsactl::ElemId>, Error> {
         let elem_info = alsactl::ElemInfo::new(ElemType::Bytes)?;
@@ -131,7 +131,7 @@ impl CardCntr {
         max: i32,
         step: i32,
         value_count: usize,
-        tlv: Option<&[i32]>,
+        tlv: Option<&[u32]>,
         unlock: bool,
     ) -> Result<Vec<ElemId>, Error> {
         let elem_info = alsactl::ElemInfo::new(ElemType::Integer)?;
@@ -174,7 +174,7 @@ impl CardCntr {
         elem_id: &alsactl::ElemId,
         elem_count: usize,
         elem_info: &P,
-        tlv: Option<&[i32]>,
+        tlv: Option<&[u32]>,
         unlock: bool,
     ) -> Result<Vec<alsactl::ElemId>, Error>
     where
@@ -246,8 +246,10 @@ impl CardCntr {
         })?;
 
         if let Some(cntr) = tlv {
+            // TODO: fix alsa-gobject and alsactl crate.
+            let alternative = cntr.iter().map(|&val| val as i32).collect::<Vec<_>>();
             elem_id_list.iter().try_for_each(|elem_id| {
-                self.card.write_elem_tlv(&elem_id, cntr)
+                self.card.write_elem_tlv(&elem_id, &alternative)
             })?;
         }
 

--- a/libs/dg00x/Cargo.toml
+++ b/libs/dg00x/Cargo.toml
@@ -15,6 +15,7 @@ nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ieee1212 = { path = "../ieee1212" }
 ta1394 = { path = "../ta1394" }

--- a/libs/dg00x/src/monitor_ctl.rs
+++ b/libs/dg00x/src/monitor_ctl.rs
@@ -4,6 +4,8 @@ use glib::{Error, FileError};
 
 use hinawa::SndUnitExt;
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use core::elem_value_accessor::ElemValueAccessor;
 
@@ -27,7 +29,7 @@ impl<'a> MonitorCtl {
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 0x80;
     const GAIN_STEP: i32 = 1;
-    const GAIN_TLV: &'a [u32; 4] = &[5, 8, -4800i32 as u32, 0];
+    const GAIN_TLV: DbInterval = DbInterval{min: -4800, max: 0, linear: false, mute_avail: false};
 
     const ENABLE_OFFSET: u64 = 0x0124;
 
@@ -62,7 +64,7 @@ impl<'a> MonitorCtl {
             Self::GAIN_MAX,
             Self::GAIN_STEP,
             Self::IN_LABELS.len(),
-            Some(Self::GAIN_TLV),
+            Some(&Into::<Vec<u32>>::into(Self::GAIN_TLV)),
             true,
         )?;
         self.notified_elems.append(&mut elem_id_list);

--- a/libs/dg00x/src/monitor_ctl.rs
+++ b/libs/dg00x/src/monitor_ctl.rs
@@ -27,7 +27,7 @@ impl<'a> MonitorCtl {
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 0x80;
     const GAIN_STEP: i32 = 1;
-    const GAIN_TLV: &'a [i32; 4] = &[5, 8, -4800, 0];
+    const GAIN_TLV: &'a [u32; 4] = &[5, 8, -4800i32 as u32, 0];
 
     const ENABLE_OFFSET: u64 = 0x0124;
 

--- a/libs/efw/Cargo.toml
+++ b/libs/efw/Cargo.toml
@@ -15,5 +15,6 @@ nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ta1394 = { path = "../ta1394" }

--- a/libs/efw/src/mixer_ctl.rs
+++ b/libs/efw/src/mixer_ctl.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use core::elem_value_accessor::ElemValueAccessor;
 
@@ -29,7 +31,7 @@ impl<'a> MixerCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 6];
+    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 6, linear: false, mute_avail: false};
 
     const PAN_MIN: i32 = 0;
     const PAN_MAX: i32 = 255;
@@ -55,7 +57,7 @@ impl<'a> MixerCtl {
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
-            self.playbacks, Some(Self::COEF_TLV), true)?;
+            self.playbacks, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_MUTE_NAME, 0);
@@ -69,7 +71,7 @@ impl<'a> MixerCtl {
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
-            self.captures, Some(Self::COEF_TLV), true)?;
+            self.captures, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_MUTE_NAME, 0);

--- a/libs/efw/src/mixer_ctl.rs
+++ b/libs/efw/src/mixer_ctl.rs
@@ -29,7 +29,7 @@ impl<'a> MixerCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: &'a [i32] = &[5, 8, -14400, 6];
+    const COEF_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 6];
 
     const PAN_MIN: i32 = 0;
     const PAN_MAX: i32 = 255;

--- a/libs/efw/src/output_ctl.rs
+++ b/libs/efw/src/output_ctl.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::{Error, FileError};
 
+use alsa_ctl_tlv_codec::items::DbInterval;
+
 use core::card_cntr;
 use core::elem_value_accessor::ElemValueAccessor;
 
@@ -20,7 +22,7 @@ impl<'a> OutputCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 6];
+    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 6, linear: false, mute_avail: false};
 
     const OUT_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "-10dBV"];
     const OUT_NOMINAL_LEVELS: &'a [NominalLevel] = &[NominalLevel::PlusFour, NominalLevel::MinusTen];
@@ -44,7 +46,7 @@ impl<'a> OutputCtl {
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
-            self.phys_outputs, Some(Self::COEF_TLV), true)?;
+            self.phys_outputs, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
             alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_MUTE_NAME, 0);

--- a/libs/efw/src/output_ctl.rs
+++ b/libs/efw/src/output_ctl.rs
@@ -20,7 +20,7 @@ impl<'a> OutputCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: &'a [i32] = &[5, 8, -14400, 6];
+    const COEF_TLV: &'a [u32] = &[5, 8, -14400i32 as u32, 6];
 
     const OUT_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "-10dBV"];
     const OUT_NOMINAL_LEVELS: &'a [NominalLevel] = &[NominalLevel::PlusFour, NominalLevel::MinusTen];

--- a/libs/ta1394/src/audio.rs
+++ b/libs/ta1394/src/audio.rs
@@ -391,6 +391,9 @@ impl FeatureCtl {
 
     const TRUE: u8 = 0x70;
     const FALSE: u8 = 0x60;
+
+    pub const INFINITY: i16 = 0x7ffeu16 as i16;
+    pub const NEG_INFINITY: i16 = 0x8000u16 as i16;
 }
 
 impl From<&FeatureCtl> for AudioFuncBlkCtl {
@@ -646,6 +649,9 @@ impl ProcessingCtl {
 
     const TRUE: u8 = 0x70;
     const FALSE: u8 = 0x60;
+
+    pub const INFINITY: i16 = 0x7ffeu16 as i16;
+    pub const NEG_INFINITY: i16 = 0x8000u16 as i16;
 }
 
 impl From<&ProcessingCtl> for AudioFuncBlkCtl {


### PR DESCRIPTION
In ALSA control interface, control element set can have data in TLV (Type-Length-Value) style. This data is added by kernel drivers or userspace applications, then it's referred by the other userspace applications.

This patchset adds a crate, alsa-ctl-tlv-codec to parse and build the data of TLV style. The crate is purely written by Rust and no dependency to the other crate or software, thus it's ready to publish.

This patchset also includes changes to existent crates for each vendor-dependent protocols and specification to use the crate for TLV data generation.