### PR TITLE
[PATCH 00/10] dice: add support for Alesis iO FireWire series

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,7 @@ your device, please contact to developer.
   * TC Electronic Desktop Konnekt 6
   * TC Electronic Impact Twin
   * TC Electronic Digital Konnekt x32
+  * Alesis MultiMix 8/12/16 FireWire
   * Alesis iO 14
   * Alesis iO 26
   * For the others, common controls are available. If supported, control extension is also available.

--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,7 @@ your device, please contact to developer.
   * Alesis MultiMix 8/12/16 FireWire
   * Alesis iO 14
   * Alesis iO 26
+  * Alesis MasterControl
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -141,6 +141,8 @@ your device, please contact to developer.
   * TC Electronic Desktop Konnekt 6
   * TC Electronic Impact Twin
   * TC Electronic Digital Konnekt x32
+  * Alesis iO 14
+  * Alesis iO 26
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/libs/dice/protocols/src/alesis.rs
+++ b/libs/dice/protocols/src/alesis.rs
@@ -6,6 +6,8 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Alesis for iO FireWire series.
 
+pub mod meter;
+
 use glib::Error;
 use hinawa::FwNode;
 

--- a/libs/dice/protocols/src/alesis.rs
+++ b/libs/dice/protocols/src/alesis.rs
@@ -7,6 +7,7 @@
 //! defined by Alesis for iO FireWire series.
 
 pub mod meter;
+pub mod mixer;
 
 use glib::Error;
 use hinawa::FwNode;

--- a/libs/dice/protocols/src/alesis.rs
+++ b/libs/dice/protocols/src/alesis.rs
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Protocol specific to Alesis iO FireWire series.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Alesis for iO FireWire series.
+
+use glib::Error;
+use hinawa::FwNode;
+
+use super::{*, tcat::*};
+
+/// The trait to represent protocol defined by Alesis for iO FireWire series.
+pub trait AlesisIoProtocol<T: AsRef<FwNode>> : GeneralProtocol<T> {
+    const BASE_OFFSET: usize = 0x00200000;
+
+    fn read_block(&self, node: &T, offset: usize, frame: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        self.read(node, Self::BASE_OFFSET + offset, frame, timeout_ms)
+    }
+
+    fn write_block(&self, node: &T, offset: usize, frame: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        self.write(node, Self::BASE_OFFSET + offset, frame, timeout_ms)
+    }
+
+    fn read_flags(&self, node: &T, offset: usize, flags: &mut [bool], timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        self.read_block(node, offset, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut val = 0u32;
+                val.parse_quadlet(&raw[..]);
+                flags.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, flag)| {
+                        *flag = val & (1 << i) > 0;
+                    });
+            })
+    }
+
+    fn write_flags(&self, node: &T, offset: usize, flags: &[bool], timeout_ms: u32) -> Result<(), Error> {
+        let val = flags.iter()
+            .enumerate()
+            .filter(|(_, &flag)| flag)
+            .fold(0 as u32, |val, (i, _)| val | (1 << i));
+        let mut raw = [0;4];
+        val.build_quadlet(&mut raw[..]);
+        self.write_block(node, offset, &mut raw, timeout_ms)
+    }
+}
+
+impl<O, T> AlesisIoProtocol<T> for O
+    where T: AsRef<FwNode>,
+          O: GeneralProtocol<T>,
+{}

--- a/libs/dice/protocols/src/alesis.rs
+++ b/libs/dice/protocols/src/alesis.rs
@@ -8,6 +8,7 @@
 
 pub mod meter;
 pub mod mixer;
+pub mod output;
 
 use glib::Error;
 use hinawa::FwNode;

--- a/libs/dice/protocols/src/alesis/meter.rs
+++ b/libs/dice/protocols/src/alesis/meter.rs
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Meter protocol specific to Alesis iO FireWire series.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for meter
+//! protocol defined by Alesis for iO FireWire series.
+
+use glib::Error;
+use hinawa::FwNode;
+
+use super::*;
+
+/// The structure to represent hardware meters. 0..0x007fff00 with 0x100 step (-90.0..0.0 dB)
+#[derive(Debug)]
+pub struct IoMeter{
+    pub analog_inputs: Vec<i32>,
+    pub stream_inputs: [i32;8],
+    pub digital_a_inputs: [i32;8],
+    pub digital_b_inputs: Vec<i32>,
+    pub mixer_outputs: [i32;8],
+}
+
+const STREAM_INPUT_COUNT: usize = 8;
+const DIGITAL_A_INPUT_COUNT: usize = 8;
+const MIXER_OUTPUT_COUNT: usize = 8;
+
+trait IoMeterSpec {
+    const ANALOG_INPUT_COUNT: usize;
+    const DIGITAL_B_INPUT_COUNT: usize;
+
+    fn create_meter() -> IoMeter {
+        IoMeter{
+            analog_inputs: vec![0;Self::ANALOG_INPUT_COUNT],
+            stream_inputs: [0;STREAM_INPUT_COUNT],
+            digital_a_inputs: [0;DIGITAL_A_INPUT_COUNT],
+            digital_b_inputs: vec![0;Self::DIGITAL_B_INPUT_COUNT],
+            mixer_outputs: [0;MIXER_OUTPUT_COUNT],
+        }
+    }
+}
+
+/// The structure to represent hardware meter for iO 14 FireWire.
+#[derive(Debug)]
+pub struct Io14Meter(IoMeter);
+
+impl IoMeterSpec for Io14Meter {
+    const ANALOG_INPUT_COUNT: usize = 4;
+    const DIGITAL_B_INPUT_COUNT: usize = 2;
+}
+
+impl Default for Io14Meter {
+    fn default() -> Self {
+        Io14Meter(Self::create_meter())
+    }
+}
+
+impl AsRef<IoMeter> for Io14Meter {
+    fn as_ref(&self) -> &IoMeter {
+        &self.0
+    }
+}
+
+impl AsMut<IoMeter> for Io14Meter {
+    fn as_mut(&mut self) -> &mut IoMeter {
+        &mut self.0
+    }
+}
+
+/// The structure to represent hardware meter for iO 26 FireWire.
+#[derive(Debug)]
+pub struct Io26Meter(IoMeter);
+
+impl IoMeterSpec for Io26Meter {
+    const ANALOG_INPUT_COUNT: usize = 8;
+    const DIGITAL_B_INPUT_COUNT: usize = 8;
+}
+
+impl Default for Io26Meter {
+    fn default() -> Self {
+        Io26Meter(Self::create_meter())
+    }
+}
+
+impl AsRef<IoMeter> for Io26Meter {
+    fn as_ref(&self) -> &IoMeter {
+        &self.0
+    }
+}
+
+impl AsMut<IoMeter> for Io26Meter {
+    fn as_mut(&mut self) -> &mut IoMeter {
+        &mut self.0
+    }
+}
+
+/// The trait to represent protofol of hardware meter.
+pub trait IoMeterProtocol<T: AsRef<FwNode>> : AlesisIoProtocol<T> {
+    const METER_OFFSET: usize = 0x04c0;
+    const SIZE: usize = 160;
+
+    fn read_meter<M>(&self, node: &T, meter: &mut M, timeout_ms: u32) -> Result<(), Error>
+        where M: AsMut<IoMeter>,
+    {
+        let mut raw = vec![0;Self::SIZE];
+        self.read_block(node, Self::METER_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let m = meter.as_mut();
+                let count = m.analog_inputs.len();
+                m.analog_inputs.parse_quadlet_block(&raw[..(count * 4)]);
+                m.stream_inputs.parse_quadlet_block(&raw[32..64]);
+                m.digital_a_inputs.parse_quadlet_block(&raw[64..96]);
+                let length = m.digital_b_inputs.len() * 4;
+                m.digital_b_inputs.parse_quadlet_block(&raw[(128 - length)..128]);
+                m.mixer_outputs.parse_quadlet_block(&raw[128..160]);
+            })
+    }
+}
+
+impl<O, T> IoMeterProtocol<T> for O
+    where T: AsRef<FwNode>,
+          O: AlesisIoProtocol<T>,
+{}

--- a/libs/dice/protocols/src/alesis/mixer.rs
+++ b/libs/dice/protocols/src/alesis/mixer.rs
@@ -1,0 +1,390 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Mixer protocol specific to Alesis iO FireWire series.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for mixer
+//! protocol defined by Alesis for iO FireWire series.
+
+use glib::*;
+use hinawa::FwNode;
+
+use super::*;
+use crate::*;
+
+/// The maximum number of analog inputs for mixer.
+pub const MAX_ANALOG_INPUT_COUNT: usize = 8;
+
+/// The number of digital A inputs for mixer.
+pub const DIGITAL_A_INPUT_COUNT: usize = 8;
+
+/// The maximum number of digital B inputs for mixer.
+pub const MAX_DIGITAL_B_INPUT_COUNT: usize = 8;
+
+/// The number of stream inputs for mixer.
+pub const STREAM_INPUT_COUNT: usize = 8;
+
+/// The structure to represent parameters of mixer. 0x00000000..0x007fffff (-60.0..0.0 dB).
+#[derive(Debug, Clone)]
+pub struct IoMixerGain{
+    pub analog_inputs: Vec<i32>,
+    pub stream_inputs: [i32;STREAM_INPUT_COUNT],
+    pub digital_a_inputs: [i32;DIGITAL_A_INPUT_COUNT],
+    pub digital_b_inputs: Vec<i32>,
+}
+
+impl IoMixerGain {
+    fn build(&self, raw: &mut [u8]) {
+        assert_eq!(raw.len(),
+                   4 * (MAX_ANALOG_INPUT_COUNT + STREAM_INPUT_COUNT + DIGITAL_A_INPUT_COUNT + MAX_DIGITAL_B_INPUT_COUNT),
+                   "Programming error...");
+        let analog_input_count = self.analog_inputs.len();
+        assert!(analog_input_count <= MAX_ANALOG_INPUT_COUNT);
+        let digital_b_input_count = self.digital_b_inputs.len();
+        assert!(digital_b_input_count <= MAX_DIGITAL_B_INPUT_COUNT);
+
+        let mut pos = 0;
+        self.analog_inputs.build_quadlet_block(&mut raw[pos..(pos + 4 * analog_input_count)]);
+
+        pos += 4 * MAX_ANALOG_INPUT_COUNT;
+        self.stream_inputs.build_quadlet_block(&mut raw[pos..(pos + 4 * STREAM_INPUT_COUNT)]);
+
+        pos += 4 * STREAM_INPUT_COUNT;
+        self.digital_a_inputs.build_quadlet_block(&mut raw[pos..(pos + 4 * DIGITAL_A_INPUT_COUNT)]);
+
+        pos += 4 * DIGITAL_A_INPUT_COUNT;
+        pos += 4 * (MAX_DIGITAL_B_INPUT_COUNT - digital_b_input_count);
+        self.digital_b_inputs.build_quadlet_block(&mut raw[pos..(pos + 4 * digital_b_input_count)]);
+    }
+
+    fn parse(&mut self, raw: &[u8]) {
+        assert_eq!(raw.len(),
+                   4 * (MAX_ANALOG_INPUT_COUNT + STREAM_INPUT_COUNT + DIGITAL_A_INPUT_COUNT + MAX_DIGITAL_B_INPUT_COUNT),
+                   "Programming error...");
+        let analog_input_count = self.analog_inputs.len();
+        assert!(analog_input_count <= MAX_ANALOG_INPUT_COUNT);
+        let digital_b_input_count = self.digital_b_inputs.len();
+        assert!(digital_b_input_count <= MAX_DIGITAL_B_INPUT_COUNT);
+
+        let mut pos = 0;
+        self.analog_inputs.parse_quadlet_block(&raw[pos..(pos + 4 * analog_input_count)]);
+
+        pos += 4 * MAX_ANALOG_INPUT_COUNT;
+        self.stream_inputs.parse_quadlet_block(&raw[pos..(pos + 4 * STREAM_INPUT_COUNT)]);
+
+        pos += 4 * STREAM_INPUT_COUNT;
+        self.digital_a_inputs.parse_quadlet_block(&raw[pos..(pos + 4 * DIGITAL_A_INPUT_COUNT)]);
+
+        pos += 4 * DIGITAL_A_INPUT_COUNT;
+        pos += 4 * (MAX_DIGITAL_B_INPUT_COUNT - digital_b_input_count);
+        self.digital_b_inputs.parse_quadlet_block(&raw[pos..(pos + 4 * digital_b_input_count)]);
+    }
+}
+
+/// The number of mixer.
+pub const IO_MIXER_COUNT: usize = 8;
+
+/// The structure to represent mute state of mixer input pairs.
+#[derive(Debug, Clone)]
+pub struct IoMixerMute{
+    pub analog_inputs: Vec<bool>,
+    pub digital_a_inputs: [bool;DIGITAL_A_INPUT_COUNT],
+    pub digital_b_inputs: Vec<bool>,
+}
+
+impl IoMixerMute {
+    fn build(&self, raw: &mut [u8]) {
+        assert_eq!(raw.len(), 4, "Programming error...");
+        assert!(self.analog_inputs.len() <= MAX_ANALOG_INPUT_COUNT, "Programming error...");
+        assert!(self.digital_b_inputs.len() <= MAX_DIGITAL_B_INPUT_COUNT, "Programming error...");
+
+        let mut val = 0u32;
+
+        let mut shift = 0;
+        self.analog_inputs.iter()
+            .take(MAX_ANALOG_INPUT_COUNT)
+            .enumerate()
+            .filter(|(_, &v)| v)
+            .for_each(|(i, _)| val |= 1 << (shift + i));
+
+        shift += MAX_ANALOG_INPUT_COUNT;
+        self.digital_a_inputs.iter()
+            .enumerate()
+            .filter(|(_, &v)| v)
+            .for_each(|(i, _)| val |= 1 << (shift + i));
+
+        shift += DIGITAL_A_INPUT_COUNT;
+        shift += MAX_DIGITAL_B_INPUT_COUNT - self.digital_b_inputs.len();
+        self.digital_b_inputs.iter()
+            .take(MAX_DIGITAL_B_INPUT_COUNT)
+            .enumerate()
+            .filter(|(_, &v)| v)
+            .for_each(|(i, _)| val |= 1 << (shift + i));
+
+        val.build_quadlet(raw);
+    }
+
+    fn parse(&mut self, raw: &[u8]) {
+        assert_eq!(raw.len(), 4, "Programming error...");
+        assert!(self.analog_inputs.len() <= MAX_ANALOG_INPUT_COUNT, "Programming error...");
+        assert!(self.digital_b_inputs.len() <= MAX_DIGITAL_B_INPUT_COUNT, "Programming error...");
+
+        let mut val = 0u32;
+        val.parse_quadlet(raw);
+
+        let mut shift = 0;
+        self.analog_inputs.iter_mut()
+            .take(MAX_ANALOG_INPUT_COUNT)
+            .enumerate()
+            .for_each(|(i, v)| *v = val & (1 << (shift + i)) > 0);
+
+        shift += MAX_ANALOG_INPUT_COUNT;
+        self.digital_a_inputs.iter_mut()
+            .enumerate()
+            .for_each(|(i, v)| *v = val & (1 << (shift + i)) > 0);
+
+        shift += DIGITAL_A_INPUT_COUNT;
+        shift += MAX_DIGITAL_B_INPUT_COUNT - self.digital_b_inputs.len();
+        self.digital_b_inputs.iter_mut()
+            .take(MAX_DIGITAL_B_INPUT_COUNT)
+            .enumerate()
+            .for_each(|(i, v)| *v = val & (1 << (shift + i)) > 0);
+    }
+}
+
+/// The structure to represent state of knobs.
+#[derive(Default, Debug, Copy, Clone)]
+pub struct IoKnobState{
+    /// The ratio to mix monitored inputs and stream inputs. 0x0000..0x0100.
+    pub mix_blend: u32,
+    /// The volume of main level. 0x0000..0x0100.
+    pub main_level: u32,
+}
+
+impl IoKnobState {
+    const SIZE: usize = 8;
+
+    fn parse(&mut self, raw: &[u8]) {
+        assert_eq!(raw.len(), Self::SIZE);
+
+        self.mix_blend.parse_quadlet(&raw[..4]);
+        self.main_level.parse_quadlet(&raw[4..8]);
+    }
+}
+
+/// The structure to represent state of mixer.
+#[derive(Debug)]
+pub struct IoMixerState{
+    pub gains: Vec<IoMixerGain>,
+    pub mutes: Vec<IoMixerMute>,
+    pub out_vols: [i32;IO_MIXER_COUNT],
+    pub out_mutes: [bool;IO_MIXER_COUNT],
+    pub knobs: IoKnobState,
+}
+
+pub trait IoMixerSpec {
+    const ANALOG_INPUT_COUNT: usize;
+    const DIGITAL_B_INPUT_COUNT: usize;
+
+    fn create_mixer_state() -> IoMixerState {
+        IoMixerState{
+            gains: vec![IoMixerGain{
+                analog_inputs: vec![0;Self::ANALOG_INPUT_COUNT],
+                stream_inputs: [0;STREAM_INPUT_COUNT],
+                digital_a_inputs: [0;DIGITAL_A_INPUT_COUNT],
+                digital_b_inputs: vec![0;Self::DIGITAL_B_INPUT_COUNT],
+            };IO_MIXER_COUNT],
+            mutes: vec![IoMixerMute{
+                analog_inputs: vec![false;Self::ANALOG_INPUT_COUNT],
+                digital_a_inputs: [false;DIGITAL_A_INPUT_COUNT],
+                digital_b_inputs: vec![false;Self::DIGITAL_B_INPUT_COUNT],
+            };IO_MIXER_COUNT / 2],
+            out_vols: [0;IO_MIXER_COUNT],
+            out_mutes: [false;IO_MIXER_COUNT],
+            knobs: Default::default(),
+        }
+    }
+}
+
+/// The structure to represent mixer of iO 14.
+#[derive(Debug)]
+pub struct Io14MixerState(IoMixerState);
+
+impl IoMixerSpec for Io14MixerState {
+    const ANALOG_INPUT_COUNT: usize = 4;
+    const DIGITAL_B_INPUT_COUNT: usize = 2;
+}
+
+impl AsRef<IoMixerState> for Io14MixerState {
+    fn as_ref(&self) -> &IoMixerState {
+        &self.0
+    }
+}
+
+impl AsMut<IoMixerState> for Io14MixerState {
+    fn as_mut(&mut self) -> &mut IoMixerState {
+        &mut self.0
+    }
+}
+
+impl Default for Io14MixerState {
+    fn default() -> Self {
+        Io14MixerState(Self::create_mixer_state())
+    }
+}
+
+/// The structure to represent mixer of iO 26.
+#[derive(Debug)]
+pub struct Io26MixerState(IoMixerState);
+
+impl IoMixerSpec for Io26MixerState {
+    const ANALOG_INPUT_COUNT: usize = 8;
+    const DIGITAL_B_INPUT_COUNT: usize = 8;
+}
+
+impl AsRef<IoMixerState> for Io26MixerState {
+    fn as_ref(&self) -> &IoMixerState {
+        &self.0
+    }
+}
+
+impl AsMut<IoMixerState> for Io26MixerState {
+    fn as_mut(&mut self) -> &mut IoMixerState {
+        &mut self.0
+    }
+}
+
+impl Default for Io26MixerState {
+    fn default() -> Self {
+        Io26MixerState(Self::create_mixer_state())
+    }
+}
+
+pub trait IoMixerProtocol<T, U> : AlesisIoProtocol<T>
+    where T: AsRef<FwNode>,
+          U: AsMut<IoMixerState> + AsRef<IoMixerState>,
+{
+    const MONITOR_SRC_GAIN_OFFSET: usize = 0x0038;
+    const MONITOR_OUT_VOL_OFFSET: usize = 0x0438;
+    const MONITOR_SRC_MUTE_OFFSET: usize = 0x0458;
+    //const MIXER_OUT_SELECT_OFFSET: usize = 0x0460;
+    // NOTE: This has no actual side-effect except for assist to software.
+    //const MONITOR_SRC_LINK_OFFSET: usize = 0x047c;
+    const MONITOR_OUT_MUTE_OFFSET: usize = 0x0468;
+    const MIXER_SELECT_OFFSET: usize = 0x0560;
+    const KNOB_STATE_OFFSET: usize = 0x0574;
+
+    const MAX_MIXER_SRC_COUNT: usize = MAX_ANALOG_INPUT_COUNT + DIGITAL_A_INPUT_COUNT +
+                                       MAX_DIGITAL_B_INPUT_COUNT + STREAM_INPUT_COUNT;
+
+    fn read_mixer_src_gains(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        state.as_mut().gains.iter_mut()
+            .enumerate()
+            .try_for_each(|(i, m)| {
+                let offset = i * 4 * Self::MAX_MIXER_SRC_COUNT;
+                let mut raw = vec![0;4 * Self::MAX_MIXER_SRC_COUNT];
+                self.read_block(node, Self::MONITOR_SRC_GAIN_OFFSET + offset, &mut raw, timeout_ms)
+                    .map(|_| m.parse(&raw))
+            })
+    }
+
+    fn write_mixer_src_gains(&self, node: &T, state: &mut U, mixer: usize, gains: &IoMixerGain, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        ((mixer / 2) as u32).build_quadlet(&mut raw);
+        self.write_block(node, Self::MIXER_SELECT_OFFSET, &mut raw, timeout_ms)?;
+
+        let mut new = vec![0;4 * Self::MAX_MIXER_SRC_COUNT];
+        gains.build(&mut new);
+        let mut old = vec![0;4 * Self::MAX_MIXER_SRC_COUNT];
+        state.as_ref().gains[mixer].build(&mut old);
+
+        let offset = 4 * mixer * Self::MAX_MIXER_SRC_COUNT;
+
+        (0..Self::MAX_MIXER_SRC_COUNT)
+            .try_for_each(|i| {
+                let pos = 4 * i;
+                if &new[pos..(pos + 4)] != &old[pos..(pos + 4)] {
+                    self.write_block(node, Self::MONITOR_SRC_GAIN_OFFSET + offset + pos, &mut new[pos..(pos + 4)],
+                                     timeout_ms)
+                } else {
+                    Ok(())
+                }
+            })
+            .map(|_| state.as_mut().gains[mixer].parse(&new))
+    }
+
+    fn read_mixer_src_mutes(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        state.as_mut().mutes.iter_mut()
+            .enumerate()
+            .try_for_each(|(i, m)| {
+                let mut raw = [0;4];
+                let offset = Self::MONITOR_SRC_MUTE_OFFSET + i * 4;
+                self.read_block(node, offset, &mut raw, timeout_ms)
+                    .map(|_| m.parse(&raw))
+            })
+    }
+
+    fn write_mixer_src_mutes(&self, node: &T, state: &mut U, mixer_pair: usize, mutes: &IoMixerMute,
+                             timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        (mixer_pair as u32).build_quadlet(&mut raw);
+        self.write_block(node, Self::MIXER_SELECT_OFFSET, &mut raw, timeout_ms)?;
+
+        mutes.build(&mut raw);
+        self.write_block(node, Self::MONITOR_SRC_MUTE_OFFSET + 4 * mixer_pair, &mut raw, timeout_ms)
+            .map(|_| state.as_mut().mutes[mixer_pair].parse(&raw))
+    }
+
+    fn read_mixer_out_vols(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4 * IO_MIXER_COUNT];
+        self.read_block(node, Self::MONITOR_OUT_VOL_OFFSET, &mut raw, timeout_ms)
+            .map(|_| state.as_mut().out_vols.parse_quadlet_block(&raw))
+    }
+
+    fn write_mixer_out_vols(&self, node: &T, state: &mut U, vols: &[i32], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(state.as_ref().out_vols.len(), vols.len());
+
+        vols.iter()
+            .zip(state.as_mut().out_vols.iter_mut())
+            .enumerate()
+            .filter(|(_, (n, o))| !n.eq(o))
+            .try_for_each(|(i, (n, o))| {
+                let mut raw = [0;4];
+                n.build_quadlet(&mut raw);
+                let offset = Self::MONITOR_OUT_VOL_OFFSET + 4 * i;
+                self.write_block(node, offset, &mut raw, timeout_ms)
+                    .map(|_| *o = *n)
+            })
+    }
+
+    fn read_mixer_out_mutes(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        self.read_flags(node, Self::MONITOR_OUT_MUTE_OFFSET, &mut state.as_mut().out_mutes, timeout_ms)
+    }
+
+    fn write_mixer_out_mutes(&self, node: &T, state: &mut U, mutes: &[bool], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(state.as_ref().out_mutes.len(), mutes.len());
+
+        self.write_flags(node, Self::MONITOR_OUT_MUTE_OFFSET, mutes, timeout_ms)
+            .map(|_| state.as_mut().out_mutes.copy_from_slice(mutes))
+    }
+
+    fn read_knob_state(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;8];
+        self.read_block(node, Self::KNOB_STATE_OFFSET, &mut raw, timeout_ms)
+            .map(|_| state.as_mut().knobs.parse(&raw))
+    }
+}
+
+impl<O, T, U> IoMixerProtocol<T, U> for O
+    where O: AlesisIoProtocol<T>,
+          T: AsRef<FwNode>,
+          U: AsMut<IoMixerState> + AsRef<IoMixerState>,
+{}

--- a/libs/dice/protocols/src/alesis/output.rs
+++ b/libs/dice/protocols/src/alesis/output.rs
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+//! Output protocol specific to Alesis iO FireWire series.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for output
+//! protocol defined by Alesis for iO FireWire series.
+
+use glib::Error;
+use hinawa::FwNode;
+
+use super::*;
+
+use crate::*;
+
+/// The enumeration to represent nominal level of signal.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum NominalSignalLevel{
+    /// -10dBV.
+    Consumer,
+    /// +4dBu.
+    Professional,
+}
+
+impl Default for NominalSignalLevel {
+    fn default() -> Self {
+        NominalSignalLevel::Consumer
+    }
+}
+
+impl From<u32> for NominalSignalLevel {
+    fn from(val: u32) -> Self {
+        if val > 0 {
+            Self::Professional
+        } else {
+            Self::Consumer
+        }
+    }
+}
+
+impl From<NominalSignalLevel> for u32 {
+    fn from(level: NominalSignalLevel) -> Self {
+        match level {
+            NominalSignalLevel::Consumer => 0,
+            NominalSignalLevel::Professional => 1,
+        }
+    }
+}
+
+/// The enumeration to represent source of 6/7 channels of digital B input.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum DigitalB67Src{
+    Spdif12,
+    Adat67,
+}
+
+impl Default for DigitalB67Src {
+    fn default() -> Self {
+        Self::Spdif12
+    }
+}
+
+impl From<u32> for DigitalB67Src {
+    fn from(val: u32) -> Self {
+        if val > 0 {
+            Self::Adat67
+        } else {
+            Self::Spdif12
+        }
+    }
+}
+
+impl From<DigitalB67Src> for u32 {
+    fn from(src: DigitalB67Src) -> Self {
+        match src {
+            DigitalB67Src::Spdif12 => 0,
+            DigitalB67Src::Adat67 => 1,
+        }
+    }
+}
+
+/// The enumeration to represent pair of mixer output.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MixerOutPair{
+    Mixer01,
+    Mixer23,
+    Mixer45,
+    Mixer67,
+}
+
+impl Default for MixerOutPair {
+    fn default() -> Self {
+        Self::Mixer01
+    }
+}
+
+impl From<u32> for MixerOutPair {
+    fn from(val: u32) -> Self {
+        match val {
+            3 => Self::Mixer67,
+            2 => Self::Mixer45,
+            1 => Self::Mixer23,
+            _ => Self::Mixer01,
+        }
+    }
+}
+
+impl From<MixerOutPair> for u32 {
+    fn from(pair: MixerOutPair) -> Self {
+        match pair {
+            MixerOutPair::Mixer01 => 0,
+            MixerOutPair::Mixer23 => 1,
+            MixerOutPair::Mixer45 => 2,
+            MixerOutPair::Mixer67 => 3,
+        }
+    }
+}
+
+/// The trait to represent output protocol for iO FireWire series.
+pub trait IoOutputProtocol<T: AsRef<FwNode>> : AlesisIoProtocol<T> {
+    const OUT_LEVEL_OFFSET: usize = 0x0564;
+    const MIXER_DIGITAL_B_67_SRC_OFFSET: usize = 0x0568;
+    const SPDIF_OUT_SRC_OFFSET: usize = 0x056c;
+    const HP34_SRC_OFFSET: usize = 0x0570;
+
+    fn read_out_levels(&self, node: &T, levels: &mut [NominalSignalLevel], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut flags = vec![false;levels.len()];
+        self.read_flags(node, Self::OUT_LEVEL_OFFSET, &mut flags[..], timeout_ms)
+            .map(|_| {
+                levels.iter_mut()
+                    .zip(flags.iter())
+                    .for_each(|(l, &f)| *l = NominalSignalLevel::from(f as u32))
+            })
+    }
+
+    fn write_out_levels(&self, node: &T, levels: &[NominalSignalLevel], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut flags: Vec<bool> = levels.iter()
+            .map(|l| u32::from(*l) > 0)
+            .collect();
+        self.write_flags(node, Self::OUT_LEVEL_OFFSET, &mut flags, timeout_ms)
+    }
+
+    fn read_mixer_digital_b_67_src(&self, node: &T, src: &mut DigitalB67Src, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_block(node, Self::MIXER_DIGITAL_B_67_SRC_OFFSET, &mut raw, timeout_ms)
+            .map(|_| src.parse_quadlet(&raw))
+    }
+
+    fn write_mixer_digital_b_67_src(&self, node: &T, src: &DigitalB67Src, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        src.build_quadlet(&mut raw);
+        self.write_block(node, Self::MIXER_DIGITAL_B_67_SRC_OFFSET, &mut raw, timeout_ms)
+    }
+
+    fn read_spdif_out_src(&self, node: &T, src: &mut MixerOutPair, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        self.read_block(node, Self::SPDIF_OUT_SRC_OFFSET, &mut raw, timeout_ms)
+            .map(|_| src.parse_quadlet(&raw))
+    }
+
+    fn write_spdif_out_src(&self, node: &T, src: &MixerOutPair, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        src.build_quadlet(&mut raw);
+        self.write_block(node, Self::SPDIF_OUT_SRC_OFFSET, &mut raw, timeout_ms)
+    }
+
+    fn read_hp23_out_src(&self, node: &T, src: &mut MixerOutPair, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        self.read_block(node, Self::HP34_SRC_OFFSET, &mut raw, timeout_ms)
+            .map(|_| src.parse_quadlet(&raw))
+    }
+
+    fn write_hp23_out_src(&self, node: &T, src: &MixerOutPair, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        src.build_quadlet(&mut raw);
+        self.write_block(node, Self::HP34_SRC_OFFSET, &mut raw, timeout_ms)
+    }
+}
+
+impl<O, T> IoOutputProtocol<T> for O
+    where T: AsRef<FwNode>,
+          O: AlesisIoProtocol<T>,
+{}

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod tcat;
 pub mod tcelectronic;
+pub mod alesis;
 pub mod maudio;
 pub mod avid;
 pub mod loud;

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+
+use crate::common_ctl::*;
+
+#[derive(Default)]
+pub struct IoFwModel{
+    proto: FwReq,
+    sections: GeneralSections,
+    ctl: CommonCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for IoFwModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+    }
+}
+
+impl NotifyModel<SndDice, u32> for IoFwModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read_notified_elem(elem_id, elem_value)
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for IoFwModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.measure_elem(elem_id, elem_value)
+    }
+}

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -5,6 +5,7 @@ mod model;
 mod common_ctl;
 mod minimal_model;
 mod tcelectronic;
+mod io_fw_model;
 
 mod tcd22xx_ctl;
 mod extension_model;

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -78,6 +78,7 @@ impl DiceModel {
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
+            (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             _ => Model::Minimal(MinimalModel::default()),
         };
 

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -19,6 +19,7 @@ use super::tcelectronic::studiok48_model::*;
 use super::tcelectronic::klive_model::*;
 use super::tcelectronic::desktopk6_model::*;
 use super::tcelectronic::itwin_model::*;
+use super::io_fw_model::*;
 use super::extension_model::ExtensionModel;
 use super::pfire_model::*;
 use super::mbox3_model::*;
@@ -32,6 +33,7 @@ enum Model {
     TcKlive(KliveModel),
     TcDesktopk6(Desktopk6Model),
     TcItwin(ItwinModel),
+    AlesisIoFw(IoFwModel),
     Extension(ExtensionModel),
     MaudioPfire2626(Pfire2626Model),
     MaudioPfire610(Pfire610Model),
@@ -70,6 +72,7 @@ impl DiceModel {
             (0x000166, 0x000023) => Model::TcKlive(KliveModel::default()),
             (0x000166, 0x000024) => Model::TcDesktopk6(Desktopk6Model::default()),
             (0x000166, 0x000027) => Model::TcItwin(ItwinModel::default()),
+            (0x000595, 0x000001) => Model::AlesisIoFw(IoFwModel::default()),
             (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
             (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
@@ -106,6 +109,7 @@ impl DiceModel {
             Model::TcKlive(m) => m.load(unit, card_cntr),
             Model::TcDesktopk6(m) => m.load(unit, card_cntr),
             Model::TcItwin(m) => m.load(unit, card_cntr),
+            Model::AlesisIoFw(m) => m.load(unit, card_cntr),
             Model::Extension(m) => m.load(unit, card_cntr),
             Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
             Model::MaudioPfire610(m) => m.load(unit, card_cntr),
@@ -121,6 +125,7 @@ impl DiceModel {
             Model::TcKlive(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::TcDesktopk6(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::TcItwin(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::AlesisIoFw(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -136,6 +141,7 @@ impl DiceModel {
             Model::TcKlive(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::TcDesktopk6(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::TcItwin(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::AlesisIoFw(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -158,6 +164,7 @@ impl DiceModel {
             Model::TcKlive(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::TcDesktopk6(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::TcItwin(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::AlesisIoFw(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -177,6 +184,7 @@ impl DiceModel {
             Model::TcKlive(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::TcDesktopk6(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::TcItwin(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::AlesisIoFw(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -196,6 +204,7 @@ impl DiceModel {
             Model::TcKlive(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::TcDesktopk6(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::TcItwin(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::AlesisIoFw(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -79,6 +79,7 @@ impl DiceModel {
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
+            (0x000595, 0x000002) |  // Alesis MasterControl.
             _ => Model::Minimal(MinimalModel::default()),
         };
 


### PR DESCRIPTION
Alesis shipped iO FireWire series 2006. Two models belongs to the series; iO 14 FireWire and iO 26 FireWire. Both of them utilizes DICE II ASIC as their communication engine and allows software to configure hardware features such like output volume.

This patchset adds support for the model. Additionally, this patchset adds entry to minimal model for MultiMix 8/12/16 FireWire shipped by Alesis 2005, as well as MasterControl shipped by Alesis 2009.

```
Takashi Sakamoto (11):
  dice-runtime: add support for Alesis iO 14/26 FireWire
  dice-runtime: alesis_model: detect iO 14 and iO 26
  dice-protocols: add protocol specific to Alesis iO FireWire series
  dice-protocols: alesis: add trait implementation for meter protocol
  dice-runtime: alesis_model: add meter control for iO 14 and 26
  dice-protocols: alesis: add trait implementation for mixer protocol
  dice-runtime: alesis_model: add mixer controls for iO 14 and 26
  dice-protocols: alesis: add trait implementation for output protocol
  dice-runtime: alesis_model: add output controls for iO 14 and 26
  dice-runtime: add support for Alesis MultiMix 8/12/16 FireWire
  dice-runtime: add support for Alesis MasterControl

 README.rst                               |   2 +
 libs/dice/protocols/src/alesis.rs        |  58 ++
 libs/dice/protocols/src/alesis/meter.rs  | 123 ++++
 libs/dice/protocols/src/alesis/mixer.rs  | 390 ++++++++++++
 libs/dice/protocols/src/alesis/output.rs | 191 ++++++
 libs/dice/protocols/src/lib.rs           |   1 +
 libs/dice/runtime/src/io_fw_model.rs     | 726 +++++++++++++++++++++++
 libs/dice/runtime/src/lib.rs             |   1 +
 libs/dice/runtime/src/model.rs           |  11 +
 9 files changed, 1503 insertions(+)
 create mode 100644 libs/dice/protocols/src/alesis.rs
 create mode 100644 libs/dice/protocols/src/alesis/meter.rs
 create mode 100644 libs/dice/protocols/src/alesis/mixer.rs
 create mode 100644 libs/dice/protocols/src/alesis/output.rs
 create mode 100644 libs/dice/runtime/src/io_fw_model.rs
```