### PR TITLE
[PATCH 00/62] dice: add service program for devices based on DICE ASICs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,6 @@ members = [
     "libs/oxfw",
     "libs/bebob",
     "libs/dice/protocols",
+    "libs/dice/runtime",
     "services",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,6 @@ members = [
     "libs/motu",
     "libs/oxfw",
     "libs/bebob",
+    "libs/dice/protocols",
     "services",
 ]

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2020/07/07
+2020/12/08
 Takashi Sakamoto
 
 Introduction
@@ -132,6 +132,7 @@ your device, please contact to developer.
 * snd-dice-ctl-service
   * M-Audio ProFire 2626
   * M-Audio ProFire 610
+  * Avid Mbox 3 Pro
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ Supported protocols
    * Protocol for Mark of the Unicorn (MOTU) FireWire series
    * Protocol for Oxford Semiconductor OXFW970/OXFW971 ASIC
    * Protocol for DM1000/DM1100/DM1500 ASIC in BridgeCo. Enhanced BreakOut Box (BeBoB)
+   * Protocol for DiceII ASIC in Digital Interface Communication Engine (DICE)
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ your device, please contact to developer.
 
 * snd-dice-ctl-service
   * M-Audio ProFire 2626
+  * M-Audio ProFire 610
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -130,7 +130,7 @@ your device, please contact to developer.
   * Stanton ScratchAmp in Final Scratch version 2
 
 * snd-dice-ctl-service
-  * For the others, common controls are available.
+  * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -129,6 +129,9 @@ your device, please contact to developer.
   * Behringer FIREPOWER FCA610
   * Stanton ScratchAmp in Final Scratch version 2
 
+* snd-dice-ctl-service
+  * For the others, common controls are available.
+
 Supported protocols
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ Supported protocols
    * Protocol for Oxford Semiconductor OXFW970/OXFW971 ASIC
    * Protocol for DM1000/DM1100/DM1500 ASIC in BridgeCo. Enhanced BreakOut Box (BeBoB)
    * Protocol for DiceII ASIC in Digital Interface Communication Engine (DICE)
+   * Protocol extension for TCD2210/TCD2220 ASIC in Digital Interface Communication Engine (DICE)
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -130,6 +130,7 @@ your device, please contact to developer.
   * Stanton ScratchAmp in Final Scratch version 2
 
 * snd-dice-ctl-service
+  * M-Audio ProFire 2626
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,8 @@ snd-oxfw-ctl-service
    For sound card bound to ALSA oxfw driver (snd-oxfw)
 snd-bebob-ctl-service
    For sound card bound to ALSA bebob driver (snd-bebob)
+snd-dice-ctl-service
+   For sound card bound to ALSA dice driver (snd-dice)
 
 License
 =======

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -8,3 +8,7 @@ description = """
 Implementation of protocols defined by TC Applied Technologies for ASICs of
 Digital Interface Communication Engine (DICE) as well as hardware vendors.
 """
+
+[dependencies]
+glib = "0.10"
+hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -12,3 +12,7 @@ Digital Interface Communication Engine (DICE) as well as hardware vendors.
 [dependencies]
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
+
+[[bin]]
+name = "tcat-general-parser"
+doc = false

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -21,3 +21,7 @@ doc = false
 [[bin]]
 name = "tcat-extension-parser"
 doc = false
+
+[[bin]]
+name = "tcat-config-rom-parser"
+doc = false

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -16,3 +16,7 @@ hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0"
 [[bin]]
 name = "tcat-general-parser"
 doc = false
+
+[[bin]]
+name = "tcat-extension-parser"
+doc = false

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -12,6 +12,7 @@ Digital Interface Communication Engine (DICE) as well as hardware vendors.
 [dependencies]
 glib = "0.10"
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
+ieee1212-config-rom = { path = "../../ieee1212-config-rom" }
 
 [[bin]]
 name = "tcat-general-parser"

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dice-protocols"
+version = "0.1.0"
+authors = ["Takashi Sakamoto <o-takashi@sakamocchi.jp>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+description = """
+Implementation of protocols defined by TC Applied Technologies for ASICs of
+Digital Interface Communication Engine (DICE) as well as hardware vendors.
+"""

--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -10,6 +10,7 @@ use glib::{Error, FileError};
 
 use hinawa::{FwReq, FwNode};
 
+use super::tcat::*;
 use super::tcat::extension::{*, appl_section::*};
 
 /// The enumeration to represent usecase of standalone mode.
@@ -561,3 +562,39 @@ pub trait AvidMbox3ReverbProtocol<T> : ApplSectionProtocol<T>
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3ReverbProtocol<T> for O {}
+
+/// The trait and its implementation to parse notification defined by Avid.
+pub trait AvidMbox3Notification : TcatNotification {
+    const PHANTOM_BUTTON_PUSHED: u32 = 0x10000000;
+    const SPKR_BUTTON_PUSHED: u32 = 0x04000000;
+    const SPKR_BUTTON_HELD: u32 = 0x02000000;
+    const MONO_BUTTON_PUSHED: u32 = 0x00800000;
+    const MUTE_BUTTON_PUSHED: u32 = 0x00400000;
+    const MUTE_BUTTON_HELD: u32 = 0x00200000;
+
+    fn has_phantom_button_pushed(self) -> bool {
+        self.bitand(Self::PHANTOM_BUTTON_PUSHED) > 0
+    }
+
+    fn has_spkr_button_pushed(self) -> bool {
+        self.bitand(Self::SPKR_BUTTON_PUSHED) > 0
+    }
+
+    fn has_spkr_button_held(self) -> bool {
+        self.bitand(Self::SPKR_BUTTON_HELD) > 0
+    }
+
+    fn has_mono_button_pushed(self) -> bool {
+        self.bitand(Self::MONO_BUTTON_PUSHED) > 0
+    }
+
+    fn has_mute_button_pushed(self) -> bool {
+        self.bitand(Self::MUTE_BUTTON_PUSHED) > 0
+    }
+
+    fn has_mute_button_held(self) -> bool {
+        self.bitand(Self::MUTE_BUTTON_HELD) > 0
+    }
+}
+
+impl<O: TcatNotification> AvidMbox3Notification for O {}

--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Application protocol specific to Avid Mbox 3 Pro
+//!
+//! The module includes structure, enumeration, and trait and its implementation for application
+//! protocol specific to Avid Mbox 3 Pro.
+
+use glib::Error;
+
+use hinawa::{FwReq, FwNode};
+
+use super::tcat::extension::{*, appl_section::*};
+
+/// The enumeration to represent usecase of standalone mode.
+pub enum StandaloneUseCase {
+    Preamp,
+    AdDa,
+    Mixer,
+}
+
+impl StandaloneUseCase {
+    const MIXER: u32 = 0;
+    const AD_DA: u32 = 1;
+    const PREAMP: u32 = 2;
+}
+
+impl From<u32> for StandaloneUseCase {
+    fn from(val: u32) -> Self {
+        match val {
+            StandaloneUseCase::MIXER => StandaloneUseCase::Mixer,
+            StandaloneUseCase::AD_DA => StandaloneUseCase::AdDa,
+            _ => StandaloneUseCase::Preamp,
+        }
+    }
+}
+
+impl From<StandaloneUseCase> for u32 {
+    fn from(use_case: StandaloneUseCase) -> u32 {
+        match use_case {
+            StandaloneUseCase::Mixer => StandaloneUseCase::MIXER,
+            StandaloneUseCase::AdDa => StandaloneUseCase::AD_DA,
+            StandaloneUseCase::Preamp => StandaloneUseCase::PREAMP,
+        }
+    }
+}
+
+/// The trait and its implementation to represent standalone protocol for Avid Mbox 3 pro.
+pub trait AvidMbox3StandaloneProtocol<T> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const USE_CASE_OFFSET: usize = 0x00;
+
+    fn read_standalone_use_case(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<StandaloneUseCase, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::USE_CASE_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data).into())
+    }
+
+    fn write_standalone_use_case(&self, node: &T, sections: &ExtensionSections,
+                                 use_case: StandaloneUseCase, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = u32::from(use_case).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::USE_CASE_OFFSET, &mut data, timeout_ms)
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3StandaloneProtocol<T> for O {}

--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -6,7 +6,7 @@
 //! The module includes structure, enumeration, and trait and its implementation for application
 //! protocol specific to Avid Mbox 3 Pro.
 
-use glib::Error;
+use glib::{Error, FileError};
 
 use hinawa::{FwReq, FwNode};
 
@@ -69,3 +69,366 @@ pub trait AvidMbox3StandaloneProtocol<T> : ApplSectionProtocol<T>
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3StandaloneProtocol<T> for O {}
+
+/// The alternative type to represent assignment map for master knob.
+pub type MasterKnobAssigns = [bool;6];
+
+/// The enumeration to represent LED state of mute button.
+#[derive(Debug)]
+pub enum MuteLedState {
+    Off,
+    Blink,
+    On,
+}
+
+impl MuteLedState {
+    const LED_MASK: u32 = 0x00000003;
+    const LED_BLINK_MASK: u32 = 0x00000001;
+}
+
+impl Default for MuteLedState {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+impl From<u32> for MuteLedState {
+    fn from(val: u32) -> Self {
+        if val & Self::LED_MASK == 0 {
+            Self::Off
+        } else if val & Self::LED_BLINK_MASK > 0 {
+            Self::Blink
+        } else {
+            Self::On
+        }
+    }
+}
+
+impl From<&MuteLedState> for u32 {
+    fn from(state: &MuteLedState) -> Self {
+        match state {
+            MuteLedState::Off => 0,
+            MuteLedState::Blink => MuteLedState::LED_BLINK_MASK,
+            MuteLedState::On => MuteLedState::LED_MASK & !MuteLedState::LED_BLINK_MASK,
+        }
+    }
+}
+
+/// The enumeration to represent LED state of mono button.
+#[derive(Debug)]
+pub enum MonoLedState {
+    Off,
+    On,
+}
+
+impl MonoLedState {
+    const LED_MASK: u32 = 0x0000000c;
+    const LED_SHIFT: usize = 2;
+}
+
+impl Default for MonoLedState {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+impl From<u32> for MonoLedState {
+    fn from(val: u32) -> Self {
+        if (val & Self::LED_MASK) >> Self::LED_SHIFT > 0 {
+            MonoLedState::On
+        } else {
+            MonoLedState::Off
+        }
+    }
+}
+
+impl From<&MonoLedState> for u32 {
+    fn from(state: &MonoLedState) -> Self {
+        match state {
+            MonoLedState::On => MonoLedState::LED_MASK,
+            MonoLedState::Off => 0,
+        }
+    }
+}
+
+/// The enumeration to represent LED state of spkr button.
+#[derive(Debug)]
+pub enum SpkrLedState {
+    Off,
+    Green,
+    GreenBlink,
+    Red,
+    RedBlink,
+    Orange,
+    OrangeBlink,
+}
+
+impl Default for SpkrLedState {
+    fn default() -> Self {
+        Self::Off
+    }
+}
+
+impl SpkrLedState {
+    const COLOR_MASK: u32 = 0x00000060;
+    const COLOR_SHIFT: usize = 5;
+    const BLINK_MASK: u32 = 0x00000010;
+    const BLINK_SHIFT: u32 = 4;
+
+    const NONE: u32 = 0;
+    const GREEN: u32 = 1;
+    const RED: u32 = 2;
+    const ORANGE: u32 = 3;
+}
+
+impl From<u32> for SpkrLedState {
+    fn from(val: u32) -> Self {
+        let color = (val & Self::COLOR_MASK) >> Self::COLOR_SHIFT;
+        let blink = (val & Self::BLINK_MASK) >> Self::BLINK_SHIFT > 0;
+
+        match color {
+            Self::NONE => SpkrLedState::Off,
+            Self::GREEN => {
+                if blink {
+                    SpkrLedState::GreenBlink
+                } else {
+                    SpkrLedState::Green
+                }
+            }
+            Self::RED => {
+                if blink {
+                    SpkrLedState::RedBlink
+                } else {
+                    SpkrLedState::Red
+                }
+            }
+            Self::ORANGE => {
+                if blink {
+                    SpkrLedState::OrangeBlink
+                } else {
+                    SpkrLedState::Orange
+                }
+            }
+            _ => SpkrLedState::Off,
+        }
+    }
+}
+
+impl From<&SpkrLedState> for u32 {
+    fn from(state: &SpkrLedState) -> Self {
+        let (color, blink) = match state {
+            SpkrLedState::GreenBlink => (SpkrLedState::GREEN, true),
+            SpkrLedState::Green => (SpkrLedState::GREEN, false),
+            SpkrLedState::RedBlink => (SpkrLedState::RED, true),
+            SpkrLedState::Red => (SpkrLedState::RED, false),
+            SpkrLedState::OrangeBlink => (SpkrLedState::RED, true),
+            SpkrLedState::Orange => (SpkrLedState::ORANGE, false),
+            SpkrLedState::Off => (SpkrLedState::NONE, false),
+        };
+
+        let mut val = color << SpkrLedState::COLOR_SHIFT;
+        if blink {
+            val |= SpkrLedState::BLINK_MASK;
+        }
+
+        val
+    }
+}
+
+/// The structure to represent status of buttons.
+#[derive(Default, Debug)]
+pub struct ButtonLedState{
+    pub mute: MuteLedState,
+    pub mono: MonoLedState,
+    pub spkr: SpkrLedState,
+}
+
+impl ButtonLedState {
+    const SIZE: usize = 8;
+}
+
+impl From<[u8;ButtonLedState::SIZE]> for ButtonLedState {
+    fn from(raw: [u8;ButtonLedState::SIZE]) -> Self {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&raw[..4]);
+        let val = u32::from_be_bytes(quadlet);
+        let mute = MuteLedState::from(val);
+
+        quadlet.copy_from_slice(&raw[4..8]);
+        let val = u32::from_be_bytes(quadlet);
+        let mono = MonoLedState::from(val);
+        let spkr = SpkrLedState::from(val);
+
+        ButtonLedState{mute, mono, spkr}
+    }
+}
+
+impl From<&ButtonLedState> for [u8;ButtonLedState::SIZE] {
+    fn from(state: &ButtonLedState) -> Self {
+        let mut data = [0;ButtonLedState::SIZE];
+
+        let val = u32::from(&state.mute);
+        data[..4].copy_from_slice(&val.to_be_bytes());
+
+        let val = u32::from(&state.mono) |
+                  u32::from(&state.spkr);
+        data[4..].copy_from_slice(&val.to_be_bytes());
+
+        data
+    }
+}
+
+/// The trait and its implementation to represent hardware protocol for Avid Mbox 3 pro.
+pub trait AvidMbox3HwProtocol<T> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const MASTER_KNOB_ASSIGN_OFFSET: usize = 0x0c;
+    const BUTTON_LED_STATE_OFFSET: usize = 0x10;
+    const DIM_LED_USAGE_OFFSET: usize = 0x1c;
+    const BUTTON_HOLD_DURATION_OFFSET: usize = 0x20;
+    const HPF_ENABLE_OFFSET: usize = 0x24;      // High pass filter for analog inputs.
+    const OUT_0_TRIM_OFFSET: usize = 0x28;
+    const OUT_1_TRIM_OFFSET: usize = 0x2c;
+    const OUT_2_TRIM_OFFSET: usize = 0x30;
+    const OUT_3_TRIM_OFFSET: usize = 0x34;
+    const OUT_4_TRIM_OFFSET: usize = 0x38;
+    const OUT_5_TRIM_OFFSET: usize = 0x3c;
+
+    const OUTPUT_COUNT: usize = 6;
+
+    const OUT_TRIM_OFFSETS: [usize;6] = [
+        Self::OUT_0_TRIM_OFFSET, Self::OUT_1_TRIM_OFFSET,
+        Self::OUT_2_TRIM_OFFSET, Self::OUT_3_TRIM_OFFSET,
+        Self::OUT_4_TRIM_OFFSET, Self::OUT_5_TRIM_OFFSET,
+    ];
+
+    fn read_hw_master_knob_assign(&self, node: &T, sections: &ExtensionSections,
+                                  assigns: &mut MasterKnobAssigns, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::MASTER_KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                assigns.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, assigned)| *assigned = val & (1 << i) > 0);
+                ()
+            })
+    }
+
+    fn write_hw_master_knob_assign(&self, node: &T, sections: &ExtensionSections,
+                                   assigns: &MasterKnobAssigns, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        let val: u32 = assigns.iter()
+            .enumerate()
+            .filter(|&(_, &assigned)| assigned)
+            .fold(0, |val, (i, _)| val | (1 << i));
+        data.copy_from_slice(&val.to_be_bytes());
+        self.write_appl_data(node, sections, Self::MASTER_KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_hw_button_led_state(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<ButtonLedState, Error>
+    {
+        let mut data = [0;ButtonLedState::SIZE];
+        self.read_appl_data(node, sections, Self::BUTTON_LED_STATE_OFFSET, &mut data, timeout_ms)
+            .map(|_| ButtonLedState::from(data))
+    }
+
+    fn write_hw_button_led_state(&self, node: &T, sections: &ExtensionSections, state: &ButtonLedState,
+                                 timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = Into::<[u8;ButtonLedState::SIZE]>::into(state);
+        self.write_appl_data(node, sections, Self::BUTTON_LED_STATE_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_hw_dim_led_usage(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::DIM_LED_USAGE_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data) > 0)
+    }
+
+    fn write_hw_dim_led_usage(&self, node: &T, sections: &ExtensionSections, usage: bool, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = (usage as u32).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::DIM_LED_USAGE_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_hw_hold_duration(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::BUTTON_HOLD_DURATION_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data) as u8)
+    }
+
+    fn write_hw_hold_duration(&self, node: &T, sections: &ExtensionSections, duration: u8, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = (duration as u32).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::BUTTON_HOLD_DURATION_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_hw_hpf_enable(&self, node: &T, sections: &ExtensionSections, inputs: &mut [bool;4], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::HPF_ENABLE_OFFSET, &mut data, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                inputs.iter_mut().enumerate().for_each(|(i, v)| *v = val & (1 << i) > 0);
+            })
+    }
+
+    fn write_hw_hpf_enable(&self, node: &T, sections: &ExtensionSections, inputs: [bool;4], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let val = inputs.iter().enumerate().filter(|(_, &v)| v).fold(0 as u32, |val, (i, _)| val | (1 << i));
+        self.write_appl_data(node, sections, Self::HPF_ENABLE_OFFSET, &mut val.to_be_bytes().clone(),
+                             timeout_ms)
+    }
+
+    fn read_hw_output_trim(&self, node: &T, sections: &ExtensionSections, idx: usize, timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        Self::OUT_TRIM_OFFSETS.iter()
+            .nth(idx)
+            .ok_or_else(|| {
+                let msg = format!("Invalid value for index of output: {} greater than {}",
+                                  idx, Self::OUT_TRIM_OFFSETS.len());
+                Error::new(FileError::Inval, &msg)
+            })
+            .and_then(|&offset| {
+                let mut data = [0;4];
+                self.read_appl_data(node, sections, offset, &mut data, timeout_ms)
+                    .map(|_| u32::from_be_bytes(data) as u8)
+            })
+    }
+
+    fn write_hw_output_trim(&self, node: &T, sections: &ExtensionSections, idx: usize, trim: u8,
+                            timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        Self::OUT_TRIM_OFFSETS.iter()
+            .nth(idx)
+            .ok_or_else(|| {
+                let msg = format!("Invalid value for index of output: {} greater than {}",
+                                  idx, Self::OUT_TRIM_OFFSETS.len());
+                Error::new(FileError::Inval, &msg)
+            })
+            .and_then(|&offset| {
+                let mut data = [0;4];
+                data.copy_from_slice(&(trim as u32).to_be_bytes());
+                self.write_appl_data(node, sections, offset, &mut data, timeout_ms)
+            })
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3HwProtocol<T> for O {}

--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -432,3 +432,132 @@ pub trait AvidMbox3HwProtocol<T> : ApplSectionProtocol<T>
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3HwProtocol<T> for O {}
+
+/// The enumration to represent type of reverb DSP.
+pub enum ReverbType {
+    Room1,
+    Room2,
+    Room3,
+    Hall1,
+    Hall2,
+    Plate,
+    Delay,
+    Echo,
+}
+
+impl ReverbType {
+    const ROOM_1: u32 = 0x01;
+    const ROOM_2: u32 = 0x04;
+    const ROOM_3: u32 = 0x05;
+    const HALL_1: u32 = 0x06;
+    const HALL_2: u32 = 0x08;
+    const PLATE: u32 = 0x0b;
+    const DELAY: u32 = 0x13;
+    const ECHO: u32 = 0x14;
+}
+
+impl From<u32> for ReverbType {
+    fn from(val: u32) -> Self {
+        match val {
+            ReverbType::ROOM_1 => ReverbType::Room1,
+            ReverbType::ROOM_2 => ReverbType::Room2,
+            ReverbType::ROOM_3 => ReverbType::Room3,
+            ReverbType::HALL_1 => ReverbType::Hall1,
+            ReverbType::HALL_2 => ReverbType::Hall2,
+            ReverbType::PLATE => ReverbType::Plate,
+            ReverbType::DELAY => ReverbType::Delay,
+            _ => ReverbType::Echo,
+        }
+    }
+}
+
+impl From<ReverbType> for u32 {
+    fn from(reverb_type: ReverbType) -> Self {
+        match reverb_type {
+            ReverbType::Room1 => ReverbType::ROOM_1,
+            ReverbType::Room2 => ReverbType::ROOM_2,
+            ReverbType::Room3 => ReverbType::ROOM_3,
+            ReverbType::Hall1 => ReverbType::HALL_1,
+            ReverbType::Hall2 => ReverbType::HALL_2,
+            ReverbType::Plate => ReverbType::PLATE,
+            ReverbType::Delay => ReverbType::DELAY,
+            ReverbType::Echo => ReverbType::ECHO,
+        }
+    }
+}
+
+/// The trait and its implementation to represent reverb protocol for Avid Mbox 3 pro.
+pub trait AvidMbox3ReverbProtocol<T> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const REVERB_TYPE_OFFSET: usize = 0x40;
+    const REVERB_VOLUME_OFFSET: usize = 0x44;
+    const REVERB_DURATION_OFFSET: usize = 0x48;
+    const REVERB_FEEDBACK_OFFSET: usize = 0x4c;
+
+    fn read_reverb_type(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<ReverbType, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::REVERB_TYPE_OFFSET, &mut data, timeout_ms)
+            .map(|_| ReverbType::from(u32::from_be_bytes(data)))
+    }
+
+    fn write_reverb_type(&self, node: &T, sections: &ExtensionSections, reverb_type: ReverbType,
+                         timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = u32::from(reverb_type).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::REVERB_TYPE_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_reverb_volume(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::REVERB_VOLUME_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data) as u8)
+    }
+
+    fn write_reverb_volume(&self, node: &T, sections: &ExtensionSections, volume: u8,
+                           timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = (volume as u32).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::REVERB_VOLUME_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_reverb_duration(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::REVERB_DURATION_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data) as u8)
+    }
+
+    fn write_reverb_duration(&self, node: &T, sections: &ExtensionSections, duration: u8,
+                             timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = (duration as u32).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::REVERB_DURATION_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_reverb_feedback(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::REVERB_FEEDBACK_OFFSET, &mut data, timeout_ms)
+            .map(|_| u32::from_be_bytes(data) as u8)
+    }
+
+    fn write_reverb_feedback(&self, node: &T, sections: &ExtensionSections, feedback: u8,
+                              timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = (feedback as u32).to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::REVERB_FEEDBACK_OFFSET, &mut data, timeout_ms)
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> AvidMbox3ReverbProtocol<T> for O {}

--- a/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::FileError;
+
+use hinawa::{FwNode, FwNodeError, FwNodeExt, FwNodeExtManual};
+
+use ieee1212_config_rom::*;
+use dice_protocols::tcat::config_rom::*;
+
+use std::io::Read;
+use std::convert::TryFrom;
+
+fn main() {
+    let code = std::env::args().nth(1)
+        .ok_or("The first argument is required for target to parse.".to_string())
+        .and_then(|path| {
+            if path == "-" {
+                let raw = read_data_from_stdin()?;
+                if raw.len() % 4 != 0 {
+                    let msg = format!("The length of data is not aligned to quadlet: {}", raw.len());
+                    Err(msg)?
+                }
+
+                let mut data = Vec::new();
+                let mut quadlet = [0;4];
+                (0..(raw.len() / 4))
+                    .for_each(|i| {
+                        let pos = i * 4;
+                        quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                        data.extend_from_slice(&u32::from_be_bytes(quadlet).to_ne_bytes());
+                    });
+                Ok(data)
+            } else {
+                let node = FwNode::new();
+                node.open(&path)
+                    .map_err(|e| {
+                        let cause = if let Some(error) = e.kind::<FileError>() {
+                            match error {
+                                FileError::Isdir => "is directory",
+                                FileError::Acces => "access permission",
+                                FileError::Noent => "not exists",
+                                _ => "unknown",
+                            }.to_string()
+                        } else if let Some(error) = e.kind::<FwNodeError>() {
+                            match error {
+                                FwNodeError::Disconnected => "disconnected",
+                                FwNodeError::Failed => "ioctl error",
+                                _ => "unknown",
+                            }.to_string()
+                        } else {
+                            e.to_string()
+                        };
+                        format!("Fail to open firewire character device {}: {} {}", path, cause, e)
+                    })?;
+
+                node.get_config_rom()
+                    .map_err(|e| format!("Fail to get content of configuration ROM: {}", e))
+                    .map(|raw| raw.to_vec())
+            }
+        })
+        .and_then(|raw| {
+            let config_rom = ConfigRom::try_from(&raw[..])
+                .map_err(|e| format!("Malformed configuration ROM detected: {}", e))?;
+
+            config_rom.get_identifier()
+                .map(|identifier| {
+                    println!("Identifier:");
+                    println!("  vendor_id:      0x{:06x}", identifier.vendor_id);
+                    println!("  category:       {}", identifier.category);
+                    println!("  product_id:     0x{:06x}", identifier.product_id);
+                    println!("  serial:         {}", identifier.serial);
+                });
+
+            config_rom.get_root_data()
+                .map(|root| {
+                    println!("Root:");
+                    println!("  vendor_id:      0x{:06x}", root.vendor_id);
+                    println!("  vendor_name:    '{}'", root.vendor_name);
+                    println!("  product_id:     0x{:06x}", root.product_id);
+                    println!("  product_name:   '{}'", root.product_name);
+                });
+
+            config_rom.get_unit_data()
+                .map(|unit| {
+                    println!("Unit:");
+                    println!("  model_id:       0x{:06x}", unit.model_id);
+                    println!("  model_name:     '{}'", unit.model_name);
+                    println!("  specifier_id:   0x{:06x}", unit.specifier_id);
+                    println!("  version:        0x{:06x}", unit.version);
+                });
+
+            Ok(())
+        })
+        .map(|_| 0)
+        .unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            print_help();
+            1
+        });
+
+    std::process::exit(code)
+}
+
+fn read_data_from_stdin() -> Result<Vec<u8>, String> {
+    let mut raw = Vec::new();
+
+    let len = std::io::stdin().lock().read_to_end(&mut raw)
+        .map_err(|e| e.to_string())?;
+
+    if len == 0 {
+        Err("Nothing available via standard input.".to_string())?;
+    }
+
+    Ok(raw)
+}
+
+fn print_help() {
+    print!(
+r###"
+Usage:
+  tcat-config-rom-parser CDEV | "-"
+
+  where:
+    CDEV:       the path to special file of firewire character device, typically '/dev/fw1'.
+    "-"         use STDIN for the content of configuration ROM to parse. It should be aligned to big endian.
+"###);
+}

--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use glib::{Error, FileError, MainContext, MainLoop};
+
+use hinawa::{FwNode, FwNodeExt, FwNodeError};
+use hinawa::FwReq;
+
+use dice_protocols::tcat::extension::{*, caps_section::*, cmd_section::*, mixer_section::*};
+use dice_protocols::tcat::extension::peak_section::*;
+use dice_protocols::tcat::extension::current_config_section::*;
+use dice_protocols::tcat::extension::standalone_section::*;
+
+use std::sync::Arc;
+use std::thread;
+
+use std::convert::TryFrom;
+
+const TIMEOUT_MS: u32 = 20;
+
+fn print_sections(sections: &ExtensionSections) {
+    println!("Extension sections:");
+    println!("  caps:           offset 0x{:x}, size: 0x{:x}", sections.caps.offset, sections.caps.size);
+    println!("  cmd:            offset 0x{:x}, size: 0x{:x}", sections.cmd.offset, sections.cmd.size);
+    println!("  mixer:          offset 0x{:x}, size: 0x{:x}", sections.mixer.offset, sections.mixer.size);
+    println!("  peak:           offset 0x{:x}, size: 0x{:x}", sections.peak.offset, sections.peak.size);
+    println!("  router:         offset 0x{:x}, size: 0x{:x}", sections.router.offset, sections.router.size);
+    println!("  stream_format:  offset 0x{:x}, size: 0x{:x}", sections.stream_format.offset, sections.stream_format.size);
+    println!("  config:         offset 0x{:x}, size: 0x{:x}", sections.current_config.offset, sections.current_config.size);
+    println!("  standalone:     offset 0x{:x}, size: 0x{:x}", sections.standalone.offset, sections.standalone.size);
+    println!("  application:    offset 0x{:x}, size: 0x{:x}", sections.application.offset, sections.application.size);
+}
+
+fn print_caps(caps: &ExtensionCaps) {
+    println!("Caps:");
+    println!("  Router:");
+    println!("    is_exposed:       {}", caps.router.is_exposed);
+    println!("    is_readonly:      {}", caps.router.is_readonly);
+    println!("    is_storable:      {}", caps.router.is_storable);
+    println!("    maximum_entry_count: {}", caps.router.maximum_entry_count);
+    println!("  Mixer:");
+    println!("    is_exposed:       {}", caps.mixer.is_exposed);
+    println!("    is_readonly:      {}", caps.mixer.is_readonly);
+    println!("    is_storable:      {}", caps.mixer.is_storable);
+    println!("    input_device_id:  {}", caps.mixer.input_device_id);
+    println!("    output_device_id: {}", caps.mixer.output_device_id);
+    println!("    input_count:      {}", caps.mixer.input_count);
+    println!("    output_count:     {}", caps.mixer.output_count);
+    println!("  General:");
+    println!("    dynamic_stream_format: {}", caps.general.dynamic_stream_format);
+    println!("    storage_avail:    {}", caps.general.storage_avail);
+    println!("    peak_avail:       {}", caps.general.peak_avail);
+    println!("    max_tx_streams:   {}", caps.general.max_tx_streams);
+    println!("    max_rx_streams:   {}", caps.general.max_rx_streams);
+    println!("    stream_format_is_storable: {}", caps.general.stream_format_is_storable);
+
+    let label = match caps.general.asic_type {
+        AsicType::DiceII => "DiceII".to_string(),
+        AsicType::Tcd2210 => "TCD2210".to_string(),
+        AsicType::Tcd2220 => "TCD2220".to_string(),
+        AsicType::Reserved(val) => format!("Reserved({})", val),
+    };
+    println!("    asic_type:        {}", label);
+}
+
+fn print_mixer(proto: &FwReq, node: &FwNode, sections: &ExtensionSections, caps: &ExtensionCaps)
+    -> Result<(), Error>
+{
+    println!("Mixer:");
+    println!("  Saturation:");
+    let entries = proto.read_saturation(node, sections, caps, TIMEOUT_MS)?;
+    entries.iter().enumerate().for_each(|(i, saturation)| {
+        println!("    dst {}: {}", i, saturation);
+    });
+
+    println!("  Coefficiency:");
+    (0..(caps.mixer.output_count as usize)).try_for_each(|dst| {
+        (0..(caps.mixer.input_count as usize)).try_for_each(|src| {
+            proto.read_coef(node, sections, caps, dst, src, TIMEOUT_MS)
+                .map(|coef| println!("    dst {} <- src {}: {}", dst, src, coef))
+        })
+    })
+}
+
+fn print_peak(proto: &FwReq, node: &FwNode, sections: &ExtensionSections, caps: &ExtensionCaps)
+    -> Result<(), Error>
+{
+    proto.read_peak_entries(node, sections, caps, TIMEOUT_MS)
+        .map(|entries| {
+            println!("Peak:");
+            entries.iter().enumerate().for_each(|(i, data)| {
+                let entry = RouterEntry::from(data);
+                println!("  entry {}: 0x{:04x}", i, entry.peak);
+            })
+        })
+}
+
+const RATE_MODES: [RateMode;3] = [RateMode::Low, RateMode::Middle, RateMode::High];
+
+fn print_current_router_entries(proto: &FwReq, node: &FwNode, sections: &ExtensionSections,
+                                caps: &ExtensionCaps)
+    -> Result<(), Error>
+{
+    println!("Current router entries:");
+    RATE_MODES.iter().try_for_each(|&mode| {
+        proto.read_current_router_entries(node, sections, caps, mode, TIMEOUT_MS)
+            .map(|entries| {
+                println!("  {}:", mode);
+                entries.iter().enumerate().for_each(|(i, data)| {
+                    let entry = RouterEntry::from(data);
+                    println!("    entry {}: {:?} <- {:?}", i, entry.dst, entry.src);
+                });
+            })
+    })
+}
+
+fn print_stream_format_entry(entry: &FormatEntry) {
+    println!("      pcm:      {}", entry.pcm_count);
+    println!("      midi:     {}", entry.midi_count);
+    println!("      channel names:");
+    entry.labels.iter().enumerate().for_each(|(i, label)| {
+        println!("        ch {}:   {}", i, label);
+    });
+    println!("      AC3 capabilities:");
+    entry.enable_ac3.iter().enumerate().filter(|&(_, enabled)| *enabled).for_each(|(i, enabled)| {
+        println!("        ch {}: {}", i, enabled);
+    });
+}
+
+fn print_current_stream_format_entries(proto: &FwReq, node: &FwNode, sections: &ExtensionSections,
+                                       caps: &ExtensionCaps)
+    -> Result<(), Error>
+{
+    println!("Current stream format entries:");
+    RATE_MODES.iter().try_for_each(|&mode| {
+        proto.read_current_stream_format_entries(node, sections, caps, mode, TIMEOUT_MS)
+            .and_then(|(tx_entries, rx_entries)| {
+                println!("  {}:", mode);
+                tx_entries.iter().enumerate().try_for_each(|(i, data)| {
+                    FormatEntry::try_from(*data)
+                        .map(|entry| {
+                            println!("    Tx stream {}:", i);
+                            print_stream_format_entry(&entry);
+                        })
+                })?;
+                rx_entries.iter().enumerate().try_for_each(|(i, data)| {
+                    FormatEntry::try_from(*data)
+                        .map(|entry| {
+                            println!("    Rx stream {}:", i);
+                            print_stream_format_entry(&entry);
+                        })
+                })
+            })
+    })
+}
+
+fn print_standalone_config(proto: &FwReq, node: &FwNode, sections: &ExtensionSections) -> Result<(), Error> {
+    println!("Standalone configurations:");
+    let src = proto.read_standalone_clock_source(node, sections, TIMEOUT_MS)?;
+    println!("  clock source: {}", src);
+    let mode = proto.read_standalone_aes_high_rate(node, sections, TIMEOUT_MS)?;
+    println!("  AES high rate: {}", mode);
+    let mode = proto.read_standalone_adat_mode(node, sections, TIMEOUT_MS)?;
+    println!("  ADAT mode: {}", mode);
+    let params = proto.read_standalone_word_clock_param(node, sections, TIMEOUT_MS)?;
+    println!("  Word clock params: {}, {} / {}", params.mode, params.rate.numerator, params.rate.denominator);
+    let rate = proto.read_standalone_internal_rate(node, sections, TIMEOUT_MS)?;
+    println!("  Internal rate: {}", rate);
+    Ok(())
+}
+
+fn main() {
+    let code = std::env::args().nth(1)
+        .ok_or("At least one argument is required for path to special file of firewire character device".to_string())
+        .and_then(|path| {
+            let node = FwNode::new();
+            node.open(&path)
+                .map_err(|e| {
+                    let cause = if let Some(error) = e.kind::<FileError>() {
+                        match error {
+                            FileError::Isdir => "is directory",
+                            FileError::Acces => "access permission",
+                            FileError::Noent => "not exists",
+                            _ => "unknown",
+                        }.to_string()
+                    } else if let Some(error) = e.kind::<FwNodeError>() {
+                        match error {
+                            FwNodeError::Disconnected => "disconnected",
+                            FwNodeError::Failed => "ioctl error",
+                            _ => "unknown",
+                        }.to_string()
+                    } else {
+                        e.to_string()
+                    };
+                    format!("Fail to open firewire character device {}: {} {}", path, cause, e)
+                })
+                .and_then(|_| {
+                    node.create_source()
+                        .map_err(|e| e.to_string())
+                        .map(|src| (node, src))
+                })
+        })
+        .and_then(|(node, src)| {
+            let ctx = MainContext::new();
+            let _ = src.attach(Some(&ctx));
+            let dispatcher = Arc::new(MainLoop::new(Some(&ctx), false));
+            let d = dispatcher.clone();
+            let th = thread::spawn(move || d.run());
+
+            let proto = FwReq::new();
+            let result = proto.read_extension_sections(&node, TIMEOUT_MS)
+                .and_then(|sections| {
+                    print_sections(&sections);
+                    let caps = proto.read_caps(&node, &sections, TIMEOUT_MS)?;
+                    print_caps(&caps);
+                    print_mixer(&proto, &node, &sections, &caps)?;
+                    print_peak(&proto, &node, &sections, &caps)?;
+                    print_current_router_entries(&proto, &node, &sections, &caps)?;
+                    print_current_stream_format_entries(&proto, &node, &sections, &caps)?;
+                    print_standalone_config(&proto, &node, &sections)?;
+                    Ok(())
+                })
+                .map_err(|e| e.to_string());
+
+            dispatcher.quit();
+            th.join().unwrap();
+            result
+        })
+        .map(|_| 0)
+        .unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            print_help();
+            1
+        });
+
+    std::process::exit(code)
+}
+
+fn print_help() {
+    print!(
+r###"
+Usage:
+  tcat-extension-parser CDEV
+
+  where:
+    CDEV:       The path to special file of firewire character device, typically '/dev/fw1'.
+"###);
+}

--- a/libs/dice/protocols/src/bin/tcat-general-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-general-parser.rs
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use glib::{Error, FileError, MainContext, MainLoop};
+
+use hinawa::{FwNode, FwNodeExt, FwNodeError};
+use hinawa::FwReq;
+
+use dice_protocols::tcat::{*, global_section::*, tx_stream_format_section::*, rx_stream_format_section::*, ext_sync_section::*};
+
+use std::sync::Arc;
+use std::thread;
+
+const TIMEOUT_MS: u32 = 20;
+
+fn print_sections(sections: &GeneralSections) {
+    println!("General sections:");
+    println!("  global:             offset 0x{:x}, size: 0x{:x}",
+             sections.global.offset, sections.global.size);
+    println!("  tx-stream-format:   offset 0x{:x}, size: 0x{:x}",
+             sections.tx_stream_format.offset, sections.tx_stream_format.size);
+    println!("  rx-stream-format:   offset 0x{:x}, size: 0x{:x}",
+             sections.rx_stream_format.offset, sections.rx_stream_format.size);
+    println!("  ext_sync:           offset 0x{:x}, size: 0x{:x}",
+             sections.ext_sync.offset, sections.ext_sync.size);
+}
+
+fn print_global_section(proto: &FwReq, node: &FwNode, sections: &GeneralSections) -> Result<(), Error> {
+    let owner = proto.read_owner_addr(node, sections, TIMEOUT_MS)?;
+    println!("Owner:");
+    println!("  node ID:        0x{:04x}", owner >> 48);
+    println!("  offset:         0x{:012x}", owner & 0xffffffffu64);
+
+    let latest_notification = proto.read_latest_notification(node, sections, TIMEOUT_MS)?;
+    println!("Last Notification:0x{:08x}", latest_notification);
+
+    let nickname = proto.read_nickname(node, sections, TIMEOUT_MS)?;
+    println!("Nickname:         '{}'", nickname);
+
+    let config = proto.read_clock_config(node, sections, TIMEOUT_MS)?;
+    println!("Clock configureation:");
+    println!("  rate:           {}", config.rate);
+    println!("  src:            {}", config.src);
+
+    let enabled = proto.read_enabled(node, sections, TIMEOUT_MS)?;
+    println!("Enabled:          {}", enabled);
+
+    let status = proto.read_clock_status(node, sections, TIMEOUT_MS)?;
+    println!("Status:");
+    println!("  rate:           {}", status.rate);
+    println!("  source is locked:  {}", status.src_is_locked);
+
+    let curr_rate = proto.read_current_rate(node, sections, TIMEOUT_MS)?;
+    println!("Sampling rate:    {}", curr_rate);
+
+    let version = proto.read_version(node, sections, TIMEOUT_MS)?;
+    println!("Version:          0x{:08x}", version);
+
+    let labels = proto.read_clock_source_labels(node, sections, TIMEOUT_MS)?;
+    let caps = proto.read_clock_caps(node, sections, TIMEOUT_MS)?;
+
+    let rates = caps.get_rate_entries().iter().map(|r| r.to_string()).collect::<Vec<_>>();
+    let srcs = caps.get_src_entries(&labels).iter().map(|s| s.get_label(&labels, false).unwrap()).collect::<Vec<_>>();
+    println!("Clock capabilities:");
+    println!("  rate:           {}", rates.join(", "));
+    println!("  src:            {}", srcs.join(", "));
+
+    let ext_srcs = ExtSourceStates::get_entries(&caps, &labels);
+    let states = proto.read_clock_source_states(node, sections, TIMEOUT_MS)?;
+    println!("Clock states:");
+    let locked = ext_srcs.iter()
+        .filter(|s| s.is_locked(&states))
+        .map(|s| s.get_label(&labels, true).unwrap())
+        .collect::<Vec<_>>();
+    let slipped = ext_srcs.iter()
+        .filter(|s| s.is_slipped(&states))
+        .map(|s| s.get_label(&labels, true).unwrap())
+        .collect::<Vec<_>>();
+    println!("  locked:         {}", locked.join(", "));
+    println!("  slipped:        {}", slipped.join(", "));
+
+    Ok(())
+}
+
+fn print_tx_stream_formats(proto: &FwReq, node: &FwNode, sections: &GeneralSections) -> Result<(), Error> {
+    let entries = proto.read_tx_stream_format_entries(node, sections, TIMEOUT_MS)?;
+    println!("Tx stream format entries:");
+    entries.iter().enumerate().for_each(|(i, entry)| {
+        println!("  Stream {}:", i);
+        println!("    iso channel:  {}", entry.iso_channel);
+        println!("    pcm:          {}", entry.pcm);
+        println!("    midi:         {}", entry.midi);
+        println!("    speed:        {}", entry.speed);
+        println!("    channel name:");
+        entry.labels.iter().enumerate().for_each(|(i, label)| {
+            println!("      ch {}:       {}", i, label);
+        });
+        println!("    IEC 60958 parameters:");
+        entry.iec60958.iter().enumerate().filter(|(_, param)| param.enable).for_each(|(i, param)| {
+            println!("      ch {}: cap: {}, enable: {}", i, param.cap, param.enable);
+        });
+    });
+    Ok(())
+}
+
+fn print_rx_stream_formats(proto: &FwReq, node: &FwNode, sections: &GeneralSections) -> Result<(), Error> {
+    let entries = proto.read_rx_stream_format_entries(node, sections, TIMEOUT_MS)?;
+    println!("Rx stream format entries:");
+    entries.iter().enumerate().for_each(|(i, entry)| {
+        println!("  Stream {}:", i);
+        println!("    iso channel:  {}", entry.iso_channel);
+        println!("    start:        {}", entry.start);
+        println!("    pcm:          {}", entry.pcm);
+        println!("    midi:         {}", entry.midi);
+        println!("    channel name:");
+        entry.labels.iter().enumerate().for_each(|(i, label)| {
+            println!("      ch {}:       {}", i, label);
+        });
+        println!("    IEC 60958 parameters:");
+        entry.iec60958.iter().enumerate().filter(|(_, param)| param.enable).for_each(|(i, param)| {
+            println!("      ch {}: cap: {}, enable: {}", i, param.cap, param.enable);
+        });
+    });
+    Ok(())
+}
+
+fn print_ext_sync(proto: &FwReq, node: &FwNode, sections: &GeneralSections) {
+    let _ = proto.read_ext_sync_block(node, sections, TIMEOUT_MS)
+        .map(|blk| {
+            println!("External sync:");
+            println!("  source:         {}", blk.get_sync_src());
+            println!("  locked:         {}", blk.get_sync_src_locked());
+            println!("  rate:           {}", blk.get_sync_src_rate());
+            print!("  ADAT user data: ");
+            if let Some(bits) = blk.get_sync_src_adat_user_data() {
+                println!("{:02x}", bits);
+            } else {
+                println!("N/A");
+            }
+        });
+}
+
+fn main() {
+    let code = std::env::args().nth(1)
+        .ok_or("At least one argument is required for path to special file of FireWire character device".to_string())
+        .and_then(|path| {
+            let node = FwNode::new();
+            node.open(&path)
+                .map_err(|e| {
+                    let cause = if let Some(error) = e.kind::<FileError>() {
+                        match error {
+                            FileError::Isdir => "is directory",
+                            FileError::Acces => "access permission",
+                            FileError::Noent => "not exists",
+                            _ => "unknown",
+                        }.to_string()
+                    } else if let Some(error) = e.kind::<FwNodeError>() {
+                        match error {
+                            FwNodeError::Disconnected => "disconnected",
+                            FwNodeError::Failed => "ioctl error",
+                            _ => "unknown",
+                        }.to_string()
+                    } else {
+                        e.to_string()
+                    };
+                    format!("Fail to open firewire character device {}: {} {}", path, cause, e)
+                })
+                .and_then(|_| {
+                    node.create_source()
+                        .map_err(|e| e.to_string())
+                        .map(|src| (node, src))
+                })
+        })
+        .and_then(|(node, src)| {
+            let ctx = MainContext::new();
+            let _ = src.attach(Some(&ctx));
+            let dispatcher = Arc::new(MainLoop::new(Some(&ctx), false));
+            let d = dispatcher.clone();
+            let th = thread::spawn(move || d.run());
+
+            let proto = FwReq::new();
+            let result = proto.read_general_sections(&node, TIMEOUT_MS)
+                .and_then(|sections| {
+                    print_sections(&sections);
+                    print_global_section(&proto, &node, &sections)?;
+                    print_tx_stream_formats(&proto, &node, &sections)?;
+                    print_rx_stream_formats(&proto, &node, &sections)?;
+                    print_ext_sync(&proto, &node, &sections);
+                    Ok(())
+                })
+                .map_err(|e| e.to_string());
+
+            dispatcher.quit();
+            th.join().unwrap();
+            result
+        })
+        .map(|_| 0)
+        .unwrap_or_else(|msg| {
+            eprintln!("{}", msg);
+            print_help();
+            1
+        });
+
+    std::process::exit(code)
+}
+
+fn print_help() {
+    print!(
+r###"
+Usage:
+  tcat-general-parser CDEV
+
+  where:
+    CDEV:       The path to special file of firewire character device, typically '/dev/fw1'.
+"###);
+}

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -8,3 +8,4 @@
 
 pub mod tcat;
 pub mod maudio;
+pub mod avid;

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -5,3 +5,5 @@
 //!
 //! The crate includes various kind of protocols defined by TC Applied Technologies (TCAT) as
 //! well as hardware vendors for ASICs of Digital Interface Communication Engine (DICE).
+
+pub mod tcat;

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Protocols defined for ASICs of Digital Interface Communication Engine (DICE).
+//!
+//! The crate includes various kind of protocols defined by TC Applied Technologies (TCAT) as
+//! well as hardware vendors for ASICs of Digital Interface Communication Engine (DICE).

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -7,3 +7,4 @@
 //! well as hardware vendors for ASICs of Digital Interface Communication Engine (DICE).
 
 pub mod tcat;
+pub mod maudio;

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Application protocol specific to M-Audio ProFire series.
+//!
+//! The modules includes trait and its implementation for application protocol specific to M-Audio
+//! ProFire series.
+
+use glib::Error;
+
+use hinawa::{FwReq, FwNode};
+
+use super::tcat::extension::{*, appl_section::*};
+
+pub const KNOB_COUNT: usize = 4;
+
+pub trait MaudioPfireApplProtocol<T> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const KNOB_ASSIGN_OFFSET: usize = 0x00;
+
+    fn write_knob_assign(&self, node: &T, sections: &ExtensionSections,
+                         targets: &[bool;KNOB_COUNT], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let val: u32 = targets.iter()
+            .enumerate()
+            .filter(|&(_, &knob)| knob)
+            .fold(0, |val, (i, _)| val | (1 << i));
+        let mut data = val.to_be_bytes().clone();
+        self.write_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> MaudioPfireApplProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -70,6 +70,8 @@ pub mod ext_sync_section;
 
 pub mod extension;
 
+pub mod config_rom;
+
 use glib::{Error, error::ErrorDomain, Quark};
 
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -277,3 +277,34 @@ pub struct Iec60958Param {
     pub cap: bool,
     pub enable: bool,
 }
+
+/// The trait and its implementation to parse notification defined by TCAT.
+pub trait TcatNotification : BitAnd<u32, Output = u32> + Sized {
+    const NOTIFY_RX_CFG_CHG: u32 = 0x00000001;
+    const NOTIFY_TX_CFG_CHG: u32 = 0x00000002;
+    const NOTIFY_LOCK_CHG: u32 = 0x00000010;
+    const NOTIFY_CLOCK_ACCEPTED: u32 = 0x00000020;
+    const NOTIFY_EXT_STATUS: u32 = 0x00000040;
+
+    fn has_rx_config_changed(self) -> bool {
+        self.bitand(Self::NOTIFY_RX_CFG_CHG) > 0
+    }
+
+    fn has_tx_config_changed(self) -> bool {
+        self.bitand(Self::NOTIFY_TX_CFG_CHG) > 0
+    }
+
+    fn has_lock_changed(self) -> bool {
+        self.bitand(Self::NOTIFY_LOCK_CHG) > 0
+    }
+
+    fn has_clock_accepted(self) -> bool {
+        self.bitand(Self::NOTIFY_CLOCK_ACCEPTED) > 0
+    }
+
+    fn has_ext_status_changed(self) -> bool {
+        self.bitand(Self::NOTIFY_EXT_STATUS) > 0
+    }
+}
+
+impl<O: BitAnd<u32, Output = u32> + Sized> TcatNotification for O {}

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -13,6 +13,33 @@
 //! All of the protocol is implemented to trait per section in which `AsRef<hinawa::FwReq>` is
 //! used for supertrait. Any call of method in the trait initiates asynchronous transaction to
 //! operate the registers.
+//!
+//! ## Utilities
+//!
+//! Some programs are available under 'src/bin' directory.
+//!
+//! ### src/bin/tcat-general-parser.rs
+//!
+//! This program retrieves information from node of target device according to general protocol,
+//! then print the information.
+//!
+//! Without any command line argument, it prints help message and exit.
+//!
+//! ```sh
+//! $ cargo run --bin tcat-general-parser
+//! Usage:
+//!   tcat-general-parser CDEV
+//!
+//!   where:
+//!     CDEV:   The path to special file of firewire character device, typically '/dev/fw1'.
+//! ```
+//!
+//! Please run with an argument for firewire character device:
+//!
+//! ```sh
+//! $ cargo run --bin tcat-general-parser /dev/fw1
+//! ...
+//! ```
 pub mod global_section;
 pub mod tx_stream_format_section;
 pub mod rx_stream_format_section;

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -13,10 +13,13 @@
 //! All of the protocol is implemented to trait per section in which `AsRef<hinawa::FwReq>` is
 //! used for supertrait. Any call of method in the trait initiates asynchronous transaction to
 //! operate the registers.
+pub mod global_section;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
+
+mod utils;
 
 /// The structure to represent section in control and status register (CSR) of node.
 #[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
@@ -73,12 +76,14 @@ impl From<&[u8]> for GeneralSections {
 /// The enumeration to represent any error of general protocol.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum GeneralProtocolError {
+    Global,
     Invalid(i32),
 }
 
 impl std::fmt::Display for GeneralProtocolError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
+            GeneralProtocolError::Global => "global",
             GeneralProtocolError::Invalid(_) => "invalid",
         };
 
@@ -93,12 +98,14 @@ impl ErrorDomain for GeneralProtocolError {
 
     fn code(self) -> i32 {
         match self {
+            GeneralProtocolError::Global => 0,
             GeneralProtocolError::Invalid(v) => v,
         }
     }
 
     fn from(code: i32) -> Option<Self> {
         let enumeration = match code {
+            0 => GeneralProtocolError::Global,
             _ => GeneralProtocolError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -63,6 +63,39 @@
 //! $ cargo run --bin tcat-extension-parser /dev/fw1
 //! ...
 //! ```
+//!
+//! ### src/bin/tcat-config-rom-parser.rs
+//!
+//! This program parse the content of configuration ROM, then print information in it.
+//!
+//! Without any command line argument, it prints help message and exit.
+//!
+//! ```sh
+//! $ cargo run --bin tcat-config-rom-parser
+//! Usage:
+//!   tcat-config-rom-parser CDEV | "-"
+//!
+//!   where:
+//!     CDEV:       the path to special file of firewire character device, typically '/dev/fw1'.
+//!     "-"         use STDIN for the content of configuration ROM to parse. It should be aligned to big endian.
+//! ```
+//!
+//! Please run with an argument for firewire character device:
+//!
+//! ```sh
+//! $ cargo run --bin tcat-config-rom-parser -- /dev/fw1
+//! ...
+//! ```
+//!
+//! Or give content of configuration ROM via STDIN:
+//!
+//! ```sh
+//! $ cat /sys/bus/firewire/devices/fw0/config_rom  | cargo run --bin tcat-config-rom-parser -- -
+//! ...
+//! ```
+//!
+//! In the above case, the content should be aligned to big-endian order.
+
 pub mod global_section;
 pub mod tx_stream_format_section;
 pub mod rx_stream_format_section;
@@ -77,6 +110,8 @@ use glib::{Error, error::ErrorDomain, Quark};
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
 
 mod utils;
+
+use std::ops::BitAnd;
 
 /// The structure to represent section in control and status register (CSR) of node.
 #[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Protocol defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol defined
+//! by TC Applied Technologies (TCAT) for ASICs of Digital Interface Communication Engine (DICE).
+//!
+//! In the protocol, all of features are categorized to several parts. Each part is represented in
+//! range of registers accessible by IEEE 1394 asynchronous transaction. In the crate, the range
+//! is called as `section`, therefore the features are categorized to the section.
+//!
+//! All of the protocol is implemented to trait per section in which `AsRef<hinawa::FwReq>` is
+//! used for supertrait. Any call of method in the trait initiates asynchronous transaction to
+//! operate the registers.
+
+use glib::{Error, error::ErrorDomain, Quark};
+
+use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
+
+/// The structure to represent section in control and status register (CSR) of node.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Section {
+    pub offset: usize,
+    pub size: usize,
+}
+
+impl Section {
+    pub const SIZE: usize = 8;
+}
+
+impl From <&[u8]> for Section {
+    fn from(data: &[u8]) -> Self {
+        assert!(data.len() >= Self::SIZE);
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[..4]);
+        let offset = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        quadlet.copy_from_slice(&data[4..8]);
+        let size = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        Section{offset, size}
+    }
+}
+
+/// The structure to represent the set of sections in CSR of node.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GeneralSections {
+    pub global: Section,
+    pub tx_stream_format: Section,
+    pub rx_stream_format: Section,
+    pub ext_sync: Section,
+    pub reserved: Section,
+}
+
+impl GeneralSections {
+    const SECTION_COUNT: usize = 5;
+    const SIZE: usize = Section::SIZE * Self::SECTION_COUNT;
+}
+
+impl From<&[u8]> for GeneralSections {
+    fn from(raw: &[u8]) -> Self {
+        GeneralSections{
+            global: Section::from(&raw[..8]),
+            tx_stream_format: Section::from(&raw[8..16]),
+            rx_stream_format: Section::from(&raw[16..24]),
+            ext_sync: Section::from(&raw[24..32]),
+            reserved: Section::from(&raw[32..40]),
+        }
+    }
+}
+
+/// The enumeration to represent any error of general protocol.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum GeneralProtocolError {
+    Invalid(i32),
+}
+
+impl std::fmt::Display for GeneralProtocolError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let msg = match self {
+            GeneralProtocolError::Invalid(_) => "invalid",
+        };
+
+        write!(f, "GeneralProtocolError::{}", msg)
+    }
+}
+
+impl ErrorDomain for GeneralProtocolError {
+    fn domain() -> Quark {
+        Quark::from_string("tcat-general-protocol-error-quark")
+    }
+
+    fn code(self) -> i32 {
+        match self {
+            GeneralProtocolError::Invalid(v) => v,
+        }
+    }
+
+    fn from(code: i32) -> Option<Self> {
+        let enumeration = match code {
+            _ => GeneralProtocolError::Invalid(code),
+        };
+        Some(enumeration)
+    }
+}
+
+/// The trait for general protocol.
+pub trait GeneralProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
+    const BASE_ADDR: u64 = 0xffffe0000000;
+    const MAX_FRAME_SIZE: usize = 512;
+
+    fn read(&self, node: &T, offset: usize, mut frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut addr = Self::BASE_ADDR + offset as u64;
+
+        while frames.len() > 0 {
+            let len = std::cmp::min(frames.len(), Self::MAX_FRAME_SIZE);
+            let tcode = if len == 4 {
+                FwTcode::ReadQuadletRequest
+            } else {
+                FwTcode::ReadBlockRequest
+            };
+
+            self.as_ref().transaction_sync(node.as_ref(), tcode, addr, len, &mut frames[0..len], timeout_ms)?;
+
+            addr += len as u64;
+            frames = &mut frames[len..];
+        }
+
+        Ok(())
+    }
+
+    fn write(&self, node: &T, offset: usize, mut frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let n = node.as_ref();
+        let mut addr = Self::BASE_ADDR + (offset as u64);
+
+        while frames.len() > 0 {
+            let len = std::cmp::min(frames.len(), Self::MAX_FRAME_SIZE);
+            let tcode = if len == 4 {
+                FwTcode::WriteQuadletRequest
+            } else {
+                FwTcode::WriteBlockRequest
+            };
+
+            self.as_ref().transaction_sync(n, tcode, addr, len, &mut frames[0..len], timeout_ms)?;
+
+            addr += len as u64;
+            frames = &mut frames[len..];
+        }
+
+        Ok(())
+    }
+
+    fn read_general_sections(&self, node: &T, timeout_ms: u32) -> Result<GeneralSections, Error> {
+        let mut data = [0;GeneralSections::SIZE];
+        self.read(node, 0, &mut data, timeout_ms)
+            .map(|_| GeneralSections::from(&data[..]))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> GeneralProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -14,6 +14,7 @@
 //! used for supertrait. Any call of method in the trait initiates asynchronous transaction to
 //! operate the registers.
 pub mod global_section;
+pub mod tx_stream_format_section;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
@@ -77,6 +78,7 @@ impl From<&[u8]> for GeneralSections {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum GeneralProtocolError {
     Global,
+    TxStreamFormat,
     Invalid(i32),
 }
 
@@ -84,6 +86,7 @@ impl std::fmt::Display for GeneralProtocolError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
             GeneralProtocolError::Global => "global",
+            GeneralProtocolError::TxStreamFormat => "tx-stream-format",
             GeneralProtocolError::Invalid(_) => "invalid",
         };
 
@@ -99,6 +102,7 @@ impl ErrorDomain for GeneralProtocolError {
     fn code(self) -> i32 {
         match self {
             GeneralProtocolError::Global => 0,
+            GeneralProtocolError::TxStreamFormat => 1,
             GeneralProtocolError::Invalid(v) => v,
         }
     }
@@ -106,6 +110,7 @@ impl ErrorDomain for GeneralProtocolError {
     fn from(code: i32) -> Option<Self> {
         let enumeration = match code {
             0 => GeneralProtocolError::Global,
+            1 => GeneralProtocolError::TxStreamFormat,
             _ => GeneralProtocolError::Invalid(code),
         };
         Some(enumeration)
@@ -170,3 +175,10 @@ pub trait GeneralProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> GeneralProtocol<T> for O {}
+
+/// The structure to represent parameter of stream format for IEC 60958.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Iec60958Param {
+    pub cap: bool,
+    pub enable: bool,
+}

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -16,6 +16,7 @@
 pub mod global_section;
 pub mod tx_stream_format_section;
 pub mod rx_stream_format_section;
+pub mod ext_sync_section;
 
 use glib::{Error, error::ErrorDomain, Quark};
 

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -40,6 +40,29 @@
 //! $ cargo run --bin tcat-general-parser /dev/fw1
 //! ...
 //! ```
+//!
+//! ### src/bin/tcat-extension-parser.rs
+//!
+//! This program retrieves information from node of target device according to protocol extension,
+//! then print the information.
+//!
+//! Without any command line argument, it prints help message and exit.
+//!
+//! ```sh
+//! $ cargo run --bin tcat-extension-parser
+//! Usage:
+//!   tcat-extension-parser CDEV
+//!
+//!   where:
+//!     CDEV:       The path to special file of firewire character device, typically '/dev/fw1'.
+//! ```
+//!
+//! Please run with an argument for firewire character device:
+//!
+//! ```sh
+//! $ cargo run --bin tcat-extension-parser /dev/fw1
+//! ...
+//! ```
 pub mod global_section;
 pub mod tx_stream_format_section;
 pub mod rx_stream_format_section;

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -15,6 +15,7 @@
 //! operate the registers.
 pub mod global_section;
 pub mod tx_stream_format_section;
+pub mod rx_stream_format_section;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
@@ -79,6 +80,7 @@ impl From<&[u8]> for GeneralSections {
 pub enum GeneralProtocolError {
     Global,
     TxStreamFormat,
+    RxStreamFormat,
     Invalid(i32),
 }
 
@@ -87,6 +89,7 @@ impl std::fmt::Display for GeneralProtocolError {
         let msg = match self {
             GeneralProtocolError::Global => "global",
             GeneralProtocolError::TxStreamFormat => "tx-stream-format",
+            GeneralProtocolError::RxStreamFormat => "rx-stream-format",
             GeneralProtocolError::Invalid(_) => "invalid",
         };
 
@@ -103,6 +106,7 @@ impl ErrorDomain for GeneralProtocolError {
         match self {
             GeneralProtocolError::Global => 0,
             GeneralProtocolError::TxStreamFormat => 1,
+            GeneralProtocolError::RxStreamFormat => 2,
             GeneralProtocolError::Invalid(v) => v,
         }
     }
@@ -111,6 +115,7 @@ impl ErrorDomain for GeneralProtocolError {
         let enumeration = match code {
             0 => GeneralProtocolError::Global,
             1 => GeneralProtocolError::TxStreamFormat,
+            2 => GeneralProtocolError::RxStreamFormat,
             _ => GeneralProtocolError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -45,6 +45,8 @@ pub mod tx_stream_format_section;
 pub mod rx_stream_format_section;
 pub mod ext_sync_section;
 
+pub mod extension;
+
 use glib::{Error, error::ErrorDomain, Quark};
 
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};

--- a/libs/dice/protocols/src/tcat/config_rom.rs
+++ b/libs/dice/protocols/src/tcat/config_rom.rs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Parser for Configuration ROM according to specification defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementaion to parse
+//! configuration ROM according to specification defined by TCAT for ASICs of DICE.
+
+use ieee1212_config_rom::{*, entry::*};
+
+/// The structure to represent identifier in bus information block of Configuration ROM.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct Identifier {
+    pub vendor_id: u32,
+    pub category: u8,
+    pub product_id: u16,
+    pub serial: u32,
+}
+
+/// The structure to represent data in root directory block of Configuration ROM.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct RootData<'a> {
+    pub vendor_id: u32,
+    pub vendor_name: &'a str,
+    pub product_id: u32,
+    pub product_name: &'a str,
+}
+
+/// The structure to represent data in unit directory block of Configuration ROM.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct UnitData<'a> {
+    pub model_id: u32,
+    pub model_name: &'a str,
+    pub specifier_id: u32,
+    pub version: u32,
+}
+
+pub trait DiceConfigRom<'a> {
+    const VENDOR_ID_MASK: u32 = 0xffffff00;
+    const VENDOR_ID_SHIFT: usize = 8;
+    const CATEGORY_MASK: u32 = 0x000000ff;
+    const CATEGORY_SHIFT: usize = 0;
+    const PRODUCT_ID_MASK: u32 = 0xffc00000;
+    const PRODUCT_ID_SHIFT: usize = 22;
+    const SERIAL_MASK: u32 = 0x003fffff;
+    const SERIAL_SHIFT: usize = 0;
+
+    fn get_identifier(&self) -> Option<Identifier>;
+    fn get_root_data(&'a self) -> Option<RootData<'a>>;
+    fn get_unit_data(&'a self) -> Option<UnitData<'a>>;
+}
+
+impl<'a> DiceConfigRom<'a> for ConfigRom<'a> {
+    fn get_identifier(&self) -> Option<Identifier> {
+        if self.bus_info.len() < 12 {
+            None
+        } else {
+            let mut quadlet = [0;4];
+
+            quadlet.copy_from_slice(&self.bus_info[8..12]);
+            let val = u32::from_be_bytes(quadlet);
+            let vendor_id = (val & Self::VENDOR_ID_MASK) >> Self::VENDOR_ID_SHIFT;
+            let category = ((val & Self::CATEGORY_MASK) >> Self::CATEGORY_SHIFT) as u8;
+
+            quadlet.copy_from_slice(&self.bus_info[12..16]);
+            let val = u32::from_be_bytes(quadlet);
+            let product_id = ((val & Self::PRODUCT_ID_MASK) >> Self::PRODUCT_ID_SHIFT) as u16;
+            let serial = (val & Self::SERIAL_MASK) >> Self::SERIAL_SHIFT;
+
+            Some(Identifier{vendor_id, category, product_id, serial})
+        }
+    }
+
+    fn get_root_data(&'a self) -> Option<RootData<'a>> {
+        detect_desc_text(&self.root, KeyType::Vendor)
+            .and_then(|(vendor_id, vendor_name)| {
+                detect_desc_text(&self.root, KeyType::Model)
+                    .map(|(product_id, product_name)| {
+                        RootData{vendor_id, vendor_name, product_id, product_name}
+                    })
+            })
+    }
+
+    fn get_unit_data(&'a self) -> Option<UnitData<'a>> {
+        self.root.iter().find_map(|entry| {
+            EntryDataAccess::<&[Entry]>::get(entry, KeyType::Unit)
+        })
+        .and_then(|entries| {
+            entries.iter().find_map(|entry| {
+                EntryDataAccess::<u32>::get(entry, KeyType::SpecifierId)
+            })
+            .and_then(|specifier_id| {
+                entries.iter().find_map(|entry| {
+                    EntryDataAccess::<u32>::get(entry, KeyType::Version)
+                })
+                .and_then(|version| {
+                    detect_desc_text(entries, KeyType::Model)
+                        .map(|(model_id, model_name)| {
+                            UnitData{model_id, model_name, specifier_id, version}
+                        })
+                })
+            })
+        })
+    }
+}
+
+fn detect_desc_text<'a>(entries: &'a [Entry], key_type: KeyType) -> Option<(u32, &'a str)> {
+    let mut peekable = entries.iter().peekable();
+
+    while let Some(entry) = peekable.next() {
+        let result = EntryDataAccess::<u32>::get(entry, key_type)
+            .and_then(|value| {
+                peekable.peek()
+                    .and_then(|&next| {
+                        EntryDataAccess::<&str>::get(next, KeyType::Descriptor)
+                            .map(|name| (value, name))
+                    })
+            });
+
+        if result.is_some() {
+            return result;
+        }
+    }
+
+    None
+}

--- a/libs/dice/protocols/src/tcat/ext_sync_section.rs
+++ b/libs/dice/protocols/src/tcat/ext_sync_section.rs
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! External synchronization section in general protocol defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for external
+//! synchronization section in general protocol defined by TCAT for ASICs of DICE.
+use glib::{Error, FileError};
+
+use super::{*, global_section::*};
+
+pub struct ExtSyncBlock(Vec<u8>);
+
+impl ExtSyncBlock {
+    const SIZE: usize = 0x10;
+
+    const SYNC_SRC_OFFSET: usize = 0x00;
+    const SYNC_LOCKED_OFFSET: usize = 0x04;
+    const SYNC_RATE_OFFSET: usize = 0x08;
+    const SYNC_ADAT_DATA_BITS: usize = 0x0c;
+
+    const ADAT_USER_DATA_MASK: u32 = 0x0f;
+    const ADAT_USER_DATA_UNAVAIL: u32 = 0x10;
+
+    pub fn get_sync_src(&self) -> ClockSource {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&self.0[Self::SYNC_SRC_OFFSET..(Self::SYNC_SRC_OFFSET + 4)]);
+        ClockSource::from(u32::from_be_bytes(quadlet) as u8)
+    }
+
+    pub fn get_sync_src_locked(&self) -> bool {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&self.0[Self::SYNC_LOCKED_OFFSET..(Self::SYNC_LOCKED_OFFSET + 4)]);
+        u32::from_be_bytes(quadlet) > 0
+    }
+
+    pub fn get_sync_src_rate(&self) -> ClockRate {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&self.0[Self::SYNC_RATE_OFFSET..(Self::SYNC_RATE_OFFSET + 4)]);
+        ClockRate::from(u32::from_be_bytes(quadlet) as u8)
+    }
+
+    pub fn get_sync_src_adat_user_data(&self) -> Option<u8> {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&self.0[Self::SYNC_ADAT_DATA_BITS..(Self::SYNC_ADAT_DATA_BITS+ 4)]);
+        let val = u32::from_be_bytes(quadlet);
+        if val & Self::ADAT_USER_DATA_UNAVAIL > 0 {
+            None
+        } else {
+            Some((val & Self::ADAT_USER_DATA_MASK) as u8)
+        }
+    }
+}
+
+pub trait ExtSyncSectionProtocol<T> : GeneralProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_ext_sync_block(&self, node: &T, sections: &GeneralSections, timeout_ms: u32) -> Result<ExtSyncBlock, Error> {
+        if sections.ext_sync.size < ExtSyncBlock::SIZE {
+            let msg = format!("Ext sync section has {} less size than {} expected",
+                              sections.ext_sync.size, ExtSyncBlock::SIZE);
+            Err(Error::new(FileError::Nxio, &msg))
+        } else {
+            let mut data = vec![0;sections.ext_sync.size];
+            self.read(node, sections.ext_sync.offset, &mut data, timeout_ms)
+                .map(|_| ExtSyncBlock(data))
+        }
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> ExtSyncSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -9,6 +9,7 @@
 
 pub mod caps_section;
 pub mod cmd_section;
+pub mod mixer_section;
 
 use super::*;
 
@@ -52,6 +53,7 @@ impl From<&[u8]> for ExtensionSections {
 pub enum ProtocolExtensionError {
     Caps,
     Cmd,
+    Mixer,
     Invalid(i32),
 }
 
@@ -60,6 +62,7 @@ impl std::fmt::Display for ProtocolExtensionError {
         let msg = match self {
             ProtocolExtensionError::Caps => "caps",
             ProtocolExtensionError::Cmd => "command",
+            ProtocolExtensionError::Mixer => "mixer",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -76,6 +79,7 @@ impl ErrorDomain for ProtocolExtensionError {
         match self {
             ProtocolExtensionError::Caps => 0,
             ProtocolExtensionError::Cmd => 1,
+            ProtocolExtensionError::Mixer => 2,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -84,6 +88,7 @@ impl ErrorDomain for ProtocolExtensionError {
         let enumeration = match code {
             0 => ProtocolExtensionError::Caps,
             1 => ProtocolExtensionError::Cmd,
+            2 => ProtocolExtensionError::Mixer,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -10,6 +10,8 @@
 pub mod caps_section;
 pub mod cmd_section;
 pub mod mixer_section;
+#[doc(hidden)]
+mod router_entry;
 
 use super::*;
 
@@ -54,6 +56,7 @@ pub enum ProtocolExtensionError {
     Caps,
     Cmd,
     Mixer,
+    RouterEntry,
     Invalid(i32),
 }
 
@@ -63,6 +66,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::Caps => "caps",
             ProtocolExtensionError::Cmd => "command",
             ProtocolExtensionError::Mixer => "mixer",
+            ProtocolExtensionError::RouterEntry => "router-entry",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -80,6 +84,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::Caps => 0,
             ProtocolExtensionError::Cmd => 1,
             ProtocolExtensionError::Mixer => 2,
+            ProtocolExtensionError::RouterEntry => 3,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -89,6 +94,7 @@ impl ErrorDomain for ProtocolExtensionError {
             0 => ProtocolExtensionError::Caps,
             1 => ProtocolExtensionError::Cmd,
             2 => ProtocolExtensionError::Mixer,
+            3 => ProtocolExtensionError::RouterEntry,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)
@@ -119,10 +125,219 @@ pub trait ProtocolExtension<T: AsRef<FwNode>> : GeneralProtocol<T> {
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> ProtocolExtension<T> for O {}
 
+/// The enumeration to represent ID of destination block.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DstBlkId {
+    Aes,
+    Adat,
+    MixerTx0,
+    MixerTx1,
+    Ins0,
+    Ins1,
+    ArmApbAudio,
+    Avs0,
+    Avs1,
+    Reserved(u8),
+}
+
+impl Default for DstBlkId {
+    fn default() -> Self {
+        DstBlkId::Reserved(0xff)
+    }
+}
+
+impl From<u8> for DstBlkId {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Aes,
+            1 => Self::Adat,
+            2 => Self::MixerTx0,
+            3 => Self::MixerTx1,
+            4 => Self::Ins0,
+            5 => Self::Ins1,
+            10 => Self::ArmApbAudio,
+            11 => Self::Avs0,
+            12 => Self::Avs1,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<DstBlkId> for u8 {
+    fn from(id: DstBlkId) -> Self {
+        match id {
+            DstBlkId::Aes => 0,
+            DstBlkId::Adat => 1,
+            DstBlkId::MixerTx0 => 2,
+            DstBlkId::MixerTx1 => 3,
+            DstBlkId::Ins0 => 4,
+            DstBlkId::Ins1 => 5,
+            DstBlkId::ArmApbAudio => 10,
+            DstBlkId::Avs0 => 11,
+            DstBlkId::Avs1 => 12,
+            DstBlkId::Reserved(val) => val,
+        }
+    }
+}
+
+/// The structure to represent destination block.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct DstBlk {
+    pub id: DstBlkId,
+    pub ch: u8,
+}
+
+impl DstBlk {
+    pub const ID_MASK: u8 = 0xf0;
+    pub const ID_SHIFT: usize = 4;
+    pub const CH_MASK: u8 = 0x0f;
+    pub const CH_SHIFT: usize = 0;
+}
+
+impl From<u8> for DstBlk {
+    fn from(val: u8) -> Self {
+        DstBlk {
+            id: DstBlkId::from((val & DstBlk::ID_MASK) >> DstBlk::ID_SHIFT),
+            ch: (val & DstBlk::CH_MASK) >> DstBlk::CH_SHIFT,
+        }
+    }
+}
+
+impl From<DstBlk> for u8 {
+    fn from(blk: DstBlk) -> Self {
+        (u8::from(blk.id) << DstBlk::ID_SHIFT) | blk.ch
+    }
+}
+
+/// The enumeration to represent ID of source block.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum SrcBlkId {
+    Aes,
+    Adat,
+    Mixer,
+    Ins0,
+    Ins1,
+    ArmAprAudio,
+    Avs0,
+    Avs1,
+    Mute,
+    Reserved(u8),
+}
+
+impl Default for SrcBlkId {
+    fn default() -> Self {
+        SrcBlkId::Reserved(0xff)
+    }
+}
+
+impl From<u8> for SrcBlkId {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Aes,
+            1 => Self::Adat,
+            2 => Self::Mixer,
+            4 => Self::Ins0,
+            5 => Self::Ins1,
+            10 => Self::ArmAprAudio,
+            11 => Self::Avs0,
+            12 => Self::Avs1,
+            15 => Self::Mute,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<SrcBlkId> for u8 {
+    fn from(id: SrcBlkId) -> Self {
+        match id {
+            SrcBlkId::Aes => 0,
+            SrcBlkId::Adat => 1,
+            SrcBlkId::Mixer => 2,
+            SrcBlkId::Ins0 => 4,
+            SrcBlkId::Ins1 => 5,
+            SrcBlkId::ArmAprAudio => 10,
+            SrcBlkId::Avs0 => 11,
+            SrcBlkId::Avs1 => 12,
+            SrcBlkId::Mute => 15,
+            SrcBlkId::Reserved(val) => val,
+        }
+    }
+}
+
+/// The structure to represent source block.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct SrcBlk {
+    pub id: SrcBlkId,
+    pub ch: u8,
+}
+
+impl SrcBlk {
+    pub const ID_MASK: u8 = 0xf0;
+    pub const ID_SHIFT: usize = 4;
+    pub const CH_MASK: u8 = 0x0f;
+    pub const CH_SHIFT: usize = 0;
+}
+
+impl From<u8> for SrcBlk {
+    fn from(val: u8) -> Self {
+        SrcBlk {
+            id: SrcBlkId::from((val & SrcBlk::ID_MASK) >> SrcBlk::ID_SHIFT),
+            ch: (val & SrcBlk::CH_MASK) >> SrcBlk::CH_SHIFT,
+        }
+    }
+}
+
+impl From<SrcBlk> for u8 {
+    fn from(blk: SrcBlk) -> Self {
+        (u8::from(blk.id) << SrcBlk::ID_SHIFT) | blk.ch
+    }
+}
+
+/// The alternative type of data for router entry.
+pub type RouterEntryData = [u8;RouterEntry::SIZE];
+
+/// The structure to represent entry of route.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct RouterEntry {
+    pub dst: DstBlk,
+    pub src: SrcBlk,
+    pub peak: u16,
+}
+
+impl RouterEntry {
+    const SIZE: usize = 4;
+
+    pub const SRC_OFFSET: usize = 2;
+    pub const DST_OFFSET: usize = 3;
+}
+
+impl From<&RouterEntryData> for RouterEntry {
+    fn from(raw: &RouterEntryData) -> Self {
+        let mut doublet = [0;2];
+        doublet.copy_from_slice(&raw[..2]);
+        RouterEntry {
+            dst: raw[Self::DST_OFFSET].into(),
+            src: raw[Self::SRC_OFFSET].into(),
+            peak: u16::from_be_bytes(doublet),
+        }
+    }
+}
+
+impl From<&RouterEntry> for RouterEntryData {
+    fn from(entry: &RouterEntry) -> RouterEntryData {
+        let mut raw = RouterEntryData::default();
+        raw.copy_from_slice(&entry.peak.to_be_bytes());
+        raw[RouterEntry::SRC_OFFSET] = entry.src.into();
+        raw[RouterEntry::DST_OFFSET] = entry.dst.into();
+        raw
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::Section;
     use super::ExtensionSections;
+    use super::{DstBlk, SrcBlk, DstBlkId, SrcBlkId};
 
     #[test]
     fn section_from() {
@@ -146,5 +361,23 @@ mod test {
             application: Section{offset: 0x04, size: 0x00},
         };
         assert_eq!(space, ExtensionSections::from(&raw[..]));
+    }
+
+    #[test]
+    fn dst_blk_from() {
+        let blk = DstBlk {
+            id: DstBlkId::ArmApbAudio,
+            ch: 0x04,
+        };
+        assert_eq!(blk, DstBlk::from(u8::from(blk)));
+    }
+
+    #[test]
+    fn src_blk_from() {
+        let blk = SrcBlk {
+            id: SrcBlkId::ArmAprAudio,
+            ch: 0x04,
+        };
+        assert_eq!(blk, SrcBlk::from(u8::from(blk)));
     }
 }

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -16,6 +16,7 @@ pub mod peak_section;
 pub mod router_section;
 #[doc(hidden)]
 mod stream_format_entry;
+pub mod stream_format_section;
 
 use super::{*, utils::*};
 
@@ -66,6 +67,7 @@ pub enum ProtocolExtensionError {
     Peak,
     Router,
     StreamFormatEntry,
+    StreamFormat,
     Invalid(i32),
 }
 
@@ -79,6 +81,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::Peak => "peak",
             ProtocolExtensionError::Router => "router",
             ProtocolExtensionError::StreamFormatEntry => "stream-format-entry",
+            ProtocolExtensionError::StreamFormat => "stream-format",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -100,6 +103,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::Peak => 4,
             ProtocolExtensionError::Router => 5,
             ProtocolExtensionError::StreamFormatEntry => 6,
+            ProtocolExtensionError::StreamFormat => 7,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -112,7 +116,7 @@ impl ErrorDomain for ProtocolExtensionError {
             3 => ProtocolExtensionError::RouterEntry,
             4 => ProtocolExtensionError::Peak,
             5 => ProtocolExtensionError::Router,
-            6 => ProtocolExtensionError::StreamFormatEntry,
+            7 => ProtocolExtensionError::StreamFormat,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -17,6 +17,7 @@ pub mod router_section;
 #[doc(hidden)]
 mod stream_format_entry;
 pub mod stream_format_section;
+pub mod current_config_section;
 
 use super::{*, utils::*};
 
@@ -68,6 +69,7 @@ pub enum ProtocolExtensionError {
     Router,
     StreamFormatEntry,
     StreamFormat,
+    CurrentConfig,
     Invalid(i32),
 }
 
@@ -82,6 +84,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::Router => "router",
             ProtocolExtensionError::StreamFormatEntry => "stream-format-entry",
             ProtocolExtensionError::StreamFormat => "stream-format",
+            ProtocolExtensionError::CurrentConfig => "current-config",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -104,6 +107,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::Router => 5,
             ProtocolExtensionError::StreamFormatEntry => 6,
             ProtocolExtensionError::StreamFormat => 7,
+            ProtocolExtensionError::CurrentConfig => 8,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -117,6 +121,7 @@ impl ErrorDomain for ProtocolExtensionError {
             4 => ProtocolExtensionError::Peak,
             5 => ProtocolExtensionError::Router,
             7 => ProtocolExtensionError::StreamFormat,
+            8 => ProtocolExtensionError::CurrentConfig,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -7,6 +7,8 @@
 //! extension defined by TC Applied Technologies (TCAT) for ASICs of Digital Interface Communication
 //! Engine (DICE).
 
+pub mod caps_section;
+
 use super::*;
 
 /// The structure to represent sections for protocol extension.
@@ -47,12 +49,14 @@ impl From<&[u8]> for ExtensionSections {
 /// The enumeration to represent any error of protocol extension.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ProtocolExtensionError {
+    Caps,
     Invalid(i32),
 }
 
 impl std::fmt::Display for ProtocolExtensionError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
+            ProtocolExtensionError::Caps => "caps",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -67,12 +71,14 @@ impl ErrorDomain for ProtocolExtensionError {
 
     fn code(self) -> i32 {
         match self {
+            ProtocolExtensionError::Caps => 0,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
 
     fn from(code: i32) -> Option<Self> {
         let enumeration = match code {
+            0 => ProtocolExtensionError::Caps,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -18,6 +18,7 @@ pub mod router_section;
 mod stream_format_entry;
 pub mod stream_format_section;
 pub mod current_config_section;
+pub mod appl_section;
 
 use super::{*, utils::*};
 
@@ -70,6 +71,7 @@ pub enum ProtocolExtensionError {
     StreamFormatEntry,
     StreamFormat,
     CurrentConfig,
+    Appl,
     Invalid(i32),
 }
 
@@ -85,6 +87,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::StreamFormatEntry => "stream-format-entry",
             ProtocolExtensionError::StreamFormat => "stream-format",
             ProtocolExtensionError::CurrentConfig => "current-config",
+            ProtocolExtensionError::Appl => "application",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -108,6 +111,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::StreamFormatEntry => 6,
             ProtocolExtensionError::StreamFormat => 7,
             ProtocolExtensionError::CurrentConfig => 8,
+            ProtocolExtensionError::Appl => 9,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -122,6 +126,7 @@ impl ErrorDomain for ProtocolExtensionError {
             5 => ProtocolExtensionError::Router,
             7 => ProtocolExtensionError::StreamFormat,
             8 => ProtocolExtensionError::CurrentConfig,
+            9 => ProtocolExtensionError::Appl,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -13,6 +13,7 @@ pub mod mixer_section;
 #[doc(hidden)]
 mod router_entry;
 pub mod peak_section;
+pub mod router_section;
 
 use super::*;
 
@@ -59,6 +60,7 @@ pub enum ProtocolExtensionError {
     Mixer,
     RouterEntry,
     Peak,
+    Router,
     Invalid(i32),
 }
 
@@ -70,6 +72,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::Mixer => "mixer",
             ProtocolExtensionError::RouterEntry => "router-entry",
             ProtocolExtensionError::Peak => "peak",
+            ProtocolExtensionError::Router => "router",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -89,6 +92,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::Mixer => 2,
             ProtocolExtensionError::RouterEntry => 3,
             ProtocolExtensionError::Peak => 4,
+            ProtocolExtensionError::Router => 5,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -100,6 +104,7 @@ impl ErrorDomain for ProtocolExtensionError {
             2 => ProtocolExtensionError::Mixer,
             3 => ProtocolExtensionError::RouterEntry,
             4 => ProtocolExtensionError::Peak,
+            5 => ProtocolExtensionError::Router,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -8,6 +8,7 @@
 //! Engine (DICE).
 
 pub mod caps_section;
+pub mod cmd_section;
 
 use super::*;
 
@@ -50,6 +51,7 @@ impl From<&[u8]> for ExtensionSections {
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ProtocolExtensionError {
     Caps,
+    Cmd,
     Invalid(i32),
 }
 
@@ -57,6 +59,7 @@ impl std::fmt::Display for ProtocolExtensionError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let msg = match self {
             ProtocolExtensionError::Caps => "caps",
+            ProtocolExtensionError::Cmd => "command",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -72,6 +75,7 @@ impl ErrorDomain for ProtocolExtensionError {
     fn code(self) -> i32 {
         match self {
             ProtocolExtensionError::Caps => 0,
+            ProtocolExtensionError::Cmd => 1,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -79,6 +83,7 @@ impl ErrorDomain for ProtocolExtensionError {
     fn from(code: i32) -> Option<Self> {
         let enumeration = match code {
             0 => ProtocolExtensionError::Caps,
+            1 => ProtocolExtensionError::Cmd,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -12,6 +12,7 @@ pub mod cmd_section;
 pub mod mixer_section;
 #[doc(hidden)]
 mod router_entry;
+pub mod peak_section;
 
 use super::*;
 
@@ -57,6 +58,7 @@ pub enum ProtocolExtensionError {
     Cmd,
     Mixer,
     RouterEntry,
+    Peak,
     Invalid(i32),
 }
 
@@ -67,6 +69,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::Cmd => "command",
             ProtocolExtensionError::Mixer => "mixer",
             ProtocolExtensionError::RouterEntry => "router-entry",
+            ProtocolExtensionError::Peak => "peak",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -85,6 +88,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::Cmd => 1,
             ProtocolExtensionError::Mixer => 2,
             ProtocolExtensionError::RouterEntry => 3,
+            ProtocolExtensionError::Peak => 4,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -95,6 +99,7 @@ impl ErrorDomain for ProtocolExtensionError {
             1 => ProtocolExtensionError::Cmd,
             2 => ProtocolExtensionError::Mixer,
             3 => ProtocolExtensionError::RouterEntry,
+            4 => ProtocolExtensionError::Peak,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! extension defined by TC Applied Technologies (TCAT) for ASICs of Digital Interface Communication
+//! Engine (DICE).
+
+use super::*;
+
+/// The structure to represent sections for protocol extension.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExtensionSections{
+    pub caps: Section,
+    pub cmd: Section,
+    pub mixer: Section,
+    pub peak: Section,
+    pub router: Section,
+    pub stream_format: Section,
+    pub current_config: Section,
+    pub standalone: Section,
+    pub application: Section,
+}
+
+impl ExtensionSections {
+    const SECTION_COUNT: usize = 9;
+    const SIZE: usize = Section::SIZE * Self::SECTION_COUNT;
+}
+
+impl From<&[u8]> for ExtensionSections {
+    fn from(raw: &[u8]) -> Self {
+        ExtensionSections{
+            caps: Section::from(&raw[..8]),
+            cmd: Section::from(&raw[8..16]),
+            mixer: Section::from(&raw[16..24]),
+            peak: Section::from(&raw[24..32]),
+            router: Section::from(&raw[32..40]),
+            stream_format: Section::from(&raw[40..48]),
+            current_config: Section::from(&raw[48..56]),
+            standalone: Section::from(&raw[56..64]),
+            application: Section::from(&raw[64..72]),
+        }
+    }
+}
+
+/// The enumeration to represent any error of protocol extension.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ProtocolExtensionError {
+    Invalid(i32),
+}
+
+impl std::fmt::Display for ProtocolExtensionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let msg = match self {
+            ProtocolExtensionError::Invalid(_) => "invalid",
+        };
+
+        write!(f, "ProtocolExtensionError::{}", msg)
+    }
+}
+
+impl ErrorDomain for ProtocolExtensionError {
+    fn domain() -> Quark {
+        Quark::from_string("tcat-protocol-extension-error-quark")
+    }
+
+    fn code(self) -> i32 {
+        match self {
+            ProtocolExtensionError::Invalid(v) => v,
+        }
+    }
+
+    fn from(code: i32) -> Option<Self> {
+        let enumeration = match code {
+            _ => ProtocolExtensionError::Invalid(code),
+        };
+        Some(enumeration)
+    }
+}
+
+pub trait ProtocolExtension<T: AsRef<FwNode>> : GeneralProtocol<T> {
+    const EXTENSION_OFFSET: usize = 0x00200000;
+
+    fn read(&self, node: &T, offset: usize, frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        GeneralProtocol::read(self, node, Self::EXTENSION_OFFSET + offset, frames, timeout_ms)
+    }
+
+    fn write(&self, node: &T, offset: usize, frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        GeneralProtocol::write(self, node, Self::EXTENSION_OFFSET + offset, frames, timeout_ms)
+    }
+
+    fn read_extension_sections(&self, node: &T, timeout_ms: u32) -> Result<ExtensionSections, Error> {
+        let mut data = [0;ExtensionSections::SIZE];
+        ProtocolExtension::read(self, node, 0, &mut data, timeout_ms)
+            .map(|_| ExtensionSections::from(&data[..]))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> ProtocolExtension<T> for O {}
+
+#[cfg(test)]
+mod test {
+    use super::Section;
+    use super::ExtensionSections;
+
+    #[test]
+    fn section_from() {
+        let raw = [
+            0x00, 0x00, 0x00, 0x11, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x0f, 0x00, 0x00,
+            0x00, 0x0e, 0x00, 0x00, 0x00, 0x0d, 0x00, 0x00, 0x00, 0x0c, 0x00, 0x00, 0x00, 0x0b,
+            0x00, 0x00, 0x00, 0x0a, 0x00, 0x00, 0x00, 0x09, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00,
+            0x00, 0x07, 0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x04,
+            0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00,
+            0x00, 0x00,
+        ];
+        let space = ExtensionSections{
+            caps: Section{offset: 0x44, size: 0x40},
+            cmd: Section{offset: 0x3c, size: 0x38},
+            mixer: Section{offset: 0x34, size: 0x30},
+            peak: Section{offset: 0x2c, size: 0x28},
+            router: Section{offset: 0x24, size: 0x20},
+            stream_format: Section{offset: 0x1c, size: 0x18},
+            current_config: Section{offset: 0x14, size: 0x10},
+            standalone: Section{offset: 0x0c, size: 0x08},
+            application: Section{offset: 0x04, size: 0x00},
+        };
+        assert_eq!(space, ExtensionSections::from(&raw[..]));
+    }
+}

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -19,6 +19,7 @@ mod stream_format_entry;
 pub mod stream_format_section;
 pub mod current_config_section;
 pub mod appl_section;
+pub mod standalone_section;
 
 use super::{*, utils::*};
 
@@ -72,6 +73,7 @@ pub enum ProtocolExtensionError {
     StreamFormat,
     CurrentConfig,
     Appl,
+    Standalone,
     Invalid(i32),
 }
 
@@ -88,6 +90,7 @@ impl std::fmt::Display for ProtocolExtensionError {
             ProtocolExtensionError::StreamFormat => "stream-format",
             ProtocolExtensionError::CurrentConfig => "current-config",
             ProtocolExtensionError::Appl => "application",
+            ProtocolExtensionError::Standalone => "standalone",
             ProtocolExtensionError::Invalid(_) => "invalid",
         };
 
@@ -112,6 +115,7 @@ impl ErrorDomain for ProtocolExtensionError {
             ProtocolExtensionError::StreamFormat => 7,
             ProtocolExtensionError::CurrentConfig => 8,
             ProtocolExtensionError::Appl => 9,
+            ProtocolExtensionError::Standalone => 10,
             ProtocolExtensionError::Invalid(v) => v,
         }
     }
@@ -127,6 +131,7 @@ impl ErrorDomain for ProtocolExtensionError {
             7 => ProtocolExtensionError::StreamFormat,
             8 => ProtocolExtensionError::CurrentConfig,
             9 => ProtocolExtensionError::Appl,
+            10 => ProtocolExtensionError::Standalone,
             _ => ProtocolExtensionError::Invalid(code),
         };
         Some(enumeration)

--- a/libs/dice/protocols/src/tcat/extension/appl_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/appl_section.rs
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Application section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for application
+//! section in protocol extension defined by TCAT for ASICs of DICE.
+
+use super::*;
+
+pub trait ApplSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_appl_data(&self, node: &T, sections: &ExtensionSections, offset: usize,
+                      frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        ProtocolExtension::read(self, node, sections.application.offset + offset, frames, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Appl, &e.to_string()))
+    }
+
+    fn write_appl_data(&self, node: &T, sections: &ExtensionSections, offset: usize,
+                       frames: &mut [u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        ProtocolExtension::write(self, node, sections.application.offset + offset, frames, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Appl, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> ApplSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/caps_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/caps_section.rs
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Capabilities section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for capabilities
+//! section in protocol extension defined by TCAT for ASICs of DICE.
+use super::*;
+
+/// The structure to represent capability of router functionality.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RouterCaps {
+    pub is_exposed: bool,
+    pub is_readonly: bool,
+    pub is_storable: bool,
+    pub maximum_entry_count: u16,
+}
+
+impl RouterCaps {
+    const SIZE: usize = 4;
+
+    const IS_EXPOSED_OFFSET: usize = 3;
+    const IS_READONLY_OFFSET: usize = 3;
+    const IS_STORABLE_OFFSET: usize = 3;
+
+    const IS_EXPOSED_FLAG: u8 = 0x01;
+    const IS_READONLY_FLAG: u8 = 0x02;
+    const IS_STORABLE_FLAG: u8 = 0x04;
+}
+
+impl From<&[u8]> for RouterCaps {
+    fn from(raw: &[u8]) -> Self {
+        let mut doublet = [0;2];
+        doublet.copy_from_slice(&raw[..2]);
+        RouterCaps {
+            is_exposed: raw[Self::IS_EXPOSED_OFFSET] & Self::IS_EXPOSED_FLAG > 0,
+            is_readonly: raw[Self::IS_READONLY_OFFSET] & Self::IS_READONLY_FLAG  > 0,
+            is_storable: raw[Self::IS_STORABLE_OFFSET] & Self::IS_STORABLE_FLAG > 0,
+            maximum_entry_count: u16::from_be_bytes(doublet),
+        }
+    }
+}
+
+/// The structure to represent capability of mixer functionality.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MixerCaps {
+    pub is_exposed: bool,
+    pub is_readonly: bool,
+    pub is_storable: bool,
+    pub input_device_id: u8,
+    pub output_device_id: u8,
+    pub input_count: u8,
+    pub output_count: u8,
+}
+
+impl MixerCaps {
+    const SIZE: usize = 0x04;
+
+    const IS_EXPOSED_OFFSET: usize = 3;
+    const IS_READONLY_OFFSET: usize = 3;
+    const IS_STORABLE_OFFSET: usize = 3;
+    const INPUT_DEVICE_ID_OFFSET: usize = 3;
+    const OUTPUT_DEVICE_ID_OFFSET: usize = 2;
+    const INPUT_COUNT_OFFSET: usize = 1;
+    const OUTPUT_COUNT_OFFSET: usize = 0;
+
+    const IS_EXPOSED_FLAG: u8 = 0x01;
+    const IS_READONLY_FLAG: u8 = 0x02;
+    const IS_STORABLE_FLAG: u8 = 0x04;
+    const INPUT_DEVICE_ID_MASK: u8 = 0x0f;
+    const OUTPUT_DEVICE_ID_MASK: u8 = 0x0f;
+
+    const INPUT_DEVICE_ID_SHIFT: usize = 4;
+}
+
+impl From<&[u8]> for MixerCaps {
+    fn from(raw: &[u8]) -> Self {
+        MixerCaps {
+            is_exposed: raw[Self::IS_EXPOSED_OFFSET] & Self::IS_EXPOSED_FLAG > 0,
+            is_readonly: raw[Self::IS_READONLY_OFFSET] & Self::IS_READONLY_FLAG > 0,
+            is_storable: raw[Self::IS_STORABLE_OFFSET] & Self::IS_STORABLE_FLAG > 0,
+            input_device_id:
+                (raw[Self::INPUT_DEVICE_ID_OFFSET] >> Self::INPUT_DEVICE_ID_SHIFT) & Self::INPUT_DEVICE_ID_MASK,
+            output_device_id: raw[Self::OUTPUT_DEVICE_ID_OFFSET] & Self::OUTPUT_DEVICE_ID_MASK,
+            input_count: raw[Self::INPUT_COUNT_OFFSET],
+            output_count: raw[Self::OUTPUT_COUNT_OFFSET],
+        }
+    }
+}
+
+/// The enumeration to represent the type of ASIC.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AsicType {
+    DiceII,
+    Tcd2210,
+    Tcd2220,
+    Reserved(u8),
+}
+
+impl Default<> for AsicType {
+    fn default() -> Self {
+        AsicType::Reserved(0xff)
+    }
+}
+
+impl From<u8> for AsicType {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::DiceII,
+            1 => Self::Tcd2210,
+            2 => Self::Tcd2220,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+/// The structure to represent capability of general functionality.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GeneralCaps {
+    pub dynamic_stream_format: bool,
+    pub storage_avail: bool,
+    pub peak_avail: bool,
+    pub max_tx_streams: u8,
+    pub max_rx_streams: u8,
+    pub stream_format_is_storable: bool,
+    pub asic_type: AsicType,
+}
+
+impl GeneralCaps {
+    const SIZE: usize = 0x04;
+
+    const DYNAMIC_STREAM_CONF_OFFSET: usize = 0x03;
+    const STORAGE_AVAIL_OFFSET: usize = 0x03;
+    const PEAK_AVAIL_OFFSET: usize = 0x03;
+    const MAX_TX_STREAMS_OFFSET: usize = 0x03;
+    const MAX_RX_STREAMS_OFFSET: usize = 0x02;
+    const STREAM_CONF_IS_STORABLE_OFFSET: usize = 0x02;
+    const ASIC_TYPE_OFFSET: usize = 0x01;
+
+    const DYNAMIC_STREAM_CONF_FLAG: u8 = 0x01;
+    const STORAGE_AVAIL_FLAG: u8 = 0x02;
+    const PEAK_AVAIL_FLAG: u8 = 0x04;
+    const MAX_TX_STREAMS_MASK: u8 = 0x0f;
+    const MAX_RX_STREAMS_MASK: u8 = 0x0f;
+    const STREAM_CONF_IS_STORABLE_FLAG: u8 = 0x10;
+
+    const MAX_TX_STREAMS_SHIFT: usize = 4;
+}
+
+impl From<&[u8]> for GeneralCaps {
+    fn from(raw: &[u8]) -> Self {
+        GeneralCaps {
+            dynamic_stream_format:
+                raw[Self::DYNAMIC_STREAM_CONF_OFFSET] & Self::DYNAMIC_STREAM_CONF_FLAG > 0,
+            storage_avail:
+                raw[Self::STORAGE_AVAIL_OFFSET] & Self::STORAGE_AVAIL_FLAG > 0,
+            peak_avail:
+                raw[Self::PEAK_AVAIL_OFFSET] & Self::PEAK_AVAIL_FLAG > 0,
+            max_tx_streams:
+                (raw[Self::MAX_TX_STREAMS_OFFSET] >> Self::MAX_TX_STREAMS_SHIFT) & Self::MAX_TX_STREAMS_MASK,
+            max_rx_streams:
+                raw[Self::MAX_RX_STREAMS_OFFSET] & Self::MAX_RX_STREAMS_MASK,
+            stream_format_is_storable:
+                raw[Self::STREAM_CONF_IS_STORABLE_OFFSET] & Self::STREAM_CONF_IS_STORABLE_FLAG > 0,
+            asic_type:
+                AsicType::from(raw[Self::ASIC_TYPE_OFFSET]),
+        }
+    }
+}
+
+/// The structure to represent capabilities of each funtions.
+#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExtensionCaps {
+    pub router: RouterCaps,
+    pub mixer: MixerCaps,
+    pub general: GeneralCaps,
+}
+
+impl ExtensionCaps {
+    const SIZE: usize = RouterCaps::SIZE + MixerCaps::SIZE + GeneralCaps::SIZE;
+}
+
+impl From<&[u8]> for ExtensionCaps {
+    fn from(raw: &[u8]) -> Self {
+        ExtensionCaps{
+            router: RouterCaps::from(&raw[..RouterCaps::SIZE]),
+            mixer: MixerCaps::from(&raw[RouterCaps::SIZE..(RouterCaps::SIZE + MixerCaps::SIZE)]),
+            general: GeneralCaps::from(&raw[(RouterCaps::SIZE + MixerCaps::SIZE)..]),
+        }
+    }
+}
+
+pub trait CapsSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_caps(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<ExtensionCaps, Error>
+    {
+        let mut data = [0;ExtensionCaps::SIZE];
+        ProtocolExtension::read(self, node, sections.caps.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Caps, &e.to_string()))
+            .map(|_| ExtensionCaps::from(&data[..]))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> CapsSectionProtocol<T> for O {}
+
+#[cfg(test)]
+mod test {
+    use super::{ExtensionCaps, RouterCaps, MixerCaps, GeneralCaps, AsicType};
+
+    #[test]
+    fn caps_from() {
+        let raw = [0xff, 0x00, 0x00, 0x07, 0x23, 0x12, 0x0c, 0xe7, 0x00, 0x00, 0x1b, 0xa3];
+        let caps = ExtensionCaps{
+            router: RouterCaps{
+                is_exposed: true,
+                is_readonly: true,
+                is_storable: true,
+                maximum_entry_count: 0xff00,
+            },
+            mixer: MixerCaps{
+                is_exposed: true,
+                is_readonly: true,
+                is_storable: true,
+                input_device_id: 0x0e,
+                output_device_id: 0x0c,
+                input_count: 0x12,
+                output_count: 0x23,
+            },
+            general: GeneralCaps{
+                dynamic_stream_format: true,
+                storage_avail: true,
+                peak_avail: false,
+                max_tx_streams: 0x0a,
+                max_rx_streams: 0x0b,
+                stream_format_is_storable: true,
+                asic_type: AsicType::DiceII,
+            },
+        };
+        assert_eq!(caps, ExtensionCaps::from(&raw[..]));
+    }
+}

--- a/libs/dice/protocols/src/tcat/extension/cmd_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/cmd_section.rs
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Command section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for command
+//! section in protocol extension defined by TCAT for ASICs of DICE.
+use super::{*, caps_section::*};
+
+use crate::tcat::global_section::ClockRate;
+
+use std::convert::TryFrom;
+
+/// The enumeration to represent the mode of sampling transfer frequency.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RateMode {
+    Low,
+    Middle,
+    High,
+}
+
+impl std::fmt::Display for RateMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            RateMode::Low => "low",
+            RateMode::Middle => "middle",
+            RateMode::High => "high",
+        };
+        write!(f, "{}", label)
+    }
+}
+
+impl From<ClockRate> for RateMode {
+    fn from(rate: ClockRate) -> Self {
+        match rate {
+            ClockRate::R32000 |
+            ClockRate::R44100 |
+            ClockRate::R48000 |
+            ClockRate::AnyLow |
+            ClockRate::None |
+            ClockRate::Reserved(_) => RateMode::Low,
+            ClockRate::R88200 |
+            ClockRate::R96000 |
+            ClockRate::AnyMid => RateMode::Middle,
+            ClockRate::R176400 |
+            ClockRate::R192000 |
+            ClockRate::AnyHigh => RateMode::High,
+        }
+    }
+}
+
+impl TryFrom<u32> for RateMode {
+    type Error = Error;
+
+    fn try_from(rate: u32) -> Result<Self, Self::Error> {
+        ClockRate::try_from(rate)
+            .map(|clock_rate| RateMode::from(clock_rate))
+    }
+}
+
+/// The enumeration to represent opcode of command.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Opcode {
+    NoOp,
+    LoadRouter(RateMode),
+    LoadStreamConfig(RateMode),
+    LoadRouterStreamConfig(RateMode),
+    LoadConfigFromFlash,
+    StoreConfigToFlash,
+}
+
+impl From<Opcode> for u16 {
+    fn from(code: Opcode) -> u16 {
+        match code {
+            Opcode::NoOp => 0x00,
+            Opcode::LoadRouter(_) => 0x01,
+            Opcode::LoadStreamConfig(_) => 0x02,
+            Opcode::LoadRouterStreamConfig(_) => 0x03,
+            Opcode::LoadConfigFromFlash => 0x04,
+            Opcode::StoreConfigToFlash => 0x05,
+        }
+    }
+}
+
+pub trait CmdSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    const OPCODE_OFFSET: usize = 0x00;
+    const RETURN_OFFSET: usize = 0x04;
+
+    const EXECUTE: u8 = 0x80;
+
+    fn initiate(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps, opcode: Opcode, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        if let Opcode::LoadRouter(_) = opcode {
+            if caps.mixer.is_readonly {
+                Err(Error::new(ProtocolExtensionError::Cmd, "Router configuration is immutable"))?
+            }
+        } else if let Opcode::LoadStreamConfig(_) = opcode {
+            if !caps.general.dynamic_stream_format {
+                Err(Error::new(ProtocolExtensionError::Cmd, "Stream format configuration is immutable"))?
+            }
+        } else if let Opcode::LoadRouterStreamConfig(_) = opcode {
+            if caps.mixer.is_readonly && !caps.general.dynamic_stream_format {
+                Err(Error::new(ProtocolExtensionError::Cmd, "Any configuration is immutable"))?
+            }
+        } else if opcode == Opcode::LoadConfigFromFlash {
+            if !caps.general.storage_avail {
+                Err(Error::new(ProtocolExtensionError::Cmd, "Storage is not available"))?
+            }
+        } else if opcode == Opcode::StoreConfigToFlash {
+            if !caps.general.storage_avail {
+                Err(Error::new(ProtocolExtensionError::Cmd, "Storage is not available"))?
+            }
+        }
+
+        let mut data = [0;4];
+        data[2..4].copy_from_slice(&u16::from(opcode).to_be_bytes());
+        data[1] = match opcode {
+            Opcode::LoadRouter(r) |
+            Opcode::LoadStreamConfig(r) |
+            Opcode::LoadRouterStreamConfig(r) => match r {
+                RateMode::Low => 1,
+                RateMode::Middle => 2,
+                RateMode::High => 4,
+            }
+            _ => 0,
+        };
+        data[0] = Self::EXECUTE;
+        ProtocolExtension::write(self, node, sections.cmd.offset + Self::OPCODE_OFFSET, &mut data,
+                                 timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Cmd, &e.to_string()))?;
+
+        let mut count = 0;
+        while count < 10 {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+
+            ProtocolExtension::read(self, node, sections.cmd.offset, &mut data, timeout_ms)
+                .map_err(|e| Error::new(ProtocolExtensionError::Cmd, &e.to_string()))?;
+
+            if (data[0] & Self::EXECUTE) != Self::EXECUTE {
+                ProtocolExtension::read(self, node, sections.cmd.offset + Self::RETURN_OFFSET, &mut data,
+                                        timeout_ms)
+                    .map_err(|e| Error::new(ProtocolExtensionError::Cmd, &e.to_string()))?;
+                return Ok(u32::from_be_bytes(data));
+            }
+            count += 1;
+        }
+
+        Err(Error::new(ProtocolExtensionError::Cmd, "Operation timeout."))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> CmdSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/current_config_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/current_config_section.rs
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Current configuration section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for current
+//! configuration section in protocol extension defined by TCAT for ASICs of DICE.
+
+use super::{*, cmd_section::*, caps_section::*};
+use super::router_entry::*;
+use super::stream_format_entry::*;
+
+pub trait CurrentConfigSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    const LOW_ROUTER_CONFIG_OFFSET: usize = 0x0000;
+    const LOW_STREAM_CONFIG_OFFSET: usize = 0x1000;
+    const MID_ROUTER_CONFIG_OFFSET: usize = 0x2000;
+    const MID_STREAM_CONFIG_OFFSET: usize = 0x3000;
+    const HIGH_ROUTER_CONFIG_OFFSET: usize = 0x4000;
+    const HIGH_STREAM_CONFIG_OFFSET: usize = 0x5000;
+
+    fn read_current_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                                   mode: RateMode, timeout_ms: u32)
+        -> Result<Vec<RouterEntryData>, Error>
+    {
+        let offset = match mode {
+            RateMode::Low => Self::LOW_ROUTER_CONFIG_OFFSET,
+            RateMode::Middle => Self::MID_ROUTER_CONFIG_OFFSET,
+            RateMode::High => Self::HIGH_ROUTER_CONFIG_OFFSET,
+        };
+
+        let mut data = [0;4];
+        let offset = sections.current_config.offset + offset;
+        ProtocolExtension::read(self, node, offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::CurrentConfig, &e.to_string()))?;
+
+        let entry_count = std::cmp::min(u32::from_be_bytes(data) as usize,
+                                        caps.router.maximum_entry_count as usize);
+
+        RouterEntryProtocol::read_router_entries(&self, node, caps, offset + 4, entry_count, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::CurrentConfig, &e.to_string()))
+    }
+
+    fn read_current_stream_format_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                                          mode: RateMode, timeout_ms: u32)
+        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+    {
+        let offset = match mode {
+            RateMode::Low => Self::LOW_STREAM_CONFIG_OFFSET,
+            RateMode::Middle => Self::MID_STREAM_CONFIG_OFFSET,
+            RateMode::High => Self::HIGH_STREAM_CONFIG_OFFSET,
+        };
+        let offset = sections.current_config.offset + offset;
+        StreamFormatEntryProtocol::read_stream_format_entries(&self, node, caps, offset, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::CurrentConfig, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> CurrentConfigSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/mixer_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/mixer_section.rs
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Mixer section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for mixer section
+//! in protocol extension defined by TCAT for ASICs of DICE.
+use super::{*, caps_section::*};
+
+pub trait MixerSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    const SATURATION_OFFSET: usize = 0x00;
+    const COEFF_OFFSET: usize = 0x04;
+
+    fn read_saturation(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps, timeout_ms: u32)
+        -> Result<Vec<bool>, Error>
+    {
+        if !caps.mixer.is_exposed {
+            Err(Error::new(ProtocolExtensionError::Mixer, "Mixer is not available"))?
+        }
+
+        let mut data = [0;4];
+        ProtocolExtension::read(self, node, sections.mixer.offset + Self::SATURATION_OFFSET, &mut data,
+                                timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Mixer, &e.to_string()))
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                (0..caps.mixer.output_count)
+                    .map(|i| val & (1 << i) > 0)
+                    .collect::<Vec<_>>()
+            })
+    }
+
+    fn read_coef(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                 dst: usize, src: usize, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        if !caps.mixer.is_exposed {
+            Err(Error::new(ProtocolExtensionError::Mixer, "Mixer is not available"))?
+        }
+
+        let offset = 4 * (src + dst * caps.mixer.input_count as usize);
+        let mut data = [0;4];
+        ProtocolExtension::read(self, node, sections.mixer.offset + Self::COEFF_OFFSET + offset,
+                                &mut data, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Mixer, &e.to_string()))
+            .map(|_|  u32::from_be_bytes(data))
+    }
+
+    fn write_coef(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                  dst: usize, src: usize, val: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        if caps.mixer.is_readonly {
+            Err(Error::new(ProtocolExtensionError::Mixer, "Mixer is immutable"))?
+        }
+
+        let offset = 4 * (src + dst * caps.mixer.input_count as usize);
+        let mut data = [0;4];
+        data.copy_from_slice(&val.to_be_bytes());
+        ProtocolExtension::write(self, node, sections.mixer.offset + Self::COEFF_OFFSET + offset,
+                                 &mut data, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Mixer, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> MixerSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/peak_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/peak_section.rs
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Peak section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for peak section
+//! in protocol extension defined by TCAT for ASICs of DICE.
+use super::{*, caps_section::*, router_entry::*};
+
+pub trait PeakSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_peak_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                         timeout_ms: u32)
+        -> Result<Vec<RouterEntryData>, Error>
+    {
+        if !caps.general.peak_avail {
+            Err(Error::new(ProtocolExtensionError::Peak, "Peak is not available"))?
+        }
+
+        let entries = caps.router.maximum_entry_count as usize;
+        RouterEntryProtocol::read_router_entries(&self, node, caps, sections.peak.offset, entries,
+                                                 timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Peak, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> PeakSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/router_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_entry.rs
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use super::{*, caps_section::*};
+
+pub trait RouterEntryProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_router_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize,
+                           entry_count: usize, timeout_ms: u32)
+        -> Result<Vec<RouterEntryData>, Error>
+    {
+        if entry_count > caps.router.maximum_entry_count as usize {
+            let msg = format!("Invalid entries to read: {} but greater than {}",
+                              entry_count, caps.router.maximum_entry_count);
+            Err(Error::new(ProtocolExtensionError::RouterEntry, &msg))?
+        }
+
+        let mut data = vec![0;entry_count * RouterEntry::SIZE];
+        ProtocolExtension::read(self, node, offset, &mut data, timeout_ms)?;
+
+        let entries = (0..entry_count)
+            .map(|i| {
+                let mut raw = RouterEntryData::default();
+                let pos = i * RouterEntry::SIZE;
+                raw.copy_from_slice(&data[pos..(pos + RouterEntry::SIZE)]);
+                raw
+            })
+            .collect::<Vec<_>>();
+
+        Ok(entries)
+    }
+
+    fn write_router_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize,
+                            entries: &Vec<RouterEntryData>, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        if entries.len() > caps.router.maximum_entry_count as usize {
+            let msg = format!("Invalid number of entries to read: {} but greater than {}",
+                              entries.len(), caps.router.maximum_entry_count * 4);
+            Err(Error::new(ProtocolExtensionError::RouterEntry, &msg))?
+        }
+
+        let mut data = [0;4];
+        data.copy_from_slice(&(entries.len() as u32).to_be_bytes());
+        ProtocolExtension::write(self, node, offset, &mut data, timeout_ms)?;
+
+        let mut data = Vec::new();
+        entries.iter().for_each(|entry| {
+            data.extend_from_slice(entry);
+        });
+        ProtocolExtension::write(self, node, offset + 4, &mut data, timeout_ms)
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> RouterEntryProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/router_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_section.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Router section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for router section
+//! in protocol extension defined by TCAT for ASICs of DICE.
+
+use super::{*, caps_section::*, router_entry::*};
+
+pub trait RouterSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                           timeout_ms: u32)
+        -> Result<Vec<RouterEntryData>, Error>
+    {
+        let mut data = [0;4];
+        ProtocolExtension::read(self, node, sections.router.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Router, &e.to_string()))?;
+
+        let entry_count = std::cmp::min(u32::from_be_bytes(data) as usize,
+                                        caps.router.maximum_entry_count as usize);
+        RouterEntryProtocol::read_router_entries(&self, node, caps, sections.router.offset + 4,
+                                                 entry_count, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Router, &e.to_string()))
+    }
+
+    fn write_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                            entries: &Vec<RouterEntryData>, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        RouterEntryProtocol::write_router_entries(&self, node, caps, sections.router.offset,
+                                                  entries, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Router, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> RouterSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/standalone_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/standalone_section.rs
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Standalone section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for standalone
+//! section in protocol extension defined by TCAT for ASICs of DICE.
+
+use super::{*, global_section::*};
+
+/// The enumeration to represent parameter of ADAT input/output.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum AdatParam {
+    Normal,
+    SMUX2,
+    SMUX4,
+    Auto,
+}
+
+impl Default for AdatParam {
+    fn default() -> Self {
+        AdatParam::Auto
+    }
+}
+
+impl std::fmt::Display for AdatParam {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            AdatParam::Normal => "normal",
+            AdatParam::SMUX2 => "S/MUX-2",
+            AdatParam::SMUX4 => "S/MUX-4",
+            AdatParam::Auto => "auto",
+        };
+        write!(f, "{}", label)
+    }
+}
+
+impl From<[u8;4]> for AdatParam {
+    fn from(raw: [u8;4]) -> Self {
+        match u32::from_be_bytes(raw) & 0x03 {
+            0x01 => AdatParam::SMUX2,
+            0x02 => AdatParam::SMUX4,
+            0x03 => AdatParam::Auto,
+            _ => AdatParam::Normal,
+        }
+    }
+}
+
+impl From<AdatParam> for [u8;4] {
+    fn from(param: AdatParam) -> Self {
+        let val = match param {
+            AdatParam::Normal => 0x00,
+            AdatParam::SMUX2 => 0x01,
+            AdatParam::SMUX4 => 0x02,
+            AdatParam::Auto => 0x03,
+        };
+        (val as u32).to_be_bytes()
+    }
+}
+
+/// The enumeration to represent mode of word clock input/output.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum WordClockMode {
+    Normal,
+    Low,
+    Middle,
+    High,
+}
+
+impl Default for WordClockMode {
+    fn default() -> Self {
+        WordClockMode::Normal
+    }
+}
+
+impl std::fmt::Display for WordClockMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            WordClockMode::Normal => "normal",
+            WordClockMode::Low => "low",
+            WordClockMode::Middle => "middle",
+            WordClockMode::High => "high",
+        };
+        write!(f, "{}", label)
+    }
+}
+
+/// The structure to represent rate of word clock input/output by enumerator and denominator.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct WordClockRate {
+    pub numerator: u16,
+    pub denominator: u16,
+}
+
+/// The structure to represent parameter of word clock input/output.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct WordClockParam {
+    pub mode: WordClockMode,
+    pub rate: WordClockRate,
+}
+
+impl From<[u8;4]> for WordClockParam {
+    fn from(raw: [u8;4]) -> Self {
+        let val = u32::from_be_bytes(raw);
+
+        let mode = match val & 0x03 {
+            0x01 => WordClockMode::Low,
+            0x02 => WordClockMode::Middle,
+            0x03 => WordClockMode::High,
+            _ => WordClockMode::Normal,
+        };
+
+        let numerator = 1 + ((val >> 4) & 0x0fff) as u16;
+        let denominator = 1 + ((val >> 16) & 0xffff) as u16;
+
+        WordClockParam {
+            mode,
+            rate: WordClockRate{
+                numerator,
+                denominator,
+            },
+        }
+    }
+}
+
+impl From<WordClockParam> for [u8;4] {
+    fn from(param: WordClockParam) -> Self {
+        let mut val = match param.mode {
+            WordClockMode::Normal => 0x00,
+            WordClockMode::Low => 0x01,
+            WordClockMode::Middle => 0x02,
+            WordClockMode::High => 0x03,
+        };
+        val |= ((param.rate.numerator as u32) - 1) << 4;
+        val |= ((param.rate.denominator as u32) - 1) << 16;
+        val.to_be_bytes()
+    }
+}
+
+pub trait StandaloneSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    const CLK_SRC_OFFSET: usize = 0x00;
+    const AES_CFG_OFFSET: usize = 0x04;
+    const ADAT_CFG_OFFSET: usize = 0x08;
+    const WC_CFG_OFFSET: usize = 0x0c;
+    const INTERNAL_CFG_OFFSET: usize = 0x10;
+
+    fn read_standalone_clock_source(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<ClockSource, Error>
+    {
+        let mut quadlet = [0;4];
+        ProtocolExtension::read(self, node, sections.standalone.offset + Self::CLK_SRC_OFFSET,
+                                &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+            .map(|_| ClockSource::from(u32::from_be_bytes(quadlet) as u8))
+    }
+
+    fn write_standalone_clock_source(&self, node: &T, sections: &ExtensionSections, src: ClockSource, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&(u8::from(src) as u32).to_be_bytes());
+        ProtocolExtension::write(self, node, sections.standalone.offset + Self::CLK_SRC_OFFSET,
+                                 &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+
+    fn read_standalone_aes_high_rate(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        let mut quadlet = [0;4];
+        ProtocolExtension::read(self, node, sections.standalone.offset + Self::AES_CFG_OFFSET,
+                                &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+            .map(|_| u32::from_be_bytes(quadlet) > 0)
+    }
+
+    fn write_standalone_aes_high_rate(&self, node: &T, sections: &ExtensionSections, enable: bool, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&(enable as u32).to_be_bytes());
+        ProtocolExtension::write(self, node, sections.standalone.offset + Self::AES_CFG_OFFSET,
+                                 &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+
+    fn read_standalone_adat_mode(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<AdatParam, Error>
+    {
+        let mut quadlet = [0;4];
+        ProtocolExtension::read(self, node, sections.standalone.offset + Self::ADAT_CFG_OFFSET,
+                                &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+            .map(|_| AdatParam::from(quadlet))
+    }
+
+    fn write_standalone_adat_mode(&self, node: &T, sections: &ExtensionSections, param: AdatParam, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        ProtocolExtension::write(self, node, sections.standalone.offset + Self::ADAT_CFG_OFFSET,
+                                 &mut Into::<[u8;4]>::into(param), timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+
+    fn read_standalone_word_clock_param(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<WordClockParam, Error>
+    {
+        let mut quadlet = [0;4];
+        ProtocolExtension::read(self, node, sections.standalone.offset + Self::WC_CFG_OFFSET,
+                                &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+            .map(|_| WordClockParam::from(quadlet))
+    }
+
+    fn write_standalone_word_clock_param(&self, node: &T, sections: &ExtensionSections, param: WordClockParam,
+                                         timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&Into::<[u8;4]>::into(param)[..4]);
+        ProtocolExtension::write(self, node, sections.standalone.offset + Self::WC_CFG_OFFSET,
+                                 &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+
+    fn read_standalone_internal_rate(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<ClockRate, Error>
+    {
+        let mut quadlet = [0;4];
+        ProtocolExtension::read(self, node, sections.standalone.offset + Self::INTERNAL_CFG_OFFSET,
+                                &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+            .map(|_| ClockRate::from(u32::from_be_bytes(quadlet) as u8))
+    }
+
+    fn write_standalone_internal_rate(&self, node: &T, sections: &ExtensionSections, rate: ClockRate, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&(u8::from(rate) as u32).to_be_bytes());
+        ProtocolExtension::write(self, node, sections.standalone.offset + Self::INTERNAL_CFG_OFFSET,
+                                 &mut quadlet, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> StandaloneSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use super::{*, caps_section::*};
+
+pub trait StreamFormatEntryProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_stream_format_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize, timeout_ms: u32)
+        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+    {
+        let mut data = [0;8];
+        ProtocolExtension::read(self, node, offset, &mut data, timeout_ms)?;
+
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[..4]);
+        let tx_count = u32::from_be_bytes(quadlet) as usize;
+        if tx_count > caps.general.max_tx_streams as usize {
+            let msg = format!("Unexpected count of tx streams: {} but {} expected",
+                              tx_count, caps.general.max_tx_streams);
+            Err(Error::new(ProtocolExtensionError::StreamFormatEntry, &msg))?
+        }
+
+        quadlet.copy_from_slice(&data[4..]);
+        let rx_count = u32::from_be_bytes(quadlet) as usize;
+        if rx_count > caps.general.max_rx_streams as usize {
+            let msg = format!("Unexpected count of rx streams: {} but {} expected",
+                              rx_count, caps.general.max_rx_streams);
+            Err(Error::new(ProtocolExtensionError::StreamFormatEntry, &msg))?
+        }
+
+        let mut tx_entries = Vec::new();
+        (0..tx_count).try_for_each(|i| {
+            let mut data = [0;FormatEntry::SIZE];
+            ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * i, &mut data,
+                                    timeout_ms)
+                .map(|_| tx_entries.push(data))
+        })?;
+
+        let mut rx_entries = Vec::new();
+        (0..rx_count).try_for_each(|i| {
+            let mut data = [0;FormatEntry::SIZE];
+            ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * (tx_count + i),
+                                    &mut data, timeout_ms)
+                .map(|_| rx_entries.push(data))
+        })?;
+
+        Ok((tx_entries, rx_entries))
+    }
+
+    fn write_stream_format_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize,
+                                   pair: &(Vec<FormatEntryData>, Vec<FormatEntryData>), timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let (tx, rx) = pair;
+
+        if tx.len() != caps.general.max_tx_streams as usize {
+            let msg = format!("Unexpected count of tx streams: {} but {} expected",
+                              tx.len(), caps.general.max_tx_streams);
+            Err(Error::new(ProtocolExtensionError::StreamFormatEntry, &msg))?
+        }
+
+        if rx.len() != caps.general.max_rx_streams as usize {
+            let msg = format!("Unexpected count of rx streams: {} but {} expected",
+                              rx.len(), caps.general.max_rx_streams);
+            Err(Error::new(ProtocolExtensionError::StreamFormatEntry, &msg))?
+        }
+
+        let mut data = Vec::new();
+        data.extend_from_slice(&(tx.len() as u32).to_be_bytes());
+        data.extend_from_slice(&(rx.len() as u32).to_be_bytes());
+        tx.iter().for_each(|entry| {
+            data.extend_from_slice(entry);
+        });
+        rx.iter().for_each(|entry| {
+            data.extend_from_slice(entry);
+        });
+        ProtocolExtension::write(self, node, offset, &mut data, timeout_ms)
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> StreamFormatEntryProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Stream format section in protocol extension defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for stream format
+//! section in protocol extension defined by TCAT for ASICs of DICE.
+
+use super::{*, caps_section::*, stream_format_entry::*};
+
+pub trait StreamFormatSectionProtocol<T> : ProtocolExtension<T>
+    where T: AsRef<FwNode>,
+{
+    fn read_stream_format_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                                  timeout_ms: u32)
+        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+    {
+        StreamFormatEntryProtocol::read_stream_format_entries(&self, node, caps, sections.stream_format.offset,
+                                                              timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::StreamFormat, &e.to_string()))
+    }
+
+    fn write_stream_format_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
+                                   pair: &(Vec<FormatEntryData>, Vec<FormatEntryData>), timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        StreamFormatEntryProtocol::write_stream_format_entries(&self, node, caps, sections.stream_format.offset,
+                                                               pair, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::StreamFormat, &e.to_string()))
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> StreamFormatSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/global_section.rs
+++ b/libs/dice/protocols/src/tcat/global_section.rs
@@ -1,0 +1,641 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Global section in general protocol defined by TCAT for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for global section
+//! in general protocol defined by TCAT for ASICs of DICE.
+use super::{*, utils::*};
+
+use std::convert::TryFrom;
+
+/// The enumeration for nominal sampling rate.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ClockRate {
+    R32000,
+    R44100,
+    R48000,
+    R88200,
+    R96000,
+    R176400,
+    R192000,
+    AnyLow,
+    AnyMid,
+    AnyHigh,
+    None,
+    Reserved(u8),
+}
+
+impl ClockRate {
+    const R32000_VAL: u8 = 0x00;
+    const R44100_VAL: u8 = 0x01;
+    const R48000_VAL: u8 = 0x02;
+    const R88200_VAL: u8 = 0x03;
+    const R96000_VAL: u8 = 0x04;
+    const R176400_VAL: u8 = 0x05;
+    const R192000_VAL: u8 = 0x06;
+    const ANY_LOW_VAL: u8 = 0x07;
+    const ANY_MID_VAL: u8 = 0x08;
+    const ANY_HIGH_VAL: u8 = 0x09;
+    const NONE_VAL: u8 = 0x0a;
+
+    pub fn is_supported(&self, caps: &ClockCaps) -> bool {
+        caps.rate_bits & (1 << u8::from(*self)) > 0
+    }
+}
+
+impl Default for ClockRate {
+    fn default() -> Self {
+        ClockRate::Reserved(0xff)
+    }
+}
+
+impl From<u8> for ClockRate {
+    fn from(val: u8) -> Self {
+        match val {
+            Self::R32000_VAL => Self::R32000,
+            Self::R44100_VAL => Self::R44100,
+            Self::R48000_VAL => Self::R48000,
+            Self::R88200_VAL => Self::R88200,
+            Self::R96000_VAL => Self::R96000,
+            Self::R176400_VAL => Self::R176400,
+            Self::R192000_VAL => Self::R192000,
+            Self::ANY_LOW_VAL => Self::AnyLow,
+            Self::ANY_MID_VAL => Self::AnyMid,
+            Self::ANY_HIGH_VAL => Self::AnyHigh,
+            Self::NONE_VAL => Self::None,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<ClockRate> for u8 {
+    fn from(rate: ClockRate) -> u8 {
+        match rate {
+            ClockRate::R32000 => ClockRate::R32000_VAL,
+            ClockRate::R44100 => ClockRate::R44100_VAL,
+            ClockRate::R48000 => ClockRate::R48000_VAL,
+            ClockRate::R88200 => ClockRate::R88200_VAL,
+            ClockRate::R96000 => ClockRate::R96000_VAL,
+            ClockRate::R176400 => ClockRate::R176400_VAL,
+            ClockRate::R192000 => ClockRate::R192000_VAL,
+            ClockRate::AnyLow => ClockRate::ANY_LOW_VAL,
+            ClockRate::AnyMid => ClockRate::ANY_MID_VAL,
+            ClockRate::AnyHigh => ClockRate::ANY_HIGH_VAL,
+            ClockRate::None => ClockRate::NONE_VAL,
+            ClockRate::Reserved(val) => val,
+        }
+    }
+}
+
+impl TryFrom<u32> for ClockRate {
+    type Error = Error;
+
+    fn try_from(val: u32) -> Result<ClockRate, Self::Error> {
+        match val {
+            32000 => Ok(Self::R32000),
+            44100 => Ok(Self::R44100),
+            48000 => Ok(Self::R48000),
+            88200 => Ok(Self::R88200),
+            96000 => Ok(Self::R96000),
+            176400 => Ok(Self::R176400),
+            192000 => Ok(Self::R192000),
+            _ => {
+                let msg = format!("Fail to convert from nominal rate: {}", val);
+                Err(Error::new(GeneralProtocolError::Global, &msg))
+            },
+        }
+    }
+}
+
+impl TryFrom<ClockRate> for u32 {
+    type Error = Error;
+
+    fn try_from(rate: ClockRate) -> Result<u32, Self::Error> {
+        match rate {
+            ClockRate::R32000 => Ok(32000),
+            ClockRate::R44100 => Ok(44100),
+            ClockRate::R48000 => Ok(48000),
+            ClockRate::R88200 => Ok(88200),
+            ClockRate::R96000 => Ok(96000),
+            ClockRate::R176400 => Ok(176400),
+            ClockRate::R192000 => Ok(192000),
+            _ => {
+                let msg = format!("Fail to convert to nominal rate: {}", rate);
+                Err(Error::new(GeneralProtocolError::Global, &msg))
+            },
+        }
+    }
+}
+
+impl std::fmt::Display for ClockRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::R32000 => "32000".to_string(),
+            Self::R44100 => "44100".to_string(),
+            Self::R48000 => "48000".to_string(),
+            Self::R88200 => "88200".to_string(),
+            Self::R96000 => "96000".to_string(),
+            Self::R176400 => "176400".to_string(),
+            Self::R192000 => "192000".to_string(),
+            Self::AnyLow => "Any-low".to_string(),
+            Self::AnyMid => "Any-mid".to_string(),
+            Self::AnyHigh => "Any-high".to_string(),
+            Self::None => "None".to_string(),
+            Self::Reserved(val) => format!("Reserved({})", val),
+        };
+        write!(f, "{}", label)
+    }
+}
+
+/// The enumeration for nominal sampling rate.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ClockSource {
+    Aes1,
+    Aes2,
+    Aes3,
+    Aes4,
+    AesAny,
+    Adat,
+    Tdif,
+    WordClock,
+    Arx1,
+    Arx2,
+    Arx3,
+    Arx4,
+    Internal,
+    Reserved(u8),
+}
+
+impl Default for ClockSource {
+    fn default() -> Self {
+        ClockSource::Reserved(0xff)
+    }
+}
+
+impl ClockSource {
+    const AES1_VAL: u8 = 0x00;
+    const AES2_VAL: u8 = 0x01;
+    const AES3_VAL: u8 = 0x02;
+    const AES4_VAL: u8 = 0x03;
+    const AES_ANY_VAL: u8 = 0x04;
+    const ADAT_VAL: u8 = 0x05;
+    const TDIF_VAL: u8 = 0x06;
+    const WORD_CLOCK_VAL: u8 = 0x07;
+    const ARX1_VAL: u8 = 0x08;
+    const ARX2_VAL: u8 = 0x09;
+    const ARX3_VAL: u8 = 0x0a;
+    const ARX4_VAL: u8 = 0x0b;
+    const INTERNAL_VAL: u8 = 0x0c;
+
+    pub fn is_supported(&self, caps: &ClockCaps, labels: &ClockSourceLabels) -> bool {
+        let idx = u8::from(*self) as usize;
+        (caps.src_bits & (1u16 << idx) > 0) &&
+            labels.entries.iter().nth(idx).filter(|&l| l != "Unused" && l != "unused").is_some()
+    }
+
+    pub fn get_label<'a>(&self, labels: &'a ClockSourceLabels, is_ext: bool) -> Option<&'a str> {
+        if is_ext && *self == ClockSource::Arx1 {
+            Some("Stream")
+        } else {
+            let idx = u8::from(*self) as usize;
+            labels.entries.iter()
+                .nth(idx)
+                .map(|l| l.as_str())
+        }
+    }
+
+    fn parse(src: ClockSource, flags: u16) -> bool {
+        ExtSourceStates::SRCS.iter()
+            .enumerate()
+            .find(|&(_, &s)| s == src)
+            .map(|(i, _)| flags & (1 << i) > 0)
+            .unwrap_or(false)
+    }
+
+    pub fn is_locked(&self, states: &ExtSourceStates) -> bool {
+        Self::parse(*self, states.locked_bits)
+    }
+
+    pub fn is_slipped(&self, states: &ExtSourceStates) -> bool {
+        Self::parse(*self, states.slipped_bits)
+    }
+}
+
+impl From<u8> for ClockSource {
+    fn from(val: u8) -> Self {
+        match val {
+            Self::AES1_VAL => Self::Aes1,
+            Self::AES2_VAL => Self::Aes2,
+            Self::AES3_VAL => Self::Aes3,
+            Self::AES4_VAL => Self::Aes4,
+            Self::AES_ANY_VAL => Self::AesAny,
+            Self::ADAT_VAL => Self::Adat,
+            Self::TDIF_VAL => Self::Tdif,
+            Self::WORD_CLOCK_VAL => Self::WordClock,
+            Self::ARX1_VAL => Self::Arx1,
+            Self::ARX2_VAL => Self::Arx2,
+            Self::ARX3_VAL => Self::Arx3,
+            Self::ARX4_VAL => Self::Arx4,
+            Self::INTERNAL_VAL => Self::Internal,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<ClockSource> for u8 {
+    fn from(src: ClockSource) -> u8 {
+        match src {
+            ClockSource::Aes1 => ClockSource::AES1_VAL,
+            ClockSource::Aes2 => ClockSource::AES2_VAL,
+            ClockSource::Aes3 => ClockSource::AES3_VAL,
+            ClockSource::Aes4 => ClockSource::AES4_VAL,
+            ClockSource::AesAny => ClockSource::AES_ANY_VAL,
+            ClockSource::Adat => ClockSource::ADAT_VAL,
+            ClockSource::Tdif => ClockSource::TDIF_VAL,
+            ClockSource::WordClock => ClockSource::WORD_CLOCK_VAL,
+            ClockSource::Arx1 => ClockSource::ARX1_VAL,
+            ClockSource::Arx2 => ClockSource::ARX2_VAL,
+            ClockSource::Arx3 => ClockSource::ARX3_VAL,
+            ClockSource::Arx4 => ClockSource::ARX4_VAL,
+            ClockSource::Internal => ClockSource::INTERNAL_VAL,
+            ClockSource::Reserved(val) => val,
+        }
+    }
+}
+
+impl std::fmt::Display for ClockSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let label = match self {
+            Self::Aes1 => "AES1".to_string(),
+            Self::Aes2 => "AES2".to_string(),
+            Self::Aes3 => "AES3".to_string(),
+            Self::Aes4 => "AES4".to_string(),
+            Self::AesAny => "AES-ANY".to_string(),
+            Self::Adat => "ADAT".to_string(),
+            Self::Tdif => "TDIF".to_string(),
+            Self::WordClock => "Word-Clock".to_string(),
+            Self::Arx1 => "ARX1".to_string(),
+            Self::Arx2 => "ARX2".to_string(),
+            Self::Arx3 => "ARX3".to_string(),
+            Self::Arx4 => "ARX4".to_string(),
+            Self::Internal=> "Internal".to_string(),
+            Self::Reserved(val) => format!("Reserved({})", val),
+        };
+        write!(f, "{}", label)
+    }
+}
+
+/// The structure to represent configuration of clock.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct ClockConfig{
+    pub rate: ClockRate,
+    pub src: ClockSource,
+}
+
+impl ClockConfig {
+    const SRC_MASK: u32 = 0x000000ff;
+    const SRC_SHIFT: usize = 0;
+    const RATE_MASK: u32 = 0x0000ff00;
+    const RATE_SHIFT: usize = 8;
+}
+
+impl From<u32> for ClockConfig {
+    fn from(val: u32) -> Self {
+        let src_val = ((val & Self::SRC_MASK) >> Self::SRC_SHIFT) as u8;
+        let rate_val = ((val & Self::RATE_MASK) >> Self::RATE_SHIFT) as u8;
+        let src = ClockSource::from(src_val);
+        let rate = ClockRate::from(rate_val);
+        ClockConfig{rate, src}
+    }
+}
+
+impl From<ClockConfig> for u32 {
+    fn from(cfg: ClockConfig) -> u32 {
+        let src_val = u8::from(cfg.src) as u32;
+        let rate_val = u8::from(cfg.rate) as u32;
+        ((rate_val << ClockConfig::RATE_SHIFT) & ClockConfig::RATE_MASK)
+            | ((src_val << ClockConfig::SRC_SHIFT) & ClockConfig::SRC_MASK)
+    }
+}
+
+/// The structure to represent status of sampling clock.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct ClockStatus{
+    pub src_is_locked: bool,
+    pub rate: ClockRate,
+}
+
+impl ClockStatus {
+    const SRC_LOCKED: u32 = 0x00000001;
+    const RATE_MASK: u32 = 0x0000ff00;
+    const RATE_SHIFT: usize = 8;
+}
+
+impl From<u32> for ClockStatus {
+    fn from(val: u32) -> Self {
+        let src_is_locked = (val & Self::SRC_LOCKED) > 0;
+        let rate_val = ((val & Self::RATE_MASK) >> Self::RATE_SHIFT) as u8;
+        let rate = ClockRate::from(rate_val);
+        ClockStatus{src_is_locked, rate}
+    }
+}
+
+/// The structure to represent states of available clock source.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct ExtSourceStates{
+    locked_bits: u16,
+    slipped_bits: u16,
+}
+
+impl ExtSourceStates {
+    const LOCKED_BITS_MASK: u32 = 0x0000ffff;
+    const LOCKED_BITS_SHIFT: usize = 0;
+    const SLIPPED_BITS_MASK: u32 = 0xffff0000;
+    const SLIPPED_BITS_SHIFT: usize = 16;
+
+    const SRCS: [ClockSource;11] = [
+        ClockSource::Aes1,
+        ClockSource::Aes2,
+        ClockSource::Aes3,
+        ClockSource::Aes4,
+        ClockSource::Adat,
+        ClockSource::Tdif,
+        ClockSource::Arx1,
+        ClockSource::Arx2,
+        ClockSource::Arx3,
+        ClockSource::Arx4,
+        ClockSource::WordClock,
+    ];
+
+    pub fn get_entries(caps: &ClockCaps, labels: &ClockSourceLabels) -> Vec<ClockSource> {
+        Self::SRCS.iter()
+            .filter(|&s| s.is_supported(caps, labels) || *s == ClockSource::Arx1)
+            .copied()
+            .collect()
+    }
+}
+
+impl From<u32> for ExtSourceStates {
+    fn from(val: u32) -> Self {
+        let locked_bits = ((val & Self::LOCKED_BITS_MASK) >> Self::LOCKED_BITS_SHIFT) as u16;
+        let slipped_bits = ((val & Self::SLIPPED_BITS_MASK) >> Self::SLIPPED_BITS_SHIFT) as u16;
+        ExtSourceStates{locked_bits, slipped_bits}
+    }
+}
+
+/// The structure to represent capabilities of clock configurations.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct ClockCaps{
+    pub rate_bits: u16,
+    pub src_bits: u16,
+}
+
+impl ClockCaps {
+    const RATE_MASK: u32 = 0x0000ffff;
+    const RATE_SHIFT: usize = 0;
+    const SRC_MASK: u32 = 0xffff0000;
+    const SRC_SHIFT: usize = 16;
+
+    const RATES: [ClockRate;11] = [
+        ClockRate::R32000,
+        ClockRate::R44100,
+        ClockRate::R48000,
+        ClockRate::R88200,
+        ClockRate::R96000,
+        ClockRate::R176400,
+        ClockRate::R192000,
+        ClockRate::AnyLow,
+        ClockRate::AnyMid,
+        ClockRate::AnyHigh,
+        ClockRate::None,
+    ];
+
+    const SRCS: [ClockSource;13] = [
+        ClockSource::Aes1,
+        ClockSource::Aes2,
+        ClockSource::Aes3,
+        ClockSource::Aes4,
+        ClockSource::AesAny,
+        ClockSource::Adat,
+        ClockSource::Tdif,
+        ClockSource::WordClock,
+        ClockSource::Arx1,
+        ClockSource::Arx2,
+        ClockSource::Arx3,
+        ClockSource::Arx4,
+        ClockSource::Internal,
+    ];
+
+    pub fn new(rates: &[ClockRate], srcs: &[ClockSource]) -> Self {
+        let rate_bits = rates.iter()
+            .fold(0, |val, &r| val | (1 << u8::from(r) as u16));
+        let src_bits = srcs.iter()
+            .fold(0, |val, &s| val | (1 << u8::from(s) as u16));
+        ClockCaps{rate_bits, src_bits}
+    }
+
+    pub fn get_rate_entries(&self) -> Vec<ClockRate> {
+        Self::RATES.iter()
+            .filter(|&r| r.is_supported(self))
+            .copied()
+            .collect()
+    }
+
+    pub fn get_src_entries(&self, labels: &ClockSourceLabels) -> Vec<ClockSource> {
+        Self::SRCS.iter()
+            .filter(|s| s.is_supported(self, labels))
+            .copied()
+            .collect()
+    }
+}
+
+impl From<u32> for ClockCaps {
+    fn from(val: u32) -> Self {
+        let rate_bits = ((val & Self::RATE_MASK) >> Self::RATE_SHIFT) as u16;
+        let src_bits = ((val & Self::SRC_MASK) >> Self::SRC_SHIFT) as u16;
+        ClockCaps{rate_bits, src_bits}
+    }
+}
+
+/// The structure with labels for source of sampling clock.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct ClockSourceLabels{
+    entries: Vec<String>,
+}
+
+/// The maximum size of nickname in bytes.
+pub const NICKNAME_MAX_SIZE: usize = 64;
+
+/// The trait for global protocol.
+pub trait GlobalSectionProtocol<T> : GeneralProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const OWNER_OFFSET: usize = 0x00;
+    const LATEST_NOTIFICATION_OFFSET: usize = 0x04;
+    const NICKNAME_OFFSET: usize = 0x0c;
+    const CLK_SELECT_OFFSET: usize = 0x4c;
+    const ENABLED_OFFSET: usize = 0x50;
+    const STATUS_OFFSET: usize = 0x54;
+    const CLK_SRC_STATES_OFFSET: usize = 0x58;
+    const CURRENT_RATE_OFFSET: usize = 0x5c;
+    const VERSION_OFFSET: usize = 0x60;
+    const CLK_CAPS_OFFSET: usize = 0x64;
+    const CLK_NAMES_OFFSET: usize = 0x68;
+
+    const CLK_NAMES_MAX_SIZE: usize = 256;
+
+    fn read_owner_addr(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<u64, Error>
+    {
+        let mut data = [0;8];
+        self.read(node, sections.global.offset + Self::OWNER_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| {
+                let mut quadlet = [0;4];
+                quadlet.copy_from_slice(&data[..4]);
+                let mut addr = (u32::from_be_bytes(quadlet) as u64) << 32;
+
+                quadlet.copy_from_slice(&data[4..8]);
+                addr |= u32::from_be_bytes(quadlet) as u64;
+
+                addr
+            })
+    }
+
+    fn read_latest_notification(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::LATEST_NOTIFICATION_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| u32::from_be_bytes(data))
+    }
+
+    fn write_nickname<N>(&self, node: &T, sections: &GeneralSections, name: N, timeout_ms: u32)
+        -> Result<(), Error>
+        where N: AsRef<str>
+    {
+        let mut data = build_label(name, NICKNAME_MAX_SIZE);
+        self.write(node, sections.global.offset + Self::NICKNAME_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+    }
+
+    fn read_nickname(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<String, Error>
+    {
+        let mut data = vec![0;NICKNAME_MAX_SIZE];
+        self.read(node, sections.global.offset + Self::NICKNAME_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .and_then(|_| {
+                parse_label(&data[..])
+                    .map_err(|e| {
+                        let msg = format!("Fail to parse data for string: {}", e);
+                        Error::new(GeneralProtocolError::Global, &msg)
+                    })
+            })
+    }
+
+    fn write_clock_config(&self, node: &T, sections: &GeneralSections, config: ClockConfig,
+                          timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        let val = u32::from(config);
+        data.copy_from_slice(&val.to_be_bytes());
+        self.write(node, sections.global.offset + Self::CLK_SELECT_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+    }
+
+    fn read_clock_config(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<ClockConfig, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::CLK_SELECT_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| ClockConfig::from(u32::from_be_bytes(data)))
+    }
+
+    fn read_enabled(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::ENABLED_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| u32::from_be_bytes(data) > 0)
+    }
+
+    fn read_clock_status(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<ClockStatus, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::STATUS_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| ClockStatus::from(u32::from_be_bytes(data)))
+    }
+
+    fn read_clock_source_states(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<ExtSourceStates, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::CLK_SRC_STATES_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| ExtSourceStates::from(u32::from_be_bytes(data)))
+    }
+
+    fn read_current_rate(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::CURRENT_RATE_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| u32::from_be_bytes(data))
+    }
+
+    fn read_version(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        let mut data = [0;4];
+        self.read(node, sections.global.offset + Self::VERSION_OFFSET, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+            .map(|_| u32::from_be_bytes(data))
+    }
+
+    fn read_clock_caps(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<ClockCaps, Error>
+    {
+        if sections.global.size > Self::CLK_CAPS_OFFSET {
+            let mut data = [0;4];
+            self.read(node, sections.global.offset + Self::CLK_CAPS_OFFSET, &mut data, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+                .map(|_| ClockCaps::from(u32::from_be_bytes(data)))
+        } else {
+            let caps = ClockCaps::new(&[ClockRate::R44100, ClockRate::R48000], &[ClockSource::Internal]);
+            Ok(caps)
+        }
+    }
+
+    fn read_clock_source_labels(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<ClockSourceLabels, Error>
+    {
+        if sections.global.size > Self::CLK_NAMES_MAX_SIZE {
+            let mut data = vec![0;Self::CLK_NAMES_MAX_SIZE];
+            self.read(node, sections.global.offset + Self::CLK_NAMES_OFFSET, &mut data, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::Global, &e.to_string()))
+                .and_then(|_| {
+                    parse_labels(&data[..])
+                        .map_err(|e| {
+                            let msg = format!("Fail to parse data for strings: {}", e);
+                            Error::new(GeneralProtocolError::Global, &msg)
+                        })
+                        .map(|entries| ClockSourceLabels{entries})
+                })
+        } else {
+            let mut entries = vec!["".to_string();12];
+            entries.push("Internal".to_string());
+            Ok(ClockSourceLabels{entries})
+        }
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> GlobalSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Rx Stream format section in general protocol for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for Rx stream
+//! format section in general protocol defined by TCAT for ASICs of DICE.
+use super::{*, utils::*};
+
+use std::convert::TryFrom;
+
+/// The structure to represent an entry for stream format in stream received by the node.
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
+pub struct RxStreamEntry {
+    pub iso_channel: i8,
+    pub start: u32,
+    pub pcm: u32,
+    pub midi: u32,
+    pub labels: Vec<String>,
+    pub iec60958: [Iec60958Param;IEC60958_CHANNELS],
+}
+
+impl TryFrom<&[u8]> for RxStreamEntry {
+    type Error = Error;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&raw[..4]);
+        let iso_channel = i32::from_be_bytes(quadlet) as i8;
+
+        quadlet.copy_from_slice(&raw[4..8]);
+        let start = u32::from_be_bytes(quadlet);
+
+        quadlet.copy_from_slice(&raw[8..12]);
+        let pcm = u32::from_be_bytes(quadlet);
+
+        quadlet.copy_from_slice(&raw[12..16]);
+        let midi = u32::from_be_bytes(quadlet);
+
+        let labels = parse_labels(&raw[16..272])
+            .map_err(|e| {
+                let msg = format!("Invalid data for string: {}", e);
+                Error::new(GeneralProtocolError::RxStreamFormat, &msg)
+            })?;
+
+        let iec60958 = if raw.len() > 272 {
+            parse_iec60958_params(&raw[272..280])
+        } else {
+            // NOTE: it's not supported by old version of firmware.
+            [Iec60958Param::default();IEC60958_CHANNELS]
+        };
+
+        let entry = RxStreamEntry{
+            iso_channel,
+            start,
+            pcm,
+            midi,
+            labels,
+            iec60958,
+        };
+
+        Ok(entry)
+    }
+}
+
+impl From<&RxStreamEntry> for Vec<u8> {
+    fn from(entry: &RxStreamEntry) -> Self {
+        let mut raw = Vec::new();
+
+        let val = entry.iso_channel as i32;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        let mut val = entry.start;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        val = entry.pcm;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        val = entry.midi;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        raw.append(&mut build_labels(&entry.labels, STREAM_NAMES_SIZE));
+
+        raw.append(&mut build_iec60958_params(&entry.iec60958));
+
+        raw
+    }
+}
+
+pub trait RxStreamFormatSectionProtocol<T> : GeneralProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const SIZE_OFFSET: usize = 0x04;
+
+    fn read_rx_stream_format_entries(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<Vec<RxStreamEntry>, Error>
+    {
+        let mut data = [0;8];
+        self.read(node, sections.rx_stream_format.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[0..4]);
+        let count = u32::from_be_bytes(quadlet) as usize;
+
+        quadlet.copy_from_slice(&data[4..8]);
+        let size = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        let mut entries = Vec::new();
+        let mut data = vec![0;size];
+        (0..count).try_for_each(|i| {
+            self.read(node, sections.rx_stream_format.offset + 8 + (i * size), &mut data, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+            let entry = RxStreamEntry::try_from(&data[..])
+                .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+            entries.push(entry);
+            Ok(())
+        })?;
+        Ok(entries)
+    }
+
+    fn write_rx_stream_format_entries(&self, node: &T, sections: &GeneralSections, entries: &[RxStreamEntry],
+                                      timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;8];
+        self.read(node, sections.rx_stream_format.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[..4]);
+        let count = std::cmp::min(u32::from_be_bytes(quadlet) as usize, entries.len());
+
+        quadlet.copy_from_slice(&data[4..8]);
+        let size = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        (0..count).try_for_each(|i| {
+            let mut expected_fmt = entries[i].clone();
+
+            let mut curr = vec![0;size];
+            self.read(node, sections.rx_stream_format.offset + 8 + (i * size), &mut curr, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+            let curr_fmt = RxStreamEntry::try_from(&curr[..])
+                .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+            expected_fmt.iso_channel = curr_fmt.iso_channel;
+
+            if expected_fmt != curr_fmt {
+                let mut raw = Into::<Vec<u8>>::into(&expected_fmt);
+                self.write(node, sections.rx_stream_format.offset + 8 + (i * size), &mut raw, timeout_ms)
+                    .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
+            }
+
+            Ok(())
+        })?;
+
+        Ok(())
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> RxStreamFormatSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/tx_stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/tx_stream_format_section.rs
@@ -1,0 +1,159 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Tx Stream format section in general protocol for ASICs of DICE.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for Tx stream
+//! format section in general protocol defined by TCAT for ASICs of DICE.
+use super::{*, utils::*};
+
+use std::convert::TryFrom;
+
+/// The structure to represent an entry for stream format in stream transmitted by the node.
+#[derive(Default, Clone, Debug, Eq, PartialEq)]
+pub struct TxStreamFormatEntry{
+    pub iso_channel: i8,
+    pub pcm: u32,
+    pub midi: u32,
+    pub speed: u32,
+    pub labels: Vec<String>,
+    pub iec60958: [Iec60958Param;IEC60958_CHANNELS],
+}
+
+impl TryFrom<&[u8]> for TxStreamFormatEntry {
+    type Error = Error;
+
+    fn try_from(raw: &[u8]) -> Result<Self, Self::Error> {
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&raw[..4]);
+        let iso_channel = i32::from_be_bytes(quadlet) as i8;
+
+        quadlet.copy_from_slice(&raw[4..8]);
+        let pcm = u32::from_be_bytes(quadlet);
+
+        quadlet.copy_from_slice(&raw[8..12]);
+        let midi = u32::from_be_bytes(quadlet);
+
+        quadlet.copy_from_slice(&raw[12..16]);
+        let speed = u32::from_be_bytes(quadlet);
+
+        let labels = parse_labels(&raw[16..272])
+            .map_err(|e| {
+                let msg = format!("Invalid data for string: {}", e);
+                Error::new(GeneralProtocolError::TxStreamFormat, &msg)
+            })?;
+
+        let iec60958 = if raw.len() > 272 {
+            parse_iec60958_params(&raw[272..280])
+        } else {
+            // NOTE: it's not supported by old version of firmware.
+            [Iec60958Param::default();IEC60958_CHANNELS]
+        };
+
+        let entry = TxStreamFormatEntry{
+            iso_channel,
+            pcm,
+            midi,
+            speed,
+            labels,
+            iec60958,
+        };
+
+        Ok(entry)
+    }
+}
+
+impl From<&TxStreamFormatEntry> for Vec<u8>
+{
+    fn from(entry: &TxStreamFormatEntry) -> Self {
+        let mut raw = Vec::new();
+
+        let val = entry.iso_channel as i32;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        let mut val = entry.pcm;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        val = entry.midi;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        val = entry.speed;
+        raw.extend_from_slice(&val.to_be_bytes());
+
+        raw.append(&mut build_labels(&entry.labels, STREAM_NAMES_SIZE));
+
+        raw.append(&mut build_iec60958_params(&entry.iec60958));
+
+        raw
+    }
+}
+
+pub trait TxStreamFormatSectionProtocol<T> : GeneralProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const SIZE_OFFSET: usize = 0x04;
+
+    fn read_tx_stream_format_entries(&self, node: &T, sections: &GeneralSections, timeout_ms: u32)
+        -> Result<Vec<TxStreamFormatEntry>, Error>
+    {
+        let mut data = [0;8];
+        self.read(node, sections.tx_stream_format.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[..4]);
+        let count = u32::from_be_bytes(quadlet) as usize;
+
+        quadlet.copy_from_slice(&data[4..8]);
+        let size = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        let mut entries = Vec::new();
+        let mut data = vec![0;size];
+        (0..count).try_for_each(|i| {
+            self.read(node, sections.tx_stream_format.offset + 8 + (i * size), &mut data, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+            let entry = TxStreamFormatEntry::try_from(&data[..])
+                .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+            entries.push(entry);
+            Ok(())
+        })
+        .map(|_| entries)
+    }
+
+    fn write_tx_stream_format_entries(&self, node: &T, sections: &GeneralSections,
+                        entries: &[TxStreamFormatEntry], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;8];
+        self.read(node, sections.tx_stream_format.offset, &mut data, timeout_ms)
+            .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+
+        let mut quadlet = [0;4];
+        quadlet.copy_from_slice(&data[..4]);
+        let count = std::cmp::min(u32::from_be_bytes(quadlet) as usize, entries.len());
+
+        quadlet.copy_from_slice(&data[4..8]);
+        let size = 4 * u32::from_be_bytes(quadlet) as usize;
+
+        (0..count).try_for_each(|i| {
+            let mut expected_fmt = entries[i].clone();
+
+            let mut curr = vec![0;size];
+            self.read(node, sections.tx_stream_format.offset + 8 + (i * size), &mut curr, timeout_ms)
+                .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+            let curr_fmt = TxStreamFormatEntry::try_from(&curr[..])
+                .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+            expected_fmt.iso_channel = curr_fmt.iso_channel;
+
+            if expected_fmt != curr_fmt {
+                let mut raw = Into::<Vec<u8>>::into(&expected_fmt);
+                self.write(node, sections.tx_stream_format.offset + 8 + (i * size), &mut raw, timeout_ms)
+                    .map_err(|e| Error::new(GeneralProtocolError::TxStreamFormat, &e.to_string()))?;
+            }
+
+            Ok(())
+        })
+    }
+}
+
+impl<O: AsRef<FwReq>, T: AsRef<FwNode>> TxStreamFormatSectionProtocol<T> for O {}

--- a/libs/dice/protocols/src/tcat/utils.rs
+++ b/libs/dice/protocols/src/tcat/utils.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
+use super::Iec60958Param;
 
 trait EndianConvert {
     fn from_ne(&mut self);
@@ -21,7 +22,7 @@ impl EndianConvert for &mut [u8] {
         (0..(self.len() / 4)).for_each(|i| {
             let pos = i * 4;
             quadlet.copy_from_slice(&self[pos..(pos + 4)]);
-            self[pos..(pos + 4)].copy_from_slice(&u32::from_be_bytes(quadlet).to_be_bytes());
+            self[pos..(pos + 4)].copy_from_slice(&u32::from_be_bytes(quadlet).to_ne_bytes());
         });
     }
 }
@@ -31,6 +32,19 @@ pub fn build_label<T: AsRef<str>>(name: T, len: usize) -> Vec<u8>
     let mut raw = name.as_ref().as_bytes().to_vec();
     raw.resize(len, 0x00);
     raw.as_mut_slice().from_ne();
+    raw
+}
+
+pub fn build_labels<T: AsRef<str>>(labels: &[T], len: usize) -> Vec<u8> {
+    let mut raw = Vec::with_capacity(len);
+    labels.iter().for_each(|label| {
+        raw.extend_from_slice(&label.as_ref().as_bytes());
+        raw.push('\\' as u8);
+    });
+    raw.push('\\' as u8);
+    raw.resize(len, 0x00);
+    raw.as_mut_slice().from_ne();
+
     raw
 }
 
@@ -62,4 +76,43 @@ pub fn parse_labels(raw: &[u8]) -> Result<Vec<String>, std::str::Utf8Error> {
                 Vec::new()
             }
         })
+}
+
+pub const STREAM_NAMES_SIZE: usize = 256;
+pub const IEC60958_CHANNELS: usize = 32;
+
+pub fn build_iec60958_params(params: &[Iec60958Param;IEC60958_CHANNELS]) -> Vec<u8> {
+    let (caps, enables) = params.iter().enumerate()
+        .fold((0, 0), |(mut caps, mut enables), (i, params)| {
+            if params.cap {
+                caps |= 1 << i;
+            }
+            if params.enable {
+                enables |= 1 << i;
+            }
+            (caps, enables)
+        });
+
+    let mut raw = Vec::new();
+    raw.extend_from_slice(&u32::to_be_bytes(caps));
+    raw.extend_from_slice(&u32::to_be_bytes(enables));
+    raw
+}
+
+pub fn parse_iec60958_params(raw: &[u8]) -> [Iec60958Param;IEC60958_CHANNELS] {
+    let mut quadlet = [0;4];
+
+    quadlet.copy_from_slice(&raw[..4]);
+    let caps = u32::from_be_bytes(quadlet);
+
+    quadlet.copy_from_slice(&raw[4..8]);
+    let enables = u32::from_be_bytes(quadlet);
+
+    let mut params = [Iec60958Param::default();IEC60958_CHANNELS];
+    params.iter_mut().enumerate().for_each(|(i, mut param)| {
+        param.cap = (1 << i) & caps > 0;
+        param.enable = (1 << i) & enables > 0;
+    });
+
+    params
 }

--- a/libs/dice/protocols/src/tcat/utils.rs
+++ b/libs/dice/protocols/src/tcat/utils.rs
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+trait EndianConvert {
+    fn from_ne(&mut self);
+    fn to_ne(&mut self);
+}
+
+impl EndianConvert for &mut [u8] {
+    fn from_ne(&mut self) {
+        let mut quadlet = [0;4];
+        (0..(self.len() / 4)).for_each(|i| {
+            let pos = i * 4;
+            quadlet.copy_from_slice(&self[pos..(pos + 4)]);
+            self[pos..(pos + 4)].copy_from_slice(&u32::from_ne_bytes(quadlet).to_be_bytes());
+        });
+    }
+
+    fn to_ne(&mut self) {
+        let mut quadlet = [0;4];
+        (0..(self.len() / 4)).for_each(|i| {
+            let pos = i * 4;
+            quadlet.copy_from_slice(&self[pos..(pos + 4)]);
+            self[pos..(pos + 4)].copy_from_slice(&u32::from_be_bytes(quadlet).to_be_bytes());
+        });
+    }
+}
+
+pub fn build_label<T: AsRef<str>>(name: T, len: usize) -> Vec<u8>
+{
+    let mut raw = name.as_ref().as_bytes().to_vec();
+    raw.resize(len, 0x00);
+    raw.as_mut_slice().from_ne();
+    raw
+}
+
+pub fn parse_label(raw: &[u8]) -> Result<String, std::str::Utf8Error> {
+    let mut raw = raw.to_vec();
+    raw.as_mut_slice().to_ne();
+
+    raw.push(0x00);
+    std::str::from_utf8(&raw)
+        .map(|text| {
+            if let Some(pos) = text.find('\0') {
+                text[..pos].to_string()
+            } else {
+                String::new()
+            }
+        })
+}
+
+pub fn parse_labels(raw: &[u8]) -> Result<Vec<String>, std::str::Utf8Error> {
+    let mut raw = raw.to_vec();
+    raw.as_mut_slice().to_ne();
+
+    raw.push(0x00);
+    std::str::from_utf8(&raw)
+        .map(|text| {
+            if let Some(pos) = text.find("\\\\") {
+                text[..pos].split("\\").map(|l| l.to_string()).collect()
+            } else {
+                Vec::new()
+            }
+        })
+}

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -15,3 +15,5 @@ nix = "0.17"
 core = { path = "../../core" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
+ieee1212-config-rom = { path = "../../ieee1212-config-rom" }
+dice-protocols = { path = "../protocols" }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -15,5 +15,6 @@ nix = "0.17"
 core = { path = "../../core" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
+alsa-ctl-tlv-codec = { path = "../../alsa-ctl-tlv-codec" }
 ieee1212-config-rom = { path = "../../ieee1212-config-rom" }
 dice-protocols = { path = "../protocols" }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -11,4 +11,5 @@ Implementation of service runtime for models based on ASICs of DICE.
 
 [dependencies]
 glib = "0.10"
+nix = "0.17"
 core = { path = "../../core" }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -13,3 +13,4 @@ Implementation of service runtime for models based on ASICs of DICE.
 glib = "0.10"
 nix = "0.17"
 core = { path = "../../core" }
+hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -13,4 +13,5 @@ Implementation of service runtime for models based on ASICs of DICE.
 glib = "0.10"
 nix = "0.17"
 core = { path = "../../core" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dice-runtime"
+version = "0.1.0"
+authors = ["Takashi Sakamoto <o-takashi@sakamocchi.jp>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+publish = false
+description = """
+Implementation of service runtime for models based on ASICs of DICE.
+"""

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -8,3 +8,7 @@ publish = false
 description = """
 Implementation of service runtime for models based on ASICs of DICE.
 """
+
+[dependencies]
+glib = "0.10"
+core = { path = "../../core" }

--- a/libs/dice/runtime/src/common_ctl.rs
+++ b/libs/dice/runtime/src/common_ctl.rs
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use alsactl::{ElemId, ElemIfaceType};
+use alsactl::{ElemValue, ElemValueExt, ElemValueExtManual};
+
+use hinawa::{SndDice, SndUnitExt};
+use hinawa::FwReq;
+
+use core::card_cntr::*;
+use core::elem_value_accessor::ElemValueAccessor;
+
+use dice_protocols::tcat::{*, global_section::*};
+
+#[derive(Default)]
+pub struct CommonCtl {
+    rates: Vec<ClockRate>,
+    srcs: Vec<ClockSource>,
+    curr_rate_idx: u32,
+    curr_src_idx: u32,
+}
+
+const CLK_RATE_NAME: & str = "clock-rate";
+const CLK_SRC_NAME: &str = "clock-source";
+const NICKNAME: &str = "nickname";
+
+impl CommonCtl {
+    pub fn load(&mut self, card_cntr: &mut CardCntr, caps: &ClockCaps, src_labels: &ClockSourceLabels)
+        -> Result<(), Error>
+    {
+        self.rates = caps.get_rate_entries();
+        self.srcs = caps.get_src_entries(src_labels);
+
+        let labels = self.rates.iter()
+            .map(|r| r.to_string())
+            .collect::<Vec<_>>();
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, CLK_RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels = self.srcs.iter()
+            .map(|s| s.get_label(&src_labels, false).unwrap())
+            .collect::<Vec<_>>();
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, CLK_SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, NICKNAME, 0);
+        let _ = card_cntr.add_bytes_elems(&elem_id, 1, NICKNAME_MAX_SIZE, None, true)?;
+
+        Ok(())
+    }
+
+    fn cache_clock_config(&mut self, config: &ClockConfig)
+        -> Result<(), Error>
+    {
+        self.rates.iter().position(|&r| r == config.rate)
+            .ok_or_else(|| {
+                let msg = format!("Unexpected value read for clock rate: {}", config.rate);
+                Error::new(FileError::Io, &msg)
+            })
+            .map(|pos| self.curr_rate_idx = pos as u32)?;
+        self.srcs.iter().position(|&s| s == config.src)
+            .ok_or_else(|| {
+                let msg = format!("Unexpected value read for clock source: {}", config.src);
+                Error::new(FileError::Io, &msg)
+            })
+            .map(|pos| self.curr_src_idx = pos as u32)
+    }
+
+    pub fn read(&mut self, unit: &SndDice, proto: &FwReq, sections: &GeneralSections,
+                elem_id: &ElemId, elem_value: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                let config = proto.read_clock_config(&unit.get_node(), sections, timeout_ms)?;
+                self.cache_clock_config(&config)?;
+                ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.curr_rate_idx))
+                .map(|_| true)
+            }
+            CLK_SRC_NAME => {
+                let config = proto.read_clock_config(&unit.get_node(), sections, timeout_ms)?;
+                self.cache_clock_config(&config)?;
+                ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.curr_src_idx))
+                .map(|_| true)
+            }
+            NICKNAME => {
+                proto.read_nickname(&unit.get_node(), sections, timeout_ms)
+                    .map(|name| {
+                        let mut vals = vec![0;NICKNAME_MAX_SIZE];
+                        let raw = name.as_bytes();
+                        vals[..raw.len()].copy_from_slice(&raw);
+                        elem_value.set_bytes(&vals);
+                        true
+                    })
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn update_clock_config(&mut self, config: &mut ClockConfig, rate: Option<u32>, src: Option<u32>)
+        -> Result<(), Error>
+    {
+        if let Some(pos) = rate {
+            self.rates.iter()
+                .nth(pos as usize)
+                .ok_or_else(|| {
+                    let msg = format!("Invalid value for index of rate: {} greater than {}",
+                                      pos, self.rates.len());
+                    Error::new(FileError::Inval, &msg)
+                })
+                .map(|&r| config.rate = r)?;
+        }
+        if let Some(pos) = src {
+            self.srcs.iter()
+                .nth(pos as usize)
+                .ok_or_else(|| {
+                    let msg = format!("Invalid value for index of source: {} greater than {}",
+                                      pos, self.srcs.len());
+                    Error::new(FileError::Inval, &msg)
+                })
+                .map(|&s| config.src = s)?;
+        }
+        Ok(())
+    }
+
+    pub fn write(&mut self, unit: &SndDice, proto: &FwReq, sections: &GeneralSections,
+                 elem_id: &ElemId, _: &ElemValue, new: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            CLK_RATE_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.read_clock_config(&unit.get_node(), sections, timeout_ms)
+                        .and_then(|mut config| {
+                            self.update_clock_config(&mut config, Some(val as u32), None)?;
+                            proto.write_clock_config(&unit.get_node(), sections, config,
+                                                     timeout_ms)?;
+                            self.curr_rate_idx = val;
+                            Ok(())
+                        });
+                    let _ = unit.unlock();
+                    res
+                })
+                .map(|_| true)
+            }
+            CLK_SRC_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.read_clock_config(&unit.get_node(), sections, timeout_ms)
+                        .and_then(|mut config| {
+                            self.update_clock_config(&mut config, None, Some(val as u32))?;
+                            proto.write_clock_config(&unit.get_node(), sections, config,
+                                                     timeout_ms)?;
+                            self.curr_src_idx = val;
+                            Ok(())
+                        });
+                    let _ = unit.unlock();
+                    res
+                })
+                .map(|_| true)
+            }
+            NICKNAME => {
+                let mut vals = vec![0;NICKNAME_MAX_SIZE];
+                new.get_bytes(&mut vals);
+                std::str::from_utf8(&vals)
+                    .map_err(|e| {
+                        let msg = format!("Invalid bytes for string: {}", e);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .and_then(|text| {
+                        text.find('\0')
+                            .ok_or(Error::new(FileError::Inval, "Unterminated string found"))
+                            .and_then(|pos| {
+                                proto.write_nickname(&unit.get_node(), sections, &text[..pos], timeout_ms)
+                            })
+                    })
+                    .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -78,16 +78,25 @@ impl NotifyModel<SndDice, u32> for ExtensionModel {
 impl MeasureModel<hinawa::SndDice> for ExtensionModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
-        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
     }
 
     fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.measure_elem(elem_id, elem_value)
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -10,8 +10,10 @@ use hinawa::{SndDice, SndUnitExt};
 use core::card_cntr::*;
 
 use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
 
 use super::common_ctl::*;
+use super::tcd22xx_spec::*;
 
 #[derive(Default)]
 pub struct ExtensionModel{
@@ -74,5 +76,53 @@ impl MeasureModel<hinawa::SndDice> for ExtensionModel {
         -> Result<bool, Error>
     {
         self.ctl.measure_elem(elem_id, elem_value)
+    }
+}
+
+#[derive(Default, Debug)]
+struct ExtensionState(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for  ExtensionState {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 16, label: None},
+        Input{id: SrcBlkId::Ins1, offset: 0, count: 16, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 2, count: 2, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 4, count: 2, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 6, count: 2, label: None},
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 16, label: None},
+        Output{id: DstBlkId::Ins1, offset: 0, count: 16, label: None},
+        Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
+        Output{id: DstBlkId::Aes,  offset: 2, count: 2, label: None},
+        Output{id: DstBlkId::Aes,  offset: 4, count: 2, label: None},
+        Output{id: DstBlkId::Aes,  offset: 6, count: 2, label: None},
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Adat, offset: 8, count: 8, label: None},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 3},
+    ];
+}
+
+impl AsRef<Tcd22xxState> for ExtensionState {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}
+
+impl AsMut<Tcd22xxState> for ExtensionState {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
     }
 }

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+
+use super::common_ctl::*;
+
+#[derive(Default)]
+pub struct ExtensionModel{
+    proto: FwReq,
+    sections: GeneralSections,
+    ctl: CommonCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for ExtensionModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+    }
+}
+
+impl NotifyModel<SndDice, u32> for ExtensionModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read_notified_elem(elem_id, elem_value)
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for ExtensionModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.measure_elem(elem_id, elem_value)
+    }
+}

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -1,2 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use core::RuntimeOperation;
+
+pub struct DiceRuntime;
+
+impl RuntimeOperation<u32> for DiceRuntime {
+    fn new(_: u32) -> Result<Self, Error> {
+        Ok(DiceRuntime{})
+    }
+
+    fn listen(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn run(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -10,17 +10,22 @@ use std::sync::mpsc;
 use hinawa::FwNodeExt;
 use hinawa::{SndDice, SndDiceExt, SndUnitExt};
 
+use alsactl::CardExt;
+
 use core::RuntimeOperation;
 use core::dispatcher;
+use core::card_cntr;
 
 enum Event {
     Shutdown,
     Disconnected,
     BusReset(u32),
+    Elem(alsactl::ElemId, alsactl::ElemEventMask),
 }
 
 pub struct DiceRuntime{
     unit: SndDice,
+    card_cntr: card_cntr::CardCntr,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
@@ -32,12 +37,15 @@ impl RuntimeOperation<u32> for DiceRuntime {
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path)?;
 
+        let card_cntr = card_cntr::CardCntr::new();
+        card_cntr.card.open(card_id, 0)?;
+
         // Use uni-directional channel for communication to child threads.
         let (tx, rx) = mpsc::sync_channel(32);
 
         let dispatchers = Vec::new();
 
-        Ok(DiceRuntime{unit, rx, tx, dispatchers})
+        Ok(DiceRuntime{unit, card_cntr, rx, tx, dispatchers})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
@@ -55,6 +63,9 @@ impl RuntimeOperation<u32> for DiceRuntime {
                     Event::Disconnected => break,
                     Event::BusReset(generation) => {
                         println!("IEEE 1394 bus is updated: {}", generation);
+                    }
+                    Event::Elem(_, _) => {
+                        ()
                     }
                 }
             }
@@ -106,6 +117,13 @@ impl<'a> DiceRuntime {
         dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
             let _ = tx.send(Event::Shutdown);
             source::Continue(false)
+        });
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_card(&self.card_cntr.card, |_| {})?;
+        self.card_cntr.card.connect_handle_elem_event(move |_, elem_id, events| {
+            let elem_id: alsactl::ElemId = elem_id.clone();
+            let _ = tx.send(Event::Elem(elem_id, events));
         });
 
         self.dispatchers.push(dispatcher);

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 mod model;
+mod minimal_model;
 
 use glib::Error;
 use glib::source;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod model;
 mod minimal_model;
 mod extension_model;
+mod tcd22xx_spec;
 mod common_ctl;
 
 use glib::Error;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 mod model;
 mod minimal_model;
+mod common_ctl;
 
 use glib::Error;
 use glib::source;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -1,21 +1,86 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
+use glib::source;
+
+use nix::sys::signal;
+
+use std::sync::mpsc;
 
 use core::RuntimeOperation;
+use core::dispatcher;
 
-pub struct DiceRuntime;
+enum Event {
+    Shutdown,
+}
+
+pub struct DiceRuntime{
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
 
 impl RuntimeOperation<u32> for DiceRuntime {
     fn new(_: u32) -> Result<Self, Error> {
-        Ok(DiceRuntime{})
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        let dispatchers = Vec::new();
+
+        Ok(DiceRuntime{rx, tx, dispatchers})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
         Ok(())
     }
 
     fn run(&mut self) -> Result<(), Error> {
+        loop {
+            if let Ok(ev) = self.rx.recv() {
+                match ev {
+                    Event::Shutdown => break,
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for DiceRuntime {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> DiceRuntime {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
         Ok(())
     }
 }

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod model;
 mod minimal_model;
 mod extension_model;
+mod pfire_model;
 mod tcd22xx_spec;
 mod common_ctl;
 mod tcd22xx_ctl;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -2,6 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 mod model;
 mod minimal_model;
+mod extension_model;
 mod common_ctl;
 
 use glib::Error;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -5,6 +5,7 @@ mod minimal_model;
 mod extension_model;
 mod tcd22xx_spec;
 mod common_ctl;
+mod tcd22xx_ctl;
 
 use glib::Error;
 use glib::source;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -4,6 +4,7 @@ mod model;
 mod minimal_model;
 mod extension_model;
 mod pfire_model;
+mod mbox3_model;
 mod tcd22xx_spec;
 mod common_ctl;
 mod tcd22xx_ctl;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+
+use super::common_ctl::*;
+use super::tcd22xx_spec::*;
+use super::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct Mbox3Model{
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<Mbox3State>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for Mbox3Model {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for Mbox3Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for Mbox3Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct Mbox3State(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for  Mbox3State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 6, label: None},
+        Input{id: SrcBlkId::Ins1, offset: 0, count: 2, label: Some("Reverb")},
+        Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
+        Output{id: DstBlkId::Ins1, offset: 0, count: 4, label: Some("Headphone")},
+        Output{id: DstBlkId::Ins1, offset: 4, count: 2, label: Some("Reverb")},
+        Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
+        Output{id: DstBlkId::Reserved(0x08), offset: 0, count: 2, label: Some("ControlRoom")},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+    ];
+}
+
+impl AsRef<Tcd22xxState> for Mbox3State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}
+
+impl AsMut<Tcd22xxState> for Mbox3State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
+    }
+}

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -44,3 +44,19 @@ impl CtlModel<SndDice> for MinimalModel {
         self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
     }
 }
+
+impl NotifyModel<SndDice, u32> for MinimalModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read_notified_elem(elem_id, elem_value)
+    }
+}

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -60,3 +60,19 @@ impl NotifyModel<SndDice, u32> for MinimalModel {
         self.ctl.read_notified_elem(elem_id, elem_value)
     }
 }
+
+impl MeasureModel<hinawa::SndDice> for MinimalModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.measure_elem(elem_id, elem_value)
+    }
+}

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::SndDice;
+
+use core::card_cntr::*;
+
+#[derive(Default)]
+pub struct MinimalModel;
+
+impl CtlModel<SndDice> for MinimalModel {
+    fn load(&mut self, _: &SndDice, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndDice, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &SndDice, _: &ElemId, _: &ElemValue, _: &ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::{Error, FileError};
+
+use hinawa::FwNodeExtManual;
+use hinawa::SndUnitExt;
+use hinawa::SndDice;
+
+use core::card_cntr::*;
+
+use ieee1212_config_rom::*;
+use dice_protocols::tcat::config_rom::*;
+
+use std::convert::TryFrom;
+
+pub struct DiceModel{
+    model: (),
+}
+
+impl DiceModel {
+    pub fn new(unit: &SndDice) -> Result<DiceModel, Error> {
+        let node = unit.get_node();
+        let raw = node.get_config_rom()?;
+        let config_rom = ConfigRom::try_from(&raw[..])
+            .map_err(|e| {
+                let msg = format!("Malformed configuration ROM detected: {}", e);
+                Error::new(FileError::Nxio, &msg)
+            })?;
+        let data = config_rom.get_root_data()
+            .and_then(|root| {
+                config_rom.get_unit_data()
+                    .map(|unit| (root.vendor_id, unit.model_id))
+            })
+            .ok_or_else(|| {
+                Error::new(FileError::Nxio, "Fail to detect information in configuration ROM")
+            })?;
+
+        let model = match data {
+            _ => (),
+        };
+
+        Ok(DiceModel{model})
+    }
+    pub fn load(&mut self, _: &SndDice, _: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+
+    pub fn dispatch_elem_event(&mut self, _: &SndDice, _: &mut CardCntr,
+                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+}

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -54,12 +54,16 @@ impl DiceModel {
         }
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &SndDice, card_cntr: &mut CardCntr,
-                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
+    pub fn dispatch_elem_event(&mut self, _: &SndDice, _: &mut CardCntr,
+                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {
-        match &mut self.model {
-            Model::Minimal(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
-        }
+        Ok(())
+    }
+
+    pub fn dispatch_msg(&mut self, _: &SndDice, _: &mut CardCntr, _: u32)
+        -> Result<(), Error>
+    {
+        Ok(())
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -15,12 +15,14 @@ use std::convert::TryFrom;
 use super::minimal_model::MinimalModel;
 use super::extension_model::ExtensionModel;
 use super::pfire_model::*;
+use super::mbox3_model::*;
 
 enum Model {
     Minimal(MinimalModel),
     Extension(ExtensionModel),
     MaudioPfire2626(Pfire2626Model),
     MaudioPfire610(Pfire610Model),
+    AvidMbox3(Mbox3Model),
 }
 
 pub struct DiceModel{
@@ -50,6 +52,7 @@ impl DiceModel {
         let model = match data {
             (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
             (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
+            (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
             _ => Model::Minimal(MinimalModel::default()),
         };
 
@@ -78,6 +81,7 @@ impl DiceModel {
             Model::Extension(m) => m.load(unit, card_cntr),
             Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
             Model::MaudioPfire610(m) => m.load(unit, card_cntr),
+            Model::AvidMbox3(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -85,6 +89,7 @@ impl DiceModel {
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::AvidMbox3(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -92,6 +97,7 @@ impl DiceModel {
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::AvidMbox3(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -106,6 +112,7 @@ impl DiceModel {
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::AvidMbox3(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -117,6 +124,7 @@ impl DiceModel {
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::AvidMbox3(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -128,6 +136,7 @@ impl DiceModel {
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::AvidMbox3(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -14,10 +14,12 @@ use std::convert::TryFrom;
 
 use super::minimal_model::MinimalModel;
 use super::extension_model::ExtensionModel;
+use super::pfire_model::*;
 
 enum Model {
     Minimal(MinimalModel),
     Extension(ExtensionModel),
+    MaudioPfire2626(Pfire2626Model),
 }
 
 pub struct DiceModel{
@@ -45,6 +47,7 @@ impl DiceModel {
             })?;
 
         let model = match data {
+            (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
             _ => Model::Minimal(MinimalModel::default()),
         };
 
@@ -71,16 +74,19 @@ impl DiceModel {
         match &mut self.model {
             Model::Minimal(m) => m.load(unit, card_cntr),
             Model::Extension(m) => m.load(unit, card_cntr),
+            Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
             Model::Minimal(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
             Model::Minimal(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -93,6 +99,7 @@ impl DiceModel {
         match &mut self.model {
             Model::Minimal(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -102,6 +109,7 @@ impl DiceModel {
         match &mut self.model {
             Model::Minimal(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -111,6 +119,7 @@ impl DiceModel {
         match &mut self.model {
             Model::Minimal(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -62,6 +62,10 @@ impl DiceModel {
             Model::Minimal(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
+        match &mut self.model {
+            Model::Minimal(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+        }
+
         Ok(())
     }
 
@@ -82,9 +86,11 @@ impl DiceModel {
         }
     }
 
-    pub fn measure_elems(&mut self, _: &hinawa::SndDice, _: &mut CardCntr)
+    pub fn measure_elems(&mut self, unit: &hinawa::SndDice, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.model {
+            Model::Minimal(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+        }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -13,8 +13,14 @@ use dice_protocols::tcat::config_rom::*;
 
 use std::convert::TryFrom;
 
+use super::minimal_model::MinimalModel;
+
+enum Model {
+    Minimal(MinimalModel),
+}
+
 pub struct DiceModel{
-    model: (),
+    model: Model,
 }
 
 impl DiceModel {
@@ -36,21 +42,25 @@ impl DiceModel {
             })?;
 
         let model = match data {
-            _ => (),
+            _ => Model::Minimal(MinimalModel::default()),
         };
 
         Ok(DiceModel{model})
     }
-    pub fn load(&mut self, _: &SndDice, _: &mut CardCntr)
+    pub fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.model {
+            Model::Minimal(m) => m.load(unit, card_cntr),
+        }
     }
 
-    pub fn dispatch_elem_event(&mut self, _: &SndDice, _: &mut CardCntr,
-                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+    pub fn dispatch_elem_event(&mut self, unit: &SndDice, card_cntr: &mut CardCntr,
+                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.model {
+            Model::Minimal(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+        }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -3,8 +3,7 @@
 use glib::{Error, FileError};
 
 use hinawa::FwNodeExtManual;
-use hinawa::SndUnitExt;
-use hinawa::SndDice;
+use hinawa::{SndDice, SndUnitExt};
 
 use core::card_cntr::*;
 

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -20,6 +20,7 @@ enum Model {
     Minimal(MinimalModel),
     Extension(ExtensionModel),
     MaudioPfire2626(Pfire2626Model),
+    MaudioPfire610(Pfire610Model),
 }
 
 pub struct DiceModel{
@@ -48,6 +49,7 @@ impl DiceModel {
 
         let model = match data {
             (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
+            (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
             _ => Model::Minimal(MinimalModel::default()),
         };
 
@@ -75,18 +77,21 @@ impl DiceModel {
             Model::Minimal(m) => m.load(unit, card_cntr),
             Model::Extension(m) => m.load(unit, card_cntr),
             Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
+            Model::MaudioPfire610(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
             Model::Minimal(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
             Model::Minimal(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -100,6 +105,7 @@ impl DiceModel {
             Model::Minimal(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -110,6 +116,7 @@ impl DiceModel {
             Model::Minimal(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -120,6 +127,7 @@ impl DiceModel {
             Model::Minimal(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -21,6 +21,7 @@ enum Model {
 pub struct DiceModel{
     model: Model,
     notified_elem_list: Vec<alsactl::ElemId>,
+    pub measured_elem_list: Vec<alsactl::ElemId>,
 }
 
 impl DiceModel {
@@ -46,8 +47,9 @@ impl DiceModel {
         };
 
         let notified_elem_list = Vec::new();
+        let measured_elem_list = Vec::new();
 
-        Ok(DiceModel{model, notified_elem_list})
+        Ok(DiceModel{model, notified_elem_list, measured_elem_list})
     }
     pub fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr)
         -> Result<(), Error>
@@ -78,5 +80,11 @@ impl DiceModel {
         match &mut self.model {
             Model::Minimal(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
+    }
+
+    pub fn measure_elems(&mut self, _: &hinawa::SndDice, _: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        Ok(())
     }
 }

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+
+use super::common_ctl::*;
+use super::tcd22xx_spec::*;
+use super::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct PfireModel<S>
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a>,
+{
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<S>,
+}
+
+pub type Pfire2626Model = PfireModel<Pfire2626State>;
+
+const TIMEOUT_MS: u32 = 20;
+
+impl<S> CtlModel<SndDice> for PfireModel<S>
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a>,
+{
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a>,
+{
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl<S> MeasureModel<hinawa::SndDice> for PfireModel<S>
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a>,
+{
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Pfire2626State(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for Pfire2626State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: None},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes, offset: 0, count: 2, label: None},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 5},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 6},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 7},
+    ];
+}
+
+impl AsMut<Tcd22xxState> for Pfire2626State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
+    }
+}
+
+impl AsRef<Tcd22xxState> for Pfire2626State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -28,6 +28,7 @@ pub struct PfireModel<S>
 }
 
 pub type Pfire2626Model = PfireModel<Pfire2626State>;
+pub type Pfire610Model = PfireModel<Pfire610State>;
 
 const TIMEOUT_MS: u32 = 20;
 
@@ -170,5 +171,35 @@ impl AsMut<Tcd22xxState> for Pfire2626State {
 impl AsRef<Tcd22xxState> for Pfire2626State {
     fn as_ref(&self) -> &Tcd22xxState {
         &self.0
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Pfire610State(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for Pfire610State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 4, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+    ];
+}
+
+impl AsRef<Tcd22xxState> for Pfire610State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}
+
+impl AsMut<Tcd22xxState> for Pfire610State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
     }
 }

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -2,15 +2,17 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExtManual};
 
 use hinawa::FwReq;
 use hinawa::{SndDice, SndUnitExt};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
 use dice_protocols::tcat::{*, global_section::*};
 use dice_protocols::tcat::extension::*;
+use dice_protocols::maudio::*;
 
 use super::common_ctl::*;
 use super::tcd22xx_spec::*;
@@ -25,6 +27,7 @@ pub struct PfireModel<S>
     extension_sections: ExtensionSections,
     ctl: CommonCtl,
     tcd22xx_ctl: Tcd22xxCtl<S>,
+    specific_ctl: SpecificCtl,
 }
 
 pub type Pfire2626Model = PfireModel<Pfire2626State>;
@@ -46,6 +49,7 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
         self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
         self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
                           TIMEOUT_MS, card_cntr)?;
+        self.specific_ctl.load(unit, &self.proto, &self.extension_sections, TIMEOUT_MS, card_cntr)?;
 
         self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
 
@@ -60,6 +64,8 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
         } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
                                     elem_value, TIMEOUT_MS)? {
             Ok(true)
+        } else if self.specific_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -72,6 +78,9 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
             Ok(true)
         } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
                                      old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.specific_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                          old, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -230,4 +239,61 @@ impl<'a> PfireClkSpec<'a> for Pfire610State {
             ClockSource::Aes1,
             ClockSource::Internal,
     ];
+}
+
+#[derive(Default, Debug)]
+struct SpecificCtl{
+    targets: [bool;KNOB_COUNT],
+}
+
+impl<'a> SpecificCtl {
+    const MASTER_KNOB_NAME: &'a str = "master-knob-target";
+
+    // MEMO: Both models support 'Output{id: DstBlkId::Ins0, count: 8}'.
+    const MASTER_KNOB_TARGET_LABELS: &'a [&'a str] = &[
+        "analog-out-1/2",
+        "analog-out-3/4",
+        "analog-out-5/6",
+        "analog-out-7/8",
+    ];
+
+    fn load(&self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections, timeout_ms: u32,
+            card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let node = unit.get_node();
+        proto.write_knob_assign(&node, sections, &self.targets, timeout_ms)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MASTER_KNOB_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::MASTER_KNOB_TARGET_LABELS.len(), true)?;
+        Ok(())
+    }
+
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MASTER_KNOB_NAME => {
+                elem_value.set_bool(&self.targets);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections,
+             elem_id: &ElemId, old: &ElemValue, new: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::MASTER_KNOB_NAME => {
+                ElemValueAccessor::<bool>::get_vals(new, old, self.targets.len(), |idx, val| {
+                    self.targets[idx] = val;
+                    Ok(())
+                })?;
+                let node = unit.get_node();
+                proto.write_knob_assign(&node, sections, &self.targets, timeout_ms)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
 }

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -2,13 +2,17 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::Error;
 
-use hinawa::FwReq;
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
+
+use hinawa::{FwNode, FwReq};
 use hinawa::{SndDice, SndUnitExt};
 
 use core::card_cntr::*;
 
 use dice_protocols::tcat::{*, global_section::*};
-use dice_protocols::tcat::extension::{*, caps_section::*, cmd_section::*};
+use dice_protocols::tcat::extension::{*, caps_section::*, cmd_section::*, mixer_section::*};
+use dice_protocols::tcat::extension::peak_section::*;
+use dice_protocols::tcat::extension::current_config_section::*;
 
 use super::tcd22xx_spec::{Tcd22xxState, Tcd22xxSpec, Tcd22xxStateOperation};
 
@@ -18,18 +22,21 @@ pub struct Tcd22xxCtl<S>
 {
     state: S,
     caps: ExtensionCaps,
+    meter_ctl: MeterCtl,
 }
 
 impl<S> Tcd22xxCtl<S>
     where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
 {
     pub fn load(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections,
-                _: &ClockCaps, _: &ClockSourceLabels, timeout_ms: u32, _: &mut CardCntr)
+                _: &ClockCaps, _: &ClockSourceLabels, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         let node = unit.get_node();
 
         self.caps = proto.read_caps(&node, sections, timeout_ms)?;
+
+        self.meter_ctl.load(&node, proto, sections, &self.caps, &self.state, timeout_ms, card_cntr)?;
 
         Ok(())
     }
@@ -43,5 +50,139 @@ impl<S> Tcd22xxCtl<S>
         let rate_mode = RateMode::from(config.rate);
 
         self.state.cache(&node, proto, extension_sections, &self.caps, rate_mode, timeout_ms)
+    }
+
+    pub fn get_measured_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.measured_elem_list);
+    }
+
+    pub fn measure_states(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections,
+                          timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        self.meter_ctl.measure_states(&unit.get_node(), proto, sections, &self.caps, timeout_ms)
+    }
+
+    pub fn measure_elem(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        self.meter_ctl.measure_elem(elem_id, elem_value)
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct MeterCtl {
+    // Maximum number block at low rate mode.
+    real_blk_dsts: Vec<u8>,
+    stream_blk_dsts: Vec<u8>,
+    mixer_blk_dsts: Vec<u8>,
+
+    real_meter: Vec<i32>,
+    stream_meter: Vec<i32>,
+    mixer_meter: Vec<i32>,
+
+    out_sat: Vec<bool>,
+
+    measured_elem_list: Vec<alsactl::ElemId>,
+}
+
+impl<'a> MeterCtl {
+    const OUT_METER_NAME: &'a str = "output-source-meter";
+    const STREAM_TX_METER_NAME: &'a str = "stream-source-meter";
+    const MIXER_INPUT_METER_NAME: &'a str = "mixer-source-meter";
+    const INPUT_SATURATION_NAME: &'a str = "mixer-out-saturation";
+
+    const COEF_MIN: i32 = 0;
+    const COEF_MAX: i32 = 0x00000fffi32; // 2:14 Fixed-point.
+    const COEF_STEP: i32 = 1;
+
+    pub fn load<T>(&mut self, node: &FwNode, proto: &FwReq, sections: &ExtensionSections,
+                   caps: &ExtensionCaps, state: &T, timeout_ms: u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+        where for<'b> T: Tcd22xxSpec<'b>,
+    {
+        let (_, real_blk_dsts) = state.compute_avail_real_blk_pair(RateMode::Low);
+        self.real_blk_dsts = real_blk_dsts;
+        let mut elem_id_list = Self::add_an_elem_for_meter(card_cntr, Self::OUT_METER_NAME, &self.real_blk_dsts)?;
+        self.measured_elem_list.append(&mut elem_id_list);
+        self.real_meter = vec![0;self.real_blk_dsts.len()];
+
+        let (tx_entries, rx_entries) =
+            proto.read_current_stream_format_entries(&node, sections, caps, RateMode::Low, timeout_ms)?;
+        let (_, stream_blk_dsts) = state.compute_avail_stream_blk_pair(&tx_entries, &rx_entries);
+        self.stream_blk_dsts = stream_blk_dsts;
+        let mut elem_id_list = Self::add_an_elem_for_meter(card_cntr, Self::STREAM_TX_METER_NAME,
+                                                           &self.stream_blk_dsts)?;
+        self.measured_elem_list.append(&mut elem_id_list);
+        self.stream_meter = vec![0;self.stream_blk_dsts.len()];
+
+        let (_, mixer_blk_dsts) = state.compute_avail_mixer_blk_pair(caps, RateMode::Low);
+        self.mixer_blk_dsts = mixer_blk_dsts;
+        let mut elem_id_list = Self::add_an_elem_for_meter(card_cntr, Self::MIXER_INPUT_METER_NAME,
+                                                           &self.mixer_blk_dsts)?;
+        self.measured_elem_list.append(&mut elem_id_list);
+        self.mixer_meter = vec![0;self.mixer_blk_dsts.len()];
+
+        self.out_sat = vec![false;self.mixer_blk_dsts.len()];
+        let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer,
+                                                   0, 0, Self::INPUT_SATURATION_NAME, 0);
+        let mut elem_id_list = card_cntr.add_bool_elems(&elem_id, 1, self.mixer_blk_dsts.len(), false)?;
+        self.measured_elem_list.append(&mut elem_id_list);
+
+        Ok(())
+    }
+
+    fn add_an_elem_for_meter(card_cntr: &mut CardCntr, label: &str, targets: &Vec<u8>)
+        -> Result<Vec<ElemId>, Error>
+    {
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, label, 0);
+        let elem_id_list = card_cntr.add_int_elems(&elem_id, 1,
+                                                   Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
+                                                   targets.len(), None, false)?;
+        Ok(elem_id_list)
+    }
+
+    pub fn measure_states(&mut self, node: &FwNode, proto: &FwReq, sections: &ExtensionSections,
+                             caps: &ExtensionCaps, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let entries = proto.read_peak_entries(&node, sections, caps, timeout_ms)?;
+
+        self.real_meter.iter_mut().chain(self.stream_meter.iter_mut()).chain(self.mixer_meter.iter_mut())
+            .zip(self.real_blk_dsts.iter().chain(self.stream_blk_dsts.iter()).chain(self.mixer_blk_dsts.iter()))
+            .for_each(|(val, &dst)| {
+                *val = entries.iter().find(|data| data[RouterEntry::DST_OFFSET] == dst)
+                    .map(|data| {
+                        let entry = RouterEntry::from(data);
+                        entry.peak as i32
+                    })
+                    .unwrap_or(0);
+            });
+
+        self.out_sat = proto.read_saturation(&node, sections, caps, timeout_ms)?;
+
+        Ok(())
+    }
+
+    pub fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::OUT_METER_NAME => {
+                elem_value.set_int(&self.real_meter);
+                Ok(true)
+            }
+            Self::STREAM_TX_METER_NAME => {
+                elem_value.set_int(&self.stream_meter);
+                Ok(true)
+            }
+            Self::MIXER_INPUT_METER_NAME => {
+                elem_value.set_int(&self.mixer_meter);
+                Ok(true)
+            }
+            Self::INPUT_SATURATION_NAME => {
+                elem_value.set_bool(&self.out_sat);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::{*, caps_section::*, cmd_section::*};
+
+use super::tcd22xx_spec::{Tcd22xxState, Tcd22xxSpec, Tcd22xxStateOperation};
+
+#[derive(Default, Debug)]
+pub struct Tcd22xxCtl<S>
+    where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+{
+    state: S,
+    caps: ExtensionCaps,
+}
+
+impl<S> Tcd22xxCtl<S>
+    where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+{
+    pub fn load(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections,
+                _: &ClockCaps, _: &ClockSourceLabels, timeout_ms: u32, _: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        let node = unit.get_node();
+
+        self.caps = proto.read_caps(&node, sections, timeout_ms)?;
+
+        Ok(())
+    }
+
+    pub fn cache(&mut self, unit: &SndDice, proto: &FwReq, sections: &GeneralSections,
+                 extension_sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let node = unit.get_node();
+        let config = proto.read_clock_config(&node, &sections, timeout_ms)?;
+        let rate_mode = RateMode::from(config.rate);
+
+        self.state.cache(&node, proto, extension_sections, &self.caps, rate_mode, timeout_ms)
+    }
+}

--- a/libs/dice/runtime/src/tcd22xx_spec.rs
+++ b/libs/dice/runtime/src/tcd22xx_spec.rs
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use dice_protocols::tcat::extension::{*, caps_section::*, cmd_section::*};
+
+use std::convert::TryFrom;
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Input<'a> {
+    pub id: SrcBlkId,
+    pub offset: u8,
+    pub count: u8,
+    pub label: Option<&'a str>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Output<'a> {
+    pub id: DstBlkId,
+    pub offset: u8,
+    pub count: u8,
+    pub label: Option<&'a str>,
+}
+
+pub trait Tcd22xxSpec<'a> {
+    // For each model.
+    const INPUTS: &'a [Input<'a>];
+    const OUTPUTS: &'a [Output<'a>];
+    const FIXED: &'a [SrcBlk];
+
+    // From specification of TCD22xx.
+    const MIXER_OUT_PORTS: [u8;3] = [16, 16, 8];
+    const MIXER_IN_PORTS: [(DstBlkId, u8);2] = [(DstBlkId::MixerTx0, 16), (DstBlkId::MixerTx1, 2)];
+
+    // From specification of ADAT/SMUX.
+    const ADAT_CHANNELS: [u8;3] = [8, 4, 2];
+
+    fn get_adat_channel_count(rate_mode: RateMode) -> u8 {
+        let index = match rate_mode {
+            RateMode::Low => 0,
+            RateMode::Middle => 1,
+            RateMode::High => 2,
+        };
+        Self::ADAT_CHANNELS[index]
+    }
+
+    fn get_mixer_out_port_count(rate_mode: RateMode) -> u8 {
+        let index = match rate_mode {
+            RateMode::Low => 0,
+            RateMode::Middle => 1,
+            RateMode::High => 2,
+        };
+        Self::MIXER_OUT_PORTS[index]
+    }
+
+    fn get_mixer_in_port_count() -> u8 {
+        Self::MIXER_IN_PORTS.iter().fold(0, |accum, (_, count)| accum + count)
+    }
+
+    fn compute_avail_real_blk_pair(&self, rate_mode: RateMode) -> (Vec<u8>, Vec<u8>)
+    {
+        let mut srcs = Vec::<u8>::new();
+        Self::INPUTS.iter().for_each(|entry| {
+            let offset = match entry.id {
+                SrcBlkId::Adat => srcs.iter().filter(|&d| SrcBlk::from(*d).id == entry.id).count() as u8,
+                _ => entry.offset,
+            };
+            let count = match entry.id {
+                SrcBlkId::Adat => Self::get_adat_channel_count(rate_mode),
+                _ => entry.count,
+            };
+            (offset..(offset + count)).for_each(|ch| {
+                srcs.push(u8::from(SrcBlk{id: entry.id, ch}));
+            });
+        });
+
+        let mut dsts = Vec::<u8>::new();
+        Self::OUTPUTS.iter().for_each(|entry| {
+            let offset = match entry.id {
+                DstBlkId::Adat => dsts.iter().filter(|&d| DstBlk::from(*d).id == entry.id).count() as u8,
+                _ => entry.offset,
+            };
+            let count = match entry.id {
+                DstBlkId::Adat => Self::get_adat_channel_count(rate_mode),
+                _ => entry.count,
+            };
+            (offset..(offset + count)).for_each(|ch| {
+                dsts.push(u8::from(DstBlk{id: entry.id, ch}));
+            });
+        });
+
+        (srcs, dsts)
+    }
+
+    fn compute_avail_stream_blk_pair(&self, tx_entries: &[FormatEntryData], rx_entries: &[FormatEntryData])
+        -> (Vec<u8>, Vec<u8>)
+    {
+        let dst_blk_list = tx_entries.iter()
+            .zip([DstBlkId::Avs0, DstBlkId::Avs1].iter())
+            .map(|(&data, &id)| {
+                let entry = FormatEntry::try_from(data).unwrap();
+                (0..entry.pcm_count).map(move |ch| u8::from(DstBlk{id, ch}))
+            }).flatten()
+            .collect();
+
+        let src_blk_list = rx_entries.iter()
+            .zip([SrcBlkId::Avs0, SrcBlkId::Avs1].iter())
+            .map(|(&data, &id)| {
+                let entry = FormatEntry::try_from(data).unwrap();
+                (0..entry.pcm_count).map(move |ch| u8::from(SrcBlk{id, ch}))
+            }).flatten()
+            .collect();
+
+        (src_blk_list, dst_blk_list)
+    }
+
+    fn compute_avail_mixer_blk_pair(&self, caps: &ExtensionCaps, rate_mode: RateMode)
+        -> (Vec<u8>, Vec<u8>)
+    {
+        let port_count = std::cmp::min(caps.mixer.output_count,
+                                       Self::get_mixer_out_port_count(rate_mode));
+
+        let id = SrcBlkId::Mixer;
+        let src_blk_list = (0..port_count).map(move |ch| u8::from(SrcBlk{id, ch})).collect();
+
+        let dst_blk_list = Self::MIXER_IN_PORTS.iter()
+            .flat_map(|&(id, count)| (0..count).map(move |ch| u8::from(DstBlk{id, ch})))
+            .take(caps.mixer.input_count as usize)
+            .collect();
+
+        (src_blk_list, dst_blk_list)
+    }
+
+    fn get_src_blk_label(&self, src_blk_data: u8) -> String {
+        let src_blk = SrcBlk::from(src_blk_data);
+        Self::INPUTS.iter()
+            .find(|entry| {
+                entry.id == src_blk.id &&
+                src_blk.ch >= entry.offset && src_blk.ch < entry.offset + entry.count &&
+                entry.label.is_some()
+            })
+            .map(|entry| format!("{}-{}", entry.label.unwrap(), src_blk.ch - entry.offset))
+            .unwrap_or_else(|| {
+                let name = match src_blk.id {
+                    SrcBlkId::Aes => "S/PDIF",
+                    SrcBlkId::Adat => "ADAT",
+                    SrcBlkId::Mixer => "Mixer",
+                    SrcBlkId::Ins0 => "Analog-A",
+                    SrcBlkId::Ins1 => "Analog-B",
+                    SrcBlkId::Avs0 => "Stream-A",
+                    SrcBlkId::Avs1 => "Stream-B",
+                    _ => "Unknown",
+                };
+                format!("{}-{}", name, src_blk.ch)
+            })
+    }
+
+    fn get_dst_blk_label(&self, dst_blk_data: u8) -> String {
+        let dst_blk = DstBlk::from(dst_blk_data);
+        Self::OUTPUTS.iter()
+            .find(|entry| {
+                entry.id == dst_blk.id &&
+                dst_blk.ch >= entry.offset && dst_blk.ch < entry.offset + entry.count &&
+                entry.label.is_some()
+            })
+            .map(|entry| format!("{}-{}", entry.label.unwrap(), dst_blk.ch - entry.offset))
+            .unwrap_or_else(|| {
+                let name = match dst_blk.id {
+                    DstBlkId::Aes => "S/PDIF",
+                    DstBlkId::Adat => "ADAT",
+                    DstBlkId::MixerTx0 => "Mixer-A",
+                    DstBlkId::MixerTx1 => "Mixer-B",
+                    DstBlkId::Ins0 => "Analog-A",
+                    DstBlkId::Ins1 => "Analog-B",
+                    DstBlkId::Avs0 => "Stream-A",
+                    DstBlkId::Avs1 => "Stream-B",
+                    _ => "Unknown",
+                };
+                format!("{}-{}", name, dst_blk.ch)
+            })
+    }
+}

--- a/libs/dice/runtime/src/tcd22xx_spec.rs
+++ b/libs/dice/runtime/src/tcd22xx_spec.rs
@@ -284,6 +284,22 @@ pub trait Tcd22xxMixerOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState
     }
 }
 
+pub trait Tcd22xxStateOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
+                                            Tcd22xxRouterOperation<'a, T, U> +  Tcd22xxMixerOperation<'a, T, U>
+    where T: AsRef<FwNode>,
+          U: CmdSectionProtocol<T> + MixerSectionProtocol<T> + RouterSectionProtocol<T> +
+             CurrentConfigSectionProtocol<T>,
+{
+    fn cache(&mut self, node: &T, proto: &U, sections: &ExtensionSections, caps: &ExtensionCaps,
+             rate_mode: RateMode, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        self.cache_router_entries(node, proto, sections, caps, rate_mode, timeout_ms)?;
+        self.cache_mixer_coefs(node, proto, sections, caps, rate_mode, timeout_ms)?;
+        Ok(())
+    }
+}
+
 impl<'a, O, T, U> Tcd22xxRouterOperation<'a, T, U> for O
     where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
           T: AsRef<FwNode>,
@@ -294,4 +310,12 @@ impl<'a, O, T, U> Tcd22xxMixerOperation<'a, T, U> for O
     where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
           T: AsRef<FwNode>,
           U: MixerSectionProtocol<T>,
+{}
+
+impl<'a, O, T, U> Tcd22xxStateOperation<'a, T, U> for O
+    where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
+             Tcd22xxRouterOperation<'a, T, U> +  Tcd22xxMixerOperation<'a, T, U>,
+          T: AsRef<FwNode>,
+          U: CmdSectionProtocol<T> + MixerSectionProtocol<T> + RouterSectionProtocol<T> +
+             CurrentConfigSectionProtocol<T>,
 {}

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -182,7 +182,7 @@ impl<'a> TryFrom<&'a [u8]> for ConfigRom<'a> {
             let msg = format!("length {} is greater than {}", bus_info_length, raw.len());
             Err(ConfigRomParseError::new(ctx, msg))?
         }
-        let bus_info = &raw[..(4 + bus_info_length)];
+        let bus_info = &raw[4..(4 + bus_info_length)];
         let data = &raw[(4 + bus_info_length)..];
 
         // Get block of root directory.

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -17,3 +17,4 @@ efw = { path = "../libs/efw" }
 motu = { path = "../libs/motu" }
 oxfw = { path = "../libs/oxfw" }
 bebob = { path = "../libs/bebob" }
+dice-runtime = { path = "../libs/dice/runtime" }

--- a/services/src/bin/snd-dice-ctl-service.rs
+++ b/services/src/bin/snd-dice-ctl-service.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use snd_firewire_ctl_services::*;
+use dice_runtime::DiceRuntime;
+
+struct DiceServiceCmd;
+
+impl<'a> ServiceCmd<'a, u32, DiceRuntime> for DiceServiceCmd {
+    const CMD_NAME: &'a str = "snd-dice-ctl-service";
+    const ARGS: &'a [(&'a str, &'a str)] = &[("CARD_ID", "The numeric ID of sound card")];
+
+    fn parse_args(args: &[String]) -> Result<u32, String> {
+        parse_arg_as_u32(&args[0])
+    }
+}
+
+fn main() {
+    DiceServiceCmd::run()
+}


### PR DESCRIPTION
[PATCH 00/62] dice: add service program for devices based on DICE ASICs

TC Applied Technologies (TCAT) designed ASICs of Digital Interface
Communication Engine (DICE) for audio and music units in IEEE 1394 bus.
The first product of the series; Dice II, were manufactured 2006 by
Wavefront Semiconductor, formerly known as Alesis Semiconductor.
TCD2210 (Dice Mini) and TCD2220 (Dice Jr.) were manufactored by TCAT
2010.

The ASICs were adopted to many models produced by third party vendors. TCAT
defined general protocol to configure functionality in the ASICs. For
TCD2210 and TCD2220, the protocol was extended. Furthermore, the vendors
implemented own protocol for specific purposes.

ALSA dice driver supports models with the ASICs for their isochronous packet
stream functionality. Although the driver allows userspace applications to
process PCM frames and MIDI messages in the packet stream, it doesn't support
the other functionalities such as volume control since it can be achieved by
any userspace application.

This patchset adds service program to satisfy the demand to control devices.
ALSA control applications can request the control by IPC to the service
program. The service program works as proxy to execute actual control.

The service consists of two crates; dice-protocols and dice-runtime. The former
includes trait and its implementation of various protocols defined by TCAT as
well as third party vendors, and well-documented for preparation of publishing.
The latter includes service runtime.

At present, below models are supported for much functionalities:

 * M-Audio ProFire 2626
 * M-Audio ProFire 610
 * Avid Mbox 3 pro

For the other models, common functionalities are available. If protocol
extension supported, extension controls are available as well.

```
Takashi Sakamoto (62):
  tcat-protocols: add crate for various protocols for ASICs of DICE
  dice-protocols: tcat: add module for protocol defined by TCAT
  dice-protocols: tcat: add trait and its implementation for global protocol
  dice-protocols: tcat: add trait and its implementation for tx stream format
  dice-protocols: tcat: add trait and its implementation for rx stream format
  dice-protocols: tcat: add trait and implementation for external sync section
  dice-protocols: tcat: bin: add program to print information according to general protocol
  dice-protocols: tcat: extension: add trait and its implementation for TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for capabilities feature of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for command feature of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for mixer feature of TCAT protocol extension
  dice-protocols: tcat: extension: add local trait and its implementation for router entry of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for peak section of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for router space of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for stream format of TCAT protocol extension
  dice-protocols: tcat: extension: add local trait and its implementation for stream format section of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for configuration section of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for application section of TCAT protocol extension
  dice-protocols: tcat: extension: add trait and its implementation for standalone space of TCAT protocol extension
  dice-protocols: tcat: bin: add program to print information according to extension protocol
  ieee1212-config-rom: fix to store content of bus information dice-protocols: tcat: add parser of configuration ROM
  dice-protocols: tcat: bin: add program to parse the content of configuration ROM according to TCAT protocol
  dice-protocol: tcat: add trait and its implementation to parse notification defined by TCAT
  dice-runtime: add crate of service runtime for models based on ASICs of DICE
  dice-runtime: add runtime structure and trait implementation
  services: add service program for models based on ASICs of DICE
  dice-runtime: launch I/O threads to dispatch event
  dice-runtime: open ALSA hwdep character device and Linux firewire character device
  dice-runtime: open ALSA control character device
  dice-runtime: add model module
  dice-runtime: add minimal model
  dice-runtime: add controls for minimal model
  dice-runtime: dispatch DICE notification
  dice-runtime: minimal_model: dispatch clock change notification
  dice-runtime: add interval timer to measure control elements
  dice-runtime: minimal_model: add controls for external sources for sampling clock
  dice-runtime: add extension model
  dice-runtime: add trait for specification of TCD2210/TCD2220
  dice-runtime: add router operation for TCD2210/2220
  dice-runtime: add mixer operation for TCD2210/2220
  dice-runtime: add state operation for TCD2210/2220
  dice-runtime: implement trait of TCD2210/TCD2220 state to extension model
  dice-runtime: add controls for TCD2210/2220
  dice-runtime: add meter controls for extension model
  dice-runtime: add router controls for extension model
  dice-runtime: add mixer controls for extension model
  dice-runtime: add standalone controls for extension model
  dice-protocol: maudio: add trait and its implementation for application protocol specific to M-Audio ProFire series.
  dice-runtime: add support for M-Audio ProFire 2626
  dice-runtime: add support for M-Audio ProFire 610
  dice-runtime: pfire_model: fixup clock capabilities
  dice-runtime: pfire_model: add control specific to ProFire series
  dice-protocol: avid: add trait and its implementation for standalone protocol specific to Avid Mbox 3 Pro
  dice-protocol: avid: add trait and its implementation for hardware protocol specific to Avid Mbox 3 Pro
  dice-protocol: avid: add trait and its implementation for reverb protocol specific to Avid Mbox 3 Pro
  dice-protocol: avid: add trait and its implementation to parse notification defined by TCAT
  dice-runtime: mbox3_model: add support for Avid Mbox 3 Pro
  dice-runtime: mbox3_model: add standalone usecase control for Avid Mbox 3 Pro
  dice-runtime: mbox3_model: add hardware control for Mbox 3 pro
  dice-runtime: mbox3_model: add reverb control for Mbox 3 pro
  dice-runtime: mbox3_model: add button controls for Avid Mbox 3 Pro

 Cargo.toml                                    |   2 +
 README.rst                                    |  12 +-
 libs/dice/protocols/Cargo.toml                |  27 +
 libs/dice/protocols/src/avid.rs               | 600 ++++++++++++++
 .../src/bin/tcat-config-rom-parser.rs         | 127 +++
 .../src/bin/tcat-extension-parser.rs          | 248 ++++++
 .../protocols/src/bin/tcat-general-parser.rs  | 216 +++++
 libs/dice/protocols/src/lib.rs                |  11 +
 libs/dice/protocols/src/maudio.rs             |  35 +
 libs/dice/protocols/src/tcat.rs               | 310 +++++++
 libs/dice/protocols/src/tcat/config_rom.rs    | 126 +++
 .../protocols/src/tcat/ext_sync_section.rs    |  71 ++
 libs/dice/protocols/src/tcat/extension.rs     | 514 ++++++++++++
 .../src/tcat/extension/appl_section.rs        |  31 +
 .../src/tcat/extension/caps_section.rs        | 243 ++++++
 .../src/tcat/extension/cmd_section.rs         | 155 ++++
 .../tcat/extension/current_config_section.rs  |  60 ++
 .../src/tcat/extension/mixer_section.rs       |  68 ++
 .../src/tcat/extension/peak_section.rs        |  28 +
 .../src/tcat/extension/router_entry.rs        |  55 ++
 .../src/tcat/extension/router_section.rs      |  39 +
 .../src/tcat/extension/standalone_section.rs  | 249 ++++++
 .../src/tcat/extension/stream_format_entry.rs |  81 ++
 .../tcat/extension/stream_format_section.rs   |  33 +
 .../dice/protocols/src/tcat/global_section.rs | 641 +++++++++++++++
 .../src/tcat/rx_stream_format_section.rs      | 160 ++++
 .../src/tcat/tx_stream_format_section.rs      | 159 ++++
 libs/dice/protocols/src/tcat/utils.rs         | 118 +++
 libs/dice/runtime/Cargo.toml                  |  20 +
 libs/dice/runtime/src/common_ctl.rs           | 265 ++++++
 libs/dice/runtime/src/extension_model.rs      | 172 ++++
 libs/dice/runtime/src/lib.rs                  | 210 +++++
 libs/dice/runtime/src/mbox3_model.rs          | 748 +++++++++++++++++
 libs/dice/runtime/src/minimal_model.rs        |  78 ++
 libs/dice/runtime/src/model.rs                | 138 ++++
 libs/dice/runtime/src/pfire_model.rs          | 299 +++++++
 libs/dice/runtime/src/tcd22xx_ctl.rs          | 764 ++++++++++++++++++
 libs/dice/runtime/src/tcd22xx_spec.rs         | 321 ++++++++
 libs/ieee1212-config-rom/src/lib.rs           |   2 +-
 services/Cargo.toml                           |   1 +
 services/src/bin/snd-dice-ctl-service.rs      |  19 +
 41 files changed, 7454 insertions(+), 2 deletions(-)
 create mode 100644 libs/dice/protocols/Cargo.toml
 create mode 100644 libs/dice/protocols/src/avid.rs
 create mode 100644 libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
 create mode 100644 libs/dice/protocols/src/bin/tcat-extension-parser.rs
 create mode 100644 libs/dice/protocols/src/bin/tcat-general-parser.rs
 create mode 100644 libs/dice/protocols/src/lib.rs
 create mode 100644 libs/dice/protocols/src/maudio.rs
 create mode 100644 libs/dice/protocols/src/tcat.rs
 create mode 100644 libs/dice/protocols/src/tcat/config_rom.rs
 create mode 100644 libs/dice/protocols/src/tcat/ext_sync_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/appl_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/caps_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/cmd_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/current_config_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/mixer_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/peak_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/router_entry.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/router_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/standalone_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
 create mode 100644 libs/dice/protocols/src/tcat/extension/stream_format_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/global_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/rx_stream_format_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/tx_stream_format_section.rs
 create mode 100644 libs/dice/protocols/src/tcat/utils.rs
 create mode 100644 libs/dice/runtime/Cargo.toml
 create mode 100644 libs/dice/runtime/src/common_ctl.rs
 create mode 100644 libs/dice/runtime/src/extension_model.rs
 create mode 100644 libs/dice/runtime/src/lib.rs
 create mode 100644 libs/dice/runtime/src/mbox3_model.rs
 create mode 100644 libs/dice/runtime/src/minimal_model.rs
 create mode 100644 libs/dice/runtime/src/model.rs
 create mode 100644 libs/dice/runtime/src/pfire_model.rs
 create mode 100644 libs/dice/runtime/src/tcd22xx_ctl.rs
 create mode 100644 libs/dice/runtime/src/tcd22xx_spec.rs
 create mode 100644 services/src/bin/snd-dice-ctl-service.rs
```