### PR TITLE
[PATCH 0/5] dice-runtime: improve support for M-Audio ProFire 2626

### DIFF
--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -19,6 +19,20 @@ pub trait MaudioPfireApplProtocol<T> : ApplSectionProtocol<T>
 {
     const KNOB_ASSIGN_OFFSET: usize = 0x00;
 
+    fn read_knob_assign(&self, node: &T, sections: &ExtensionSections, targets: &mut [bool;KNOB_COUNT],
+                        timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                targets.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, v)| *v = val & (1 << i) > 0)
+            })
+    }
+
     fn write_knob_assign(&self, node: &T, sections: &ExtensionSections,
                          targets: &[bool;KNOB_COUNT], timeout_ms: u32)
         -> Result<(), Error>

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -12,12 +12,33 @@ use hinawa::{FwReq, FwNode};
 
 use super::tcat::extension::{*, appl_section::*};
 
+/// The number of targets available to knob master.
 pub const KNOB_COUNT: usize = 4;
 
+/// The enumeration for mode of optical interface.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OptIfaceMode{
+    Spdif,
+    Adat,
+}
+
+/// The enumeration for mode of standalone converter.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum StandaloneConerterMode{
+    AdDa,
+    AdOnly,
+}
+
+/// The trait for protocol defined by M-Audio specific to ProFire series.
 pub trait MaudioPfireApplProtocol<T> : ApplSectionProtocol<T>
     where T: AsRef<FwNode>,
 {
     const KNOB_ASSIGN_OFFSET: usize = 0x00;
+    const STANDALONE_MODE_OFFSET: usize = 0x04;
+
+    const KNOB_ASSIGN_MASK: u32 = 0x0f;
+    const OPT_IFACE_B_IS_SPDIF_FLAG: u32 = 0x10;
+    const STANDALONE_CONVERTER_IS_AD_ONLY_FLAG: u32 = 0x02;
 
     fn read_knob_assign(&self, node: &T, sections: &ExtensionSections, targets: &mut [bool;KNOB_COUNT],
                         timeout_ms: u32)
@@ -37,12 +58,85 @@ pub trait MaudioPfireApplProtocol<T> : ApplSectionProtocol<T>
                          targets: &[bool;KNOB_COUNT], timeout_ms: u32)
         -> Result<(), Error>
     {
-        let val: u32 = targets.iter()
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)?;
+        let mut val = u32::from_be_bytes(data);
+
+        targets.iter()
             .enumerate()
-            .filter(|&(_, &knob)| knob)
-            .fold(0, |val, (i, _)| val | (1 << i));
-        let mut data = val.to_be_bytes().clone();
+            .for_each(|(i, knob)| {
+                val &= !(1 << i);
+                if *knob {
+                    val |= 1 << i;
+                }
+            });
+        data.copy_from_slice(&val.to_be_bytes());
+
         self.write_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_opt_iface_b_mode(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<OptIfaceMode, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                if val & Self::OPT_IFACE_B_IS_SPDIF_FLAG > 0 {
+                    OptIfaceMode::Spdif
+                } else {
+                    OptIfaceMode::Adat
+                }
+            })
+    }
+
+    fn write_opt_iface_b_mode(&self, node: &T, sections: &ExtensionSections, mode: OptIfaceMode,
+                              timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)?;
+        let mut val = u32::from_be_bytes(data);
+
+        val &= !Self::OPT_IFACE_B_IS_SPDIF_FLAG;
+        if mode == OptIfaceMode::Spdif {
+            val |= Self::OPT_IFACE_B_IS_SPDIF_FLAG;
+        }
+        data.copy_from_slice(&val.to_be_bytes());
+
+        self.write_appl_data(node, sections, Self::KNOB_ASSIGN_OFFSET, &mut data, timeout_ms)
+    }
+
+    fn read_standalone_converter_mode(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<StandaloneConerterMode, Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::STANDALONE_MODE_OFFSET, &mut data, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(data);
+                if val & Self::STANDALONE_CONVERTER_IS_AD_ONLY_FLAG > 0 {
+                    StandaloneConerterMode::AdOnly
+                } else {
+                    StandaloneConerterMode::AdDa
+                }
+            })
+    }
+
+    fn write_standalone_converter_mode(&self, node: &T, sections: &ExtensionSections,
+                                       mode: StandaloneConerterMode, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut data = [0;4];
+        self.read_appl_data(node, sections, Self::STANDALONE_MODE_OFFSET, &mut data, timeout_ms)?;
+        let mut val = u32::from_be_bytes(data);
+
+        val &= !Self::STANDALONE_CONVERTER_IS_AD_ONLY_FLAG;
+        if mode == StandaloneConerterMode::AdOnly {
+            val |= Self::STANDALONE_CONVERTER_IS_AD_ONLY_FLAG;
+        }
+        data.copy_from_slice(&val.to_be_bytes());
+
+        self.write_appl_data(node, sections, Self::STANDALONE_MODE_OFFSET, &mut data, timeout_ms)
     }
 }
 

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -159,26 +159,26 @@ pub struct Pfire2626State(Tcd22xxState);
 
 impl<'a> Tcd22xxSpec<'a> for Pfire2626State {
     const INPUTS: &'a [Input<'a>] = &[
-        Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Ins1, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
-        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Adat, offset: 8, count: 16, label: None},
         Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: None},
     ];
     const OUTPUTS: &'a [Output<'a>] = &[
-        Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
-        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Adat, offset: 8, count: 16, label: None},
         Output{id: DstBlkId::Aes, offset: 0, count: 2, label: None},
     ];
     const FIXED: &'a [SrcBlk] = &[
-        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 4},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 5},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 6},
-        SrcBlk{id: SrcBlkId::Ins0, ch: 7},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 5},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 6},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 7},
     ];
 }
 


### PR DESCRIPTION
M-Audio ProFire 2626 supports two operations in application section 
of TCAT protocol extension. It has second optical interface and allows
software to decide which types of signal is used for the interface.
Additionally, it supports two types of mode for standalone converter.
Furthermore, it uses `Ins1` instead of `Ins0` for source and destination block.

This patchset improves support for M-Audio ProFire 2626

```
Takashi Sakamoto (5):
  dice-protocols: maudio: add read method for master knob assignment
  dice-runtime: pfire_model: use read transaction to get current assignment of master knob
  dice-runtime: pfire_model: fix specification of ProFire 2626
  dice-protocols: maudio: add methods specific to ProFire 2626
  dice-runtime: pfire_model: add controls specific to ProFire 2626

 libs/dice/protocols/src/maudio.rs    | 116 ++++++++++++++++++++++++++-
 libs/dice/runtime/src/pfire_model.rs | 110 ++++++++++++++++++++-----
 2 files changed, 201 insertions(+), 25 deletions(-)

```