### PR TITLE
[PATCH 00/10]: dice: add support for Focusrite Saffire Pro series

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -147,6 +147,7 @@ your device, please contact to developer.
   * Alesis MasterControl
   * Lexicon I-ONIX FW810s
   * Focusrite Saffire Pro 40
+  * Focusrite Liquid Saffire 56
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -148,6 +148,7 @@ your device, please contact to developer.
   * Lexicon I-ONIX FW810s
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
+  * Focusrite Saffire Pro 26
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ your device, please contact to developer.
   * Alesis iO 26
   * Alesis MasterControl
   * Lexicon I-ONIX FW810s
+  * Focusrite Saffire Pro 40
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire series.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire series.
+
+pub mod spro40;

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -7,3 +7,4 @@
 //! defined by Focusrite for Saffire series.
 
 pub mod spro40;
+pub mod liquids56;

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -9,3 +9,324 @@
 pub mod spro40;
 pub mod liquids56;
 pub mod spro26;
+
+use glib::Error;
+
+use hinawa::FwNode;
+
+use super::tcat::*;
+use super::tcat::extension::{*, appl_section::*};
+use super::*;
+
+/// The structure to represent a set of entries for output control.
+#[derive(Debug)]
+pub struct OutGroupState{
+    pub vols: Vec<i8>,
+    pub vol_mutes: Vec<bool>,
+    pub vol_hwctls: Vec<bool>,
+
+    pub mute_enabled: bool,
+    pub mute_hwctls: Vec<bool>,
+
+    pub dim_enabled: bool,
+    pub dim_hwctls: Vec<bool>,
+
+    pub hw_knob_value: i8,
+}
+
+pub trait OutGroupSpec {
+    const ENTRY_COUNT: usize;
+    const HAS_VOL_HWCTL: bool;
+
+    const OUT_CTL_OFFSET: usize;
+    const SW_NOTICE_OFFSET: usize;
+
+    const SRC_NOTICE: u32;
+    const DIM_MUTE_NOTICE: u32;
+
+    const MUTE_OFFSET: usize = Self::OUT_CTL_OFFSET + 0x0000;
+    const DIM_OFFSET: usize = Self::OUT_CTL_OFFSET + 0x0004;
+    const VOL_OFFSET: usize = Self::OUT_CTL_OFFSET + 0x0008;
+    const VOL_HWCTL_OFFSET: usize =  Self::OUT_CTL_OFFSET + 0x001c;
+    const DIM_MUTE_HWCTL_OFFSET: usize = Self::OUT_CTL_OFFSET + 0x0030;
+    const HW_KNOB_VALUE_OFFSET: usize = Self::OUT_CTL_OFFSET + 0x0048;
+
+    fn create_out_group_state() -> OutGroupState {
+        OutGroupState{
+            vols: vec![0;Self::ENTRY_COUNT],
+            vol_mutes: vec![false;Self::ENTRY_COUNT],
+            vol_hwctls: vec![false;Self::ENTRY_COUNT],
+            mute_enabled: false,
+            mute_hwctls: vec![false;Self::ENTRY_COUNT],
+            dim_enabled: false,
+            dim_hwctls: vec![false;Self::ENTRY_COUNT],
+            hw_knob_value: 0,
+        }
+    }
+}
+
+pub trait FocusriteSaffireOutGroupProtocol<T, S> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+          S: OutGroupSpec + AsRef<OutGroupState> + AsMut<OutGroupState>,
+{
+    fn write_notice(&self, node: &T, sections: &ExtensionSections, notice: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        notice.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, S::SW_NOTICE_OFFSET, &mut raw, timeout_ms)
+    }
+
+    fn read_out_group_mute(&self, node: &T, sections: &ExtensionSections, state: &mut S, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = vec![0;4];
+        self.read_appl_data(node, sections, S::MUTE_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut val = 0u32;
+                val.parse_quadlet(&raw);
+                state.as_mut().mute_enabled = val > 0;
+            })
+    }
+
+    fn write_out_group_mute(&self, node: &T, sections: &ExtensionSections, state: &mut S, enable: bool,
+                          timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        enable.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, S::MUTE_OFFSET, &mut raw, timeout_ms)?;
+        self.write_notice(node, sections, S::DIM_MUTE_NOTICE, timeout_ms)
+            .map(|_| state.as_mut().mute_enabled = enable)
+    }
+
+    fn read_out_group_dim(&self, node: &T, sections: &ExtensionSections, state: &mut S, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = vec![0;4];
+        self.read_appl_data(node, sections, S::DIM_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut val = 0u32;
+                val.parse_quadlet(&raw);
+                state.as_mut().dim_enabled = val > 0;
+            })
+    }
+
+    fn write_out_group_dim(&self, node: &T, sections: &ExtensionSections, state: &mut S, enable: bool,
+                         timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        enable.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, S::DIM_OFFSET, &mut raw, timeout_ms)?;
+        self.write_notice(node, sections, S::DIM_MUTE_NOTICE, timeout_ms)
+            .map(|_| state.as_mut().dim_enabled = enable)
+    }
+
+    fn read_out_group_vols(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                           timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = vec![0;(S::ENTRY_COUNT + 1) / 2 * 4];
+        self.read_appl_data(node, sections, S::VOL_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let s = state.as_mut();
+                let mut val = 0u32;
+                (0..(S::ENTRY_COUNT / 2))
+                    .for_each(|i| {
+                        let pos = i * 4;
+                        val.parse_quadlet(&raw[pos..(pos + 4)]);
+                        s.vols[2 * i] = (val & 0x000000ff) as i8;
+                        s.vols[2 * i + 1] = ((val & 0x0000ff00) >> 8) as i8;
+                    })
+            })
+    }
+
+    fn write_out_group_vols(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                            vols: &[i8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(state.as_ref().vols.len(), vols.len());
+
+        let mut raw = vec![0;(S::ENTRY_COUNT + 1) / 2 * 4];
+        let s = state.as_mut();
+        (0..(S::ENTRY_COUNT / 2))
+            .for_each(|i| {
+                let left_vol = s.vols[2 * i] as u32;
+                let right_vol = s.vols[2 * i + 1] as u32;
+                let val = (right_vol << 24) | (left_vol << 16) | (right_vol << 8) | left_vol;
+                let pos = i * 4;
+                val.build_quadlet(&mut raw[pos..(pos + 4)]);
+            });
+        self.write_appl_data(node, sections, S::VOL_OFFSET, &mut raw, timeout_ms)?;
+        self.write_notice(node, sections, S::SRC_NOTICE, timeout_ms)
+            .map(|_| state.as_mut().vols.copy_from_slice(&vols))
+    }
+
+    fn read_out_group_vol_mute_hwctls(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                                      timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = vec![0;(S::ENTRY_COUNT + 1) / 2 * 4];
+        self.read_appl_data(node, sections, S::VOL_HWCTL_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let s = state.as_mut();
+                let mut val = 0u32;
+                (0..(S::ENTRY_COUNT / 2))
+                    .for_each(|i| {
+                        let pos = i * 4;
+                        val.parse_quadlet(&raw[pos..(pos + 4)]);
+                        if S::HAS_VOL_HWCTL {
+                            s.vol_hwctls[2 * i] = val & 0x00000001 > 0;
+                            s.vol_hwctls[2 * i + 1] = val & 0x00000002 > 0;
+                        } else {
+                            s.vol_hwctls[2 * i] = false;
+                            s.vol_hwctls[2 * i + 1] = false;
+                        }
+                        s.vol_mutes[2 * i] = val & 0x00000004 > 0;
+                        s.vol_mutes[2 * i + 1] = val & 0x00000008 > 0;
+                    })
+            })
+    }
+
+    fn write_out_group_vol_mute_hwctls(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                                       vol_mutes: &[bool], vol_hwctls: &[bool], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(vol_mutes.len(), vol_hwctls.len());
+        assert_eq!(state.as_ref().vol_mutes.len(), vol_mutes.len());
+        assert_eq!(state.as_ref().vol_hwctls.len(), vol_hwctls.len());
+
+        let mut raw = vec![0;(S::ENTRY_COUNT + 1) / 2 * 4];
+        (0..(S::ENTRY_COUNT / 2))
+            .for_each(|i| {
+                let mut val = 0u32;
+                if S::HAS_VOL_HWCTL {
+                    if vol_hwctls[2 * i] {
+                        val |= 0x00000001;
+                    }
+                    if vol_hwctls[2 * i + 1] {
+                        val |= 0x00000002;
+                    }
+                }
+                if vol_mutes[2 * i] {
+                    val |= 0x00000004;
+                }
+                if vol_mutes[2 * i + 1] {
+                    val |= 0x00000008;
+                }
+                let pos = i * 4;
+                val.build_quadlet(&mut raw[pos..(pos + 4)]);
+            });
+        self.write_appl_data(node, sections, S::VOL_HWCTL_OFFSET, &mut raw, timeout_ms)?;
+
+        vol_hwctls.iter()
+            .enumerate()
+            .try_for_each(|(i, &hwctl)| {
+                if !hwctl && state.as_ref().vol_hwctls[i] {
+                    let pos = i / 2;
+                    let mut raw = [0;4];
+                    self.read_appl_data(node, sections, S::VOL_OFFSET + pos * 4, &mut raw, timeout_ms)?;
+                    let mut val = u32::from_be_bytes(raw);
+                    let ch = i % 2;
+                    if ch == 0 {
+                        val &= 0x00ff00ff;
+                        val |= (state.as_ref().vols[i] as u32) << 24;
+                        val |= (state.as_ref().vols[i] as u32) << 8;
+                    } else {
+                        val &= 0xff00ff00;
+                        val |= (state.as_ref().vols[i] as u32) << 16;
+                        val |= state.as_ref().vols[i] as u32;
+                    }
+                    val.build_quadlet(&mut raw);
+                    self.write_appl_data(node, sections, S::VOL_OFFSET + pos * 4, &mut raw, timeout_ms)
+                } else {
+                    Ok(())
+                }
+            })?;
+
+        self.write_notice(node, sections, S::SRC_NOTICE, timeout_ms)
+            .map(|_| {
+                state.as_mut().vol_mutes.copy_from_slice(&vol_mutes);
+                state.as_mut().vol_hwctls.copy_from_slice(&vol_hwctls);
+            })
+    }
+
+    fn read_out_group_dim_mute_hwctls(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                                     timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, S::DIM_MUTE_HWCTL_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut val = 0u32;
+                val.parse_quadlet(&raw);
+                state.as_mut().dim_hwctls.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, assign)| *assign = val & (1 << (i + 10)) > 0);
+                state.as_mut().mute_hwctls.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, assign)| *assign = val & (1 << i) > 0);
+            })
+    }
+
+    fn write_out_group_dim_mute_hwctls(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                                      dim_hwctls: &[bool], mute_hwctls: &[bool], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(dim_hwctls.len(), mute_hwctls.len());
+        assert_eq!(state.as_ref().dim_hwctls.len(), dim_hwctls.len());
+        assert_eq!(state.as_ref().mute_hwctls.len(), mute_hwctls.len());
+
+        let dim_assign_flags = dim_hwctls.iter()
+            .enumerate()
+            .filter(|(_, &assign)| assign)
+            .fold(0u32, |v, (i, _)| v | (1 << (i + 10)));
+        let mute_assign_flags = mute_hwctls.iter()
+            .enumerate()
+            .filter(|(_, &assign)| assign)
+            .fold(0u32, |v, (i, _)| v + (1 << i));
+        let val = dim_assign_flags | mute_assign_flags;
+        let mut raw = [0;4];
+        val.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, S::DIM_MUTE_HWCTL_OFFSET, &mut raw, timeout_ms)?;
+        self.write_notice(node, sections, S::SRC_NOTICE, timeout_ms)
+            .map(|_| {
+                state.as_mut().dim_hwctls.copy_from_slice(&dim_hwctls);
+                state.as_mut().mute_hwctls.copy_from_slice(&mute_hwctls);
+            })
+    }
+
+    fn read_out_group_knob_value(&self, node: &T, sections: &ExtensionSections, state: &mut S,
+                                 timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, S::HW_KNOB_VALUE_OFFSET, &mut raw, timeout_ms)
+            .map(|_| state.as_mut().hw_knob_value = u32::from_be_bytes(raw) as i8)
+    }
+}
+
+impl<O, T, S> FocusriteSaffireOutGroupProtocol<T, S> for O
+    where O: ApplSectionProtocol<T>,
+          T: AsRef<FwNode>,
+          S: OutGroupSpec + AsRef<OutGroupState> + AsMut<OutGroupState>,
+{}
+
+/// The trait to parse notification defined by Focusrite.
+pub trait FocusriteSaffireOutGroupNotification :  TcatNotification {
+    const NOTIFY_DIM_MUTE_CHANGE: u32 = 0x00200000;
+
+    /// Just supported by Liquid Saffire 56 and Saffire Pro 40.
+    const NOTIFY_VOL_CHANGE: u32 = 0x00400000;
+
+    fn has_dim_mute_change(self) -> bool {
+        self.bitand(Self::NOTIFY_DIM_MUTE_CHANGE) > 0
+    }
+
+    fn has_vol_change(self) -> bool {
+        self.bitand(Self::NOTIFY_VOL_CHANGE) > 0
+    }
+}
+
+impl<O: TcatNotification> FocusriteSaffireOutGroupNotification for O {}

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -8,3 +8,4 @@
 
 pub mod spro40;
 pub mod liquids56;
+pub mod spro26;

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -9,10 +9,22 @@
 use crate::tcat::extension::*;
 use crate::tcat::tcd22xx_spec::*;
 
+use super::*;
+
 /// The structure to represent state of TCD22xx on Liquid Saffire 56.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct LiquidS56State{
     tcd22xx: Tcd22xxState,
+    out_grp: OutGroupState,
+}
+
+impl Default for LiquidS56State {
+    fn default() -> Self {
+        LiquidS56State{
+            tcd22xx: Tcd22xxState::default(),
+            out_grp: Self::create_out_group_state(),
+        }
+    }
 }
 
 impl<'a> Tcd22xxSpec<'a> for LiquidS56State {
@@ -75,5 +87,32 @@ impl AsMut<Tcd22xxState> for LiquidS56State {
 impl AsRef<Tcd22xxState> for LiquidS56State {
     fn as_ref(&self) -> &Tcd22xxState {
         &self.tcd22xx
+    }
+}
+
+const SW_NOTICE_OFFSET: usize = 0x02c8;
+
+const SRC_SW_NOTICE: u32 = 0x00000001;
+const DIM_MUTE_SW_NOTICE: u32 = 0x00000003;
+
+impl OutGroupSpec for LiquidS56State {
+    const ENTRY_COUNT: usize = 10;
+    const HAS_VOL_HWCTL: bool = true;
+    const OUT_CTL_OFFSET: usize = 0x000c;
+    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
+
+    const SRC_NOTICE: u32 = SRC_SW_NOTICE;
+    const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;
+}
+
+impl AsMut<OutGroupState> for LiquidS56State {
+    fn as_mut(&mut self) -> &mut OutGroupState {
+        &mut self.out_grp
+    }
+}
+
+impl AsRef<OutGroupState> for LiquidS56State {
+    fn as_ref(&self) -> &OutGroupState {
+        &self.out_grp
     }
 }

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -8,6 +8,7 @@
 
 use crate::tcat::extension::*;
 use crate::tcat::tcd22xx_spec::*;
+use crate::*;
 
 use super::*;
 
@@ -94,6 +95,13 @@ const SW_NOTICE_OFFSET: usize = 0x02c8;
 
 const SRC_SW_NOTICE: u32 = 0x00000001;
 const DIM_MUTE_SW_NOTICE: u32 = 0x00000003;
+const IO_FLAG_SW_NOTICE: u32 = 0x00000004;
+const MIC_AMP_1_HARMONICS_SW_NOTICE: u32 = 0x00000006;
+const MIC_AMP_2_HARMONICS_SW_NOTICE: u32 = 0x00000007;
+const MIC_AMP_1_EMULATION_SW_NOTICE: u32 = 0x00000008;
+const MIC_AMP_2_EMULATION_SW_NOTICE: u32 = 0x00000009;
+const MIC_AMP_POLARITY_SW_NOTICE: u32 = 0x0000000a;
+const INPUT_LEVEL_SW_NOTICE: u32 = 0x0000000b;
 
 impl OutGroupSpec for LiquidS56State {
     const ENTRY_COUNT: usize = 10;
@@ -116,3 +124,435 @@ impl AsRef<OutGroupState> for LiquidS56State {
         &self.out_grp
     }
 }
+
+/// The enumeration to represent type of signal for optical output interface.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OptOutIfaceMode {
+    Adat,
+    Spdif,
+    AesEbu,
+}
+
+/// The enumeration to represent emulation type of mic pre amp.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum MicAmpEmulationType{
+    Flat,
+    Trany1h,
+    Silver2,
+    FfRed1h,
+    Savillerow,
+    Dunk,
+    ClassA2a,
+    OldTube,
+    Deutsch72,
+    Stellar1b,
+    NewAge,
+    Reserved(u32),
+}
+
+impl From<u32> for MicAmpEmulationType {
+    fn from(val: u32) -> Self {
+        match val {
+            0x00 => Self::Flat,
+            0x01 => Self::Trany1h,
+            0x02 => Self::Silver2,
+            0x03 => Self::FfRed1h,
+            0x04 => Self::Savillerow,
+            0x05 => Self::Dunk,
+            0x06 => Self::ClassA2a,
+            0x07 => Self::OldTube,
+            0x08 => Self::Deutsch72,
+            0x09 => Self::Stellar1b,
+            0x0a => Self::NewAge,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<MicAmpEmulationType> for u32 {
+    fn from(emulation_type: MicAmpEmulationType) -> Self {
+        match emulation_type {
+            MicAmpEmulationType::Flat => 0x00,
+            MicAmpEmulationType::Trany1h => 0x01,
+            MicAmpEmulationType::Silver2 => 0x02,
+            MicAmpEmulationType::FfRed1h => 0x03,
+            MicAmpEmulationType::Savillerow => 0x04,
+            MicAmpEmulationType::Dunk => 0x05,
+            MicAmpEmulationType::ClassA2a => 0x06,
+            MicAmpEmulationType::OldTube => 0x07,
+            MicAmpEmulationType::Deutsch72 => 0x08,
+            MicAmpEmulationType::Stellar1b => 0x09,
+            MicAmpEmulationType::NewAge => 0x0a,
+            MicAmpEmulationType::Reserved(val) => val,
+        }
+    }
+}
+
+/// The enumeration to represent level of analog input.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum AnalogInputLevel {
+    Line,
+    Mic,
+    /// Available for Analog input 3 and 4 only.
+    Inst,
+    Reserved(u8),
+}
+
+impl From<u8> for AnalogInputLevel {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Line,
+            1 => Self::Mic,
+            2 => Self::Inst,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<AnalogInputLevel> for u8 {
+    fn from(level: AnalogInputLevel) -> Self {
+        match level {
+            AnalogInputLevel::Line => 0,
+            AnalogInputLevel::Mic => 1,
+            AnalogInputLevel::Inst => 2,
+            AnalogInputLevel::Reserved(val) => val,
+        }
+    }
+}
+
+/// The enumeration to represent target of meter display.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct LedState{
+    pub adat1: bool,
+    pub adat2: bool,
+    pub spdif: bool,
+    pub midi_in: bool,
+}
+
+impl LedState {
+    fn parse(&mut self, raw: &[u8]) {
+        assert_eq!(raw.len() ,4);
+
+        let mut val = 0u32;
+        val.parse_quadlet(&raw);
+
+        if val & 0x00000001 > 0 {
+            self.adat1 = true;
+        }
+        if val & 0x00000002 > 0 {
+            self.adat2 = true;
+        }
+        if val & 0x00000004 > 0 {
+            self.spdif = true;
+        }
+        if val & 0x00000008 > 0 {
+            self.midi_in = true;
+        }
+    }
+
+    fn build(&self, raw: &mut [u8]) {
+        assert_eq!(raw.len() ,4);
+
+        let mut val = 0u32;
+        if self.adat1 {
+            val |= 0x00000001;
+        }
+        if self.adat2 {
+            val |= 0x00000002;
+        }
+        if self.spdif {
+            val |= 0x00000004;
+        }
+        if self.midi_in {
+            val |= 0x00000008;
+        }
+        val.build_quadlet(raw);
+    }
+}
+
+/// The trait to represent protocol specific to Saffire Pro 26.
+pub trait LiquidS56Protocol<T> : ApplSectionProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const ANALOG_OUT_0_1_PAD_OFFSET: usize = 0x0040;
+    const IO_FLAGS_OFFSET: usize = 0x005c;
+    const EMULATION_TYPE_OFFSET: usize = 0x0278;
+    const HARMONICS_OFFSET: usize = 0x0280;
+    const POLARITY_OFFSET: usize = 0x0288;
+    const METER_DISPLAY_TARGET_OFFSET: usize = 0x029c;
+    const ANALOG_INPUT_LEVEL_OFFSET: usize = 0x02b4;
+    const LED_OFFSET: usize = 0x02bc;
+
+    fn write_sw_notice(&self, node: &T, sections: &ExtensionSections, notice: u32, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        notice.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, SW_NOTICE_OFFSET, &mut raw, timeout_ms)
+    }
+
+    fn read_analog_out_0_1_pad_offset(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        ->Result<bool, Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::ANALOG_OUT_0_1_PAD_OFFSET, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw) > 0)
+    }
+
+    fn write_analog_out_0_1_pad_offset(&self, node: &T, sections: &ExtensionSections, enable: bool,
+                                       timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        enable.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, Self::ANALOG_OUT_0_1_PAD_OFFSET, &mut raw, timeout_ms)?;
+        self.write_sw_notice(node, sections, DIM_MUTE_SW_NOTICE, timeout_ms)
+    }
+
+    fn read_opt_out_iface_mode(&self, node: &T, sections: &ExtensionSections, timeout_ms: u32)
+        -> Result<OptOutIfaceMode, Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let val = u32::from_be_bytes(raw);
+                if val & 0x00000001 > 0 {
+                    OptOutIfaceMode::Spdif
+                } else if val & 0x00000002 > 0 {
+                    OptOutIfaceMode::AesEbu
+                } else {
+                    OptOutIfaceMode::Adat
+                }
+            })
+    }
+
+    fn write_opt_out_iface_mode(&self, node: &T, sections: &ExtensionSections, mode: OptOutIfaceMode,
+                                timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)?;
+
+        let mut val = u32::from_be_bytes(raw);
+        val &= !0x00000003;
+
+        if mode == OptOutIfaceMode::Spdif {
+            val |= 0x00000001;
+        } else if mode == OptOutIfaceMode::AesEbu {
+            val |= 0x00000002;
+        }
+        val.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)?;
+        self.write_sw_notice(node, sections, IO_FLAG_SW_NOTICE, timeout_ms)
+    }
+
+    fn read_mic_amp_transformer(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw) & (1 << (ch + 4)) > 0)
+    }
+
+    fn write_mic_amp_transformer(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                 state: bool, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)?;
+
+        let mut val = u32::from_be_bytes(raw);
+        val &= !0x00000018;
+        if state {
+            val |= 1 << (ch + 4);
+        } else {
+            val &= !(1 << (ch + 4));
+        }
+        val.build_quadlet(&mut raw);
+        self.write_appl_data(node, sections, Self::IO_FLAGS_OFFSET, &mut raw, timeout_ms)?;
+        let sw_notice = if ch == 0 {
+            MIC_AMP_1_EMULATION_SW_NOTICE
+        } else {
+            MIC_AMP_2_EMULATION_SW_NOTICE
+        };
+        self.write_sw_notice(node, sections, sw_notice, timeout_ms)
+    }
+
+    fn read_mic_amp_emulation_type(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                   timeout_ms: u32)
+        -> Result<MicAmpEmulationType, Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        let offset = Self::EMULATION_TYPE_OFFSET + ch * 4;
+        self.read_appl_data(node, sections, offset, &mut raw, timeout_ms)
+            .map(|_| MicAmpEmulationType::from(u32::from_be_bytes(raw)))
+    }
+
+    fn write_mic_amp_emulation_type(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                    emulation_type: MicAmpEmulationType, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        emulation_type.build_quadlet(&mut raw);
+        let offset = Self::EMULATION_TYPE_OFFSET + ch * 4;
+        self.write_appl_data(node, sections, offset, &mut raw, timeout_ms)?;
+
+        let sw_notice = if ch == 0 {
+            MIC_AMP_1_EMULATION_SW_NOTICE
+        } else {
+            MIC_AMP_2_EMULATION_SW_NOTICE
+        };
+        self.write_sw_notice(node, sections, sw_notice, timeout_ms)
+    }
+
+    /// The return value is between 0x00 to 0x15.
+    fn read_mic_amp_harmonics(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                 timeout_ms: u32)
+        -> Result<u8, Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        let offset = Self::HARMONICS_OFFSET + ch * 4;
+        self.read_appl_data(node, sections, offset, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw) as u8)
+    }
+
+    fn write_mic_amp_harmonics(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                  harmonics: u8, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        (harmonics as u32).build_quadlet(&mut raw);
+        let offset = Self::HARMONICS_OFFSET + ch * 4;
+        self.write_appl_data(node, sections, offset, &mut raw, timeout_ms)?;
+
+        let sw_notice = if ch == 0 {
+            MIC_AMP_1_HARMONICS_SW_NOTICE
+        } else {
+            MIC_AMP_2_HARMONICS_SW_NOTICE
+        };
+        self.write_sw_notice(node, sections, sw_notice, timeout_ms)
+    }
+
+    fn read_mic_amp_polarity(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        let offset = Self::POLARITY_OFFSET + ch * 4;
+        self.read_appl_data(node, sections, offset, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw) > 0)
+    }
+
+    fn write_mic_amp_polarity(&self, node: &T, sections: &ExtensionSections, ch: usize,
+                                 inverted: bool, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert!(ch < 2);
+
+        let mut raw = [0;4];
+        inverted.build_quadlet(&mut raw);
+        let offset = Self::POLARITY_OFFSET + ch * 4;
+        self.write_appl_data(node, sections, offset, &mut raw, timeout_ms)?;
+        self.write_sw_notice(node, sections, MIC_AMP_POLARITY_SW_NOTICE, timeout_ms)
+    }
+
+    fn read_analog_input_level(&self, node: &T, sections: &ExtensionSections,
+                               levels: &mut [AnalogInputLevel;8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;8];
+        self.read_appl_data(node, sections, Self::ANALOG_INPUT_LEVEL_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut quads = [0u32;2];
+                quads.parse_quadlet_block(&raw);
+                levels[..4].iter_mut()
+                    .zip(quads[0].to_ne_bytes().iter())
+                    .for_each(|(level, &val)| *level = AnalogInputLevel::from(val));
+                levels[4..].iter_mut()
+                    .zip(quads[1].to_ne_bytes().iter())
+                    .for_each(|(level, &val)| *level = AnalogInputLevel::from(val));
+            })
+    }
+
+    fn write_analog_input_level(&self, node: &T, sections: &ExtensionSections, levels: &[AnalogInputLevel;8],
+                                timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quads = [0u32;2];
+        levels[..4].iter()
+            .enumerate()
+            .for_each(|(i, &level)| quads[0] |= (u8::from(level) as u32) << (i * 8));
+        levels[4..].iter()
+            .enumerate()
+            .for_each(|(i, &level)| quads[1] |= (u8::from(level) as u32) << (i * 8));
+        let mut raw = [0;8];
+        quads.build_quadlet_block(&mut raw);
+        self.write_appl_data(node, sections, Self::ANALOG_INPUT_LEVEL_OFFSET, &mut raw, timeout_ms)?;
+        self.write_sw_notice(node, sections, INPUT_LEVEL_SW_NOTICE, timeout_ms)
+    }
+
+    fn read_led_state(&self, node: &T, sections: &ExtensionSections, state: &mut LedState, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        self.read_appl_data(node, sections, Self::LED_OFFSET, &mut raw, timeout_ms)
+            .map(|_| state.parse(&raw))
+    }
+
+    fn write_led_state(&self, node: &T, sections: &ExtensionSections, state: &LedState, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;4];
+        state.build(&mut raw);
+        self.write_appl_data(node, sections, Self::LED_OFFSET, &mut raw, timeout_ms)
+    }
+
+    /// The target of meter display represent index of router entry.
+    fn read_meter_display_targets(&self, node: &T, sections: &ExtensionSections, targets: &mut [usize;8],
+                                  timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut raw = [0;8];
+        self.read_appl_data(node, sections, Self::METER_DISPLAY_TARGET_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut quads = [0u32;2];
+                quads[0].parse_quadlet(&raw[..4]);
+                quads[1].parse_quadlet(&raw[4..]);
+                targets[..4].iter_mut()
+                    .zip(quads[0].to_ne_bytes().iter())
+                    .for_each(|(target, &val)| *target = val as usize);
+                targets[4..].iter_mut()
+                    .zip(quads[1].to_ne_bytes().iter())
+                    .for_each(|(target, &val)| *target = val as usize);
+            })
+    }
+
+    fn write_meter_display_targets(&self, node: &T, sections: &ExtensionSections, targets: &[usize;8],
+                                   timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let mut quads = [0u32;2];
+        targets[..4].iter()
+            .enumerate()
+            .for_each(|(i, &target)| quads[0] |= (target as u32) << (i * 8));
+        targets[4..].iter()
+            .enumerate()
+            .for_each(|(i, &target)| quads[1] |= (target as u32) << (i * 8));
+        let mut raw = [0;8];
+        quads.build_quadlet_block(&mut raw);
+        self.write_appl_data(node,  sections, Self::METER_DISPLAY_TARGET_OFFSET, &mut raw, timeout_ms)
+    }
+}
+
+impl<O: ApplSectionProtocol<T>, T: AsRef<FwNode>> LiquidS56Protocol<T> for O {}

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Liquid Saffire 56.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Liquid Saffire 56.
+
+use crate::tcat::extension::*;
+use crate::tcat::tcd22xx_spec::*;
+
+/// The structure to represent state of TCD22xx on Liquid Saffire 56.
+#[derive(Default, Debug)]
+pub struct LiquidS56State{
+    tcd22xx: Tcd22xxState,
+}
+
+impl<'a> Tcd22xxSpec<'a> for LiquidS56State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: None},
+        Input{id: SrcBlkId::Ins1, offset: 0, count: 6, label: None},
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-opt")},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 2, label: None},
+        Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Output{id: DstBlkId::Adat, offset: 8, count: 8, label: None},
+        Output{id: DstBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-opt")},
+    ];
+    // NOTE: The 8 entries are selected by unique protocol from the first 26 entries in router
+    // section are used to display hardware metering.
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins1, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 5},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 6},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 7},
+        SrcBlk{id: SrcBlkId::Aes, ch: 0},
+        SrcBlk{id: SrcBlkId::Aes, ch: 1},
+        SrcBlk{id: SrcBlkId::Adat, ch: 0},
+        SrcBlk{id: SrcBlkId::Adat, ch: 1},
+        SrcBlk{id: SrcBlkId::Adat, ch: 2},
+        SrcBlk{id: SrcBlkId::Adat, ch: 3},
+        SrcBlk{id: SrcBlkId::Adat, ch: 4},
+        SrcBlk{id: SrcBlkId::Adat, ch: 5},
+        SrcBlk{id: SrcBlkId::Adat, ch: 6},
+        SrcBlk{id: SrcBlkId::Adat, ch: 7},
+        SrcBlk{id: SrcBlkId::Adat, ch: 8},
+        SrcBlk{id: SrcBlkId::Adat, ch: 9},
+        SrcBlk{id: SrcBlkId::Adat, ch: 10},
+        SrcBlk{id: SrcBlkId::Adat, ch: 11},
+        SrcBlk{id: SrcBlkId::Adat, ch: 12},
+        SrcBlk{id: SrcBlkId::Adat, ch: 13},
+        SrcBlk{id: SrcBlkId::Adat, ch: 14},
+        SrcBlk{id: SrcBlkId::Adat, ch: 15},
+    ];
+}
+
+impl AsMut<Tcd22xxState> for LiquidS56State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.tcd22xx
+    }
+}
+
+impl AsRef<Tcd22xxState> for LiquidS56State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.tcd22xx
+    }
+}

--- a/libs/dice/protocols/src/focusrite/spro26.rs
+++ b/libs/dice/protocols/src/focusrite/spro26.rs
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire Pro 26.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 26.
+
+use crate::tcat::extension::*;
+use crate::tcat::tcd22xx_spec::*;
+
+/// The structure to represent state of TCD22xx on Saffire Pro 26.
+#[derive(Default, Debug)]
+pub struct SPro26State{
+    tcd22xx: Tcd22xxState,
+}
+
+impl<'a> Tcd22xxSpec<'a> for SPro26State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 6, label: None},
+        Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-opt")},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
+        Output{id: DstBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-coax")},
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+    ];
+    // NOTE: The first 6 entries in router section are used to display hardware metering.
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 5},
+    ];
+}
+
+impl AsMut<Tcd22xxState> for SPro26State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.tcd22xx
+    }
+}
+
+impl AsRef<Tcd22xxState> for SPro26State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.tcd22xx
+    }
+}

--- a/libs/dice/protocols/src/focusrite/spro26.rs
+++ b/libs/dice/protocols/src/focusrite/spro26.rs
@@ -9,10 +9,22 @@
 use crate::tcat::extension::*;
 use crate::tcat::tcd22xx_spec::*;
 
+use super::*;
+
 /// The structure to represent state of TCD22xx on Saffire Pro 26.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SPro26State{
     tcd22xx: Tcd22xxState,
+    out_grp: OutGroupState,
+}
+
+impl Default for SPro26State {
+    fn default() -> Self {
+        SPro26State{
+            tcd22xx: Tcd22xxState::default(),
+            out_grp: Self::create_out_group_state(),
+        }
+    }
 }
 
 impl<'a> Tcd22xxSpec<'a> for SPro26State {
@@ -48,5 +60,32 @@ impl AsMut<Tcd22xxState> for SPro26State {
 impl AsRef<Tcd22xxState> for SPro26State {
     fn as_ref(&self) -> &Tcd22xxState {
         &self.tcd22xx
+    }
+}
+
+const SW_NOTICE_OFFSET: usize = 0x000c;
+
+const SRC_SW_NOTICE: u32 = 0x00000001;
+const DIM_MUTE_SW_NOTICE: u32 = 0x00000002;
+
+impl OutGroupSpec for SPro26State {
+    const ENTRY_COUNT: usize = 6;
+    const HAS_VOL_HWCTL: bool = false;
+    const OUT_CTL_OFFSET: usize = 0x0010;
+    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
+
+    const SRC_NOTICE: u32 = SRC_SW_NOTICE;
+    const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;
+}
+
+impl AsMut<OutGroupState> for SPro26State {
+    fn as_mut(&mut self) -> &mut OutGroupState {
+        &mut self.out_grp
+    }
+}
+
+impl AsRef<OutGroupState> for SPro26State {
+    fn as_ref(&self) -> &OutGroupState {
+        &self.out_grp
     }
 }

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire Pro 40.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 40.
+
+use crate::tcat::extension::*;
+use crate::tcat::tcd22xx_spec::*;
+
+/// The structure to represent state of TCD22xx on Saffire Pro 40.
+#[derive(Default, Debug)]
+pub struct SPro40State{
+    tcd22xx: Tcd22xxState,
+}
+
+impl<'a> Tcd22xxSpec<'a> for SPro40State {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins1, offset: 0, count: 6, label: None},
+        Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 2, label: None},
+        Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
+    ];
+    // NOTE: The first 8 entries in router section are used to display hardware metering.
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins1, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 5},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 6},
+        SrcBlk{id: SrcBlkId::Ins1, ch: 7},
+    ];
+}
+
+impl AsMut<Tcd22xxState> for SPro40State {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.tcd22xx
+    }
+}
+
+impl AsRef<Tcd22xxState> for SPro40State {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.tcd22xx
+    }
+}

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -9,10 +9,22 @@
 use crate::tcat::extension::*;
 use crate::tcat::tcd22xx_spec::*;
 
+use super::*;
+
 /// The structure to represent state of TCD22xx on Saffire Pro 40.
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct SPro40State{
     tcd22xx: Tcd22xxState,
+    out_grp: OutGroupState,
+}
+
+impl Default for SPro40State {
+    fn default() -> Self {
+        SPro40State{
+            tcd22xx: Tcd22xxState::default(),
+            out_grp: Self::create_out_group_state(),
+        }
+    }
 }
 
 impl<'a> Tcd22xxSpec<'a> for SPro40State {
@@ -53,5 +65,32 @@ impl AsMut<Tcd22xxState> for SPro40State {
 impl AsRef<Tcd22xxState> for SPro40State {
     fn as_ref(&self) -> &Tcd22xxState {
         &self.tcd22xx
+    }
+}
+
+const SW_NOTICE_OFFSET: usize = 0x0068;
+
+const SRC_SW_NOTICE: u32 = 0x00000001;
+const DIM_MUTE_SW_NOTICE: u32 = 0x00000002;
+
+impl OutGroupSpec for SPro40State {
+    const ENTRY_COUNT: usize = 10;
+    const HAS_VOL_HWCTL: bool = true;
+    const OUT_CTL_OFFSET: usize = 0x000c;
+    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
+
+    const SRC_NOTICE: u32 = SRC_SW_NOTICE;
+    const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;
+}
+
+impl AsMut<OutGroupState> for SPro40State {
+    fn as_mut(&mut self) -> &mut OutGroupState {
+        &mut self.out_grp
+    }
+}
+
+impl AsRef<OutGroupState> for SPro40State {
+    fn as_ref(&self) -> &OutGroupState {
+        &self.out_grp
     }
 }

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -13,6 +13,7 @@ pub mod lexicon;
 pub mod maudio;
 pub mod avid;
 pub mod loud;
+pub mod focusrite;
 
 const QUADLET_SIZE: usize = 4;
 

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -33,13 +33,13 @@ impl<'a> Tcd22xxSpec<'a> for Pfire2626State {
     const INPUTS: &'a [Input<'a>] = &[
         Input{id: SrcBlkId::Ins1, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
-        Input{id: SrcBlkId::Adat, offset: 8, count: 16, label: None},
+        Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: None},
     ];
     const OUTPUTS: &'a [Output<'a>] = &[
         Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
-        Output{id: DstBlkId::Adat, offset: 8, count: 16, label: None},
+        Output{id: DstBlkId::Adat, offset: 8, count: 8, label: None},
         Output{id: DstBlkId::Aes, offset: 0, count: 2, label: None},
     ];
     const FIXED: &'a [SrcBlk] = &[

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -2,3 +2,4 @@
 // Copyright (c) 2021 Takashi Sakamoto
 
 pub mod spro40_model;
+pub mod liquids56_model;

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+pub mod spro40_model;

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -3,3 +3,4 @@
 
 pub mod spro40_model;
 pub mod liquids56_model;
+pub mod spro26_model;

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -4,3 +4,5 @@
 pub mod spro40_model;
 pub mod liquids56_model;
 pub mod spro26_model;
+
+mod out_grp_ctl;

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -16,6 +16,8 @@ use dice_protocols::focusrite::liquids56::*;
 use crate::common_ctl::*;
 use crate::tcd22xx_ctl::*;
 
+use super::out_grp_ctl::*;
+
 #[derive(Default)]
 pub struct LiquidS56Model {
     proto: FwReq,
@@ -23,6 +25,7 @@ pub struct LiquidS56Model {
     extension_sections: ExtensionSections,
     ctl: CommonCtl,
     tcd22xx_ctl: Tcd22xxCtl<LiquidS56State>,
+    out_grp_ctl: OutGroupCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -42,6 +45,9 @@ impl CtlModel<SndDice> for LiquidS56Model {
 
         self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
 
+        self.out_grp_ctl.load(card_cntr, unit, &self.proto, &self.extension_sections,
+                              &mut self.tcd22xx_ctl.state, TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -52,6 +58,8 @@ impl CtlModel<SndDice> for LiquidS56Model {
             Ok(true)
         } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
                                     elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -66,6 +74,9 @@ impl CtlModel<SndDice> for LiquidS56Model {
         } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
                                      old, new, TIMEOUT_MS)? {
             Ok(true)
+        } else if self.out_grp_ctl.write(unit, &self.proto, &self.extension_sections,
+                                         &mut self.tcd22xx_ctl.state, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -76,12 +87,15 @@ impl NotifyModel<SndDice, u32> for LiquidS56Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+        self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;
+        self.out_grp_ctl.parse_notification(unit, &self.proto, &self.extension_sections,
+                                            &mut self.tcd22xx_ctl.state, *msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -91,6 +105,8 @@ impl NotifyModel<SndDice, u32> for LiquidS56Model {
         if self.ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read_notified_elem(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+use dice_protocols::focusrite::liquids56::*;
+
+use crate::common_ctl::*;
+use crate::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct LiquidS56Model {
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<LiquidS56State>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for LiquidS56Model {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for LiquidS56Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for LiquidS56Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -1,13 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use hinawa::FwReq;
 use hinawa::{SndDice, SndUnitExt};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
 use dice_protocols::tcat::{*, global_section::*};
 use dice_protocols::tcat::extension::*;
@@ -26,6 +27,7 @@ pub struct LiquidS56Model {
     ctl: CommonCtl,
     tcd22xx_ctl: Tcd22xxCtl<LiquidS56State>,
     out_grp_ctl: OutGroupCtl,
+    specific_ctl: SpecificCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -47,6 +49,7 @@ impl CtlModel<SndDice> for LiquidS56Model {
 
         self.out_grp_ctl.load(card_cntr, unit, &self.proto, &self.extension_sections,
                               &mut self.tcd22xx_ctl.state, TIMEOUT_MS)?;
+        self.specific_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -60,6 +63,9 @@ impl CtlModel<SndDice> for LiquidS56Model {
                                     elem_value, TIMEOUT_MS)? {
             Ok(true)
         } else if self.out_grp_ctl.read(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.specific_ctl.read(unit, &self.proto, &self.extension_sections, elem_id, elem_value,
+                                         TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -76,6 +82,9 @@ impl CtlModel<SndDice> for LiquidS56Model {
             Ok(true)
         } else if self.out_grp_ctl.write(unit, &self.proto, &self.extension_sections,
                                          &mut self.tcd22xx_ctl.state, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.specific_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                          old, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -135,6 +144,338 @@ impl MeasureModel<hinawa::SndDice> for LiquidS56Model {
             Ok(true)
         } else {
             Ok(false)
+        }
+    }
+}
+
+fn opt_out_iface_mode_to_string(mode: &OptOutIfaceMode) -> String {
+    match mode {
+        OptOutIfaceMode::Adat => "ADAT",
+        OptOutIfaceMode::Spdif => "S/PDIF",
+        OptOutIfaceMode::AesEbu => "AES/EBU",
+    }.to_string()
+}
+
+fn analog_input_level_to_string(level: &AnalogInputLevel) -> String {
+    match level {
+        AnalogInputLevel::Mic => "Microphone".to_string(),
+        AnalogInputLevel::Line => "Line".to_string(),
+        AnalogInputLevel::Inst => "Instrument".to_string(),
+        AnalogInputLevel::Reserved(val) => format!("Reserved-{}", val),
+    }
+}
+
+fn mic_amp_emulation_type_to_string(emulation_type: &MicAmpEmulationType) -> String {
+    match emulation_type {
+        MicAmpEmulationType::Flat => "Flat",
+        MicAmpEmulationType::Trany1h => "TRANY-1-H",
+        MicAmpEmulationType::Silver2 => "SILVER-2",
+        MicAmpEmulationType::FfRed1h => "FF-RED1-H",
+        MicAmpEmulationType::Savillerow => "SAVILLEROW",
+        MicAmpEmulationType::Dunk => "DUNK",
+        MicAmpEmulationType::ClassA2a => "CLASS-A-2A",
+        MicAmpEmulationType::OldTube => "OLD-TUBE",
+        MicAmpEmulationType::Deutsch72 => "DEUTSCH-72",
+        MicAmpEmulationType::Stellar1b => "STELLAR-1B",
+        MicAmpEmulationType::NewAge => "NEW-AGE-1",
+        MicAmpEmulationType::Reserved(_) => "Reserved",
+    }.to_string()
+}
+
+#[derive(Default, Debug)]
+struct SpecificCtl;
+
+impl<'a> SpecificCtl {
+    const ANALOG_OUT_0_1_PAD_NAME: &'a str = "analog-output-1/2-pad";
+    const OPT_OUT_IFACE_MODE_NAME: &'a str = "optical-output-interface-mode";
+    const MIC_AMP_TRANSFORMER_NAME: &'a str = "mic-amp-transformer";
+    const ANALOG_INPUT_LEVEL_NAME: &'a str = "analog-input-levels";
+    const MIC_AMP_EMULATION_TYPE_NAME: &'a str = "mic-amp-emulation-types";
+    const MIC_AMP_HARMONICS_NAME: &'a str = "mic-amp-harmonics";
+    const MIC_AMP_POLARITY_NAME: &'a str = "mic-amp-polarities";
+    const LED_STATE_NAME: &'a str = "LED-states";
+    const METER_DISPLAY_TARGETS_NAME: &'a str = "meter-display-targets";
+
+    const OPT_OUT_IFACE_MODES: [OptOutIfaceMode;3] = [
+        OptOutIfaceMode::Adat,
+        OptOutIfaceMode::Spdif,
+        OptOutIfaceMode::AesEbu,
+    ];
+
+    const ANALOG_INPUT_LEVELS: [AnalogInputLevel;3] = [
+        AnalogInputLevel::Mic,
+        AnalogInputLevel::Line,
+        AnalogInputLevel::Inst,
+    ];
+
+    const MIC_AMP_EMULATION_TYPES: [MicAmpEmulationType;11] = [
+        MicAmpEmulationType::Flat,
+        MicAmpEmulationType::Trany1h,
+        MicAmpEmulationType::Silver2,
+        MicAmpEmulationType::FfRed1h,
+        MicAmpEmulationType::Savillerow,
+        MicAmpEmulationType::Dunk,
+        MicAmpEmulationType::ClassA2a,
+        MicAmpEmulationType::OldTube,
+        MicAmpEmulationType::Deutsch72,
+        MicAmpEmulationType::Stellar1b,
+        MicAmpEmulationType::NewAge,
+    ];
+
+    const HARMONICS_MIN: i32 = 0;
+    const HARMONICS_MAX: i32 = 21;
+    const HARMONICS_STEP: i32 = 1;
+
+    const LED_STATE_LABELS: [&'a str;4] = ["ADAT1", "ADAT2", "S/PDIF", "MIDI-in"];
+
+    const METER_DISPLAY_TARGETS: [&'a str;26] = [
+        "Analog-input-1", "Analog-input-2", "Analog-input-3", "Analog-input-4",
+        "Analog-input-5", "Analog-input-6", "Analog-input-7", "Analog-input-8",
+        "S/PDIF-input-1", "S/PDIF-input-2",
+        "ADAT-input-1", "ADAT-input-2", "ADAT-input-3", "ADAT-input-4",
+        "ADAT-input-5", "ADAT-input-6", "ADAT-input-7", "ADAT-input-8",
+        "ADAT-input-9", "ADAT-input-10", "ADAT-input-11", "ADAT-input-12",
+        "ADAT-input-13", "ADAT-input-14", "ADAT-input-15", "ADAT-input-16",
+    ];
+
+    pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ANALOG_OUT_0_1_PAD_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_IFACE_MODES.iter()
+            .map(|mode| opt_out_iface_mode_to_string(mode))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUT_IFACE_MODE_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_AMP_TRANSFORMER_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
+
+        let labels: Vec<String> = Self::ANALOG_INPUT_LEVELS.iter()
+            .map(|level| analog_input_level_to_string(level))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ANALOG_INPUT_LEVEL_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 8, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::MIC_AMP_EMULATION_TYPES.iter()
+            .map(|emulation_type| mic_amp_emulation_type_to_string(emulation_type))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_AMP_EMULATION_TYPE_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 2, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_AMP_HARMONICS_NAME, 0);
+        card_cntr.add_int_elems(&elem_id, 1, Self::HARMONICS_MIN, Self::HARMONICS_MAX, Self::HARMONICS_STEP,
+                                2, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_AMP_POLARITY_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LED_STATE_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, Self::LED_STATE_LABELS.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::METER_DISPLAY_TARGETS_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 8, &Self::METER_DISPLAY_TARGETS, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections, elem_id: &ElemId,
+                elem_value: &mut ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::ANALOG_OUT_0_1_PAD_NAME => {
+                let enabled = proto.read_analog_out_0_1_pad_offset(&unit.get_node(), sections, timeout_ms)?;
+                elem_value.set_bool(&[enabled]);
+                Ok(true)
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                let mode = proto.read_opt_out_iface_mode(&unit.get_node(), sections, timeout_ms)?;
+                let pos = Self::OPT_OUT_IFACE_MODES.iter()
+                    .position(|m| m.eq(&mode))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::MIC_AMP_TRANSFORMER_NAME => {
+                ElemValueAccessor::<bool>::set_vals(elem_value, 2, |idx| {
+                    proto.read_mic_amp_transformer(&unit.get_node(), sections, idx, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::ANALOG_INPUT_LEVEL_NAME => {
+                let mut levels = [AnalogInputLevel::Reserved(0);8];
+                proto.read_analog_input_level(&unit.get_node(), sections, &mut levels, timeout_ms)?;
+                let vals: Vec<u32> = levels.iter()
+                    .map(|level| {
+                        let pos = Self::ANALOG_INPUT_LEVELS.iter()
+                            .position(|l| l.eq(level))
+                            .unwrap();
+                        pos as u32
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::MIC_AMP_EMULATION_TYPE_NAME => {
+                ElemValueAccessor::<u32>::set_vals(elem_value, 2, |idx| {
+                    proto.read_mic_amp_emulation_type(&unit.get_node(), sections, idx, timeout_ms)
+                        .map(|emulation_type| {
+                            let pos = Self::MIC_AMP_EMULATION_TYPES.iter()
+                                .position(|t| t.eq(&emulation_type))
+                                .unwrap();
+                            pos as u32
+                        })
+                })
+                .map(|_| true)
+            }
+            Self::MIC_AMP_HARMONICS_NAME => {
+                ElemValueAccessor::<i32>::set_vals(elem_value, 2, |idx| {
+                    proto.read_mic_amp_harmonics(&unit.get_node(), sections, idx, timeout_ms)
+                        .map(|harmonics| harmonics as i32)
+                })
+                .map(|_| true)
+            }
+            Self::MIC_AMP_POLARITY_NAME => {
+                ElemValueAccessor::<bool>::set_vals(elem_value, 2, |idx| {
+                    proto.read_mic_amp_polarity(&unit.get_node(), sections, idx, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::LED_STATE_NAME => {
+                let mut state = LedState::default();
+                proto.read_led_state(&unit.get_node(), sections, &mut state, timeout_ms)?;
+                let vals = [state.adat1, state.adat2, state.spdif, state.midi_in];
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::METER_DISPLAY_TARGETS_NAME => {
+                let mut targets = [0;8];
+                proto.read_meter_display_targets(&unit.get_node(), sections, &mut targets, timeout_ms)?;
+                let vals: Vec<u32> = targets.iter()
+                    .map(|&target| {
+                        if target < Self::METER_DISPLAY_TARGETS.len() {
+                            target as u32
+                        } else {
+                            0
+                        }
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections, elem_id: &ElemId,
+                 old: &ElemValue, new: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::ANALOG_OUT_0_1_PAD_NAME => {
+                let mut vals = [false];
+                new.get_bool(&mut vals);
+                proto.write_analog_out_0_1_pad_offset(&unit.get_node(), sections, vals[0], timeout_ms)
+                    .map(|_| true)
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                let mut vals = [0];
+                new.get_enum(&mut vals);
+                let mode = Self::OPT_OUT_IFACE_MODES.iter()
+                    .nth(vals[0] as usize)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of optical output interface mode: {}", vals[0]);
+                        Error::new(FileError::Inval, &msg)
+                    })?;
+                proto.write_opt_out_iface_mode(&unit.get_node(), sections, *mode, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::MIC_AMP_TRANSFORMER_NAME => {
+                ElemValueAccessor::<bool>::get_vals(new, old, 2, |idx, val| {
+                    proto.write_mic_amp_transformer(&unit.get_node(), sections, idx, val, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::ANALOG_INPUT_LEVEL_NAME => {
+                let mut vals = [0;8];
+                new.get_enum(&mut vals);
+                let mut levels = [AnalogInputLevel::Reserved(0);8];
+                levels.iter_mut()
+                    .zip(vals.iter())
+                    .enumerate()
+                    .try_for_each(|(i, (level, &val))| {
+                        let l = Self::ANALOG_INPUT_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of analog input level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })?;
+
+                        if (i < 2 || i > 3) && *l == AnalogInputLevel::Inst {
+                            let msg = "Instrument level is just available for channel 3 and 4";
+                            Err(Error::new(FileError::Inval, &msg))
+                        } else {
+                            *level = *l;
+                            Ok(())
+                        }
+                    })?;
+                proto.write_analog_input_level(&unit.get_node(), sections, &levels, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::MIC_AMP_EMULATION_TYPE_NAME => {
+                ElemValueAccessor::<u32>::get_vals(new, old, 2, |idx, val| {
+                    Self::MIC_AMP_EMULATION_TYPES.iter()
+                        .nth(val as usize)
+                        .ok_or_else(|| {
+                            let msg = format!("Invalid value for index of emulation type: {}", val);
+                            Error::new(FileError::Inval, &msg)
+                        })
+                        .and_then(|&emulation_type| {
+                            proto.write_mic_amp_emulation_type(&unit.get_node(), sections, idx,
+                                                               emulation_type, timeout_ms)
+                        })
+                })
+                .map(|_| true)
+            }
+            Self::MIC_AMP_HARMONICS_NAME => {
+                ElemValueAccessor::<i32>::get_vals(new, old, 2, |idx, val| {
+                    proto.write_mic_amp_harmonics(&unit.get_node(), sections, idx, val as u8, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::MIC_AMP_POLARITY_NAME => {
+                ElemValueAccessor::<bool>::get_vals(new, old, 2, |idx, val| {
+                    proto.write_mic_amp_polarity(&unit.get_node(), sections, idx, val, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::LED_STATE_NAME => {
+                let mut vals = [false;4];
+                new.get_bool(&mut vals);
+                let state = LedState{adat1: vals[0], adat2: vals[1], spdif: vals[2], midi_in: vals[3]};
+                proto.write_led_state(&unit.get_node(), sections, &state, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::METER_DISPLAY_TARGETS_NAME => {
+                let mut vals = [0;8];
+                new.get_enum(&mut vals);
+                let mut targets = [0;8];
+                targets.iter_mut()
+                    .zip(vals.iter())
+                    .try_for_each(|(target, &val)| {
+                        if val < Self::METER_DISPLAY_TARGETS.len() as u32 {
+                            *target = val as usize;
+                            Ok(())
+                        } else {
+                            let msg = format!("Invalid value for index of meter display target: {}", val);
+                            Err(Error::new(FileError::Inval, &msg))
+                        }
+                    })?;
+                proto.write_meter_display_targets(&unit.get_node(), sections, &targets, timeout_ms)
+                    .map(|_| true)
+            }
+            _ => Ok(false),
         }
     }
 }

--- a/libs/dice/runtime/src/focusrite/out_grp_ctl.rs
+++ b/libs/dice/runtime/src/focusrite/out_grp_ctl.rs
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use glib::Error;
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
+
+use hinawa::{FwNode, SndDice, SndUnitExt};
+
+use dice_protocols::tcat::extension::*;
+use dice_protocols::focusrite::*;
+
+use core::card_cntr::*;
+use core::elem_value_accessor::*;
+
+#[derive(Default, Debug)]
+pub struct OutGroupCtl(Vec<ElemId>);
+
+impl<'a> OutGroupCtl {
+    const VOL_NAME: &'a str = "output-group-volume";
+    const VOL_HWCTL_NAME: &'a str = "output-group-volume-hwctl";
+    const VOL_MUTE_NAME: &'a str = "output-group-volume-mute";
+    const MUTE_NAME: &'a str = "output-group-mute";
+    const DIM_NAME: &'a str = "output-group-dim";
+    const DIM_HWCTL_NAME: &'a str= "output-group-dim-hwctl";
+    const MUTE_HWCTL_NAME: &'a str = "output-group-mute-hwctl";
+
+    const LEVEL_MIN: i32 = 0x00;
+    const LEVEL_MAX: i32 = 0x7f;
+    const LEVEL_STEP: i32 = 0x01;
+
+    pub fn load<T, S>(&mut self, card_cntr: &mut CardCntr, unit: &SndDice, proto: &T,
+                      sections: &ExtensionSections, state: &mut S, timeout_ms: u32)
+        -> Result<(), Error>
+        where T: FocusriteSaffireOutGroupProtocol<FwNode, S>,
+              S: OutGroupSpec + AsRef<OutGroupState> + AsMut<OutGroupState>,
+    {
+        let node = unit.get_node();
+        proto.read_out_group_mute(&node, sections, state, timeout_ms)?;
+        proto.read_out_group_dim(&node, sections, state, timeout_ms)?;
+        proto.read_out_group_vols(&node, sections, state, timeout_ms)?;
+        proto.read_out_group_vol_mute_hwctls(&node, sections, state, timeout_ms)?;
+        proto.read_out_group_dim_mute_hwctls(&node, sections, state, timeout_ms)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MUTE_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::DIM_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
+
+        let output_count = S::ENTRY_COUNT;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::VOL_NAME, 0);
+        card_cntr.add_int_elems(&elem_id, 1, Self::LEVEL_MIN, Self::LEVEL_MAX, Self::LEVEL_STEP,
+                                output_count, None, true)
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::VOL_MUTE_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, output_count, true)?;
+
+        if S::HAS_VOL_HWCTL {
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::VOL_HWCTL_NAME, 0);
+            card_cntr.add_bool_elems(&elem_id, 1, output_count, true)?;
+        }
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::DIM_HWCTL_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, output_count, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MUTE_HWCTL_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, output_count, true)?;
+
+        Ok(())
+    }
+
+    pub fn read<S>(&mut self, state: &S, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+        where S: AsRef<OutGroupState>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::VOL_MUTE_NAME => {
+                elem_value.set_bool(&state.as_ref().vol_mutes);
+                Ok(true)
+            }
+            Self::VOL_HWCTL_NAME => {
+                elem_value.set_bool(&state.as_ref().vol_hwctls);
+                Ok(true)
+            }
+            Self::DIM_HWCTL_NAME => {
+                elem_value.set_bool(&state.as_ref().dim_hwctls);
+                Ok(true)
+            }
+            Self::MUTE_HWCTL_NAME => {
+                elem_value.set_bool(&state.as_ref().mute_hwctls);
+                Ok(true)
+            }
+            _ => self.read_notified_elem(state, elem_id, elem_value),
+        }
+    }
+
+    pub fn write<T, S>(&mut self, unit: &SndDice, proto: &T, sections: &ExtensionSections,
+                       state: &mut S, elem_id: &ElemId, elem_value: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+        where T: FocusriteSaffireOutGroupProtocol<FwNode, S>,
+              S: OutGroupSpec + AsRef<OutGroupState> + AsMut<OutGroupState>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::MUTE_NAME => {
+                ElemValueAccessor::<bool>::get_val(elem_value, |val| {
+                    proto.write_out_group_mute(&unit.get_node(), sections, state, val, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::DIM_NAME => {
+                ElemValueAccessor::<bool>::get_val(elem_value, |val| {
+                    proto.write_out_group_dim(&unit.get_node(), sections, state, val, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            Self::VOL_NAME => {
+                let mut vals = vec![0i32;state.as_ref().vols.len()];
+                elem_value.get_int(&mut vals);
+                let vols: Vec<i8> = vals.iter()
+                    .map(|&v| (Self::LEVEL_MAX - v) as i8)
+                    .collect();
+                proto.write_out_group_vols(&unit.get_node(), sections, state, &vols, timeout_ms)
+                .map(|_| true)
+            }
+            Self::VOL_MUTE_NAME => {
+                let mut vol_mutes = state.as_ref().vol_mutes.clone();
+                let vol_hwctls = state.as_ref().vol_hwctls.clone();
+                elem_value.get_bool(&mut vol_mutes);
+                proto.write_out_group_vol_mute_hwctls(&unit.get_node(), sections, state, &vol_mutes,
+                                                      &vol_hwctls, timeout_ms)
+                .map(|_| true)
+            }
+            Self::VOL_HWCTL_NAME => {
+                let vol_mutes = state.as_ref().vol_mutes.clone();
+                let mut vol_hwctls = state.as_ref().vol_hwctls.clone();
+                elem_value.get_bool(&mut vol_hwctls);
+                proto.write_out_group_vol_mute_hwctls(&unit.get_node(), sections, state, &vol_mutes,
+                                                      &vol_hwctls, timeout_ms)
+                .map(|_| true)
+            }
+            Self::DIM_HWCTL_NAME => {
+                let mute_hwctls = state.as_ref().mute_hwctls.clone();
+                let mut dim_hwctls = state.as_ref().dim_hwctls.clone();
+                elem_value.get_bool(&mut dim_hwctls);
+                proto.write_out_group_dim_mute_hwctls(&unit.get_node(), sections, state,
+                                                      &dim_hwctls, &mute_hwctls, timeout_ms)?;
+                Ok(true)
+            }
+            Self::MUTE_HWCTL_NAME => {
+                let mut mute_hwctls = state.as_ref().mute_hwctls.clone();
+                let dim_hwctls = state.as_ref().dim_hwctls.clone();
+                elem_value.get_bool(&mut mute_hwctls);
+                proto.write_out_group_dim_mute_hwctls(&unit.get_node(), sections, state,
+                                                      &dim_hwctls, &mute_hwctls, timeout_ms)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn get_notified_elem_list(&self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.0);
+    }
+
+    pub fn parse_notification<T, S>(&mut self, unit: &SndDice, proto: &T, sections: &ExtensionSections,
+                                    state: &mut S, msg: u32, timeout_ms: u32)
+        -> Result<(), Error>
+        where T: FocusriteSaffireOutGroupProtocol<FwNode, S>,
+              S: OutGroupSpec + AsRef<OutGroupState> + AsMut<OutGroupState>,
+    {
+        if msg.has_dim_mute_change() {
+            let node = unit.get_node();
+            proto.read_out_group_mute(&node, sections, state, timeout_ms)?;
+            proto.read_out_group_dim(&node, sections, state, timeout_ms)?;
+        }
+
+        if msg.has_vol_change() {
+            proto.read_out_group_knob_value(&unit.get_node(), sections, state, timeout_ms)?;
+
+            let vol = state.as_ref().hw_knob_value;
+            let hwctls = state.as_ref().vol_hwctls.clone();
+            state.as_mut().vols.iter_mut()
+                .zip(hwctls.iter())
+                .filter(|(_, &hwctl)| hwctl)
+                .for_each(|(v, _)| *v = vol);
+        }
+
+        Ok(())
+    }
+
+    pub fn read_notified_elem<S>(&self, state: &S, elem_id: &ElemId, elem_value: &ElemValue)
+        -> Result<bool, Error>
+        where S: AsRef<OutGroupState>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::MUTE_NAME => {
+                elem_value.set_bool(&[state.as_ref().mute_enabled]);
+                Ok(true)
+            }
+            Self::DIM_NAME => {
+                elem_value.set_bool(&[state.as_ref().dim_enabled]);
+                Ok(true)
+            }
+            Self::VOL_NAME => {
+                let vols: Vec<i32> = state.as_ref().vols.iter()
+                    .map(|&v| Self::LEVEL_MAX - (v as i32))
+                    .collect();
+                elem_value.set_int(&vols);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+use dice_protocols::focusrite::spro26::*;
+
+use crate::common_ctl::*;
+use crate::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct SPro26Model {
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<SPro26State>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for SPro26Model {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for SPro26Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for SPro26Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -16,6 +16,8 @@ use dice_protocols::focusrite::spro26::*;
 use crate::common_ctl::*;
 use crate::tcd22xx_ctl::*;
 
+use super::out_grp_ctl::*;
+
 #[derive(Default)]
 pub struct SPro26Model {
     proto: FwReq,
@@ -23,6 +25,7 @@ pub struct SPro26Model {
     extension_sections: ExtensionSections,
     ctl: CommonCtl,
     tcd22xx_ctl: Tcd22xxCtl<SPro26State>,
+    out_grp_ctl: OutGroupCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -42,6 +45,9 @@ impl CtlModel<SndDice> for SPro26Model {
 
         self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
 
+        self.out_grp_ctl.load(card_cntr, unit, &self.proto, &self.extension_sections,
+                              &mut self.tcd22xx_ctl.state, TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -52,6 +58,8 @@ impl CtlModel<SndDice> for SPro26Model {
             Ok(true)
         } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
                                     elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -66,6 +74,9 @@ impl CtlModel<SndDice> for SPro26Model {
         } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
                                      old, new, TIMEOUT_MS)? {
             Ok(true)
+        } else if self.out_grp_ctl.write(unit, &self.proto, &self.extension_sections,
+                                         &mut self.tcd22xx_ctl.state, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -76,12 +87,15 @@ impl NotifyModel<SndDice, u32> for SPro26Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+        self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;
+        self.out_grp_ctl.parse_notification(unit, &self.proto, &self.extension_sections,
+                                            &mut self.tcd22xx_ctl.state, *msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -91,6 +105,8 @@ impl NotifyModel<SndDice, u32> for SPro26Model {
         if self.ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read_notified_elem(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -16,6 +16,8 @@ use dice_protocols::focusrite::spro40::*;
 use crate::common_ctl::*;
 use crate::tcd22xx_ctl::*;
 
+use super::out_grp_ctl::*;
+
 #[derive(Default)]
 pub struct SPro40Model {
     proto: FwReq,
@@ -23,6 +25,7 @@ pub struct SPro40Model {
     extension_sections: ExtensionSections,
     ctl: CommonCtl,
     tcd22xx_ctl: Tcd22xxCtl<SPro40State>,
+    out_grp_ctl: OutGroupCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -42,6 +45,9 @@ impl CtlModel<SndDice> for SPro40Model {
 
         self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
 
+        self.out_grp_ctl.load(card_cntr, unit, &self.proto, &self.extension_sections,
+                              &mut self.tcd22xx_ctl.state, TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -52,6 +58,8 @@ impl CtlModel<SndDice> for SPro40Model {
             Ok(true)
         } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
                                     elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -66,6 +74,9 @@ impl CtlModel<SndDice> for SPro40Model {
         } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
                                      old, new, TIMEOUT_MS)? {
             Ok(true)
+        } else if self.out_grp_ctl.write(unit, &self.proto, &self.extension_sections,
+                                         &mut self.tcd22xx_ctl.state, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -76,12 +87,15 @@ impl NotifyModel<SndDice, u32> for SPro40Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+        self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;
+        self.out_grp_ctl.parse_notification(unit, &self.proto, &self.extension_sections,
+                                            &mut self.tcd22xx_ctl.state, *msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -91,6 +105,8 @@ impl NotifyModel<SndDice, u32> for SPro40Model {
         if self.ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read_notified_elem(&self.tcd22xx_ctl.state, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+use dice_protocols::focusrite::spro40::*;
+
+use crate::common_ctl::*;
+use crate::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct SPro40Model {
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<SPro40State>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for SPro40Model {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for SPro40Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for SPro40Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -13,6 +13,7 @@ mod extension_model;
 mod pfire_model;
 mod mbox3_model;
 mod blackbird_model;
+mod focusrite;
 
 use glib::Error;
 use glib::source;

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -27,6 +27,7 @@ use super::mbox3_model::*;
 use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
+use super::focusrite::spro26_model::*;
 
 enum Model {
     Minimal(MinimalModel),
@@ -45,6 +46,7 @@ enum Model {
     LoudBlackbird(BlackbirdModel),
     FocusriteSPro40(SPro40Model),
     FocusriteLiquidS56(LiquidS56Model),
+    FocusriteSPro26(SPro26Model),
 }
 
 pub struct DiceModel{
@@ -86,6 +88,7 @@ impl DiceModel {
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
+            (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -129,6 +132,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
+            Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -148,6 +152,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -167,6 +172,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -193,6 +199,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -216,6 +223,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -239,6 +247,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -26,6 +26,7 @@ use super::pfire_model::*;
 use super::mbox3_model::*;
 use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
+use super::focusrite::liquids56_model::*;
 
 enum Model {
     Minimal(MinimalModel),
@@ -43,6 +44,7 @@ enum Model {
     AvidMbox3(Mbox3Model),
     LoudBlackbird(BlackbirdModel),
     FocusriteSPro40(SPro40Model),
+    FocusriteLiquidS56(LiquidS56Model),
 }
 
 pub struct DiceModel{
@@ -83,6 +85,7 @@ impl DiceModel {
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
+            (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -125,6 +128,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.load(unit, card_cntr),
             Model::LoudBlackbird(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
+            Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -143,6 +147,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -161,6 +166,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -186,6 +192,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -208,6 +215,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::LoudBlackbird(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -230,6 +238,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -25,6 +25,7 @@ use super::extension_model::ExtensionModel;
 use super::pfire_model::*;
 use super::mbox3_model::*;
 use super::blackbird_model::*;
+use super::focusrite::spro40_model::*;
 
 enum Model {
     Minimal(MinimalModel),
@@ -41,6 +42,7 @@ enum Model {
     MaudioPfire610(Pfire610Model),
     AvidMbox3(Mbox3Model),
     LoudBlackbird(BlackbirdModel),
+    FocusriteSPro40(SPro40Model),
 }
 
 pub struct DiceModel{
@@ -80,6 +82,7 @@ impl DiceModel {
             (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
+            (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -121,6 +124,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => m.load(unit, card_cntr),
             Model::AvidMbox3(m) => m.load(unit, card_cntr),
             Model::LoudBlackbird(m) => m.load(unit, card_cntr),
+            Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -138,6 +142,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::AvidMbox3(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -155,6 +160,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::AvidMbox3(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -179,6 +185,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::AvidMbox3(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -200,6 +207,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::AvidMbox3(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::LoudBlackbird(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -221,6 +229,7 @@ impl DiceModel {
             Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::AvidMbox3(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -22,7 +22,7 @@ use dice_protocols::tcat::tcd22xx_spec::*;
 pub struct Tcd22xxCtl<S>
     where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
 {
-    state: S,
+    pub state: S,
     caps: ExtensionCaps,
     meter_ctl: MeterCtl,
     router_ctl: RouterCtl,


### PR DESCRIPTION
Focusrite Audio Engineering Ltd. produced Saffire Pro series between 2008 and 2014. The models in the series adopted TC Applied Technologies DICE TCD2220.

The models support TCAT protocol extension as well as unique protocol for output grouping. 

This patchset adds implementation of the protocol and support for the models.

```
Takashi Sakamoto (10):
  dice-protocols: maudio: fix specification of M-Audio ProFire 2626
  dice-runtime: focusrite: add support for Focusrite Saffire Pro 40
  dice-runtime: focusrite: add support for Focusrite Liquid Saffire 56
  dice-runtime: focusrite: add support for Focusrite Saffire Pro 26
  dice-protocols: focusrite: add trait implementation for output group
    protocol
  dice-runtime: focusrinte: add output group controls
  dice-protocols: focusrite: add trait implementation for protocol
    specific to Saffire Pro 40
  dice-runtime: focusrite: add controls specific to Saffire Pro 40
  dice-protocols: focusrite: add trait implementation for protocol
    specific to Liquid Saffire 56
  dice-runtime: focusrite: add controls specific to Liquid Saffire 56

 README.rst                                    |   3 +
 libs/dice/protocols/src/focusrite.rs          | 332 +++++++++++
 .../dice/protocols/src/focusrite/liquids56.rs | 558 ++++++++++++++++++
 libs/dice/protocols/src/focusrite/spro26.rs   |  91 +++
 libs/dice/protocols/src/focusrite/spro40.rs   | 174 ++++++
 libs/dice/protocols/src/lib.rs                |   1 +
 libs/dice/protocols/src/maudio.rs             |   4 +-
 libs/dice/runtime/src/focusrite.rs            |   8 +
 .../runtime/src/focusrite/liquids56_model.rs  | 481 +++++++++++++++
 .../dice/runtime/src/focusrite/out_grp_ctl.rs | 219 +++++++
 .../runtime/src/focusrite/spro26_model.rs     | 140 +++++
 .../runtime/src/focusrite/spro40_model.rs     | 230 ++++++++
 libs/dice/runtime/src/lib.rs                  |   1 +
 libs/dice/runtime/src/model.rs                |  27 +
 libs/dice/runtime/src/tcd22xx_ctl.rs          |   2 +-
 15 files changed, 2268 insertions(+), 3 deletions(-)
 create mode 100644 libs/dice/protocols/src/focusrite.rs
 create mode 100644 libs/dice/protocols/src/focusrite/liquids56.rs
 create mode 100644 libs/dice/protocols/src/focusrite/spro26.rs
 create mode 100644 libs/dice/protocols/src/focusrite/spro40.rs
 create mode 100644 libs/dice/runtime/src/focusrite.rs
 create mode 100644 libs/dice/runtime/src/focusrite/liquids56_model.rs
 create mode 100644 libs/dice/runtime/src/focusrite/out_grp_ctl.rs
 create mode 100644 libs/dice/runtime/src/focusrite/spro26_model.rs
 create mode 100644 libs/dice/runtime/src/focusrite/spro40_model.rs
```