### PR TITLE
[PATCH 0/5] dice-protocols: tcelectronic: add output group support for Studio Konnekt 48

### DIFF
--- a/libs/dice/protocols/src/tcelectronic/studio.rs
+++ b/libs/dice/protocols/src/tcelectronic/studio.rs
@@ -742,7 +742,7 @@ impl PhysOutPairSrc {
 /// The group to aggregate several outputs for surround channels.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct OutGroup{
-    pub phys_out_pair_assigns: [bool;STUDIO_PHYS_OUT_PAIR_COUNT],
+    pub assigned_phys_outs: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
     pub bass_management: bool,
 }
 
@@ -751,7 +751,7 @@ impl OutGroup {
 
     fn build(&self, raw: &mut [u8]) {
         let mut val = 0u32;
-        self.phys_out_pair_assigns.iter()
+        self.assigned_phys_outs.iter()
             .enumerate()
             .filter(|(_, &a)| a)
             .for_each(|(i, _)| {
@@ -764,7 +764,7 @@ impl OutGroup {
     fn parse(&mut self, raw: &[u8]) {
         let mut val = 0u32;
         val.parse_quadlet(&raw[..4]);
-        self.phys_out_pair_assigns.iter_mut()
+        self.assigned_phys_outs.iter_mut()
             .enumerate()
             .for_each(|(i, a)| {
                 *a = val & (1 << i) > 0;
@@ -793,9 +793,9 @@ pub struct StudioPhysOut{
     /// - ADAT out 1/2, 3/4, 5/6, 7/8,
     pub out_pair_srcs: [PhysOutPairSrc;STUDIO_PHYS_OUT_PAIR_COUNT],
     /// The state of assignment to output group.
-    pub out_grp_assigns: [bool;STUDIO_PHYS_OUT_PAIR_COUNT],
+    pub out_grp_assigns: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
     /// Whether to mute any source to the physical output.
-    pub muted: [bool;STUDIO_PHYS_OUT_PAIR_COUNT],
+    pub muted: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
     /// The settings of each group for surround channels.
     pub out_grps: [OutGroup;STUDIO_OUTPUT_GROUP_COUNT],
 }

--- a/libs/dice/protocols/src/tcelectronic/studio.rs
+++ b/libs/dice/protocols/src/tcelectronic/studio.rs
@@ -793,9 +793,9 @@ pub struct StudioPhysOut{
     /// - ADAT out 1/2, 3/4, 5/6, 7/8,
     pub out_pair_srcs: [PhysOutPairSrc;STUDIO_PHYS_OUT_PAIR_COUNT],
     /// The state of assignment to output group.
-    pub out_grp_assigns: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
+    pub out_assign_to_grp: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
     /// Whether to mute any source to the physical output.
-    pub muted: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
+    pub out_mutes: [bool;STUDIO_PHYS_OUT_PAIR_COUNT * 2],
     /// The settings of each group for surround channels.
     pub out_grps: [OutGroup;STUDIO_OUTPUT_GROUP_COUNT],
 }
@@ -814,7 +814,7 @@ impl TcKonnektSegmentData for StudioPhysOut {
                 p.build(&mut raw[pos..(pos + PhysOutPairSrc::SIZE)]);
             });
         let mut val = 0u32;
-        self.out_grp_assigns.iter()
+        self.out_assign_to_grp.iter()
             .enumerate()
             .filter(|(_, &m)| m)
             .for_each(|(i, _)| {
@@ -822,7 +822,7 @@ impl TcKonnektSegmentData for StudioPhysOut {
             });
         val.build_quadlet(&mut raw[324..328]);
         let mut val = 0u32;
-        self.muted.iter()
+        self.out_mutes.iter()
             .enumerate()
             .filter(|(_, &d)| d)
             .for_each(|(i, _)| {
@@ -847,14 +847,14 @@ impl TcKonnektSegmentData for StudioPhysOut {
             });
         let mut val = 0u32;
         val.parse_quadlet(&raw[324..328]);
-        self.out_grp_assigns.iter_mut()
+        self.out_assign_to_grp.iter_mut()
             .enumerate()
             .for_each(|(i, m)| {
                 *m = val & (1 << i) > 0;
             });
         let mut val = 0u32;
         val.parse_quadlet(&raw[328..332]);
-        self.muted.iter_mut()
+        self.out_mutes.iter_mut()
             .enumerate()
             .for_each(|(i, d)| {
                 *d = val & (1 << i) > 0;

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -358,8 +358,8 @@ impl<'a> PhysOutCtl {
     const PHYS_OUT_STEREO_LINK_NAME: &'a str = "phys-out-stereo-link";
     const PHYS_OUT_SRC_NAME: &'a str = "phys-out-source";
     const PHYS_OUT_LEVEL_NAME: &'a str = "phys-out-level";
-    const PHYS_OUT_SPKR_TRIM_NAME: &'a str = "phys-out-speaker-trim";
-    const PHYS_OUT_SPKR_DELAY_NAME: &'a str = "phys-out-speaker-delay";
+    const OUT_GRP_SRC_TRIM_NAME: &'a str = "output-group-source-trim";
+    const OUT_GRP_SRC_DELAY_NAME: &'a str = "output-group-source-delay";
 
     const PHYS_OUT_SRCS: &'a [SrcEntry] = &[
         SrcEntry::Unused,
@@ -433,12 +433,12 @@ impl<'a> PhysOutCtl {
                                  None, true)
             .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::PHYS_OUT_SPKR_TRIM_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::OUT_GRP_SRC_TRIM_NAME, 0);
         card_cntr.add_int_elems(&elem_id, 1, Self::TRIM_MIN, Self::TRIM_MAX, Self::TRIM_STEP,
                                 STUDIO_PHYS_OUT_PAIR_COUNT * 2, None, true)
             .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::PHYS_OUT_SPKR_DELAY_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::OUT_GRP_SRC_DELAY_NAME, 0);
         card_cntr.add_int_elems(&elem_id, 1, Self::DELAY_MIN, Self::DELAY_MAX, Self::DELAY_STEP,
                                 STUDIO_PHYS_OUT_PAIR_COUNT * 2, None, true)
             .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
@@ -487,7 +487,7 @@ impl<'a> PhysOutCtl {
                  ElemValueAccessor::<u32>::set_vals(elem_value, STUDIO_PHYS_OUT_PAIR_COUNT, |idx| {
                     let val = if segments.phys_out.data.muted[idx] {
                         0
-                    } else if !segments.phys_out.data.spkr_assigns[idx] {
+                    } else if !segments.phys_out.data.out_grp_assigns[idx] {
                          1
                      } else {
                         2
@@ -496,12 +496,12 @@ impl<'a> PhysOutCtl {
                  })
                  .map(|_| true)
             }
-            Self::PHYS_OUT_SPKR_TRIM_NAME => {
+            Self::OUT_GRP_SRC_TRIM_NAME => {
                 Self::read_out_src_param(segments, elem_value, |param| {
                     Ok(param.vol)
                 })
             }
-            Self::PHYS_OUT_SPKR_DELAY_NAME => {
+            Self::OUT_GRP_SRC_DELAY_NAME => {
                 Self::read_out_src_param(segments, elem_value, |param| {
                     Ok(param.delay)
                 })
@@ -584,9 +584,9 @@ impl<'a> PhysOutCtl {
                     } else {
                         segments.phys_out.data.muted[idx] = false;
                         if val == 1 {
-                            segments.phys_out.data.spkr_assigns[idx] = false;
+                            segments.phys_out.data.out_grp_assigns[idx] = false;
                         } else {
-                            segments.phys_out.data.spkr_assigns[idx] = true;
+                            segments.phys_out.data.out_grp_assigns[idx] = true;
                         }
                     }
                     Ok(())
@@ -594,7 +594,7 @@ impl<'a> PhysOutCtl {
                 .and_then(|_| proto.write_segment(&unit.get_node(), &mut segments.phys_out, timeout_ms))
                 .map(|_| true)
             }
-            Self::PHYS_OUT_SPKR_TRIM_NAME => {
+            Self::OUT_GRP_SRC_TRIM_NAME => {
                 Self::write_out_src_param(unit, proto, segments, new, old, timeout_ms, |param, val| {
                     param.vol = val;
                     Ok(())
@@ -602,7 +602,7 @@ impl<'a> PhysOutCtl {
                 .and_then(|_| proto.write_segment(&unit.get_node(), &mut segments.phys_out, timeout_ms))
                 .map(|_| true)
             }
-            Self::PHYS_OUT_SPKR_DELAY_NAME => {
+            Self::OUT_GRP_SRC_DELAY_NAME => {
                 Self::write_out_src_param(unit, proto, segments, new, old, timeout_ms, |param, val| {
                     param.delay = val;
                     Ok(())

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -484,7 +484,7 @@ impl<'a> PhysOutCtl {
                 .map(|_| true)
             }
             Self::PHYS_OUT_LEVEL_NAME => {
-                 ElemValueAccessor::<u32>::set_vals(elem_value, STUDIO_PHYS_OUT_PAIR_COUNT, |idx| {
+                 ElemValueAccessor::<u32>::set_vals(elem_value, STUDIO_PHYS_OUT_PAIR_COUNT * 2, |idx| {
                     let val = if segments.phys_out.data.muted[idx] {
                         0
                     } else if !segments.phys_out.data.out_grp_assigns[idx] {
@@ -578,7 +578,7 @@ impl<'a> PhysOutCtl {
                  })
             }
             Self::PHYS_OUT_LEVEL_NAME => {
-                 ElemValueAccessor::<u32>::get_vals(new, old, STUDIO_PHYS_OUT_PAIR_COUNT, |idx, val| {
+                 ElemValueAccessor::<u32>::get_vals(new, old, STUDIO_PHYS_OUT_PAIR_COUNT * 2, |idx, val| {
                     if val == 0 {
                         segments.phys_out.data.muted[idx] = true;
                     } else {


### PR DESCRIPTION
TC Electronic Studio Konnekt 48 supports a function to aggregate several outputs to three groups for surround channels.

This commit supports the function.

```
Takashi Sakamoto (5):
  dice-protocols: rename virtual speaker to output group
  dice-protocols: tcelectronic: correct the number of entries for output mute and assignment to group
  dice-runtime: tcelectronic: obsolete phys out level controls
  dice-protocols: tcelectronic: add implementation for output group
  dice-runtime: tcelectronic: add output group controls for Studio Konnekt 48

 .../dice/protocols/src/tcelectronic/studio.rs | 203 +++++++++--
 .../src/tcelectronic/studiok48_model.rs       | 331 +++++++++++++++---
 2 files changed, 459 insertions(+), 75 deletions(-)
```