### PR TITLE
alsa-ctl-tlv-codec: use trait boundary to Vec::<u32>::from(&Self) Instead of Into::<u32>

### DIFF
--- a/libs/alsa-ctl-tlv-codec/README.md
+++ b/libs/alsa-ctl-tlv-codec/README.md
@@ -62,7 +62,8 @@ match TlvItem::try_from(&raw[..]) {
 `TlvItem` enumeration is a good start to use the crate. It implements `TryFrom<&[u32]>` to
 decode raw data of TLV which is array of u32 elements. The type of data is retrieved by a shape
 of Rust enumeration items. Each item has associated value. Both of enumeration itself and the
-structure of associated value implements `Into<Vec<u32>>` to generate raw data of TLV.
+structure of associated value has trait boundary to `Vec::<u32>: From(&Self)` to generate raw
+data of TLV.
 
 The associated value can be instantiated directly, then raw data can be generated:
 

--- a/libs/alsa-ctl-tlv-codec/src/containers.rs
+++ b/libs/alsa-ctl-tlv-codec/src/containers.rs
@@ -85,9 +85,9 @@ impl From<&DbRangeEntry> for Vec<u32> {
         raw.push(entry.min_val as u32);
         raw.push(entry.max_val as u32);
         let mut data_raw = match &entry.data {
-            DbRangeEntryData::DbScale(d) => Into::<Vec<u32>>::into(d),
-            DbRangeEntryData::DbRange(d) => Into::<Vec<u32>>::into(d),
-            DbRangeEntryData::DbInterval(d) => Into::<Vec<u32>>::into(d),
+            DbRangeEntryData::DbScale(d) => Vec::<u32>::from(d),
+            DbRangeEntryData::DbRange(d) => Vec::<u32>::from(d),
+            DbRangeEntryData::DbInterval(d) => Vec::<u32>::from(d),
         };
         raw.append(&mut data_raw);
         raw
@@ -121,7 +121,7 @@ impl<'a> TlvData<'a> for DbRange {
     fn value(&self) -> Vec<u32> {
         let mut raw = Vec::new();
         self.entries.iter().for_each(|entry| {
-            let mut entry_raw = Into::<Vec<u32>>::into(entry);
+            let mut entry_raw = Vec::<u32>::from(entry);
             raw.append(&mut entry_raw);
         });
         raw
@@ -285,7 +285,7 @@ mod test {
         assert_eq!(entry.min_val, -9);
         assert_eq!(entry.max_val, 100);
         assert_eq!(entry.data, DbRangeEntryData::DbScale(DbScale{min: 0, step: 10, mute_avail: false}));
-        assert_eq!(&Into::<Vec<u32>>::into(entry)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(entry)[..], &raw[..]);
     }
 
     #[test]
@@ -295,7 +295,7 @@ mod test {
         assert_eq!(entry.min_val, -9);
         assert_eq!(entry.max_val, 100);
         assert_eq!(entry.data, DbRangeEntryData::DbInterval(DbInterval{min: 0, max: 10, linear: true, mute_avail: true}));
-        assert_eq!(&Into::<Vec<u32>>::into(entry)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(entry)[..], &raw[..]);
     }
 
     #[test]
@@ -321,7 +321,7 @@ mod test {
             max_val: 30,
             data: DbRangeEntryData::DbInterval(DbInterval{min: 0, max: 20, linear: false, mute_avail: true}),
         });
-        assert_eq!(&Into::<Vec<u32>>::into(range)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(range)[..], &raw[..]);
     }
 
     #[test]
@@ -333,7 +333,7 @@ mod test {
         let cntr = Container::try_from(&raw[..]).unwrap();
         assert_eq!(cntr.entries[0], TlvItem::DbScale(DbScale{min: 0, step: 5, mute_avail: false}));
         assert_eq!(cntr.entries[1], TlvItem::DbScale(DbScale{min: 5, step: 5, mute_avail: false}));
-        assert_eq!(&Into::<Vec<u32>>::into(cntr)[..], &raw);
+        assert_eq!(&Vec::<u32>::from(cntr)[..], &raw);
     }
 
     #[test]
@@ -381,6 +381,6 @@ mod test {
                 },
             ],
         }));
-        assert_eq!(&Into::<Vec<u32>>::into(cntr)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(cntr)[..], &raw[..]);
     }
 }

--- a/libs/alsa-ctl-tlv-codec/src/items.rs
+++ b/libs/alsa-ctl-tlv-codec/src/items.rs
@@ -502,7 +502,7 @@ mod test {
         assert_eq!(item.min, -10);
         assert_eq!(item.step, 16);
         assert_eq!(item.mute_avail, false);
-        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(item)[..], &raw[..]);
     }
 
     #[test]
@@ -512,7 +512,7 @@ mod test {
         assert_eq!(item.min, 10);
         assert_eq!(item.step, 16);
         assert_eq!(item.mute_avail, true);
-        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(item)[..], &raw[..]);
     }
 
     #[test]
@@ -523,7 +523,7 @@ mod test {
         assert_eq!(item.max, 100);
         assert_eq!(item.linear, false);
         assert_eq!(item.mute_avail, false);
-        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(item)[..], &raw[..]);
     }
 
     #[test]
@@ -534,7 +534,7 @@ mod test {
         assert_eq!(item.max, 100);
         assert_eq!(item.linear, false);
         assert_eq!(item.mute_avail, true);
-        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(item)[..], &raw[..]);
     }
 
     #[test]
@@ -545,7 +545,7 @@ mod test {
         assert_eq!(item.max, 100);
         assert_eq!(item.linear, true);
         assert_eq!(item.mute_avail, true);
-        assert_eq!(&Into::<Vec<u32>>::into(item)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(item)[..], &raw[..]);
     }
 
     #[test]
@@ -592,7 +592,7 @@ mod test {
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontLeft), phase_inverse: false},
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), phase_inverse: false},
         ]);
-        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(map)[..], &raw[..]);
     }
 
     #[test]
@@ -605,7 +605,7 @@ mod test {
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::FrontRight), phase_inverse: false},
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::LowFrequencyEffect), phase_inverse: false},
         ][..]);
-        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(map)[..], &raw[..]);
     }
 
     #[test]
@@ -619,6 +619,6 @@ mod test {
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearLeft), phase_inverse: false},
             ChmapEntry{pos: ChmapPos::Generic(ChmapGenericPos::RearRight), phase_inverse: false},
         ][..]);
-        assert_eq!(&Into::<Vec<u32>>::into(map)[..], &raw[..]);
+        assert_eq!(&Vec::<u32>::from(map)[..], &raw[..]);
     }
 }

--- a/libs/alsa-ctl-tlv-codec/src/lib.rs
+++ b/libs/alsa-ctl-tlv-codec/src/lib.rs
@@ -63,7 +63,8 @@
 //! `TlvItem` enumeration is a good start to use the crate. It implements `TryFrom<&[u32]>` to
 //! decode raw data of TLV which is array of u32 elements. The type of data is retrieved by a shape
 //! of Rust enumeration items. Each item has associated value. Both of enumeration itself and the
-//! structure of associated value implements `Into<Vec<u32>>` to generate raw data of TLV.
+//! structure of associated value has trait boundary to `Vec::<u32>: From(&Self)` to generate raw
+//! data of TLV.
 //!
 //! The associated value can be instantiated directly, then raw data can be generated:
 //!
@@ -274,9 +275,11 @@ impl std::error::Error for InvalidTlvDataError {}
 
 /// The trait for common methods to data of TLV (Type-Length-Value) in ALSA control interface.
 /// The TryFrom supertrait should be implemented to parse the array of u32 elements and it
-/// can return InvalidTlvDataError at failure. The Into supertrait should be implemented as well
-/// to build the array of u32 element.
-pub trait TlvData<'a> : std::convert::TryFrom<&'a [u32]> + Into<Vec<u32>> {
+/// can return InvalidTlvDataError at failure. The trait boundary to Vec::<u32>::From(&Self)
+/// should be implemented as well to build the array of u32 element.
+pub trait TlvData<'a> : std::convert::TryFrom<&'a [u32]>
+    where for<'b> Vec<u32>: From<&'b Self>,
+{
     /// Return the value of type field. It should come from UAPI of Linux kernel.
     fn value_type(&self) -> u32;
 
@@ -293,9 +296,9 @@ use containers::*;
 
 /// Available items as data of TLV (Type-Length-Value) style in ALSA control interface.
 ///
-/// When docoding from data of TLV, use implementation of `TryFrom<&[u32]>` trait.  Data assigned
-/// to each enumeration implements `TlvData`, `TryFrom<&[u32]`, and `Into<Vec<u32>>` trait. When
-/// decoding to data of TLV, use implementation of `Into<Vec<u32>>` for the data.
+/// When decoding from data of TLV, use implementation of `TryFrom<&[u32]>` trait.  Data assigned
+/// to each enumeration implements `TlvData`, `TryFrom<&[u32]`, and `Vec::<u32>::from(&Self)` trait.
+/// When decoding to data of TLV, use implementation of `Vec::<u32>::from(&Self)` for the data.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TlvItem{
     Container(Container),


### PR DESCRIPTION
It's possible to add trait boundary to 'Vec::\<u32\>: From<&Self>' instead
of supertrait of 'Into::\<u32\>'.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>