### PR TITLE
[PATCH 0/6] dice-protocols: tcat: extension: code refactoring for router entries

### DIFF
--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -14,8 +14,6 @@ use dice_protocols::tcat::extension::standalone_section::*;
 use std::sync::Arc;
 use std::thread;
 
-use std::convert::TryFrom;
-
 const TIMEOUT_MS: u32 = 20;
 
 fn print_sections(sections: &ExtensionSections) {
@@ -134,22 +132,20 @@ fn print_current_stream_format_entries(proto: &FwReq, node: &FwNode, sections: &
     println!("Current stream format entries:");
     RATE_MODES.iter().try_for_each(|&mode| {
         proto.read_current_stream_format_entries(node, sections, caps, mode, TIMEOUT_MS)
-            .and_then(|(tx_entries, rx_entries)| {
+            .map(|(tx_entries, rx_entries)| {
                 println!("  {}:", mode);
-                tx_entries.iter().enumerate().try_for_each(|(i, data)| {
-                    FormatEntry::try_from(*data)
-                        .map(|entry| {
-                            println!("    Tx stream {}:", i);
-                            print_stream_format_entry(&entry);
-                        })
-                })?;
-                rx_entries.iter().enumerate().try_for_each(|(i, data)| {
-                    FormatEntry::try_from(*data)
-                        .map(|entry| {
-                            println!("    Rx stream {}:", i);
-                            print_stream_format_entry(&entry);
-                        })
-                })
+                tx_entries.iter()
+                    .enumerate()
+                    .for_each(|(i, entry)| {
+                        println!("    Tx stream {}:", i);
+                        print_stream_format_entry(entry);
+                    });
+                rx_entries.iter()
+                    .enumerate()
+                    .for_each(|(i, entry)| {
+                        println!("    Rx stream {}:", i);
+                        print_stream_format_entry(entry);
+                    });
             })
     })
 }

--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -88,8 +88,9 @@ fn print_peak(proto: &FwReq, node: &FwNode, sections: &ExtensionSections, caps: 
     proto.read_peak_entries(node, sections, caps, TIMEOUT_MS)
         .map(|entries| {
             println!("Peak:");
-            entries.iter().enumerate().for_each(|(i, data)| {
-                let entry = RouterEntry::from(data);
+            entries.iter()
+                .enumerate()
+                .for_each(|(i, entry)| {
                 println!("  entry {}: 0x{:04x}", i, entry.peak);
             })
         })
@@ -106,8 +107,7 @@ fn print_current_router_entries(proto: &FwReq, node: &FwNode, sections: &Extensi
         proto.read_current_router_entries(node, sections, caps, mode, TIMEOUT_MS)
             .map(|entries| {
                 println!("  {}:", mode);
-                entries.iter().enumerate().for_each(|(i, data)| {
-                    let entry = RouterEntry::from(data);
+                entries.iter().enumerate().for_each(|(i, entry)| {
                     println!("    entry {}: {:?} <- {:?}", i, entry.dst, entry.src);
                 });
             })

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -24,6 +24,7 @@ pub mod standalone_section;
 use super::{*, utils::*};
 
 use std::convert::TryFrom;
+use std::cmp::Ordering;
 
 /// The structure to represent sections for protocol extension.
 #[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
@@ -246,6 +247,18 @@ impl From<DstBlk> for u8 {
     }
 }
 
+impl Ord for DstBlk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
+    }
+}
+
+impl PartialOrd for DstBlk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(u8::from(*self).cmp(&u8::from(*other)))
+    }
+}
+
 /// The enumeration to represent ID of source block.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum SrcBlkId {
@@ -327,6 +340,18 @@ impl From<u8> for SrcBlk {
 impl From<SrcBlk> for u8 {
     fn from(blk: SrcBlk) -> Self {
         (u8::from(blk.id) << SrcBlk::ID_SHIFT) | blk.ch
+    }
+}
+
+impl Ord for SrcBlk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
+    }
+}
+
+impl PartialOrd for SrcBlk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(u8::from(*self).cmp(&u8::from(*other)))
     }
 }
 

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -184,79 +184,11 @@ impl Default for DstBlkId {
     }
 }
 
-impl From<u8> for DstBlkId {
-    fn from(val: u8) -> Self {
-        match val {
-            0 => Self::Aes,
-            1 => Self::Adat,
-            2 => Self::MixerTx0,
-            3 => Self::MixerTx1,
-            4 => Self::Ins0,
-            5 => Self::Ins1,
-            10 => Self::ArmApbAudio,
-            11 => Self::Avs0,
-            12 => Self::Avs1,
-            _ => Self::Reserved(val),
-        }
-    }
-}
-
-impl From<DstBlkId> for u8 {
-    fn from(id: DstBlkId) -> Self {
-        match id {
-            DstBlkId::Aes => 0,
-            DstBlkId::Adat => 1,
-            DstBlkId::MixerTx0 => 2,
-            DstBlkId::MixerTx1 => 3,
-            DstBlkId::Ins0 => 4,
-            DstBlkId::Ins1 => 5,
-            DstBlkId::ArmApbAudio => 10,
-            DstBlkId::Avs0 => 11,
-            DstBlkId::Avs1 => 12,
-            DstBlkId::Reserved(val) => val,
-        }
-    }
-}
-
 /// The structure to represent destination block.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct DstBlk {
     pub id: DstBlkId,
     pub ch: u8,
-}
-
-impl DstBlk {
-    pub const ID_MASK: u8 = 0xf0;
-    pub const ID_SHIFT: usize = 4;
-    pub const CH_MASK: u8 = 0x0f;
-    pub const CH_SHIFT: usize = 0;
-}
-
-impl From<u8> for DstBlk {
-    fn from(val: u8) -> Self {
-        DstBlk {
-            id: DstBlkId::from((val & DstBlk::ID_MASK) >> DstBlk::ID_SHIFT),
-            ch: (val & DstBlk::CH_MASK) >> DstBlk::CH_SHIFT,
-        }
-    }
-}
-
-impl From<DstBlk> for u8 {
-    fn from(blk: DstBlk) -> Self {
-        (u8::from(blk.id) << DstBlk::ID_SHIFT) | blk.ch
-    }
-}
-
-impl Ord for DstBlk {
-    fn cmp(&self, other: &Self) -> Ordering {
-        u8::from(*self).cmp(&u8::from(*other))
-    }
-}
-
-impl PartialOrd for DstBlk {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(u8::from(*self).cmp(&u8::from(*other)))
-    }
 }
 
 /// The enumeration to represent ID of source block.
@@ -280,40 +212,6 @@ impl Default for SrcBlkId {
     }
 }
 
-impl From<u8> for SrcBlkId {
-    fn from(val: u8) -> Self {
-        match val {
-            0 => Self::Aes,
-            1 => Self::Adat,
-            2 => Self::Mixer,
-            4 => Self::Ins0,
-            5 => Self::Ins1,
-            10 => Self::ArmAprAudio,
-            11 => Self::Avs0,
-            12 => Self::Avs1,
-            15 => Self::Mute,
-            _ => Self::Reserved(val),
-        }
-    }
-}
-
-impl From<SrcBlkId> for u8 {
-    fn from(id: SrcBlkId) -> Self {
-        match id {
-            SrcBlkId::Aes => 0,
-            SrcBlkId::Adat => 1,
-            SrcBlkId::Mixer => 2,
-            SrcBlkId::Ins0 => 4,
-            SrcBlkId::Ins1 => 5,
-            SrcBlkId::ArmAprAudio => 10,
-            SrcBlkId::Avs0 => 11,
-            SrcBlkId::Avs1 => 12,
-            SrcBlkId::Mute => 15,
-            SrcBlkId::Reserved(val) => val,
-        }
-    }
-}
-
 /// The structure to represent source block.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct SrcBlk {
@@ -321,78 +219,12 @@ pub struct SrcBlk {
     pub ch: u8,
 }
 
-impl SrcBlk {
-    pub const ID_MASK: u8 = 0xf0;
-    pub const ID_SHIFT: usize = 4;
-    pub const CH_MASK: u8 = 0x0f;
-    pub const CH_SHIFT: usize = 0;
-}
-
-impl From<u8> for SrcBlk {
-    fn from(val: u8) -> Self {
-        SrcBlk {
-            id: SrcBlkId::from((val & SrcBlk::ID_MASK) >> SrcBlk::ID_SHIFT),
-            ch: (val & SrcBlk::CH_MASK) >> SrcBlk::CH_SHIFT,
-        }
-    }
-}
-
-impl From<SrcBlk> for u8 {
-    fn from(blk: SrcBlk) -> Self {
-        (u8::from(blk.id) << SrcBlk::ID_SHIFT) | blk.ch
-    }
-}
-
-impl Ord for SrcBlk {
-    fn cmp(&self, other: &Self) -> Ordering {
-        u8::from(*self).cmp(&u8::from(*other))
-    }
-}
-
-impl PartialOrd for SrcBlk {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(u8::from(*self).cmp(&u8::from(*other)))
-    }
-}
-
-/// The alternative type of data for router entry.
-pub type RouterEntryData = [u8;RouterEntry::SIZE];
-
 /// The structure to represent entry of route.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct RouterEntry {
     pub dst: DstBlk,
     pub src: SrcBlk,
     pub peak: u16,
-}
-
-impl RouterEntry {
-    const SIZE: usize = 4;
-
-    pub const SRC_OFFSET: usize = 2;
-    pub const DST_OFFSET: usize = 3;
-}
-
-impl From<&RouterEntryData> for RouterEntry {
-    fn from(raw: &RouterEntryData) -> Self {
-        let mut doublet = [0;2];
-        doublet.copy_from_slice(&raw[..2]);
-        RouterEntry {
-            dst: raw[Self::DST_OFFSET].into(),
-            src: raw[Self::SRC_OFFSET].into(),
-            peak: u16::from_be_bytes(doublet),
-        }
-    }
-}
-
-impl From<&RouterEntry> for RouterEntryData {
-    fn from(entry: &RouterEntry) -> RouterEntryData {
-        let mut raw = RouterEntryData::default();
-        raw.copy_from_slice(&entry.peak.to_be_bytes());
-        raw[RouterEntry::SRC_OFFSET] = entry.src.into();
-        raw[RouterEntry::DST_OFFSET] = entry.dst.into();
-        raw
-    }
 }
 
 /// The structure to represent entry of stream format.
@@ -473,7 +305,6 @@ impl From<FormatEntry> for FormatEntryData {
 mod test {
     use super::Section;
     use super::ExtensionSections;
-    use super::{DstBlk, SrcBlk, DstBlkId, SrcBlkId};
     use super::{FormatEntry, FormatEntryData, AC3_CHANNELS};
 
     use std::convert::TryFrom;
@@ -500,24 +331,6 @@ mod test {
             application: Section{offset: 0x04, size: 0x00},
         };
         assert_eq!(space, ExtensionSections::from(&raw[..]));
-    }
-
-    #[test]
-    fn dst_blk_from() {
-        let blk = DstBlk {
-            id: DstBlkId::ArmApbAudio,
-            ch: 0x04,
-        };
-        assert_eq!(blk, DstBlk::from(u8::from(blk)));
-    }
-
-    #[test]
-    fn src_blk_from() {
-        let blk = SrcBlk {
-            id: SrcBlkId::ArmAprAudio,
-            ch: 0x04,
-        };
-        assert_eq!(blk, SrcBlk::from(u8::from(blk)));
     }
 
     #[test]

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -239,75 +239,10 @@ pub struct FormatEntry{
 /// The number of channels in stream format for AC3 channels.
 pub const AC3_CHANNELS: usize = 32;
 
-/// The alternative type of data for stream format.
-pub type FormatEntryData = [u8;FormatEntry::SIZE];
-
-impl FormatEntry {
-    const SIZE: usize = 268;
-    const NAMES_MAX_SIZE: usize = 256;
-}
-
-impl TryFrom<FormatEntryData> for FormatEntry {
-    type Error = Error;
-
-    fn try_from(raw: FormatEntryData) -> Result<Self, Self::Error> {
-        let mut quadlet = [0;4];
-
-        quadlet.copy_from_slice(&raw[..4]);
-        let pcm_count = u32::from_be_bytes(quadlet) as u8;
-
-        quadlet.copy_from_slice(&raw[4..8]);
-        let midi_count = u32::from_be_bytes(quadlet) as u8;
-
-        let labels = parse_labels(&raw[8..264])
-            .map_err(|e| {
-                let msg = format!("Invalid data for string: {}", e);
-                Error::new(ProtocolExtensionError::StreamFormatEntry, &msg)
-            })?;
-
-        let mut enable_ac3 = [false;AC3_CHANNELS];
-        quadlet.copy_from_slice(&raw[264..268]);
-        let val = u32::from_be_bytes(quadlet);
-        enable_ac3.iter_mut()
-            .enumerate()
-            .for_each(|(i, v)| *v = (1 << i) & val > 0);
-
-        let entry = FormatEntry{
-            pcm_count,
-            midi_count,
-            labels,
-            enable_ac3,
-        };
-
-        Ok(entry)
-    }
-}
-
-impl From<FormatEntry> for FormatEntryData {
-    fn from(entry: FormatEntry) -> Self {
-        let mut raw = [0;FormatEntry::SIZE];
-        raw[..4].copy_from_slice(&(entry.pcm_count as u32).to_be_bytes());
-        raw[4..8].copy_from_slice(&(entry.midi_count as u32).to_be_bytes());
-
-        raw[8..264].copy_from_slice(&build_labels(&entry.labels, FormatEntry::NAMES_MAX_SIZE));
-
-        let val = entry.enable_ac3.iter()
-            .enumerate()
-            .filter(|(_, &enabled)| enabled)
-            .fold(0 as u32, |val, (i, _)| val | (1 << i));
-        raw[264..268].copy_from_slice(&val.to_be_bytes());
-
-        raw
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::Section;
     use super::ExtensionSections;
-    use super::{FormatEntry, FormatEntryData, AC3_CHANNELS};
-
-    use std::convert::TryFrom;
 
     #[test]
     fn section_from() {
@@ -331,22 +266,5 @@ mod test {
             application: Section{offset: 0x04, size: 0x00},
         };
         assert_eq!(space, ExtensionSections::from(&raw[..]));
-    }
-
-    #[test]
-    fn stream_format_entry_from() {
-        let entry = FormatEntry{
-            pcm_count: 0xfe,
-            midi_count: 0x3c,
-            labels: vec![
-                "To say".to_string(),
-                "Good bye".to_string(),
-                "is to die".to_string(),
-                "a little.".to_string(),
-            ],
-            enable_ac3: [true;AC3_CHANNELS],
-        };
-        let data = Into::<FormatEntryData>::into(entry.clone());
-        assert_eq!(entry, FormatEntry::try_from(data).unwrap());
     }
 }

--- a/libs/dice/protocols/src/tcat/extension/current_config_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/current_config_section.rs
@@ -22,7 +22,7 @@ pub trait CurrentConfigSectionProtocol<T> : ProtocolExtension<T>
 
     fn read_current_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
                                    mode: RateMode, timeout_ms: u32)
-        -> Result<Vec<RouterEntryData>, Error>
+        -> Result<Vec<RouterEntry>, Error>
     {
         let offset = match mode {
             RateMode::Low => Self::LOW_ROUTER_CONFIG_OFFSET,

--- a/libs/dice/protocols/src/tcat/extension/current_config_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/current_config_section.rs
@@ -44,7 +44,7 @@ pub trait CurrentConfigSectionProtocol<T> : ProtocolExtension<T>
 
     fn read_current_stream_format_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
                                           mode: RateMode, timeout_ms: u32)
-        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+        -> Result<(Vec<FormatEntry>, Vec<FormatEntry>), Error>
     {
         let offset = match mode {
             RateMode::Low => Self::LOW_STREAM_CONFIG_OFFSET,

--- a/libs/dice/protocols/src/tcat/extension/peak_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/peak_section.rs
@@ -12,7 +12,7 @@ pub trait PeakSectionProtocol<T> : ProtocolExtension<T>
 {
     fn read_peak_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
                          timeout_ms: u32)
-        -> Result<Vec<RouterEntryData>, Error>
+        -> Result<Vec<RouterEntry>, Error>
     {
         if !caps.general.peak_avail {
             Err(Error::new(ProtocolExtensionError::Peak, "Peak is not available"))?

--- a/libs/dice/protocols/src/tcat/extension/router_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_entry.rs
@@ -2,6 +2,163 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use super::{*, caps_section::*};
 
+impl From<u8> for DstBlkId {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Aes,
+            1 => Self::Adat,
+            2 => Self::MixerTx0,
+            3 => Self::MixerTx1,
+            4 => Self::Ins0,
+            5 => Self::Ins1,
+            10 => Self::ArmApbAudio,
+            11 => Self::Avs0,
+            12 => Self::Avs1,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<DstBlkId> for u8 {
+    fn from(id: DstBlkId) -> Self {
+        match id {
+            DstBlkId::Aes => 0,
+            DstBlkId::Adat => 1,
+            DstBlkId::MixerTx0 => 2,
+            DstBlkId::MixerTx1 => 3,
+            DstBlkId::Ins0 => 4,
+            DstBlkId::Ins1 => 5,
+            DstBlkId::ArmApbAudio => 10,
+            DstBlkId::Avs0 => 11,
+            DstBlkId::Avs1 => 12,
+            DstBlkId::Reserved(val) => val,
+        }
+    }
+}
+
+impl DstBlk {
+    const ID_MASK: u8 = 0xf0;
+    const ID_SHIFT: usize = 4;
+    const CH_MASK: u8 = 0x0f;
+    const CH_SHIFT: usize = 0;
+}
+
+impl From<u8> for DstBlk {
+    fn from(val: u8) -> Self {
+        DstBlk {
+            id: DstBlkId::from((val & DstBlk::ID_MASK) >> DstBlk::ID_SHIFT),
+            ch: (val & DstBlk::CH_MASK) >> DstBlk::CH_SHIFT,
+        }
+    }
+}
+
+impl From<DstBlk> for u8 {
+    fn from(blk: DstBlk) -> Self {
+        (u8::from(blk.id) << DstBlk::ID_SHIFT) | blk.ch
+    }
+}
+
+impl Ord for DstBlk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
+    }
+}
+
+impl PartialOrd for DstBlk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(u8::from(*self).cmp(&u8::from(*other)))
+    }
+}
+
+impl From<u8> for SrcBlkId {
+    fn from(val: u8) -> Self {
+        match val {
+            0 => Self::Aes,
+            1 => Self::Adat,
+            2 => Self::Mixer,
+            4 => Self::Ins0,
+            5 => Self::Ins1,
+            10 => Self::ArmAprAudio,
+            11 => Self::Avs0,
+            12 => Self::Avs1,
+            15 => Self::Mute,
+            _ => Self::Reserved(val),
+        }
+    }
+}
+
+impl From<SrcBlkId> for u8 {
+    fn from(id: SrcBlkId) -> Self {
+        match id {
+            SrcBlkId::Aes => 0,
+            SrcBlkId::Adat => 1,
+            SrcBlkId::Mixer => 2,
+            SrcBlkId::Ins0 => 4,
+            SrcBlkId::Ins1 => 5,
+            SrcBlkId::ArmAprAudio => 10,
+            SrcBlkId::Avs0 => 11,
+            SrcBlkId::Avs1 => 12,
+            SrcBlkId::Mute => 15,
+            SrcBlkId::Reserved(val) => val,
+        }
+    }
+}
+
+impl SrcBlk {
+    const ID_MASK: u8 = 0xf0;
+    const ID_SHIFT: usize = 4;
+    const CH_MASK: u8 = 0x0f;
+    const CH_SHIFT: usize = 0;
+}
+
+impl From<u8> for SrcBlk {
+    fn from(val: u8) -> Self {
+        SrcBlk {
+            id: SrcBlkId::from((val & SrcBlk::ID_MASK) >> SrcBlk::ID_SHIFT),
+            ch: (val & SrcBlk::CH_MASK) >> SrcBlk::CH_SHIFT,
+        }
+    }
+}
+
+impl From<SrcBlk> for u8 {
+    fn from(blk: SrcBlk) -> Self {
+        (u8::from(blk.id) << SrcBlk::ID_SHIFT) | blk.ch
+    }
+}
+
+impl Ord for SrcBlk {
+    fn cmp(&self, other: &Self) -> Ordering {
+        u8::from(*self).cmp(&u8::from(*other))
+    }
+}
+
+impl PartialOrd for SrcBlk {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(u8::from(*self).cmp(&u8::from(*other)))
+    }
+}
+
+impl RouterEntry {
+    const SIZE: usize = 4;
+
+    const SRC_OFFSET: usize = 2;
+    const DST_OFFSET: usize = 3;
+
+    fn build(&self, raw: &mut [u8]) {
+        raw[Self::DST_OFFSET] = u8::from(self.dst);
+        raw[Self::SRC_OFFSET] = u8::from(self.src);
+        raw[..Self::SRC_OFFSET].copy_from_slice(&self.peak.to_be_bytes());
+    }
+
+    fn parse(&mut self, raw: &[u8]) {
+        self.dst = raw[Self::DST_OFFSET].into();
+        self.src = raw[Self::SRC_OFFSET].into();
+        let mut doublet = [0;2];
+        doublet.copy_from_slice(&raw[..Self::SRC_OFFSET]);
+        self.peak = u16::from_be_bytes(doublet);
+    }
+}
+
 pub trait RouterEntryProtocol<T> : ProtocolExtension<T>
     where T: AsRef<FwNode>,
 {
@@ -15,19 +172,18 @@ pub trait RouterEntryProtocol<T> : ProtocolExtension<T>
             Err(Error::new(ProtocolExtensionError::RouterEntry, &msg))?
         }
 
-        let mut data = vec![0;entry_count * RouterEntry::SIZE];
-        ProtocolExtension::read(self, node, offset, &mut data, timeout_ms)?;
-
-        let entries = (0..entry_count)
-            .map(|i| {
-                let mut raw = RouterEntryData::default();
-                let pos = i * RouterEntry::SIZE;
-                raw.copy_from_slice(&data[pos..(pos + RouterEntry::SIZE)]);
-                RouterEntry::from(&raw)
+        let mut raw = vec![0;entry_count * RouterEntry::SIZE];
+        ProtocolExtension::read(self, node, offset, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut entries = vec![RouterEntry::default();entry_count];
+                entries.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, entry)| {
+                        let pos = i * 4;
+                        entry.parse(&raw[pos..(pos + 4)]);
+                    });
+                entries
             })
-            .collect::<Vec<_>>();
-
-        Ok(entries)
     }
 
     fn write_router_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize,
@@ -44,13 +200,38 @@ pub trait RouterEntryProtocol<T> : ProtocolExtension<T>
         data.copy_from_slice(&(entries.len() as u32).to_be_bytes());
         ProtocolExtension::write(self, node, offset, &mut data, timeout_ms)?;
 
-        let mut data = Vec::new();
-        entries.iter().for_each(|entry| {
-            let raw = RouterEntryData::from(entry);
-            data.extend_from_slice(&raw);
-        });
-        ProtocolExtension::write(self, node, offset + 4, &mut data, timeout_ms)
+        let mut raw = vec![0;entries.len() * RouterEntry::SIZE];
+        entries.iter()
+            .enumerate()
+            .for_each(|(i, entry)| {
+                let pos = i * 4;
+                entry.build(&mut raw[pos..(pos + 4)]);
+            });
+        ProtocolExtension::write(self, node, offset + 4, &mut raw, timeout_ms)
     }
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> RouterEntryProtocol<T> for O {}
+
+#[cfg(test)]
+mod test {
+    use super::{DstBlk, SrcBlk, DstBlkId, SrcBlkId};
+
+    #[test]
+    fn dst_blk_from() {
+        let blk = DstBlk {
+            id: DstBlkId::ArmApbAudio,
+            ch: 0x04,
+        };
+        assert_eq!(blk, DstBlk::from(u8::from(blk)));
+    }
+
+    #[test]
+    fn src_blk_from() {
+        let blk = SrcBlk {
+            id: SrcBlkId::ArmAprAudio,
+            ch: 0x04,
+        };
+        assert_eq!(blk, SrcBlk::from(u8::from(blk)));
+    }
+}

--- a/libs/dice/protocols/src/tcat/extension/router_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_section.rs
@@ -13,7 +13,7 @@ pub trait RouterSectionProtocol<T> : ProtocolExtension<T>
 {
     fn read_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
                            timeout_ms: u32)
-        -> Result<Vec<RouterEntryData>, Error>
+        -> Result<Vec<RouterEntry>, Error>
     {
         let mut data = [0;4];
         ProtocolExtension::read(self, node, sections.router.offset, &mut data, timeout_ms)
@@ -27,7 +27,7 @@ pub trait RouterSectionProtocol<T> : ProtocolExtension<T>
     }
 
     fn write_router_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
-                            entries: &Vec<RouterEntryData>, timeout_ms: u32)
+                            entries: &[RouterEntry], timeout_ms: u32)
         -> Result<(), Error>
     {
         RouterEntryProtocol::write_router_entries(&self, node, caps, sections.router.offset,

--- a/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
@@ -2,11 +2,73 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use super::{*, caps_section::*};
 
+/// The alternative type of data for stream format.
+pub type FormatEntryData = [u8;FormatEntry::SIZE];
+
+impl FormatEntry {
+    const SIZE: usize = 268;
+    const NAMES_MAX_SIZE: usize = 256;
+}
+
+impl TryFrom<FormatEntryData> for FormatEntry {
+    type Error = Error;
+
+    fn try_from(raw: FormatEntryData) -> Result<Self, Self::Error> {
+        let mut quadlet = [0;4];
+
+        quadlet.copy_from_slice(&raw[..4]);
+        let pcm_count = u32::from_be_bytes(quadlet) as u8;
+
+        quadlet.copy_from_slice(&raw[4..8]);
+        let midi_count = u32::from_be_bytes(quadlet) as u8;
+
+        let labels = parse_labels(&raw[8..264])
+            .map_err(|e| {
+                let msg = format!("Invalid data for string: {}", e);
+                Error::new(ProtocolExtensionError::StreamFormatEntry, &msg)
+            })?;
+
+        let mut enable_ac3 = [false;AC3_CHANNELS];
+        quadlet.copy_from_slice(&raw[264..268]);
+        let val = u32::from_be_bytes(quadlet);
+        enable_ac3.iter_mut()
+            .enumerate()
+            .for_each(|(i, v)| *v = (1 << i) & val > 0);
+
+        let entry = FormatEntry{
+            pcm_count,
+            midi_count,
+            labels,
+            enable_ac3,
+        };
+
+        Ok(entry)
+    }
+}
+
+impl From<FormatEntry> for FormatEntryData {
+    fn from(entry: FormatEntry) -> Self {
+        let mut raw = [0;FormatEntry::SIZE];
+        raw[..4].copy_from_slice(&(entry.pcm_count as u32).to_be_bytes());
+        raw[4..8].copy_from_slice(&(entry.midi_count as u32).to_be_bytes());
+
+        raw[8..264].copy_from_slice(&build_labels(&entry.labels, FormatEntry::NAMES_MAX_SIZE));
+
+        let val = entry.enable_ac3.iter()
+            .enumerate()
+            .filter(|(_, &enabled)| enabled)
+            .fold(0 as u32, |val, (i, _)| val | (1 << i));
+        raw[264..268].copy_from_slice(&val.to_be_bytes());
+
+        raw
+    }
+}
+
 pub trait StreamFormatEntryProtocol<T> : ProtocolExtension<T>
     where T: AsRef<FwNode>,
 {
     fn read_stream_format_entries(&self, node: &T, caps: &ExtensionCaps, offset: usize, timeout_ms: u32)
-        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+        -> Result<(Vec<FormatEntry>, Vec<FormatEntry>), Error>
     {
         let mut data = [0;8];
         ProtocolExtension::read(self, node, offset, &mut data, timeout_ms)?;
@@ -29,20 +91,32 @@ pub trait StreamFormatEntryProtocol<T> : ProtocolExtension<T>
         }
 
         let mut tx_entries = Vec::new();
-        (0..tx_count).try_for_each(|i| {
-            let mut data = [0;FormatEntry::SIZE];
-            ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * i, &mut data,
-                                    timeout_ms)
-                .map(|_| tx_entries.push(data))
-        })?;
+        (0..tx_count)
+            .try_for_each(|i| {
+                let mut raw = [0;FormatEntry::SIZE];
+                ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * i, &mut raw,
+                                        timeout_ms)?;
+                FormatEntry::try_from(raw)
+                    .map_err(|e| {
+                        let msg = format!("Fail to parse TX stream entry {}: {}", i, e);
+                        Error::new(ProtocolExtensionError::StreamFormatEntry, &msg)
+                    })
+                    .map(|entry| tx_entries.push(entry))
+            })?;
 
         let mut rx_entries = Vec::new();
-        (0..rx_count).try_for_each(|i| {
-            let mut data = [0;FormatEntry::SIZE];
-            ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * (tx_count + i),
-                                    &mut data, timeout_ms)
-                .map(|_| rx_entries.push(data))
-        })?;
+        (0..rx_count)
+            .try_for_each(|i| {
+                let mut raw = [0;FormatEntry::SIZE];
+                ProtocolExtension::read(self, node, offset + 8 + FormatEntry::SIZE * (tx_count + i),
+                                        &mut raw, timeout_ms)?;
+                FormatEntry::try_from(raw)
+                    .map_err(|e| {
+                        let msg = format!("Fail to parse RX stream entry {}: {}", i, e);
+                        Error::new(ProtocolExtensionError::StreamFormatEntry, &msg)
+                    })
+                    .map(|entry| rx_entries.push(entry))
+            })?;
 
         Ok((tx_entries, rx_entries))
     }
@@ -79,3 +153,27 @@ pub trait StreamFormatEntryProtocol<T> : ProtocolExtension<T>
 }
 
 impl<O: AsRef<FwReq>, T: AsRef<FwNode>> StreamFormatEntryProtocol<T> for O {}
+
+#[cfg(test)]
+mod test {
+    use super::{FormatEntry, FormatEntryData, AC3_CHANNELS};
+
+    use std::convert::TryFrom;
+
+    #[test]
+    fn stream_format_entry_from() {
+        let entry = FormatEntry{
+            pcm_count: 0xfe,
+            midi_count: 0x3c,
+            labels: vec![
+                "To say".to_string(),
+                "Good bye".to_string(),
+                "is to die".to_string(),
+                "a little.".to_string(),
+            ],
+            enable_ac3: [true;AC3_CHANNELS],
+        };
+        let data = Into::<FormatEntryData>::into(entry.clone());
+        assert_eq!(entry, FormatEntry::try_from(data).unwrap());
+    }
+}

--- a/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
@@ -13,7 +13,7 @@ pub trait StreamFormatSectionProtocol<T> : ProtocolExtension<T>
 {
     fn read_stream_format_entries(&self, node: &T, sections: &ExtensionSections, caps: &ExtensionCaps,
                                   timeout_ms: u32)
-        -> Result<(Vec<FormatEntryData>, Vec<FormatEntryData>), Error>
+        -> Result<(Vec<FormatEntry>, Vec<FormatEntry>), Error>
     {
         StreamFormatEntryProtocol::read_stream_format_entries(&self, node, caps, sections.stream_format.offset,
                                                               timeout_ms)

--- a/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
+++ b/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
@@ -11,7 +11,7 @@ use std::convert::TryFrom;
 
 #[derive(Default, Debug)]
 pub struct Tcd22xxState {
-    pub router_entries: Vec<RouterEntryData>,
+    pub router_entries: Vec<RouterEntry>,
     pub mixer_cache: Vec<Vec<i32>>,
 
     rate_mode: RateMode,
@@ -76,7 +76,7 @@ pub trait Tcd22xxSpec<'a> {
         let mut srcs = Vec::<SrcBlk>::new();
         Self::INPUTS.iter().for_each(|entry| {
             let offset = match entry.id {
-                SrcBlkId::Adat => srcs.iter().filter(|&d| SrcBlk::from(*d).id == entry.id).count() as u8,
+                SrcBlkId::Adat => srcs.iter().filter(|&s| s.id.eq(&entry.id)).count() as u8,
                 _ => entry.offset,
             };
             let count = match entry.id {
@@ -91,7 +91,7 @@ pub trait Tcd22xxSpec<'a> {
         let mut dsts = Vec::<DstBlk>::new();
         Self::OUTPUTS.iter().for_each(|entry| {
             let offset = match entry.id {
-                DstBlkId::Adat => dsts.iter().filter(|&d| DstBlk::from(*d).id == entry.id).count() as u8,
+                DstBlkId::Adat => dsts.iter().filter(|d| d.id.eq(&entry.id)).count() as u8,
                 _ => entry.offset,
             };
             let count = match entry.id {
@@ -198,7 +198,7 @@ pub trait Tcd22xxRouterOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxStat
           U: CmdSectionProtocol<T> + RouterSectionProtocol<T> + CurrentConfigSectionProtocol<T>,
 {
     fn update_router_entries(&mut self, node: &T, proto: &U, sections: &ExtensionSections,
-                             caps: &ExtensionCaps, entries: Vec<RouterEntryData>, timeout_ms: u32)
+                             caps: &ExtensionCaps, entries: Vec<RouterEntry>, timeout_ms: u32)
         -> Result<(), Error>
     {
         if entries.len() > caps.router.maximum_entry_count as usize {

--- a/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
+++ b/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
@@ -7,8 +7,6 @@ use hinawa::FwNode;
 use super::extension::{*, caps_section::*, cmd_section::*, mixer_section::*, router_section::*,
                        current_config_section::*};
 
-use std::convert::TryFrom;
-
 #[derive(Default, Debug)]
 pub struct Tcd22xxState {
     pub router_entries: Vec<RouterEntry>,
@@ -106,21 +104,19 @@ pub trait Tcd22xxSpec<'a> {
         (srcs, dsts)
     }
 
-    fn compute_avail_stream_blk_pair(&self, tx_entries: &[FormatEntryData], rx_entries: &[FormatEntryData])
+    fn compute_avail_stream_blk_pair(&self, tx_entries: &[FormatEntry], rx_entries: &[FormatEntry])
         -> (Vec<SrcBlk>, Vec<DstBlk>)
     {
         let dst_blk_list = tx_entries.iter()
             .zip([DstBlkId::Avs0, DstBlkId::Avs1].iter())
-            .map(|(&data, &id)| {
-                let entry = FormatEntry::try_from(data).unwrap();
+            .map(|(entry, &id)| {
                 (0..entry.pcm_count).map(move |ch| DstBlk{id, ch})
             }).flatten()
             .collect();
 
         let src_blk_list = rx_entries.iter()
             .zip([SrcBlkId::Avs0, SrcBlkId::Avs1].iter())
-            .map(|(&data, &id)| {
-                let entry = FormatEntry::try_from(data).unwrap();
+            .map(|(entry, &id)| {
                 (0..entry.pcm_count).map(move |ch| SrcBlk{id, ch})
             }).flatten()
             .collect();


### PR DESCRIPTION
Current implementation for TCAT protocol extension returns byte data to runtime crate, however it's inconvenient since the runtime requires recompile the data to structured data.

This patchset refactors the implementation to return the structured data instead of byte data.

```
Takashi Sakamoto (6):
  dice-protocols: tcat: tcd22xx_spec: use structured data for router source and destination
  dice-protocols: tcat: extension: return vector of RouterEntry instead of RouterEntryData
  dice-protocols: tcat: extension: code refactoring to obsolete RouterEntryData
  dice-protocols: tcat: extension: code refactoring to obsolete FormatEntryData
  dice-protocols: tcat: tcd22xx_spec: optimization for fixed-position router entries
  dice-protocols: tcat: extension: refine router entries with available sources and destinations

 .../src/bin/tcat-extension-parser.rs          |  38 ++-
 libs/dice/protocols/src/tcat/extension.rs     | 246 +-----------------
 .../tcat/extension/current_config_section.rs  |   4 +-
 .../src/tcat/extension/peak_section.rs        |   2 +-
 .../src/tcat/extension/router_entry.rs        | 220 ++++++++++++++--
 .../src/tcat/extension/router_section.rs      |   4 +-
 .../src/tcat/extension/stream_format_entry.rs | 124 ++++++++-
 .../tcat/extension/stream_format_section.rs   |   2 +-
 libs/dice/protocols/src/tcat/tcd22xx_spec.rs  |  82 +++---
 libs/dice/runtime/src/tcd22xx_ctl.rs          |  87 ++++---
 10 files changed, 433 insertions(+), 376 deletions(-)
```