### PR TITLE
[PATCH 0/2] dice: add support for PreSonus FireStudio project/mobile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,7 @@ your device, please contact to developer.
   * Focusrite Liquid Saffire 56
   * Focusrite Saffire Pro 26
   * PreSonus FireStudio Project
+  * PreSonus FireStudio Mobile
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,7 @@ your device, please contact to developer.
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
   * Focusrite Saffire Pro 26
+  * PreSonus FireStudio Project
   * For the others, common controls are available. If supported, control extension is also available.
 
 Supported protocols

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -14,6 +14,7 @@ pub mod maudio;
 pub mod avid;
 pub mod loud;
 pub mod focusrite;
+pub mod presonus;
 
 const QUADLET_SIZE: usize = 4;
 

--- a/libs/dice/protocols/src/presonus.rs
+++ b/libs/dice/protocols/src/presonus.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 pub mod fstudioproject;
+pub mod fstudiomobile;

--- a/libs/dice/protocols/src/presonus.rs
+++ b/libs/dice/protocols/src/presonus.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+pub mod fstudioproject;

--- a/libs/dice/protocols/src/presonus/fstudiomobile.rs
+++ b/libs/dice/protocols/src/presonus/fstudiomobile.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use crate::tcat::extension::*;
+use crate::tcat::tcd22xx_spec::*;
+
+#[derive(Default, Debug)]
+pub struct FStudioMobileState(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for  FStudioMobileState {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 4, label: None},
+        Output{id: DstBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+    ];
+}
+
+impl AsRef<Tcd22xxState> for FStudioMobileState {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}
+
+impl AsMut<Tcd22xxState> for FStudioMobileState {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
+    }
+}

--- a/libs/dice/protocols/src/presonus/fstudioproject.rs
+++ b/libs/dice/protocols/src/presonus/fstudioproject.rs
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use crate::tcat::extension::*;
+use crate::tcat::tcd22xx_spec::*;
+
+#[derive(Default, Debug)]
+pub struct FStudioProjectState(Tcd22xxState);
+
+impl<'a> Tcd22xxSpec<'a> for  FStudioProjectState {
+    const INPUTS: &'a [Input<'a>] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
+    ];
+    const OUTPUTS: &'a [Output<'a>] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
+        Output{id: DstBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
+    ];
+    const FIXED: &'a [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 4},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 5},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 6},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 7},
+    ];
+}
+
+impl AsRef<Tcd22xxState> for FStudioProjectState {
+    fn as_ref(&self) -> &Tcd22xxState {
+        &self.0
+    }
+}
+
+impl AsMut<Tcd22xxState> for FStudioProjectState {
+    fn as_mut(&mut self) -> &mut Tcd22xxState {
+        &mut self.0
+    }
+}

--- a/libs/dice/protocols/src/tcat/global_section.rs
+++ b/libs/dice/protocols/src/tcat/global_section.rs
@@ -461,7 +461,7 @@ impl From<u32> for ClockCaps {
 /// The structure with labels for source of sampling clock.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct ClockSourceLabels{
-    entries: Vec<String>,
+    pub entries: Vec<String>,
 }
 
 /// The maximum size of nickname in bytes.

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -7,6 +7,7 @@ mod minimal_model;
 mod tcelectronic;
 mod io_fw_model;
 mod ionix_model;
+mod presonus;
 
 mod tcd22xx_ctl;
 mod extension_model;

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -28,6 +28,7 @@ use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
 use super::focusrite::spro26_model::*;
+use super::presonus::fstudioproject_model::*;
 
 enum Model {
     Minimal(MinimalModel),
@@ -47,6 +48,7 @@ enum Model {
     FocusriteSPro40(SPro40Model),
     FocusriteLiquidS56(LiquidS56Model),
     FocusriteSPro26(SPro26Model),
+    PresonusFStudioProject(FStudioProjectModel),
 }
 
 pub struct DiceModel{
@@ -89,6 +91,7 @@ impl DiceModel {
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
+            (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -133,6 +136,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
+            Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -153,6 +157,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::PresonusFStudioProject(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -173,6 +178,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::PresonusFStudioProject(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -200,6 +206,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::PresonusFStudioProject(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -224,6 +231,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::PresonusFStudioProject(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -248,6 +256,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::PresonusFStudioProject(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -29,6 +29,7 @@ use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
 use super::focusrite::spro26_model::*;
 use super::presonus::fstudioproject_model::*;
+use super::presonus::fstudiomobile_model::*;
 
 enum Model {
     Minimal(MinimalModel),
@@ -49,6 +50,7 @@ enum Model {
     FocusriteLiquidS56(LiquidS56Model),
     FocusriteSPro26(SPro26Model),
     PresonusFStudioProject(FStudioProjectModel),
+    PresonusFStudioMobile(FStudioMobileModel),
 }
 
 pub struct DiceModel{
@@ -92,6 +94,7 @@ impl DiceModel {
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
+            (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -137,6 +140,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
+            Model::PresonusFStudioMobile(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
@@ -158,6 +162,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioProject(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::PresonusFStudioMobile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -179,6 +184,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioProject(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::PresonusFStudioMobile(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -207,6 +213,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::PresonusFStudioMobile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -232,6 +239,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::PresonusFStudioMobile(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
         }
     }
 
@@ -257,6 +265,7 @@ impl DiceModel {
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::PresonusFStudioMobile(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -1,0 +1,3 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+pub mod fstudioproject_model;

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -1,3 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 pub mod fstudioproject_model;
+pub mod fstudiomobile_model;

--- a/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+use dice_protocols::presonus::fstudiomobile::*;
+
+use crate::common_ctl::*;
+use crate::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct FStudioMobileModel{
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<FStudioMobileState>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for FStudioMobileModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for FStudioMobileModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for FStudioMobileModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/libs/dice/runtime/src/presonus/fstudioproject_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudioproject_model.rs
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::FwReq;
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::{*, global_section::*};
+use dice_protocols::tcat::extension::*;
+use dice_protocols::presonus::fstudioproject::*;
+
+use crate::common_ctl::*;
+use crate::tcd22xx_ctl::*;
+
+#[derive(Default)]
+pub struct FStudioProjectModel{
+    proto: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: Tcd22xxCtl<FStudioProjectState>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for FStudioProjectModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = self.proto.read_extension_sections(&node, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.load(unit, &self.proto, &self.extension_sections, &caps, &src_labels,
+                          TIMEOUT_MS, card_cntr)?;
+
+        self.tcd22xx_ctl.cache(unit, &self.proto, &self.sections, &self.extension_sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(unit, &self.proto, &self.extension_sections, elem_id,
+                                    elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(unit, &self.proto, &self.extension_sections, elem_id,
+                                     old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for FStudioProjectModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
+                                        &self.extension_sections, TIMEOUT_MS, *msg)?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for FStudioProjectModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}


### PR DESCRIPTION
FireStudio series was shipped by PreSonus Audio Electronics, Inc. 2007 to 2010. The models of series use TCAT DICE ASICs.

This commit adds support for a part of the series, which adapts to TCAT protocol extension.

```
Takashi Sakamoto (2):
  dice-runtime: add support for PreSonus FireStudio Project
  dice-runtime: add support for PreSonus FireStudio Mobile

 libs/dice/protocols/src/lib.rs                |   1 +
 libs/dice/protocols/src/presonus.rs           |   4 +
 .../protocols/src/presonus/fstudiomobile.rs   |  34 +++++
 .../protocols/src/presonus/fstudioproject.rs  |  40 ++++++
 .../dice/protocols/src/tcat/global_section.rs |   2 +-
 libs/dice/runtime/src/lib.rs                  |   1 +
 libs/dice/runtime/src/model.rs                |  18 +++
 libs/dice/runtime/src/presonus.rs             |   4 +
 .../src/presonus/fstudiomobile_model.rs       | 124 ++++++++++++++++++
 .../src/presonus/fstudioproject_model.rs      | 124 ++++++++++++++++++
 10 files changed, 351 insertions(+), 1 deletion(-)
 create mode 100644 libs/dice/protocols/src/presonus.rs
 create mode 100644 libs/dice/protocols/src/presonus/fstudiomobile.rs
 create mode 100644 libs/dice/protocols/src/presonus/fstudioproject.rs
 create mode 100644 libs/dice/runtime/src/presonus.rs
 create mode 100644 libs/dice/runtime/src/presonus/fstudiomobile_model.rs
 create mode 100644 libs/dice/runtime/src/presonus/fstudioproject_model.rs
```