### PR TITLE
dice-runtime: fix argument order to process value change correctly

### DIFF
--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -376,7 +376,7 @@ impl<'a> HwCtl {
                 Ok(true)
             }
             Self::OUTPUT_TRIM_NAME => {
-                ElemValueAccessor::<i32>::get_vals(old, new, Self::OUTPUT_COUNT, |idx, val| {
+                ElemValueAccessor::<i32>::get_vals(new, old, Self::OUTPUT_COUNT, |idx, val| {
                     proto.write_hw_output_trim(&unit.get_node(), sections, idx, val as u8, timeout_ms)
                 })
                 .map(|_| true)


### PR DESCRIPTION
ElemValueAccessor::get_vals() takes ElemValue structure for new values in
its first argument. However mbox3_model has call of the API with old values
in its first argument.

This commit fixes the bug.

Fixes: 9cf57f27073a ("dice-runtime: mbox3_model: add hardware control for Mbox 3 pro")
Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>