### PR TITLE
dice: add support for Lexicon I-ONIX FW810s

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,6 +145,7 @@ your device, please contact to developer.
   * Alesis iO 14
   * Alesis iO 26
   * Alesis MasterControl
+  * Lexicon I-ONIX FW810s
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/libs/dice/protocols/src/lexicon.rs
+++ b/libs/dice/protocols/src/lexicon.rs
@@ -8,6 +8,7 @@
 
 pub mod meter;
 pub mod mixer;
+pub mod effect;
 
 use glib::Error;
 use hinawa::FwNode;

--- a/libs/dice/protocols/src/lexicon.rs
+++ b/libs/dice/protocols/src/lexicon.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Lexicon I-ONIX FW810s.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Lexicon for I-ONIX FW810s.
+
+use glib::Error;
+use hinawa::FwNode;
+
+use super::tcat::*;
+
+/// The trait to represent protocol defined by Lexicon for I-ONIX FW810s.
+pub trait IonixProtocol<T: AsRef<FwNode>> : GeneralProtocol<T> {
+    const BASE_OFFSET: usize = 0x00200000;
+
+    fn read(&self, node: &T, offset: usize, frame: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        GeneralProtocol::read(self, node, Self::BASE_OFFSET + offset, frame, timeout_ms)
+    }
+
+    fn write(&self, node: &T, offset: usize, frame: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        GeneralProtocol::write(self, node, Self::BASE_OFFSET + offset, frame, timeout_ms)
+    }
+}
+
+impl<O, T> IonixProtocol<T> for O
+    where T: AsRef<FwNode>,
+          O: GeneralProtocol<T>,
+{}

--- a/libs/dice/protocols/src/lexicon.rs
+++ b/libs/dice/protocols/src/lexicon.rs
@@ -7,6 +7,7 @@
 //! defined by Lexicon for I-ONIX FW810s.
 
 pub mod meter;
+pub mod mixer;
 
 use glib::Error;
 use hinawa::FwNode;

--- a/libs/dice/protocols/src/lexicon.rs
+++ b/libs/dice/protocols/src/lexicon.rs
@@ -6,6 +6,8 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Lexicon for I-ONIX FW810s.
 
+pub mod meter;
+
 use glib::Error;
 use hinawa::FwNode;
 

--- a/libs/dice/protocols/src/lexicon/effect.rs
+++ b/libs/dice/protocols/src/lexicon/effect.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Effect protocol specific to Lexicon I-ONIX FW810s.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for effect protocol
+//! defined by Lexicon for I-ONIX FW810s.
+
+use glib::Error;
+use hinawa::FwNode;
+
+use super::*;
+
+pub trait IonixEffectProtocol<T: AsRef<FwNode>> : IonixProtocol<T> {
+    // NOTE: states of all effect are available with structured data by read block request with 512 bytes.
+    const EFFECT_OFFSET: usize = 0x00004000;
+
+    const DATA_PREFIX: [u8;5] = [0x06, 0x00, 0x1b, 0x01, 0x41];
+
+    const SYSEX_MSG_PREFIX: u8 = 0xf0;
+    const SYSEX_MSG_SUFFIX: u8 = 0xf7;
+
+    fn write_data(&self, node: &T, data: &[u8], timeout_ms: u32) -> Result<(), Error> {
+        // NOTE: The data has prefix.
+        let mut msgs = Self::DATA_PREFIX.to_vec();
+        msgs.extend_from_slice(&data);
+
+        // NOTE: Append checksum calculated by XOR for all the data.
+        let checksum = msgs.iter()
+            .fold(0u8, |val, &msg| val | msg);
+        msgs.push(checksum);
+
+        // NOTE: Construct MIDI system exclusive message.
+        msgs.insert(0, 0xf0);
+        msgs.push(0xf7);
+
+        // NOTE: One quadlet deliver one byte of message.
+        let mut raw = Vec::<u8>::new();
+        msgs.iter()
+            .for_each(|&msg| raw.extend_from_slice(&(msg as u32).to_be_bytes()));
+
+        IonixProtocol::write(self, node, Self::EFFECT_OFFSET, &mut raw, timeout_ms)
+    }
+}
+
+impl<O, T> IonixEffectProtocol<T> for O
+    where T: AsRef<FwNode>,
+          O: IonixProtocol<T>,
+{}

--- a/libs/dice/protocols/src/lexicon/meter.rs
+++ b/libs/dice/protocols/src/lexicon/meter.rs
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Meter protocol specific to Lexicon I-ONIX FW810s.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for meter protocol
+//! defined by Lexicon for I-ONIX FW810s.
+
+use super::*;
+
+use crate::*;
+use crate::tcat::extension::*;
+
+#[derive(Default, Debug)]
+/// The structure to represent hardware meter.
+pub struct IonixMeter{
+    pub analog_inputs: [i32;8],
+    pub spdif_inputs: [i32;8],
+    pub stream_inputs: [i32;10],
+    pub bus_outputs: [i32;8],
+    pub main_outputs: [i32;2],
+}
+
+/// The structure to represent entry of hardware meter.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+struct IonixMeterEntry{
+    /// The level of audio signal from the source to the destination.
+    level: i16,
+    /// The source of audio signal.
+    src: SrcBlk,
+    /// The destination of audio signal.
+    dst: DstBlk,
+}
+
+impl From<u32> for IonixMeterEntry {
+    fn from(val: u32) -> Self {
+        IonixMeterEntry{
+            level: ((val & 0xffff0000) >> 16) as i16,
+            src: SrcBlk::from(((val & 0x0000ff00) >> 8) as u8),
+            dst: DstBlk::from(((val & 0x000000ff) >> 0) as u8),
+        }
+    }
+}
+
+impl From<IonixMeterEntry> for u32 {
+    fn from(entry: IonixMeterEntry) -> Self {
+        ((entry.level as u32) << 16) | ((u8::from(entry.src) as u32) << 8) | (u8::from(entry.dst) as u32)
+    }
+}
+
+/// The trait to represent protocol for hardware meter.
+pub trait IonixMeterProtocol<T: AsRef<FwNode>> : IonixProtocol<T> {
+    const METER_OFFSET: usize = 0x0500;
+
+    // NOTE: 90 entries are valid at all of supported sampling rate.
+    const ENTRY_COUNT: usize = 90;
+
+    fn read_meters(&self, node: &T, meters: &mut IonixMeter, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = vec![0;Self::ENTRY_COUNT * 4];
+        IonixProtocol::read(self, node, Self::METER_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut entries = vec![IonixMeterEntry::default();Self::ENTRY_COUNT];
+                entries.parse_quadlet_block(&raw);
+
+                entries.iter()
+                    .filter(|entry| entry.src.id == SrcBlkId::Avs0 && entry.dst.id == DstBlkId::MixerTx0)
+                    .take(meters.stream_inputs.len())
+                    .enumerate()
+                    .for_each(|(i, entry)| meters.stream_inputs[i] = entry.level as i32);
+
+                entries.iter()
+                    .filter(|entry| entry.src.id == SrcBlkId::Ins0 && entry.dst.id == DstBlkId::MixerTx0)
+                    .take(meters.analog_inputs.len())
+                    .enumerate()
+                    .for_each(|(i, entry)| meters.analog_inputs[i] = entry.level as i32);
+
+                entries.iter()
+                    .filter(|entry| entry.src.id == SrcBlkId::Aes && entry.dst.id == DstBlkId::MixerTx0)
+                    .take(meters.spdif_inputs.len())
+                    .enumerate()
+                    .for_each(|(i, entry)| meters.spdif_inputs[i] = entry.level as i32);
+
+                entries.iter()
+                    .filter(|entry| entry.src.id == SrcBlkId::Mixer && entry.dst.id == DstBlkId::Ins0)
+                    .take(meters.bus_outputs.len())
+                    .enumerate()
+                    .for_each(|(i, entry)| meters.bus_outputs[i] = entry.level as i32);
+
+                entries.iter()
+                    .filter(|entry| {
+                        entry.src.id == SrcBlkId::Mixer &&
+                            entry.dst.id == DstBlkId::Ins1 && entry.dst.ch < 2
+                    })
+                    .take(meters.main_outputs.len())
+                    .enumerate()
+                    .for_each(|(i, entry)| meters.main_outputs[i] = entry.level as i32);
+            })
+    }
+}
+
+impl<O, T> IonixMeterProtocol<T> for O
+    where O: IonixProtocol<T>,
+          T: AsRef<FwNode>,
+{}

--- a/libs/dice/protocols/src/lexicon/mixer.rs
+++ b/libs/dice/protocols/src/lexicon/mixer.rs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Mixer protocol specific to Lexicon I-ONIX FW810s.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for mixer protocol
+//! defined by Lexicon for I-ONIX FW810s.
+
+use super::*;
+
+/// The number of channels in bus mixer.
+pub const MIXER_BUS_CHANNEL_COUNT: usize = 8;
+
+/// The number of channels in main mixer.
+pub const MIXER_MAIN_CHANNEL_COUNT: usize = 2;
+
+/// The number of channels in reverb mixer.
+pub const MIXER_REVERB_CHANNEL_COUNT: usize = 2;
+
+/// The enumeration to represent source of mixer.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MixerSrc{
+    Stream(usize),
+    Spdif(usize),
+    Analog(usize),
+}
+
+// Followed by gains for 8 channels of stream input.
+const STREAM_SRC_OFFSET: usize = 0x00;
+
+// Followed by gains for 2 channels of spdif input.
+const SPDIF_SRC_OFFSET: usize = 0x20;
+
+// Followed by gains for 8 channels of analog input.
+const ANALOG_SRC_OFFSET: usize = 0x28;
+
+// Including gains for the above channels.
+const MIXER_SRC_SIZE: usize = STREAM_SRC_OFFSET + SPDIF_SRC_OFFSET + ANALOG_SRC_OFFSET;
+
+impl From<MixerSrc> for usize {
+    fn from(src: MixerSrc) -> Self {
+        match src {
+            MixerSrc::Stream(ch) => STREAM_SRC_OFFSET + 4 * ch,
+            MixerSrc::Spdif(ch) => SPDIF_SRC_OFFSET + 4 * ch,
+            MixerSrc::Analog(ch) => ANALOG_SRC_OFFSET + 4 * ch,
+        }
+    }
+}
+
+pub trait IonixMixerProtocol<T: AsRef<FwNode>> : IonixProtocol<T> {
+    const MIXER_BUS_SRC_OFFSET: usize = 0x0000;
+    const MIXER_MAIN_SRC_OFFSET: usize = 0x02d0;
+    const MIXER_REVERB_SRC_OFFSET: usize = 0x0360;
+
+    fn read_mixer_bus_src_gain(&self, node: &T, dst: usize, src: MixerSrc, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        assert!(dst < MIXER_BUS_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::read(self, node, Self::MIXER_BUS_SRC_OFFSET + offset, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw))
+    }
+
+    fn write_mixer_bus_src_gain(&self, node: &T, dst: usize, src: MixerSrc, gain: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(dst < MIXER_BUS_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        raw.copy_from_slice(&gain.to_be_bytes());
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::write(self, node, Self::MIXER_BUS_SRC_OFFSET + offset, &mut raw, timeout_ms)
+    }
+
+    fn read_mixer_main_src_gain(&self, node: &T, dst: usize, src: MixerSrc, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        assert!(dst < MIXER_MAIN_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::read(self, node, Self::MIXER_MAIN_SRC_OFFSET + offset, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw))
+    }
+
+    fn write_mixer_main_src_gain(&self, node: &T, dst: usize, src: MixerSrc, gain: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(dst < MIXER_MAIN_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        raw.copy_from_slice(&gain.to_be_bytes());
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::write(self, node, Self::MIXER_MAIN_SRC_OFFSET + offset, &mut raw, timeout_ms)
+    }
+
+    fn read_mixer_reverb_src_gain(&self, node: &T, dst: usize, src: MixerSrc, timeout_ms: u32)
+        -> Result<u32, Error>
+    {
+        assert!(dst < MIXER_REVERB_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::read(self, node, Self::MIXER_REVERB_SRC_OFFSET + offset, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw))
+    }
+
+    fn write_mixer_reverb_src_gain(&self, node: &T, dst: usize, src: MixerSrc, gain: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(dst < MIXER_REVERB_CHANNEL_COUNT);
+
+        let mut raw = [0;4];
+        raw.copy_from_slice(&gain.to_be_bytes());
+        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
+        IonixProtocol::write(self, node, Self::MIXER_REVERB_SRC_OFFSET + offset, &mut raw, timeout_ms)
+    }
+}
+
+impl<O, T> IonixMixerProtocol<T> for O
+    where O: IonixProtocol<T>,
+          T: AsRef<FwNode>,
+{}

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -9,6 +9,7 @@
 pub mod tcat;
 pub mod tcelectronic;
 pub mod alesis;
+pub mod lexicon;
 pub mod maudio;
 pub mod avid;
 pub mod loud;

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -10,9 +10,10 @@ use hinawa::{SndDice, SndUnitExt};
 use alsa_ctl_tlv_codec::items::DbInterval;
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
 use dice_protocols::tcat::{*, global_section::*};
-use dice_protocols::lexicon::meter::*;
+use dice_protocols::lexicon::{meter::*, mixer::*};
 
 use crate::common_ctl::*;
 
@@ -22,6 +23,7 @@ pub struct IonixModel{
     sections: GeneralSections,
     ctl: CommonCtl,
     meter_ctl: MeterCtl,
+    mixer_ctl: MixerCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -36,6 +38,7 @@ impl CtlModel<SndDice> for IonixModel {
         self.ctl.load(card_cntr, &caps, &src_labels)?;
 
         self.meter_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -43,13 +46,25 @@ impl CtlModel<SndDice> for IonixModel {
     fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -155,6 +170,128 @@ impl<'a> MeterCtl {
             Self::MAIN_OUTPUT_NAME => {
                 elem_value.set_int(&self.meters.main_outputs);
                 Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+fn mixer_src_to_string(src: &MixerSrc) -> String {
+    match src {
+        MixerSrc::Stream(ch) => format!("Stream-{}", ch + 1),
+        MixerSrc::Spdif(ch) => format!("S/PDIF-{}", ch + 1),
+        MixerSrc::Analog(ch) => format!("Analog-{}", ch + 1),
+    }
+}
+
+#[derive(Default, Debug)]
+struct MixerCtl;
+
+impl<'a> MixerCtl {
+    const BUS_SRC_GAIN_NAME: &'a str = "mixer-bus-input-gain";
+    const MAIN_SRC_GAIN_NAME: &'a str = "mixer-main-input-gain";
+    const REVERB_SRC_GAIN_NAME: &'a str = "mixer-reverb-input-gain";
+
+    const GAIN_MIN: i32 = 0;
+    const GAIN_MAX: i32 = 0x00007fff;
+    const GAIN_STEP: i32 = 1;
+    const GAIN_TLV: DbInterval = DbInterval{min: -6000, max: 0, linear: false, mute_avail: false};
+
+    const MIXER_SRCS: [MixerSrc;20] = [
+        MixerSrc::Analog(0), MixerSrc::Analog(1), MixerSrc::Analog(2), MixerSrc::Analog(3),
+        MixerSrc::Analog(4), MixerSrc::Analog(5), MixerSrc::Analog(6), MixerSrc::Analog(7),
+        MixerSrc::Spdif(0), MixerSrc::Spdif(1),
+        MixerSrc::Stream(0), MixerSrc::Stream(1), MixerSrc::Stream(2), MixerSrc::Stream(3),
+        MixerSrc::Stream(4), MixerSrc::Stream(5), MixerSrc::Stream(6), MixerSrc::Stream(7),
+        MixerSrc::Stream(8), MixerSrc::Stream(9),
+    ];
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let labels: Vec<String> = Self::MIXER_SRCS.iter()
+            .map(|s| mixer_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::BUS_SRC_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, MIXER_BUS_CHANNEL_COUNT,
+                                        Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP, labels.len(),
+                                        Some(&Vec::<u32>::from(Self::GAIN_TLV)), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MAIN_SRC_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, MIXER_MAIN_CHANNEL_COUNT,
+                                        Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP, labels.len(),
+                                        Some(&Vec::<u32>::from(Self::GAIN_TLV)), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_SRC_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, MIXER_REVERB_CHANNEL_COUNT,
+                                        Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP, labels.len(),
+                                        Some(&Vec::<u32>::from(Self::GAIN_TLV)), true)?;
+
+        Ok(())
+    }
+
+    fn read(&self, unit: &SndDice, proto: &FwReq, elem_id: &ElemId, elem_value: &mut ElemValue,
+            timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::BUS_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
+                    proto.read_mixer_bus_src_gain(&node, mixer, Self::MIXER_SRCS[idx], timeout_ms)
+                        .map(|val| val as i32)
+                })
+                .map(|_| true)
+            }
+            Self::MAIN_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
+                    proto.read_mixer_main_src_gain(&node, mixer, Self::MIXER_SRCS[idx], timeout_ms)
+                        .map(|val| val as i32)
+                })
+                .map(|_| true)
+            }
+            Self::REVERB_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
+                    proto.read_mixer_reverb_src_gain(&node, mixer, Self::MIXER_SRCS[idx], timeout_ms)
+                        .map(|val| val as i32)
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, proto: &FwReq, elem_id: &ElemId, old: &ElemValue, new: &ElemValue,
+             timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::BUS_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
+                    proto.write_mixer_bus_src_gain(&node, mixer, Self::MIXER_SRCS[idx], val as u32, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::MAIN_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
+                    proto.write_mixer_main_src_gain(&node, mixer, Self::MIXER_SRCS[idx], val as u32, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::REVERB_SRC_GAIN_NAME => {
+                let mixer = elem_id.get_index() as usize;
+                let node = unit.get_node();
+                ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
+                    proto.write_mixer_reverb_src_gain(&node, mixer, Self::MIXER_SRCS[idx], val as u32, timeout_ms)
+                })
+                .map(|_| true)
             }
             _ => Ok(false),
         }

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+
+use crate::common_ctl::*;
+
+#[derive(Default)]
+pub struct IonixModel{
+    proto: FwReq,
+    sections: GeneralSections,
+    ctl: CommonCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for IonixModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+    }
+}
+
+impl NotifyModel<SndDice, u32> for IonixModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read_notified_elem(elem_id, elem_value)
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for IonixModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.measure_elem(elem_id, elem_value)
+    }
+}

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -6,6 +6,7 @@ mod common_ctl;
 mod minimal_model;
 mod tcelectronic;
 mod io_fw_model;
+mod ionix_model;
 
 mod tcd22xx_ctl;
 mod extension_model;

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -20,6 +20,7 @@ use super::tcelectronic::klive_model::*;
 use super::tcelectronic::desktopk6_model::*;
 use super::tcelectronic::itwin_model::*;
 use super::io_fw_model::*;
+use super::ionix_model::*;
 use super::extension_model::ExtensionModel;
 use super::pfire_model::*;
 use super::mbox3_model::*;
@@ -34,6 +35,7 @@ enum Model {
     TcDesktopk6(Desktopk6Model),
     TcItwin(ItwinModel),
     AlesisIoFw(IoFwModel),
+    LexiconIonix(IonixModel),
     Extension(ExtensionModel),
     MaudioPfire2626(Pfire2626Model),
     MaudioPfire610(Pfire610Model),
@@ -73,6 +75,7 @@ impl DiceModel {
             (0x000166, 0x000024) => Model::TcDesktopk6(Desktopk6Model::default()),
             (0x000166, 0x000027) => Model::TcItwin(ItwinModel::default()),
             (0x000595, 0x000001) => Model::AlesisIoFw(IoFwModel::default()),
+            (0x000fd7, 0x000001) => Model::LexiconIonix(IonixModel::default()),
             (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
             (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
@@ -112,6 +115,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => m.load(unit, card_cntr),
             Model::TcItwin(m) => m.load(unit, card_cntr),
             Model::AlesisIoFw(m) => m.load(unit, card_cntr),
+            Model::LexiconIonix(m) => m.load(unit, card_cntr),
             Model::Extension(m) => m.load(unit, card_cntr),
             Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
             Model::MaudioPfire610(m) => m.load(unit, card_cntr),
@@ -128,6 +132,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::TcItwin(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::AlesisIoFw(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::LexiconIonix(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -144,6 +149,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::TcItwin(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::AlesisIoFw(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::LexiconIonix(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -167,6 +173,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::TcItwin(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::AlesisIoFw(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::LexiconIonix(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -187,6 +194,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::TcItwin(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::AlesisIoFw(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::LexiconIonix(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -207,6 +215,7 @@ impl DiceModel {
             Model::TcDesktopk6(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::TcItwin(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::AlesisIoFw(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::LexiconIonix(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),


### PR DESCRIPTION
I-ONIX FW810s was shipped in Lexicon brand of HARMAN International industries, Inc 2009. This model uses TCD2220 ASIC as its communication engine and support TCAT general protocol. Unique protocol is used to configure major functions such as audio signal routing, instead of TCAT protocol extension.

This patchset adds support for the model.

At this time, no controls are added for effect functions such as reverb. They can be controlled by write transaction to specific address with data frame which includes MIDI system exclusive message.  I investigated the message and realize that reverb effect requires multiple entities to be controlled. At present, ALSA control interface doesn't support such entities and I postpone its implementation

For yoru information, I write a sheet about the implementation of message:
https://docs.google.com/spreadsheets/d/1y_3RxBhldrkdEaBCBK01V4sKzmdwZ6rvmtjnFXuJz7I/edit?usp=sharing

```
Takashi Sakamoto (7):
  dice-runtime: add support for Lexicon I-ONIX FW810s
  dice-protocols: lexicon: add common protocol defined by Lexicon for
    I-ONIX FW810s
  dice-protocols: lexicon: add trait implementation for meter protocol
  dice-runtime: ionix_model: add meter controls
  dice-protocols: lexicon: add trait implementation for mixer protocol
  dice-runtime: ionix_model: add mixer controls
  dice-protocols: lexicon: add trait implementation for effect protocol

 README.rst                                |   1 +
 libs/dice/protocols/src/lexicon.rs        |  34 +++
 libs/dice/protocols/src/lexicon/effect.rs |  49 ++++
 libs/dice/protocols/src/lexicon/meter.rs  | 104 ++++++++
 libs/dice/protocols/src/lexicon/mixer.rs  | 125 +++++++++
 libs/dice/protocols/src/lib.rs            |   1 +
 libs/dice/runtime/src/ionix_model.rs      | 299 ++++++++++++++++++++++
 libs/dice/runtime/src/lib.rs              |   1 +
 libs/dice/runtime/src/model.rs            |   9 +
 9 files changed, 623 insertions(+)
 create mode 100644 libs/dice/protocols/src/lexicon.rs
 create mode 100644 libs/dice/protocols/src/lexicon/effect.rs
 create mode 100644 libs/dice/protocols/src/lexicon/meter.rs
 create mode 100644 libs/dice/protocols/src/lexicon/mixer.rs
 create mode 100644 libs/dice/runtime/src/ionix_model.rs
```