### PR TITLE
update dependency version for alsa-gobject to v0.2.0 or later

### DIFF
--- a/libs/bebob/Cargo.toml
+++ b/libs/bebob/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ta1394 = { path = "../ta1394" }

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -14,5 +14,5 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
-alsaseq = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
+alsaseq = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -246,10 +246,8 @@ impl CardCntr {
         })?;
 
         if let Some(cntr) = tlv {
-            // TODO: fix alsa-gobject and alsactl crate.
-            let alternative = cntr.iter().map(|&val| val as i32).collect::<Vec<_>>();
             elem_id_list.iter().try_for_each(|elem_id| {
-                self.card.write_elem_tlv(&elem_id, &alternative)
+                self.card.write_elem_tlv(&elem_id, &cntr)
             })?;
         }
 

--- a/libs/dg00x/Cargo.toml
+++ b/libs/dg00x/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ieee1212 = { path = "../ieee1212" }

--- a/libs/efw/Cargo.toml
+++ b/libs/efw/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 alsa-ctl-tlv-codec = { path = "../alsa-ctl-tlv-codec" }
 core = { path = "../core" }
 ta1394 = { path = "../ta1394" }

--- a/libs/motu/Cargo.toml
+++ b/libs/motu/Cargo.toml
@@ -14,6 +14,6 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 core = { path = "../core" }
 ieee1212 = { path = "../ieee1212" }

--- a/libs/oxfw/Cargo.toml
+++ b/libs/oxfw/Cargo.toml
@@ -14,6 +14,6 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 core = { path = "../core" }
 ta1394 = { path = "../ta1394" }

--- a/libs/tascam/Cargo.toml
+++ b/libs/tascam/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 nix = "0.17"
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
-alsaseq = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.1.1", version = "0.1" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
+alsaseq = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 core = { path = "../core" }
 ieee1212 = { path = "../ieee1212" }


### PR DESCRIPTION
The new release of alsa-gobject is public and corresponding Rust crate
is also released.

This commit changes dependency version to the above so that new features
are available.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>