### PR TITLE
[PATCH 00/10] dice: add support for PreSonus FireStudio

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,7 @@ your device, please contact to developer.
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
   * Focusrite Saffire Pro 26
+  * PreSonus FireStudio
   * PreSonus FireStudio Project
   * PreSonus FireStudio Mobile
   * For the others, common controls are available. If supported, control extension is also available.

--- a/libs/dice/protocols/src/presonus.rs
+++ b/libs/dice/protocols/src/presonus.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
+pub mod fstudio;
+
 pub mod fstudioproject;
 pub mod fstudiomobile;

--- a/libs/dice/protocols/src/presonus/fstudio.rs
+++ b/libs/dice/protocols/src/presonus/fstudio.rs
@@ -5,6 +5,7 @@ use glib::Error;
 use hinawa::{FwNode, FwReq};
 
 use crate::tcat::*;
+use crate::*;
 
 #[derive(Default, Debug)]
 pub struct FStudioProto(FwReq);
@@ -68,3 +69,191 @@ pub trait PresonusFStudioMeterProtocol<T> : PresonusFStudioProto<T>
 }
 
 impl<T: AsRef<FwNode>> PresonusFStudioMeterProtocol<T> for FStudioProto {}
+
+/// The enumeration to represent source of output.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OutputSrc{
+    Analog(usize),
+    Adat0(usize),
+    Spdif(usize),
+    Stream(usize),
+    StreamAdat1(usize),
+    MixerOut(usize),
+    Reserved(usize),
+}
+
+impl From<u32> for OutputSrc {
+    fn from(val: u32) -> Self {
+        let v = val as usize;
+        match v {
+            0x00..=0x07 => Self::Analog(v),
+            0x08..=0x0f => Self::Adat0(v - 0x08),
+            0x10..=0x11 => Self::Spdif(v - 0x10),
+            0x12..=0x1b => Self::Stream(v - 0x12),
+            0x1c..=0x23 => Self::StreamAdat1(v - 0x1c),
+            0x24..=0x35 => Self::MixerOut(v - 0x24),
+            _ => Self::Reserved(v),
+        }
+    }
+}
+
+impl From<OutputSrc> for u32 {
+    fn from(src: OutputSrc) -> Self {
+        (match src {
+            OutputSrc::Analog(val) => val,
+            OutputSrc::Adat0(val) => val + 0x08,
+            OutputSrc::Spdif(val) => val + 0x10,
+            OutputSrc::Stream(val) => val + 0x12,
+            OutputSrc::StreamAdat1(val) => val + 0x1c,
+            OutputSrc::MixerOut(val) => val + 0x24,
+            OutputSrc::Reserved(val) => val,
+        }) as u32
+    }
+}
+
+impl Default for OutputSrc {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
+}
+
+/// The structure to represent state of outputs for FireStudio.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct OutputState{
+    pub vols: [u8;18],
+    pub mutes: [bool;18],
+    pub srcs: [OutputSrc;18],
+    pub links: [bool;9],
+}
+
+/// The trait to represent output protocol for FireStudio.
+pub trait PresonusFStudioOutputProtocol<T>  : PresonusFStudioProto<T>
+    where T: AsRef<FwNode>,
+{
+    const PARAMS_OFFSET: usize = 0x0f68;
+    const SRC_OFFSET: usize = 0x10ac;
+    const LINK_OFFSET: usize = 0x1150;
+    const BNC_TERMINATE_OFFSET: usize = 0x1118;
+
+    fn read_output_states(&self, node: &T, states: &mut OutputState, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = vec![0;4 * states.vols.len() * 3];
+        PresonusFStudioProto::read(self, node, Self::PARAMS_OFFSET, &mut raw, timeout_ms)?;
+        let mut quadlet = [0;4];
+        let quads: Vec<u32> = (0..(states.vols.len() * 3))
+            .map(|i| {
+                let pos = i * 4;
+                quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                u32::from_be_bytes(quadlet)
+            })
+            .collect();
+        states.vols.iter_mut()
+            .enumerate()
+            .for_each(|(i, vol)| {
+                let pos = i * 3;
+                *vol = quads[pos] as u8;
+            });
+        states.mutes.iter_mut()
+            .enumerate()
+            .for_each(|(i, mute)| {
+                let pos = 2 + i * 3;
+                *mute = quads[pos] > 0;
+            });
+
+        let mut raw = vec![0;4 * states.srcs.len()];
+        PresonusFStudioProto::read(self, node, Self::SRC_OFFSET, &mut raw, timeout_ms)
+            .map(|_| states.srcs.parse_quadlet_block(&raw))?;
+
+        let mut raw = [0;4];
+        PresonusFStudioProto::read(self, node, Self::LINK_OFFSET, &mut raw, timeout_ms)?;
+        let val = u32::from_be_bytes(raw);
+        states.links.iter_mut()
+            .enumerate()
+            .for_each(|(i, link)| *link = val & (1 << i) > 0);
+
+        Ok(())
+    }
+
+    fn write_output_vols(&self, node: &T, states: &mut OutputState, vols: &[u8], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(vols.len(), states.vols.len());
+
+        let mut raw = [0;4];
+        states.vols.iter_mut()
+            .zip(vols.iter())
+            .enumerate()
+            .filter(|(_, (old, new))| !new.eq(old))
+            .try_for_each(|(i, (old, new))| {
+                let pos = i * 3 * 4;
+                raw.copy_from_slice(&(*new as u32).to_be_bytes());
+                PresonusFStudioProto::write(self, node, Self::PARAMS_OFFSET + pos, &mut raw, timeout_ms)
+                    .map(|_| *old = *new)
+            })
+    }
+
+    fn write_output_mute(&self, node: &T, states: &mut OutputState, mutes: &[bool], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(mutes.len(), states.mutes.len());
+
+        let mut raw = [0;4];
+        states.mutes.iter_mut()
+            .zip(mutes.iter())
+            .enumerate()
+            .filter(|(_, (old, new))| !new.eq(old))
+            .try_for_each(|(i, (old, new))| {
+                let pos = (2 + i * 3) * 4;
+                raw.copy_from_slice(&(*new as u32).to_be_bytes());
+                PresonusFStudioProto::write(self, node, Self::PARAMS_OFFSET + pos, &mut raw, timeout_ms)
+                    .map(|_| *old = *new)
+            })
+    }
+
+    fn write_output_src(&self, node: &T, states: &mut OutputState, srcs: &[OutputSrc], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(srcs.len(), states.srcs.len());
+
+        let mut raw = [0;4];
+        states.srcs.iter_mut()
+            .zip(srcs.iter())
+            .enumerate()
+            .filter(|(_, (old, new))| !new.eq(old))
+            .try_for_each(|(i, (old, new))| {
+                let pos = i * 4;
+                raw.copy_from_slice(&u32::from(*new).to_be_bytes());
+                PresonusFStudioProto::write(self, node, Self::SRC_OFFSET + pos, &mut raw, timeout_ms)
+                    .map(|_| *old = *new)
+            })
+    }
+
+    fn write_output_link(&self, node: &T, states: &mut OutputState, links: &[bool], timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        assert_eq!(links.len(), states.links.len());
+
+        let val: u32 = links.iter()
+            .enumerate()
+            .filter(|(_, &link)| link)
+            .fold(0u32, |val, (i, _)| val | (1 << i));
+
+        let mut raw = [0;4];
+        val.build_quadlet(&mut raw);
+        PresonusFStudioProto::write(self, node, Self::LINK_OFFSET, &mut raw, timeout_ms)
+            .map(|_| states.links.copy_from_slice(links))
+    }
+
+    fn read_bnc_terminate(&self, node: &T, timeout_ms: u32) -> Result<bool, Error> {
+        let mut raw = [0;4];
+        PresonusFStudioProto::read(self, node, Self::BNC_TERMINATE_OFFSET, &mut raw, timeout_ms)
+            .map(|_| u32::from_be_bytes(raw) > 0)
+    }
+
+    fn write_bnc_terminalte(&self, node: &T, terminate: bool, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        terminate.build_quadlet(&mut raw);
+        PresonusFStudioProto::write(self, node, Self::BNC_TERMINATE_OFFSET, &mut raw, timeout_ms)
+    }
+}
+
+impl<T: AsRef<FwNode>> PresonusFStudioOutputProtocol<T> for FStudioProto {}

--- a/libs/dice/protocols/src/presonus/fstudio.rs
+++ b/libs/dice/protocols/src/presonus/fstudio.rs
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use hinawa::FwReq;
+
+#[derive(Default, Debug)]
+pub struct FStudioProto(FwReq);
+
+impl AsRef<FwReq> for FStudioProto {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}

--- a/libs/dice/protocols/src/presonus/fstudio.rs
+++ b/libs/dice/protocols/src/presonus/fstudio.rs
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use hinawa::FwReq;
+use glib::Error;
+
+use hinawa::{FwNode, FwReq};
+
+use crate::tcat::*;
 
 #[derive(Default, Debug)]
 pub struct FStudioProto(FwReq);
@@ -10,3 +14,20 @@ impl AsRef<FwReq> for FStudioProto {
         &self.0
     }
 }
+
+/// The trait to represent protocol specific to FireStudio.
+pub trait PresonusFStudioProto<T> : GeneralProtocol<T>
+    where T: AsRef<FwNode>,
+{
+    const OFFSET: usize = 0x00700000;
+
+    fn read(&self, node: &T, offset: usize, raw: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        GeneralProtocol::read(self, node, Self::OFFSET + offset, raw, timeout_ms)
+    }
+
+    fn write(&self, node: &T, offset: usize, raw: &mut [u8], timeout_ms: u32) -> Result<(), Error> {
+        GeneralProtocol::write(self, node, Self::OFFSET + offset, raw, timeout_ms)
+    }
+}
+
+impl<T: AsRef<FwNode>> PresonusFStudioProto<T> for FStudioProto {}

--- a/libs/dice/protocols/src/presonus/fstudio.rs
+++ b/libs/dice/protocols/src/presonus/fstudio.rs
@@ -31,3 +31,40 @@ pub trait PresonusFStudioProto<T> : GeneralProtocol<T>
 }
 
 impl<T: AsRef<FwNode>> PresonusFStudioProto<T> for FStudioProto {}
+
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct FStudioMeter{
+    pub analog_inputs: [u8;8],
+    pub stream_inputs: [u8;18],
+    pub mixer_outputs: [u8;18],
+}
+
+impl FStudioMeter {
+    const SIZE: usize = 0x40;
+}
+
+pub trait PresonusFStudioMeterProtocol<T> : PresonusFStudioProto<T>
+    where T: AsRef<FwNode>,
+{
+    const METER_OFFSET: usize = 0x13e8;
+
+    fn read_meter(&self, node: &T, meter: &mut FStudioMeter, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = vec![0;FStudioMeter::SIZE];
+        PresonusFStudioProto::read(self, node, Self::METER_OFFSET, &mut raw, timeout_ms)
+            .map(|_| {
+                let mut quadlet = [0;4];
+                (0..(FStudioMeter::SIZE / 4))
+                    .for_each(|i| {
+                        let pos = i * 4;
+                        quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                        let val = u32::from_be_bytes(quadlet);
+                        raw[pos..(pos + 4)].copy_from_slice(&val.to_le_bytes());
+                    });
+                meter.analog_inputs.copy_from_slice(&raw[8..16]);
+                meter.stream_inputs.copy_from_slice(&raw[16..34]);
+                meter.mixer_outputs.copy_from_slice(&raw[40..58]);
+            })
+    }
+}
+
+impl<T: AsRef<FwNode>> PresonusFStudioMeterProtocol<T> for FStudioProto {}

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -21,6 +21,7 @@ use super::tcelectronic::desktopk6_model::*;
 use super::tcelectronic::itwin_model::*;
 use super::io_fw_model::*;
 use super::ionix_model::*;
+use super::presonus::fstudio_model::*;
 use super::extension_model::ExtensionModel;
 use super::pfire_model::*;
 use super::mbox3_model::*;
@@ -41,6 +42,7 @@ enum Model {
     TcItwin(ItwinModel),
     AlesisIoFw(IoFwModel),
     LexiconIonix(IonixModel),
+    PresonusFStudio(FStudioModel),
     Extension(ExtensionModel),
     MaudioPfire2626(Pfire2626Model),
     MaudioPfire610(Pfire610Model),
@@ -86,6 +88,7 @@ impl DiceModel {
             (0x000166, 0x000027) => Model::TcItwin(ItwinModel::default()),
             (0x000595, 0x000001) => Model::AlesisIoFw(IoFwModel::default()),
             (0x000fd7, 0x000001) => Model::LexiconIonix(IonixModel::default()),
+            (0x000a92, 0x000008) => Model::PresonusFStudio(FStudioModel::default()),
             (0x000d6c, 0x000010) => Model::MaudioPfire2626(Pfire2626Model::default()),
             (0x000d6c, 0x000011) => Model::MaudioPfire610(Pfire610Model::default()),
             (0x00a07e, 0x000004) => Model::AvidMbox3(Mbox3Model::default()),
@@ -131,6 +134,7 @@ impl DiceModel {
             Model::TcItwin(m) => m.load(unit, card_cntr),
             Model::AlesisIoFw(m) => m.load(unit, card_cntr),
             Model::LexiconIonix(m) => m.load(unit, card_cntr),
+            Model::PresonusFStudio(m) => m.load(unit, card_cntr),
             Model::Extension(m) => m.load(unit, card_cntr),
             Model::MaudioPfire2626(m) => m.load(unit, card_cntr),
             Model::MaudioPfire610(m) => m.load(unit, card_cntr),
@@ -153,6 +157,7 @@ impl DiceModel {
             Model::TcItwin(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::AlesisIoFw(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::LexiconIonix(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::PresonusFStudio(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::Extension(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire2626(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::MaudioPfire610(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -175,6 +180,7 @@ impl DiceModel {
             Model::TcItwin(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::AlesisIoFw(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::LexiconIonix(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::PresonusFStudio(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Extension(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire2626(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::MaudioPfire610(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -204,6 +210,7 @@ impl DiceModel {
             Model::TcItwin(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::AlesisIoFw(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::LexiconIonix(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::PresonusFStudio(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Extension(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -230,6 +237,7 @@ impl DiceModel {
             Model::TcItwin(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::AlesisIoFw(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::LexiconIonix(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::PresonusFStudio(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::Extension(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -256,6 +264,7 @@ impl DiceModel {
             Model::TcItwin(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::AlesisIoFw(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::LexiconIonix(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::PresonusFStudio(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Extension(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire2626(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::MaudioPfire610(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
+pub mod fstudio_model;
+
 pub mod fstudioproject_model;
 pub mod fstudiomobile_model;

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -2,9 +2,11 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::Error;
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt};
 
 use hinawa::{SndDice, SndUnitExt};
+
+use alsa_ctl_tlv_codec::items::DbInterval;
 
 use core::card_cntr::*;
 
@@ -19,6 +21,7 @@ pub struct FStudioModel{
     proto: FStudioProto,
     sections: GeneralSections,
     ctl: CommonCtl,
+    meter_ctl: MeterCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -51,6 +54,8 @@ impl CtlModel<SndDice> for FStudioModel {
             .collect();
         let src_labels = ClockSourceLabels{entries};
         self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.meter_ctl.load(card_cntr, unit, &self.proto, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -87,15 +92,96 @@ impl NotifyModel<SndDice, u32> for FStudioModel {
 impl MeasureModel<hinawa::SndDice> for FStudioModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        elem_id_list.extend_from_slice(&self.meter_ctl.measured_elem_list);
     }
 
     fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
-        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
+        self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
+        Ok(())
     }
 
     fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.measure_elem(elem_id, elem_value)
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read_measured_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct MeterCtl{
+    meter: FStudioMeter,
+    measured_elem_list: Vec<ElemId>,
+}
+
+impl<'a> MeterCtl {
+    const ANALOG_INPUT_NAME: &'a str = "analog-input-meter";
+    const STREAM_INPUT_NAME: &'a str = "stream-input-meter";
+    const MIXER_OUTPUT_NAME: &'a str = "mixer-output-meter";
+
+    const LEVEL_MIN: i32 = 0x00;
+    const LEVEL_MAX: i32 = 0xff;
+    const LEVEL_STEP: i32 = 1;
+    const LEVEL_TLV: DbInterval = DbInterval{min: -9600, max: 0, linear: false, mute_avail: false};
+
+    fn load(&mut self, card_cntr: &mut CardCntr, unit: &SndDice, proto: &FStudioProto, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.read_meter(&unit.get_node(), &mut self.meter, timeout_ms)?;
+
+        [
+            (Self::ANALOG_INPUT_NAME, self.meter.analog_inputs.len()),
+            (Self::STREAM_INPUT_NAME, self.meter.stream_inputs.len()),
+            (Self::MIXER_OUTPUT_NAME, self.meter.mixer_outputs.len()),
+        ].iter()
+            .try_for_each(|&(name, count)| {
+                let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
+                card_cntr.add_int_elems(&elem_id, 1, Self::LEVEL_MIN, Self::LEVEL_MAX, Self::LEVEL_STEP,
+                                        count, Some(&Into::<Vec<u32>>::into(Self::LEVEL_TLV)), false)
+                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+            })?;
+
+        Ok(())
+    }
+
+    fn measure_states(&mut self, unit: &SndDice, proto: &FStudioProto, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.read_meter(&unit.get_node(), &mut self.meter, timeout_ms)
+    }
+
+    fn read_measured_elem(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::ANALOG_INPUT_NAME => {
+                let vals: Vec<i32> = self.meter.analog_inputs.iter()
+                    .map(|&l| l as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::STREAM_INPUT_NAME => {
+                let vals: Vec<i32> = self.meter.stream_inputs.iter()
+                    .map(|&l| l as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::MIXER_OUTPUT_NAME => {
+                let vals: Vec<i32> = self.meter.mixer_outputs.iter()
+                    .map(|&l| l as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use hinawa::{SndDice, SndUnitExt};
 
@@ -22,6 +22,7 @@ pub struct FStudioModel{
     sections: GeneralSections,
     ctl: CommonCtl,
     meter_ctl: MeterCtl,
+    out_ctl: OutputCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -56,6 +57,7 @@ impl CtlModel<SndDice> for FStudioModel {
         self.ctl.load(card_cntr, &caps, &src_labels)?;
 
         self.meter_ctl.load(card_cntr, unit, &self.proto, TIMEOUT_MS)?;
+        self.out_ctl.load(card_cntr, unit, &self.proto, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -63,13 +65,25 @@ impl CtlModel<SndDice> for FStudioModel {
     fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+        if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_ctl.read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+        if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -180,6 +194,181 @@ impl<'a> MeterCtl {
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct OutputCtl{
+    states: OutputState,
+}
+
+fn output_src_to_string(src: &OutputSrc) -> String {
+    match src {
+        OutputSrc::Analog(ch) => format!("Analog-{}", ch + 1),
+        OutputSrc::Adat0(ch) => format!("ADAT-A-{}", ch + 1),
+        OutputSrc::Spdif(ch) => format!("S/PDIF-{}", ch + 1),
+        OutputSrc::Stream(ch) => format!("Stream-{}", ch + 1),
+        OutputSrc::StreamAdat1(ch) => format!("Stream-{}/ADAT-B-{}", ch + 11, ch + 1),
+        OutputSrc::MixerOut(ch) => format!("Mixer-{}", ch + 1),
+        OutputSrc::Reserved(val) => format!("Reserved({})", val),
+    }
+}
+
+impl<'a> OutputCtl {
+    const SRC_NAME: &'a str = "output-source";
+    const VOL_NAME: &'a str = "output-volume";
+    const MUTE_NAME: &'a str = "output-mute";
+    const LINK_NAME: &'a str = "output-link";
+    const TERMINATE_BNC_NAME: &'a str = "terminate-bnc";
+
+    const VOL_MIN: i32 = 0;
+    const VOL_MAX: i32 = 0xff;
+    const VOL_STEP: i32 = 1;
+    const VOL_TLV: DbInterval = DbInterval{min: -9600, max: 0, linear: false, mute_avail: false};
+
+    const SRCS: [OutputSrc;54] = [
+        OutputSrc::Analog(0), OutputSrc::Analog(1), OutputSrc::Analog(2), OutputSrc::Analog(3),
+        OutputSrc::Analog(4), OutputSrc::Analog(5), OutputSrc::Analog(6), OutputSrc::Analog(7),
+        OutputSrc::Adat0(0), OutputSrc::Adat0(1), OutputSrc::Adat0(2), OutputSrc::Adat0(3),
+        OutputSrc::Adat0(4), OutputSrc::Adat0(5), OutputSrc::Adat0(6), OutputSrc::Adat0(7),
+        OutputSrc::Spdif(0), OutputSrc::Spdif(1),
+        OutputSrc::Stream(0), OutputSrc::Stream(1), OutputSrc::Stream(2), OutputSrc::Stream(3),
+        OutputSrc::Stream(4), OutputSrc::Stream(5), OutputSrc::Stream(6), OutputSrc::Stream(7),
+        OutputSrc::Stream(8), OutputSrc::Stream(9),
+        OutputSrc::StreamAdat1(0), OutputSrc::StreamAdat1(1),
+        OutputSrc::StreamAdat1(2), OutputSrc::StreamAdat1(3),
+        OutputSrc::StreamAdat1(4), OutputSrc::StreamAdat1(5),
+        OutputSrc::StreamAdat1(6), OutputSrc::StreamAdat1(7),
+        OutputSrc::MixerOut(0), OutputSrc::MixerOut(1), OutputSrc::MixerOut(2), OutputSrc::MixerOut(3),
+        OutputSrc::MixerOut(4), OutputSrc::MixerOut(5), OutputSrc::MixerOut(6), OutputSrc::MixerOut(7),
+        OutputSrc::MixerOut(8), OutputSrc::MixerOut(9), OutputSrc::MixerOut(10), OutputSrc::MixerOut(11),
+        OutputSrc::MixerOut(12), OutputSrc::MixerOut(13), OutputSrc::MixerOut(14), OutputSrc::MixerOut(15),
+        OutputSrc::MixerOut(16), OutputSrc::MixerOut(17),
+    ];
+
+    fn load(&mut self, card_cntr: &mut CardCntr, unit: &SndDice, proto: &FStudioProto, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.read_output_states(&unit.get_node(), &mut self.states, timeout_ms)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::VOL_NAME, 0);
+        card_cntr.add_int_elems(&elem_id, 1, Self::VOL_MIN, Self::VOL_MAX, Self::VOL_STEP,
+                                self.states.vols.len(), Some(&Into::<Vec<u32>>::into(Self::VOL_TLV)), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MUTE_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, self.states.mutes.len(), true)?;
+
+        let labels: Vec<String> = Self::SRCS.iter()
+            .map(|s| output_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SRC_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, self.states.srcs.len(), &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINK_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, self.states.links.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::TERMINATE_BNC_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, proto: &FStudioProto, elem_id: &ElemId, elem_value: &mut ElemValue,
+            timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::VOL_NAME => {
+                let vals: Vec<i32> = self.states.vols.iter()
+                    .map(|&vol| vol as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::MUTE_NAME => {
+                elem_value.set_bool(&self.states.mutes);
+                Ok(true)
+            }
+            Self::SRC_NAME => {
+                let vals: Vec<u32> = self.states.srcs.iter()
+                    .map(|src| {
+                        let pos = Self::SRCS.iter()
+                            .position(|s| s.eq(src))
+                            .unwrap();
+                        pos as u32
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::LINK_NAME => {
+                elem_value.set_bool(&self.states.links);
+                Ok(true)
+            }
+            Self::TERMINATE_BNC_NAME => {
+                proto.read_bnc_terminate(&unit.get_node(), timeout_ms)
+                    .map(|terminate| {
+                        elem_value.set_bool(&[terminate]);
+                        true
+                    })
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndDice, proto: &FStudioProto, elem_id: &ElemId, elem_value: &ElemValue,
+             timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::VOL_NAME => {
+                let mut vals = vec![0;self.states.vols.len()];
+                elem_value.get_int(&mut vals);
+                let vols: Vec<u8> = vals.iter()
+                    .map(|&val| val as u8)
+                    .collect();
+                proto.write_output_vols(&unit.get_node(), &mut self.states, &vols, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::MUTE_NAME => {
+                let mut vals = self.states.mutes.clone();
+                elem_value.get_bool(&mut vals);
+                proto.write_output_mute(&unit.get_node(), &mut self.states, &vals, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::SRC_NAME => {
+                let mut vals = vec![0;self.states.srcs.len()];
+                elem_value.get_enum(&mut vals);
+
+                let mut srcs = self.states.srcs.clone();
+                vals.iter()
+                    .enumerate()
+                    .try_for_each(|(i, &val)| {
+                        Self::SRCS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of output source: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&src| srcs[i] = src)
+                    })?;
+                proto.write_output_src(&unit.get_node(), &mut self.states, &srcs, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::LINK_NAME => {
+                let mut vals = self.states.links.clone();
+                elem_value.get_bool(&mut vals);
+                proto.write_output_link(&unit.get_node(), &mut self.states, &vals, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::TERMINATE_BNC_NAME => {
+                let mut vals = [false];
+                elem_value.get_bool(&mut vals);
+                proto.write_bnc_terminalte(&unit.get_node(), vals[0], timeout_ms)
+                    .map(|_| true)
             }
             _ => Ok(false),
         }

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::{SndDice, SndUnitExt};
+
+use core::card_cntr::*;
+
+use dice_protocols::tcat::*;
+use dice_protocols::tcat::global_section::*;
+use dice_protocols::presonus::fstudio::*;
+
+use crate::common_ctl::*;
+
+#[derive(Default)]
+pub struct FStudioModel{
+    proto: FStudioProto,
+    sections: GeneralSections,
+    ctl: CommonCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+// MEMO: the device returns 'SPDIF\ADAT\Word Clock\Unused\Unused\Unused\Unused\Internal\\'.
+const AVAIL_CLK_SRC_LABELS: [&str;13] = [
+    "S/PDIF",
+    "Unused",
+    "Unused",
+    "Unused",
+    "Unused",
+    "ADAT",
+    "Unused",
+    "WordClock",
+    "Unused",
+    "Unused",
+    "Unused",
+    "Unused",
+    "Internal",
+];
+
+impl CtlModel<SndDice> for FStudioModel {
+    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let node = unit.get_node();
+
+        self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
+        let caps = self.proto.read_clock_caps(&node, &self.sections, TIMEOUT_MS)?;
+        let entries: Vec<_> = AVAIL_CLK_SRC_LABELS.iter()
+            .map(|l| l.to_string())
+            .collect();
+        let src_labels = ClockSourceLabels{entries};
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
+    }
+
+    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)
+    }
+}
+
+impl NotifyModel<SndDice, u32> for FStudioModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.read_notified_elem(elem_id, elem_value)
+    }
+}
+
+impl MeasureModel<hinawa::SndDice> for FStudioModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+    }
+
+    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.ctl.measure_elem(elem_id, elem_value)
+    }
+}


### PR DESCRIPTION
FireStudio was shipped by PreSonus Audio Electronics, Inc. 2007. The model uses TCAT Dice II ASIC and supports unique protocol to configure.

This patchset adds support for the model.

```
Takashi Sakamoto (10):
  dice-runtime: add support for PreSonus FireStudio
  dice-protocols: presonus: add trait implementation for protocol of FireStudio
  dice-protocols: presonus: add trait implementation for meter protocol
  dice-runtime: presonus: add meter controls for FireStudio
  dice-protocols: presonus: add trait implementation for output protocol
  dice-runtime: presonus: add output controls for FireStudio
  dice-protocols: presonus: add trait implementation for assignment protocol
  dice-runtime: presonus: add assignment controls for FireStudio
  dice-protocols: presonus: add trait implementation for mixer protocol
  dice-runtime: presonus: add mixer controls for FireStudio

 README.rst                                    |   1 +
 libs/dice/protocols/src/presonus.rs           |   2 +
 libs/dice/protocols/src/presonus/fstudio.rs   | 706 +++++++++++++++
 libs/dice/runtime/src/model.rs                |   9 +
 libs/dice/runtime/src/presonus.rs             |   2 +
 .../runtime/src/presonus/fstudio_model.rs     | 827 ++++++++++++++++++
 6 files changed, 1547 insertions(+)
 create mode 100644 libs/dice/protocols/src/presonus/fstudio.rs
 create mode 100644 libs/dice/runtime/src/presonus/fstudio_model.rs
```