### PR TITLE
core: elem_value_accessor: fix to read and compare element value

### DIFF
--- a/libs/core/src/elem_value_accessor.rs
+++ b/libs/core/src/elem_value_accessor.rs
@@ -28,7 +28,7 @@ pub trait ElemValueAccessor<T> : IsA<alsactl::ElemValue>
         -> Result<(), Error>
         where F: FnMut(usize, T) -> Result<(), Error>
     {
-        let mut vals = vec![Default::default();len];
+        let mut vals = vec![Default::default();len * 2];
         self.get(&mut vals[..len]);
         old.get(&mut vals[len..]);
         vals[..len].iter().zip(vals[len..].iter()).enumerate()


### PR DESCRIPTION
Enough length of vactor is not allocated to store old and new element value.
This brings partial comparison between them and failure to handle write
request from applications.

This commit fixes the bug.

Fixes: 1ada77aa6414 ("core: add ElemValueAccessor trait and implement for each type of element value")
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>