### PR TITLE
[PATCH 00/70] ff: add service program for models in RME Fireface series

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ members = [
     "libs/dice/protocols",
     "libs/dice/runtime",
     "libs/ff/protocols",
+    "libs/ff/runtime",
     "services",
 ]

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,8 @@ snd-bebob-ctl-service
    For sound card bound to ALSA bebob driver (snd-bebob)
 snd-dice-ctl-service
    For sound card bound to ALSA dice driver (snd-dice)
+snd-fireface-ctl-service
+   For sound card bound to ALSA fireface driver (snd-fireface)
 
 License
 =======

--- a/README.rst
+++ b/README.rst
@@ -183,6 +183,7 @@ Supported protocols
    * Protocol for DiceII ASIC in Digital Interface Communication Engine (DICE)
    * Protocol extension for TCD2210/TCD2220 ASIC in Digital Interface Communication Engine (DICE)
    * Protocol for former models of Fireface series of RME GmbH
+   * Protocol for latter models of Fireface series of RME GmbH
 
 Design note
 ===========

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ your device, please contact to developer.
 
   * Fireface 800
   * Fireface 400
+  * Fireface 802
 
 Supported protocols
 ===================

--- a/README.rst
+++ b/README.rst
@@ -160,6 +160,7 @@ your device, please contact to developer.
 
   * Fireface 800
   * Fireface 400
+  * Fireface UCX
   * Fireface 802
 
 Supported protocols

--- a/README.rst
+++ b/README.rst
@@ -156,6 +156,10 @@ your device, please contact to developer.
   * PreSonus FireStudio Mobile
   * For the others, common controls are available. If supported, control extension is also available.
 
+* snd-fireface-ctl-service
+
+  * Fireface 800
+
 Supported protocols
 ===================
 

--- a/README.rst
+++ b/README.rst
@@ -159,6 +159,7 @@ your device, please contact to developer.
 * snd-fireface-ctl-service
 
   * Fireface 800
+  * Fireface 400
 
 Supported protocols
 ===================

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -4,6 +4,7 @@
 //! Protocol defined by RME GmbH for former models of Firewire series.
 
 pub mod ff800;
+pub mod ff400;
 
 use glib::Error;
 

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -4,3 +4,96 @@
 //! Protocol defined by RME GmbH for former models of Firewire series.
 
 pub mod ff800;
+
+use glib::Error;
+
+use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
+
+/// The structure to represent state of hardware meter.
+///
+/// Each value of 32 bit integer is between 0x00000000 and 0x7fffff00 to represent -90.03 and
+/// 0.00 dB. When reaching saturation, 1 byte in LSB side represent ratio of overload.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct FormerMeterState{
+    pub analog_inputs: Vec<i32>,
+    pub spdif_inputs: Vec<i32>,
+    pub adat_inputs: Vec<i32>,
+    pub stream_inputs: Vec<i32>,
+    pub analog_outputs: Vec<i32>,
+    pub spdif_outputs: Vec<i32>,
+    pub adat_outputs: Vec<i32>,
+}
+
+/// The trait to represent specification of hardware meter.
+pub trait FormerMeterSpec {
+    const ANALOG_INPUT_COUNT: usize;
+    const SPDIF_INPUT_COUNT: usize;
+    const ADAT_INPUT_COUNT: usize;
+    const STREAM_INPUT_COUNT: usize;
+
+    const ANALOG_OUTPUT_COUNT: usize;
+    const SPDIF_OUTPUT_COUNT: usize;
+    const ADAT_OUTPUT_COUNT: usize;
+
+    fn create_meter_state() -> FormerMeterState {
+        FormerMeterState{
+            analog_inputs: vec![0;Self::ANALOG_INPUT_COUNT],
+            spdif_inputs: vec![0;Self::SPDIF_INPUT_COUNT],
+            adat_inputs: vec![0;Self::ADAT_INPUT_COUNT],
+            stream_inputs: vec![0;Self::STREAM_INPUT_COUNT],
+            analog_outputs: vec![0;Self::ANALOG_OUTPUT_COUNT],
+            spdif_outputs: vec![0;Self::SPDIF_OUTPUT_COUNT],
+            adat_outputs: vec![0;Self::ADAT_OUTPUT_COUNT],
+        }
+    }
+}
+
+/// The trait to represent meter protocol of Fireface 400.
+pub trait RmeFfFormerMeterProtocol<T, U> : AsRef<FwReq>
+    where T: AsRef<FwNode>,
+          U: FormerMeterSpec + AsRef<FormerMeterState> + AsMut<FormerMeterState>,
+{
+    const METER_OFFSET: usize;
+
+    fn read_meter(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        let phys_input_count = U::ANALOG_INPUT_COUNT + U::SPDIF_INPUT_COUNT + U::ADAT_INPUT_COUNT;
+        let phys_output_count = U::ANALOG_OUTPUT_COUNT + U::SPDIF_OUTPUT_COUNT + U::ADAT_OUTPUT_COUNT;
+
+        // NOTE:
+        // Each of the first octuples is for level of corresponding source to mixer.
+        // Each of the following octuples is for level of corresponding output from mixer (pre-fader).
+        // Each of the following octuples is for level of corresponding output from mixer (post-fader).
+        // Each of the following quadlets is for level of corresponding physical input.
+        // Each of the following quadlets is for level of corresponding stream input.
+        // Each of the following quadlets is for level of corresponding physical output.
+        let length = 8 * (phys_input_count + phys_output_count * 2) +
+                     4 * (phys_input_count + U::STREAM_INPUT_COUNT + phys_output_count);
+        let mut raw = vec![0;length];
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, Self::METER_OFFSET as u64,
+                                       raw.len(), &mut raw, timeout_ms)
+            .map(|_| {
+                let s = state.as_mut();
+
+                // TODO: pick up overload.
+                let mut quadlet = [0;4];
+                let mut offset = 8 * (phys_input_count + phys_output_count * 2);
+                [
+                    &mut s.analog_inputs[..],
+                    &mut s.spdif_inputs[..],
+                    &mut s.adat_inputs[..],
+                    &mut s.stream_inputs[..],
+                    &mut s.analog_outputs[..],
+                    &mut s.spdif_outputs[..],
+                    &mut s.adat_outputs[..],
+                ].iter_mut()
+                    .for_each(|meters| {
+                        meters.iter_mut()
+                            .for_each(|v| {
+                                quadlet.copy_from_slice(&raw[offset..(offset + 4)]);
+                                *v = i32::from_le_bytes(quadlet) & 0x7fffff00;
+                                offset += 4;
+                            });
+                    });
+            })
+    }
+}

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -256,3 +256,19 @@ pub struct FormerSpdifOutput {
     /// Whether to transfer non-audio bit in preemble.
     pub non_audio: bool,
 }
+
+/// The enumeration to represent nominal level of line inputs.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum FormerLineInNominalLevel {
+    Low,
+    /// -10 dBV.
+    Consumer,
+    /// +4 dBu.
+    Professional,
+}
+
+impl Default for FormerLineInNominalLevel {
+    fn default() -> Self {
+        Self::Low
+    }
+}

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -9,6 +9,8 @@ use glib::Error;
 
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
 
+use super::*;
+
 /// The structure to represent state of hardware meter.
 ///
 /// Each value of 32 bit integer is between 0x00000000 and 0x7fffff00 to represent -90.03 and
@@ -242,4 +244,15 @@ pub trait RmeFormerMixerProtocol<T, U> : AsRef<FwReq>
         self.write_mixer_src_gains(node, mixer, Self::AVAIL_COUNT, gains, timeout_ms)
             .map(|_| state.as_mut()[mixer].stream_gains.copy_from_slice(&gains))
     }
+}
+
+/// The structure to represent configuration of S/PDIF output.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct FormerSpdifOutput {
+    /// The format of S/PDIF signal.
+    pub format: SpdifFormat,
+    /// Whether to boost signal.
+    pub emphasis: bool,
+    /// Whether to transfer non-audio bit in preemble.
+    pub non_audio: bool,
 }

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -5,6 +5,8 @@
 
 use hinawa::FwReq;
 
+use super::*;
+
 /// The structure to represent unique protocol for Fireface 400.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Ff400Protocol(FwReq);
@@ -13,4 +15,55 @@ impl AsRef<FwReq> for Ff400Protocol {
     fn as_ref(&self) -> &FwReq {
         &self.0
     }
+}
+
+const METER_OFFSET: usize       = 0x000080100000;
+
+const ANALOG_INPUT_COUNT: usize = 8;
+const SPDIF_INPUT_COUNT: usize = 2;
+const ADAT_INPUT_COUNT: usize = 8;
+const STREAM_INPUT_COUNT: usize = 18;
+
+const ANALOG_OUTPUT_COUNT: usize = 8;
+const SPDIF_OUTPUT_COUNT: usize = 2;
+const ADAT_OUTPUT_COUNT: usize = 8;
+
+/// The structure to represent state of hardware meter for Fireface 400.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff400MeterState(FormerMeterState);
+
+impl AsRef<FormerMeterState> for Ff400MeterState {
+    fn as_ref(&self) -> &FormerMeterState {
+        &self.0
+    }
+}
+
+impl AsMut<FormerMeterState> for Ff400MeterState {
+    fn as_mut(&mut self) -> &mut FormerMeterState {
+        &mut self.0
+    }
+}
+
+impl FormerMeterSpec for Ff400MeterState {
+    const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff400MeterState {
+    fn default() -> Self {
+        Self(Self::create_meter_state())
+    }
+}
+
+impl<T, O> RmeFfFormerMeterProtocol<T, Ff400MeterState> for O
+    where T: AsRef<FwNode>,
+          O: AsRef<FwReq>,
+{
+    const METER_OFFSET: usize = METER_OFFSET;
 }

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -31,6 +31,9 @@ const ANALOG_OUTPUT_COUNT: usize = 8;
 const SPDIF_OUTPUT_COUNT: usize = 2;
 const ADAT_OUTPUT_COUNT: usize = 8;
 
+const AMP_MIC_IN_CH_OFFSET: u8 = 0;
+const AMP_LINE_IN_CH_OFFSET: u8 = 2;
+
 /// The structure to represent state of hardware meter for Fireface 400.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Ff400MeterState(FormerMeterState);
@@ -83,3 +86,73 @@ pub trait RmeFf400AmpProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
 }
 
 impl<T: AsRef<FwNode>> RmeFf400AmpProtocol<T> for Ff400Protocol {}
+
+/// The structure to represent status of input gains of Fireface 400.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff400InputGainStatus{
+    /// The level of gain for input 1 and 2. The value is between 0 and 65 by step 1 to represent
+    /// the range from 0 to 65 dB.
+    pub mic: [i8;2],
+    /// The level of gain for input 3 and 4. The value is between 0 and 36 by step 1 to represent
+    /// the range from 0 to 18 dB.
+    pub line: [i8;2],
+}
+
+/// The trait to represent amplifier protocol of Fireface 400.
+pub trait RmeFf400InputGainProtocol<T: AsRef<FwNode>> : RmeFf400AmpProtocol<T> {
+    fn write_input_mic_gain(&self, node: &T, ch: usize, gain: i8, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        self.write_amp_cmd(node, AMP_MIC_IN_CH_OFFSET + ch as u8, gain, timeout_ms)
+    }
+
+    fn write_input_line_gain(&self, node: &T, ch: usize, gain: i8, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        self.write_amp_cmd(node, AMP_LINE_IN_CH_OFFSET + ch as u8, gain, timeout_ms)
+    }
+
+    fn init_input_gains(&self, node: &T, status: &Ff400InputGainStatus, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        status.mic.iter()
+            .enumerate()
+            .try_for_each(|(i, gain)| self.write_input_mic_gain(node, i, *gain, timeout_ms))?;
+
+        status.line.iter()
+            .enumerate()
+            .try_for_each(|(i, gain)| self.write_input_line_gain(node, i, *gain, timeout_ms))?;
+
+        Ok(())
+    }
+
+    fn write_input_mic_gains(&self, node: &T, status: &mut Ff400InputGainStatus, gains: &[i8],
+                             timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        status.mic.iter_mut()
+            .zip(gains.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(i, (o, n))| {
+                self.write_input_mic_gain(node, i, *n, timeout_ms)
+                    .map(|_| *o = *n)
+            })
+    }
+
+    fn write_input_line_gains(&self, node: &T, status: &mut Ff400InputGainStatus, gains: &[i8],
+                             timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        status.line.iter_mut()
+            .zip(gains.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(i, (o, n))| {
+                self.write_input_line_gain(node, i, *n, timeout_ms)
+                    .map(|_| *o = *n)
+            })
+    }
+}
+
+impl<T: AsRef<FwNode>, O: RmeFf400AmpProtocol<T>> RmeFf400InputGainProtocol<T> for O {}

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -19,6 +19,7 @@ impl AsRef<FwReq> for Ff400Protocol {
     }
 }
 
+const MIXER_OFFSET: usize       = 0x000080080000;
 const OUTPUT_OFFSET: usize      = 0x000080080f80;
 const METER_OFFSET: usize       = 0x000080100000;
 const AMP_OFFSET: usize         = 0x0000801c0180;
@@ -193,4 +194,46 @@ impl<T: AsRef<FwNode>> RmeFormerOutputProtocol<T, Ff400OutputVolumeState> for Ff
                 self.write_amp_cmd(node, amp_offset, level, timeout_ms)
             })
     }
+}
+
+
+/// The structure to represent state of mixer for RME Fireface 400.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff400MixerState(pub Vec<FormerMixerSrc>);
+
+impl AsRef<[FormerMixerSrc]> for Ff400MixerState {
+    fn as_ref(&self) -> &[FormerMixerSrc] {
+        &self.0
+    }
+}
+
+impl AsMut<[FormerMixerSrc]> for Ff400MixerState {
+    fn as_mut(&mut self) -> &mut [FormerMixerSrc] {
+        &mut self.0
+    }
+}
+
+impl RmeFormerMixerSpec for Ff400MixerState {
+    const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff400MixerState {
+    fn default() -> Self {
+        Self(Self::create_mixer_state())
+    }
+}
+
+impl<T, U> RmeFormerMixerProtocol<T, U> for Ff400Protocol
+    where T: AsRef<FwNode>,
+          U: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
+{
+    const MIXER_OFFSET: usize = MIXER_OFFSET as usize;
+    const AVAIL_COUNT: usize = 18;
 }

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol defined by RME GmbH for Fireface 400.
+
+use hinawa::FwReq;
+
+/// The structure to represent unique protocol for Fireface 400.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct Ff400Protocol(FwReq);
+
+impl AsRef<FwReq> for Ff400Protocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -2,8 +2,9 @@
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface 800.
+use hinawa::{FwNode, FwReq};
 
-use hinawa::FwReq;
+use super::*;
 
 /// The structure to represent unique protocol for Fireface 800.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -13,4 +14,55 @@ impl AsRef<FwReq> for Ff800Protocol {
     fn as_ref(&self) -> &FwReq {
         &self.0
     }
+}
+
+const METER_OFFSET: usize       = 0x000080100000;
+
+const ANALOG_INPUT_COUNT: usize = 10;
+const SPDIF_INPUT_COUNT: usize = 2;
+const ADAT_INPUT_COUNT: usize = 16;
+const STREAM_INPUT_COUNT: usize = 28;
+
+const ANALOG_OUTPUT_COUNT: usize = 10;
+const SPDIF_OUTPUT_COUNT: usize = 2;
+const ADAT_OUTPUT_COUNT: usize = 16;
+
+/// The structure to represent state of hardware meter for Fireface 400.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff800MeterState(FormerMeterState);
+
+impl AsRef<FormerMeterState> for Ff800MeterState {
+    fn as_ref(&self) -> &FormerMeterState {
+        &self.0
+    }
+}
+
+impl AsMut<FormerMeterState> for Ff800MeterState {
+    fn as_mut(&mut self) -> &mut FormerMeterState {
+        &mut self.0
+    }
+}
+
+impl FormerMeterSpec for Ff800MeterState {
+    const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff800MeterState {
+    fn default() -> Self {
+        Self(Self::create_meter_state())
+    }
+}
+
+impl<T, O> RmeFfFormerMeterProtocol<T, Ff800MeterState> for O
+    where T: AsRef<FwNode>,
+          O: AsRef<FwReq>,
+{
+    const METER_OFFSET: usize = METER_OFFSET;
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -16,6 +16,8 @@ impl AsRef<FwReq> for Ff800Protocol {
     }
 }
 
+
+const OUTPUT_OFFSET: usize      = 0x000080081f80;
 const METER_OFFSET: usize       = 0x000080100000;
 
 const ANALOG_INPUT_COUNT: usize = 10;
@@ -65,4 +67,33 @@ impl<T, O> RmeFfFormerMeterProtocol<T, Ff800MeterState> for O
           O: AsRef<FwReq>,
 {
     const METER_OFFSET: usize = METER_OFFSET;
+}
+
+/// The structure to represent volume of outputs for Fireface 800.
+///
+/// The value for volume is between 0x00000000 and 0x00010000 through 0x00000001 and 0x00080000 to
+/// represent the range from negative infinite to 6.00 dB through -90.30 dB and 0.00 dB.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Ff800OutputVolumeState([i32;ANALOG_OUTPUT_COUNT + SPDIF_OUTPUT_COUNT + ADAT_OUTPUT_COUNT]);
+
+impl AsRef<[i32]> for Ff800OutputVolumeState {
+    fn as_ref(&self) -> &[i32] {
+        &self.0
+    }
+}
+
+impl AsMut<[i32]> for Ff800OutputVolumeState {
+    fn as_mut(&mut self) -> &mut [i32] {
+        &mut self.0
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFormerOutputProtocol<T, Ff800OutputVolumeState> for Ff800Protocol {
+    fn write_output_vol(&self, node: &T, ch: usize, vol: i32, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        raw.copy_from_slice(&vol.to_le_bytes());
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest,
+                                       (OUTPUT_OFFSET + ch * 4) as u64, raw.len(), &mut raw,
+                                       timeout_ms)
+    }
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -5,6 +5,7 @@
 use hinawa::{FwNode, FwReq};
 
 use super::*;
+use crate::*;
 
 /// The structure to represent unique protocol for Fireface 800.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
@@ -20,6 +21,7 @@ impl AsRef<FwReq> for Ff800Protocol {
 const MIXER_OFFSET: usize       = 0x000080080000;
 const OUTPUT_OFFSET: usize      = 0x000080081f80;
 const METER_OFFSET: usize       = 0x000080100000;
+const STATUS_OFFSET: usize      = 0x0000801c0000;
 
 const ANALOG_INPUT_COUNT: usize = 10;
 const SPDIF_INPUT_COUNT: usize = 2;
@@ -138,4 +140,492 @@ impl<T, U> RmeFormerMixerProtocol<T, U> for Ff800Protocol
 {
     const MIXER_OFFSET: usize = MIXER_OFFSET;
     const AVAIL_COUNT: usize = 32;
+}
+
+/// The enumeration to represent source of sampling clock.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Ff800ClkSrc{
+    Internal,
+    WordClock,
+    AdatA,
+    AdatB,
+    Spdif,
+    Tco,
+}
+
+impl Default for Ff800ClkSrc {
+    fn default() -> Self {
+        Self::AdatA
+    }
+}
+
+// NOTE: for first quadlet of status quadlets.
+const Q0_SYNC_WORD_CLOCK_MASK: u32          = 0x40000000;
+const Q0_LOCK_WORD_CLOCK_MASK: u32          = 0x20000000;
+const Q0_EXT_CLK_RATE_MASK: u32             = 0x1e000000;
+const  Q0_EXT_CLK_RATE_192000_FLAGS: u32    = 0x12000000;
+const  Q0_EXT_CLK_RATE_176400_FLAGS: u32    = 0x10000000;
+const  Q0_EXT_CLK_RATE_128000_FLAGS: u32    = 0x0c000000;
+const  Q0_EXT_CLK_RATE_96000_FLAGS: u32     = 0x0e000000;
+const  Q0_EXT_CLK_RATE_88200_FLAGS: u32     = 0x0a000000;
+const  Q0_EXT_CLK_RATE_64000_FLAGS: u32     = 0x08000000;
+const  Q0_EXT_CLK_RATE_48000_FLAGS: u32     = 0x06000000;
+const  Q0_EXT_CLK_RATE_44100_FLAGS: u32     = 0x04000000;
+const  Q0_EXT_CLK_RATE_32000_FLAGS: u32     = 0x02000000;
+const Q0_ACTIVE_CLK_SRC_MASK: u32           = 0x01c00000;
+const  Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS: u32= 0x01c00000;
+const  Q0_ACTIVE_CLK_SRC_TCO_FLAGS: u32     = 0x01800000;
+const  Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS: u32= 0x01000000;
+const  Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS: u32   = 0x00c00000;
+const  Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS: u32  = 0x00400000;
+const  Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS: u32  = 0x00000000;
+const Q0_SYNC_SPDIF_MASK: u32               = 0x00100000;
+const Q0_LOCK_SPDIF_MASK: u32               = 0x00040000;
+const Q0_SPDIF_RATE_MASK: u32               = 0x0003c000;
+const  Q0_SPDIF_RATE_192000_FLAGS: u32      = 0x00024000;
+const  Q0_SPDIF_RATE_176400_FLAGS: u32      = 0x00020000;
+const  Q0_SPDIF_RATE_128000_FLAGS: u32      = 0x0001c000;
+const  Q0_SPDIF_RATE_96000_FLAGS: u32       = 0x00018000;
+const  Q0_SPDIF_RATE_88200_FLAGS: u32       = 0x00014000;
+const  Q0_SPDIF_RATE_64000_FLAGS: u32       = 0x00010000;
+const  Q0_SPDIF_RATE_48000_FLAGS: u32       = 0x0000c000;
+const  Q0_SPDIF_RATE_44100_FLAGS: u32       = 0x00008000;
+const  Q0_SPDIF_RATE_32000_FLAGS: u32       = 0x00004000;
+const Q0_LOCK_ADAT_B_MASK: u32              = 0x00002000;
+const Q0_LOCK_ADAT_A_MASK: u32              = 0x00001000;
+const Q0_SYNC_ADAT_B_MASK: u32              = 0x00000800;
+const Q0_SYNC_ADAT_A_MASK: u32              = 0x00000400;
+
+// NOTE: for second quadlet of status quadlets.
+const Q1_SYNC_TCO_MASK: u32                 = 0x00800000;
+const Q1_LOCK_TCO_MASK: u32                 = 0x00400000;
+const Q1_WORD_OUT_SINGLE_MASK: u32          = 0x00002000;
+const Q1_CONF_CLK_SRC_MASK: u32             = 0x00001c01;
+const  Q1_CONF_CLK_SRC_TCO_FLAGS: u32       = 0x00001800;
+const  Q1_CONF_CLK_SRC_WORD_CLK_FLAGS: u32  = 0x00001000;
+const  Q1_CONF_CLK_SRC_SPDIF_FLAGS: u32     = 0x00000c00;
+const  Q1_CONF_CLK_SRC_ADAT_B_FLAGS: u32    = 0x00000400;
+const  Q1_CONF_CLK_SRC_INTERNAL_FLAGS: u32  = 0x00000001;
+const  Q1_CONF_CLK_SRC_ADAT_A_FLAGS: u32    = 0x00000000;
+const Q1_SPDIF_IN_IFACE_MASK: u32           = 0x00000200;
+const Q1_OPT_OUT_SIGNAL_MASK: u32           = 0x00000100;
+const Q1_SPDIF_OUT_EMPHASIS_MASK: u32       = 0x00000040;
+const Q1_SPDIF_OUT_FMT_MASK: u32            = 0x00000020;
+const Q1_CONF_CLK_RATE_MASK: u32            = 0x0000001e;
+const  Q1_CONF_CLK_RATE_192000_FLAGS: u32   = 0x00000016;
+const  Q1_CONF_CLK_RATE_176400_FLAGS: u32   = 0x00000010;
+const  Q1_CONF_CLK_RATE_128000_FLAGS: u32   = 0x00000012;
+const  Q1_CONF_CLK_RATE_96000_FLAGS: u32    = 0x0000000e;
+const  Q1_CONF_CLK_RATE_88200_FLAGS: u32    = 0x00000008;
+const  Q1_CONF_CLK_RATE_64000_FLAGS: u32    = 0x0000000a;
+const  Q1_CONF_CLK_RATE_48000_FLAGS: u32    = 0x00000006;
+const  Q1_CONF_CLK_RATE_44100_FLAGS: u32    = 0x00000000;
+const  Q1_CONF_CLK_RATE_32000_FLAGS: u32    = 0x00000002;
+
+/// The structure to represent status of clock locking.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800ClkLockStatus {
+    pub adat_a: bool,
+    pub adat_b: bool,
+    pub spdif: bool,
+    pub word_clock: bool,
+    pub tco: bool,
+}
+
+impl Ff800ClkLockStatus {
+    fn parse(&mut self, quads: &[u32]) {
+        self.adat_a = quads[0] & Q0_LOCK_ADAT_A_MASK > 0;
+        self.adat_b = quads[0] & Q0_LOCK_ADAT_B_MASK > 0;
+        self.spdif = quads[0] & Q0_LOCK_SPDIF_MASK > 0;
+        self.word_clock = quads[0] & Q0_LOCK_WORD_CLOCK_MASK > 0;
+        self.tco = quads[1] & Q1_LOCK_TCO_MASK > 0;
+
+    }
+}
+
+/// The structure to represent status of clock synchronization.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800ClkSyncStatus {
+    pub adat_a: bool,
+    pub adat_b: bool,
+    pub spdif: bool,
+    pub word_clock: bool,
+    pub tco: bool,
+}
+
+impl Ff800ClkSyncStatus {
+    fn parse(&mut self, quads: &[u32]) {
+        self.adat_a = quads[0] & Q0_SYNC_ADAT_A_MASK > 0;
+        self.adat_b = quads[0] & Q0_SYNC_ADAT_B_MASK > 0;
+        self.spdif = quads[0] & Q0_SYNC_SPDIF_MASK > 0;
+        self.word_clock = quads[0] & Q0_SYNC_WORD_CLOCK_MASK > 0;
+        self.tco = quads[1] & Q1_SYNC_TCO_MASK > 0;
+    }
+}
+
+/// The structure to represent status of clock synchronization.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800Status {
+    /// For S/PDIF input.
+    pub spdif_in: SpdifInput,
+    /// For S/PDIF output.
+    pub spdif_out: FormerSpdifOutput,
+    /// The type of signal to optical output interface.
+    pub opt_out_signal: OpticalOutputSignal,
+    /// Whether to fix speed to single even if at double/quadruple rate.
+    pub word_out_single: bool,
+    /// For status of synchronization to external clocks.
+    pub sync: Ff800ClkSyncStatus,
+    /// For status of locking to external clocks.
+    pub lock: Ff800ClkLockStatus,
+
+    pub spdif_rate: Option<ClkNominalRate>,
+    pub active_clk_src: Ff800ClkSrc,
+    pub external_clk_rate: Option<ClkNominalRate>,
+    pub configured_clk_src: Ff800ClkSrc,
+    pub configured_clk_rate: ClkNominalRate,
+}
+
+impl Ff800Status {
+    const QUADLET_COUNT: usize = 2;
+
+    fn parse(&mut self, quads: &[u32]) {
+        assert_eq!(quads.len(), Self::QUADLET_COUNT);
+
+        self.lock.parse(&quads);
+        self.sync.parse(&quads);
+
+        self.spdif_rate = match quads[0] & Q0_SPDIF_RATE_MASK {
+            Q0_SPDIF_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
+            Q0_SPDIF_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
+            Q0_SPDIF_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
+            Q0_SPDIF_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
+            Q0_SPDIF_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
+            Q0_SPDIF_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
+            Q0_SPDIF_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
+            Q0_SPDIF_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
+            Q0_SPDIF_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
+            _ => None,
+        };
+
+        self.active_clk_src = match quads[0] & Q0_ACTIVE_CLK_SRC_MASK {
+            Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS => Ff800ClkSrc::AdatA,
+            Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
+            Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
+            Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
+            Q0_ACTIVE_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
+            Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
+            _ => unreachable!(),
+        };
+
+        self.external_clk_rate = match quads[0] & Q0_EXT_CLK_RATE_MASK {
+            Q0_EXT_CLK_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
+            Q0_EXT_CLK_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
+            Q0_EXT_CLK_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
+            Q0_EXT_CLK_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
+            Q0_EXT_CLK_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
+            Q0_EXT_CLK_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
+            Q0_EXT_CLK_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
+            Q0_EXT_CLK_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
+            Q0_EXT_CLK_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
+            _ => None,
+        };
+
+        self.spdif_in.iface = if quads[1] & Q1_SPDIF_IN_IFACE_MASK > 0 {
+            SpdifIface::Optical
+        } else {
+            SpdifIface::Coaxial
+        };
+
+        self.spdif_out.format = if quads[1] & Q1_SPDIF_OUT_FMT_MASK > 0 {
+            SpdifFormat::Professional
+        } else {
+            SpdifFormat::Consumer
+        };
+
+        self.spdif_out.emphasis = quads[1] & Q1_SPDIF_OUT_EMPHASIS_MASK > 0;
+
+        self.opt_out_signal = if quads[1] & Q1_OPT_OUT_SIGNAL_MASK > 0 {
+            OpticalOutputSignal::Spdif
+        } else {
+            OpticalOutputSignal::Adat
+        };
+
+        self.word_out_single = quads[1] & Q1_WORD_OUT_SINGLE_MASK > 0;
+
+        self.configured_clk_src = match quads[1] & Q1_CONF_CLK_SRC_MASK {
+            Q1_CONF_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
+            Q1_CONF_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
+            Q1_CONF_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
+            Q1_CONF_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
+            Q1_CONF_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
+            Q1_CONF_CLK_SRC_ADAT_A_FLAGS | _ => Ff800ClkSrc::AdatA,
+        };
+
+        self.configured_clk_rate = match quads[1] & Q1_CONF_CLK_RATE_MASK {
+            Q1_CONF_CLK_RATE_32000_FLAGS => ClkNominalRate::R32000,
+            Q1_CONF_CLK_RATE_48000_FLAGS => ClkNominalRate::R48000,
+            Q1_CONF_CLK_RATE_64000_FLAGS => ClkNominalRate::R64000,
+            Q1_CONF_CLK_RATE_88200_FLAGS => ClkNominalRate::R88200,
+            Q1_CONF_CLK_RATE_96000_FLAGS => ClkNominalRate::R96000,
+            Q1_CONF_CLK_RATE_128000_FLAGS => ClkNominalRate::R128000,
+            Q1_CONF_CLK_RATE_176400_FLAGS => ClkNominalRate::R176400,
+            Q1_CONF_CLK_RATE_192000_FLAGS => ClkNominalRate::R192000,
+            Q1_CONF_CLK_RATE_44100_FLAGS | _ => ClkNominalRate::R44100,
+        };
+
+    }
+}
+
+/// The trait to represent status protocol specific to RME Fireface 800.
+pub trait RmeFf800StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
+    fn read_status(&self, node: &T, status: &mut Ff800Status, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;8];
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, STATUS_OFFSET as u64,
+                                       raw.len(), &mut raw, timeout_ms)
+            .map(|_| {
+                let mut quadlet = [0;4];
+                let mut quads = [0u32;2];
+                quads.iter_mut()
+                    .enumerate()
+                    .for_each(|(i, quad)| {
+                        let pos = i * 4;
+                        quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                        *quad = u32::from_le_bytes(quadlet);
+                    });
+                status.parse(&quads)
+            })
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFf800StatusProtocol<T> for Ff800Protocol {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_status() {
+        let mut status = Ff800Status::default();
+
+        let quads = [0x02001000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.lock.adat_a, true);
+
+        let quads = [0x02002000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.lock.adat_b, true);
+
+        let quads = [0x02040000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.lock.spdif, true);
+
+        let quads = [0x22000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.lock.word_clock, true);
+
+        let quads = [0x02000400, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.sync.adat_a, true);
+
+        let quads = [0x02000800, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.sync.adat_b, true);
+
+        let quads = [0x02100800, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.sync.spdif, true);
+
+        let quads = [0x42000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.sync.word_clock, true);
+
+        let quads = [0x02000000, 0x00800000];
+        status.parse(&quads);
+        assert_eq!(status.sync.tco, true);
+
+        let quads = [0x02004000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R32000));
+
+        let quads = [0x02008000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R44100));
+
+        let quads = [0x0200c000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R48000));
+
+        let quads = [0x02010000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R64000));
+
+        let quads = [0x02014000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R88200));
+
+        let quads = [0x02018000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R96000));
+
+        let quads = [0x0201c000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R128000));
+
+        let quads = [0x02020000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R176400));
+
+        let quads = [0x02024000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.spdif_rate, Some(ClkNominalRate::R192000));
+
+        let quads = [0x02000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::AdatA);
+
+        let quads = [0x02400000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::AdatB);
+
+        let quads = [0x02c00000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::Spdif);
+
+        let quads = [0x03000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::WordClock);
+
+        let quads = [0x03800000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::Tco);
+
+        let quads = [0x03c00000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.active_clk_src, Ff800ClkSrc::Internal);
+
+        let quads = [0x02000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R32000));
+
+        let quads = [0x04000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R44100));
+
+        let quads = [0x06000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R48000));
+
+        let quads = [0x08000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R64000));
+
+        let quads = [0x0a000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R88200));
+
+        let quads = [0x0e000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R96000));
+
+        let quads = [0x0c000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R128000));
+
+        let quads = [0x10000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R176400));
+
+        let quads = [0x12000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R192000));
+
+        let quads = [0x02000000, 0x00400000];
+        status.parse(&quads);
+        assert_eq!(status.lock.tco, true);
+
+        let quads = [0x02000000, 0x00800000];
+        status.parse(&quads);
+        assert_eq!(status.sync.tco, true);
+
+        let quads = [0x02000000, 0x00002000];
+        status.parse(&quads);
+        assert_eq!(status.word_out_single, true);
+
+        let quads = [0x02000000, 0x00000200];
+        status.parse(&quads);
+        assert_eq!(status.spdif_in.iface, SpdifIface::Optical);
+
+        let quads = [0x02000000, 0x00000100];
+        status.parse(&quads);
+        assert_eq!(status.opt_out_signal, OpticalOutputSignal::Spdif);
+
+        let quads = [0x02000000, 0x00000040];
+        status.parse(&quads);
+        assert_eq!(status.spdif_out.emphasis, true);
+
+        let quads = [0x02000000, 0x00000020];
+        status.parse(&quads);
+        assert_eq!(status.spdif_out.format, SpdifFormat::Professional);
+
+        let quads = [0x02000000, 0x00000002];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R32000);
+
+        let quads = [0x02000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R44100);
+
+        let quads = [0x02000000, 0x00000006];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R48000);
+
+        let quads = [0x02000000, 0x0000000a];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R64000);
+
+        let quads = [0x02000000, 0x00000008];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R88200);
+
+        let quads = [0x02000000, 0x0000000e];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R96000);
+
+        let quads = [0x02000000, 0x00000012];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R128000);
+
+        let quads = [0x02000000, 0x00000010];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R176400);
+
+        let quads = [0x02000000, 0x00000016];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_rate, ClkNominalRate::R192000);
+
+        let quads = [0x02000000, 0x00001000];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::WordClock);
+
+        let quads = [0x02000000, 0x00001800];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::Tco);
+
+        let quads = [0x02000000, 0x00000c00];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::Spdif);
+
+        let quads = [0x02000000, 0x00000400];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::AdatB);
+
+        let quads = [0x02000000, 0x00000001];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::Internal);
+
+        let quads = [0x02000000, 0x00000000];
+        status.parse(&quads);
+        assert_eq!(status.configured_clk_src, Ff800ClkSrc::AdatA);
+    }
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -17,11 +17,19 @@ impl AsRef<FwReq> for Ff800Protocol {
     }
 }
 
-
 const MIXER_OFFSET: usize       = 0x000080080000;
 const OUTPUT_OFFSET: usize      = 0x000080081f80;
 const METER_OFFSET: usize       = 0x000080100000;
 const STATUS_OFFSET: usize      = 0x0000801c0000;
+const CFG_OFFSET: usize         = 0x0000fc88f014;
+
+// TODO: 4 quadlets are read at once.
+#[allow(dead_code)]
+const TCO_STATUS_OFFSET: usize  = 0x0000801f0000;
+
+// TODO; 4 quadlets are written at once.
+#[allow(dead_code)]
+const TCO_CFG_OFFSET: usize     = 0x0000810f0020;
 
 const ANALOG_INPUT_COUNT: usize = 10;
 const SPDIF_INPUT_COUNT: usize = 2;
@@ -400,6 +408,428 @@ pub trait RmeFf800StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
 
 impl<T: AsRef<FwNode>> RmeFf800StatusProtocol<T> for Ff800Protocol {}
 
+// NOTE: for first quadlet of configuration quadlets.
+const Q0_LINE_OUT_LEVEL_MASK: u32 =             0x00001c00;
+const  Q0_LINE_OUT_LEVEL_CON_FLAG: u32 =        0x00001000;
+const  Q0_LINE_OUT_LEVEL_PRO_FLAG: u32 =        0x00000800;
+const  Q0_LINE_OUT_LEVEL_HIGH_FLAG: u32 =       0x00000400;
+const Q0_INPUT_0_INST_DRIVE_MASK: u32 =         0x00000200;
+const Q0_INPUT_9_POWERING_MASK: u32 =           0x00000100;
+const Q0_INPUT_7_POWERING_MASK: u32 =           0x00000080;
+const Q0_LINE_IN_LEVEL_MASK: u32 =              0x00000038;
+const  Q0_LINE_IN_LEVEL_PRO_FLAG: u32 =         0x00000010;
+const  Q0_LINE_IN_LEVEL_CON_FLAG: u32 =         0x00000020;
+const  Q0_LINE_IN_LEVEL_LOW_FLAG: u32 =         0x00000008;
+const Q0_INPUT_0_INST_SPKR_EMU_MASK: u32 =      0x00000004;
+const Q0_INPUT_8_POWERING_MASK: u32 =           0x00000002;
+const Q0_INPUT_6_POWERING_MASK: u32 =           0x00000001;
+
+// NOTE: for second quadlet of configuration quadlets.
+const Q1_INPUT_0_FRONT_JACK_MASK: u32 =         0x00000800;
+const Q1_INPUT_0_INST_DRIVE_MASK: u32 =         0x00000200;
+const Q1_INPUT_7_REAR_JACK_MASK: u32 =          0x00000100;
+const Q1_INPUT_7_FRONT_JACK_MASK: u32 =         0x00000080;
+const Q1_INPUT_6_REAR_JACK_MASK: u32 =          0x00000040;
+const Q1_INPUT_6_FRONT_JACK_MASK: u32 =         0x00000020;
+const Q1_LINE_OUT_LEVEL_MASK: u32 =             0x00000018;
+const  Q1_LINE_OUT_LEVEL_PRO_FLAG: u32 =        0x00000018;
+const  Q1_LINE_OUT_LEVEL_HIGH_FLAG: u32 =       0x00000010;
+const  Q1_LINE_OUT_LEVEL_CON_FLAG: u32 =        0x00000008;
+const Q1_INPUT_0_REAR_JACK_MASK: u32 =          0x00000004;
+const Q1_LINE_IN_LEVEL_MASK: u32 =              0x00000003;
+const  Q1_LINE_IN_LEVEL_CON_FLAG: u32 =         0x00000003;
+const  Q1_LINE_IN_LEVEL_PRO_FLAG: u32 =         0x00000002;
+const  Q1_LINE_IN_LEVEL_LOW_FLAG: u32 =         0x00000000;
+
+// NOTE: for third quadlet of configuration quadlets.
+const Q2_SPDIF_IN_USE_PREEMBLE: u32 =           0x40000000;
+const Q2_INPUT_0_INST_LIMITTER_MASK: u32 =      0x00010000;
+const Q2_WORD_OUT_SINGLE_SPEED_MASK: u32 =      0x00002000;
+const Q2_CLK_SRC_MASK: u32 =                    0x00001c01;
+const  Q2_CLK_SRC_TCO_FLAG: u32 =               0x00001c00;
+const  Q2_CLK_SRC_WORD_CLK_FLAG: u32 =          0x00001400;
+const  Q2_CLK_SRC_SPDIF_FLAG: u32 =             0x00000c00;
+const  Q2_CLK_SRC_ADAT_B_FLAG: u32 =            0x00000400;
+const  Q2_CLK_SRC_INTERNAL_FLAG: u32 =          0x00000001;
+const  Q2_CLK_SRC_ADAT_A_FLAG: u32 =            0x00000000;
+const Q2_SPDIF_IN_IFACE_OPT_MASK: u32 =         0x00000200;
+const Q2_OPT_OUT_SIGNAL_MASK: u32 =             0x00000100;
+const Q2_SPDIF_OUT_NON_AUDIO_MASK: u32 =        0x00000080;
+const Q2_SPDIF_OUT_EMPHASIS_MASK: u32 =         0x00000040;
+const Q2_SPDIF_OUT_FMT_PRO_MASK: u32 =          0x00000020;
+const Q2_CLK_AVAIL_RATE_QUADRUPLE_MASK: u32 =   0x00000010;
+const Q2_CLK_AVAIL_RATE_DOUBLE_MASK: u32 =      0x00000008;
+const Q2_CLK_AVAIL_RATE_BASE_48000_MASK: u32 =  0x00000004;
+const Q2_CLK_AVAIL_RATE_BASE_44100_MASK: u32 =  0x00000002;
+const Q2_CONTINUE_AT_ERRORS: u32 =              0x80000000;
+
+/// The structure to represent configurations of sampling clock.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800ClkConfig{
+    pub primary_src: Ff800ClkSrc,
+    avail_rate_44100: bool,
+    avail_rate_48000: bool,
+    avail_rate_double: bool,
+    avail_rate_quadruple: bool,
+}
+
+impl Default for Ff800ClkConfig {
+    fn default() -> Self {
+        Self{
+            primary_src: Ff800ClkSrc::default(),
+            avail_rate_44100: true,
+            avail_rate_48000: true,
+            avail_rate_double: true,
+            avail_rate_quadruple: true,
+        }
+    }
+}
+
+impl Ff800ClkConfig {
+    fn build(&self, quads: &mut [u32]) {
+        let mask = match self.primary_src {
+            Ff800ClkSrc::Internal => Q2_CLK_SRC_INTERNAL_FLAG,
+            Ff800ClkSrc::WordClock => Q2_CLK_SRC_WORD_CLK_FLAG,
+            Ff800ClkSrc::AdatA => Q2_CLK_SRC_ADAT_A_FLAG,
+            Ff800ClkSrc::AdatB => Q2_CLK_SRC_ADAT_B_FLAG,
+            Ff800ClkSrc::Spdif => Q2_CLK_SRC_SPDIF_FLAG,
+            Ff800ClkSrc::Tco => Q2_CLK_SRC_TCO_FLAG,
+        };
+        quads[2] |= mask;
+
+        if self.avail_rate_44100 {
+            quads[2] |= Q2_CLK_AVAIL_RATE_BASE_44100_MASK;
+        }
+        if self.avail_rate_48000 {
+            quads[2] |= Q2_CLK_AVAIL_RATE_BASE_48000_MASK;
+        }
+        if self.avail_rate_double {
+            quads[2] |= Q2_CLK_AVAIL_RATE_DOUBLE_MASK;
+        }
+        if self.avail_rate_quadruple {
+            quads[2] |= Q2_CLK_AVAIL_RATE_QUADRUPLE_MASK;
+        }
+    }
+
+    fn parse(&mut self, quads: &[u32]) {
+        self.primary_src = match quads[2] & Q2_CLK_SRC_MASK {
+            Q2_CLK_SRC_INTERNAL_FLAG => Ff800ClkSrc::Internal,
+            Q2_CLK_SRC_WORD_CLK_FLAG => Ff800ClkSrc::WordClock,
+            Q2_CLK_SRC_ADAT_B_FLAG => Ff800ClkSrc::AdatB,
+            Q2_CLK_SRC_SPDIF_FLAG => Ff800ClkSrc::Spdif,
+            Q2_CLK_SRC_TCO_FLAG => Ff800ClkSrc::Tco,
+            Q2_CLK_SRC_ADAT_A_FLAG | _ => Ff800ClkSrc::AdatA,
+        };
+
+        self.avail_rate_44100 = quads[2] & Q2_CLK_AVAIL_RATE_BASE_44100_MASK > 0;
+        self.avail_rate_48000 = quads[2] & Q2_CLK_AVAIL_RATE_BASE_48000_MASK > 0;
+        self.avail_rate_double = quads[2] & Q2_CLK_AVAIL_RATE_DOUBLE_MASK > 0;
+        self.avail_rate_quadruple = quads[2] & Q2_CLK_AVAIL_RATE_QUADRUPLE_MASK > 0;
+    }
+}
+
+/// The structure to represent configurations for instrument.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800InstConfig{
+    /// Whether to add extra gain by 25 dB.
+    pub drive: bool,
+    /// Whether to soft limitter to reduce by -10 dB.
+    pub limitter: bool,
+    /// Whether to enable low pass and high pass filter.
+    pub speaker_emulation: bool,
+}
+
+impl Ff800InstConfig {
+    fn build(&self, quads: &mut [u32]) {
+        if self.drive {
+            quads[0] |= Q0_INPUT_0_INST_DRIVE_MASK;
+            quads[1] |= Q1_INPUT_0_INST_DRIVE_MASK;
+        }
+
+        if self.limitter {
+            quads[2] |= Q2_INPUT_0_INST_LIMITTER_MASK;
+        }
+
+        if self.speaker_emulation {
+            quads[0] |= Q0_INPUT_0_INST_SPKR_EMU_MASK;
+        }
+    }
+
+    fn parse(&mut self, quads: &[u32]) {
+        self.drive = quads[0] & Q0_INPUT_0_INST_DRIVE_MASK > 0 && quads[0] & Q1_INPUT_0_INST_DRIVE_MASK > 0;
+        self.limitter = quads[2] & Q2_INPUT_0_INST_LIMITTER_MASK > 0;
+        self.speaker_emulation = quads[0] & Q0_INPUT_0_INST_SPKR_EMU_MASK > 0;
+    }
+}
+
+/// The enumeration to represent jack of analog inputs.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Ff800AnalogInputJack {
+    Front,
+    Rear,
+    FrontRear,
+}
+
+impl Default for Ff800AnalogInputJack {
+    fn default() -> Self {
+        Self::Front
+    }
+}
+
+/// The structure to represent configuration for analog inputs.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800AnalogInConfig{
+    /// Whether to use rear jack instead of front jack for input 1, 7, and 8.
+    pub jacks: [Ff800AnalogInputJack;3],
+    /// The nominal level of audio signal for line input.
+    pub line_level: FormerLineInNominalLevel,
+    /// Whether to deliver +48 V powering for mic 7, 8, 9, 10.
+    pub phantom_powering: [bool;4],
+    /// The configurations for instrument input.
+    pub inst: Ff800InstConfig,
+}
+
+impl Ff800AnalogInConfig {
+    fn build(&self, quads: &mut [u32]) {
+        [
+            (Q1_INPUT_0_REAR_JACK_MASK, Q1_INPUT_0_FRONT_JACK_MASK),
+            (Q1_INPUT_6_REAR_JACK_MASK, Q1_INPUT_6_FRONT_JACK_MASK),
+            (Q1_INPUT_7_REAR_JACK_MASK, Q1_INPUT_7_FRONT_JACK_MASK),
+        ].iter()
+            .zip(self.jacks.iter())
+            .for_each(|(&(rear_mask, front_mask), &jack)| {
+                if jack != Ff800AnalogInputJack::Front {
+                    quads[1] |= rear_mask;
+                }
+                if jack != Ff800AnalogInputJack::Rear {
+                    quads[1] |= front_mask;
+                }
+            });
+
+        match self.line_level {
+            FormerLineInNominalLevel::Low => {
+                quads[0] |= Q0_LINE_IN_LEVEL_LOW_FLAG;
+                quads[1] |= Q1_LINE_IN_LEVEL_LOW_FLAG;
+            }
+            FormerLineInNominalLevel::Consumer => {
+                quads[0] |= Q0_LINE_IN_LEVEL_CON_FLAG;
+                quads[1] |= Q1_LINE_IN_LEVEL_CON_FLAG;
+            }
+            FormerLineInNominalLevel::Professional => {
+                quads[0] |= Q0_LINE_IN_LEVEL_PRO_FLAG;
+                quads[1] |= Q1_LINE_IN_LEVEL_PRO_FLAG;
+            }
+        }
+
+        if self.phantom_powering[0] {
+            quads[0] |= Q0_INPUT_6_POWERING_MASK;
+        }
+        if self.phantom_powering[1] {
+            quads[0] |= Q0_INPUT_7_POWERING_MASK;
+        }
+        if self.phantom_powering[2] {
+            quads[0] |= Q0_INPUT_8_POWERING_MASK;
+        }
+        if self.phantom_powering[3] {
+            quads[0] |= Q0_INPUT_9_POWERING_MASK;
+        }
+
+        self.inst.build(quads);
+    }
+
+    fn parse(&mut self, quads: &[u32]) {
+        [
+            (Q1_INPUT_0_REAR_JACK_MASK, Q1_INPUT_0_FRONT_JACK_MASK),
+            (Q1_INPUT_6_REAR_JACK_MASK, Q1_INPUT_6_FRONT_JACK_MASK),
+            (Q1_INPUT_7_REAR_JACK_MASK, Q1_INPUT_7_FRONT_JACK_MASK),
+        ].iter()
+            .zip(self.jacks.iter_mut())
+            .for_each(|(&(rear_mask, front_mask), jack)| {
+                *jack = match (quads[1] & rear_mask > 0, quads[1] & front_mask > 0) {
+                    (true, true) => Ff800AnalogInputJack::FrontRear,
+                    (true, false) => Ff800AnalogInputJack::Rear,
+                    (false, true) => Ff800AnalogInputJack::Front,
+                    _ => unreachable!(),
+                };
+            });
+
+        let pair = (quads[0] & Q0_LINE_IN_LEVEL_MASK, quads[1] & Q1_LINE_IN_LEVEL_MASK);
+        self.line_level = match pair {
+            (Q0_LINE_IN_LEVEL_LOW_FLAG, Q1_LINE_IN_LEVEL_LOW_FLAG) => FormerLineInNominalLevel::Low,
+            (Q0_LINE_IN_LEVEL_CON_FLAG, Q1_LINE_IN_LEVEL_CON_FLAG) => FormerLineInNominalLevel::Consumer,
+            (Q0_LINE_IN_LEVEL_PRO_FLAG, Q1_LINE_IN_LEVEL_PRO_FLAG) => FormerLineInNominalLevel::Professional,
+            _ => unreachable!(),
+        };
+
+        self.phantom_powering[0] = quads[0] & Q0_INPUT_6_POWERING_MASK > 0;
+        self.phantom_powering[1] = quads[0] & Q0_INPUT_7_POWERING_MASK > 0;
+        self.phantom_powering[2] = quads[0] & Q0_INPUT_8_POWERING_MASK > 0;
+        self.phantom_powering[3] = quads[0] & Q0_INPUT_9_POWERING_MASK > 0;
+
+        self.inst.parse(quads);
+    }
+}
+
+/// The structure to represent configurations.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub struct Ff800Config{
+    /// For sampling clock.
+    pub clk: Ff800ClkConfig,
+    /// For analog inputs.
+    pub analog_in: Ff800AnalogInConfig,
+    /// The nominal level of audio signal for line output.
+    pub line_out_level: LineOutNominalLevel,
+    /// For S/PDIF input.
+    pub spdif_in: SpdifInput,
+    /// For S/PDIF output.
+    pub spdif_out: FormerSpdifOutput,
+    /// The type of signal to optical output interface.
+    pub opt_out_signal: OpticalOutputSignal,
+    /// Whether to fix speed to single even if at double/quadruple rate.
+    pub word_out_single: bool,
+    /// Whether to continue audio processing against any synchronization corruption.
+    continue_at_errors: bool,
+}
+
+impl Default for Ff800Config {
+    fn default() -> Self {
+        Self{
+            clk: Default::default(),
+            analog_in: Default::default(),
+            line_out_level: Default::default(),
+            spdif_in: Default::default(),
+            spdif_out: Default::default(),
+            opt_out_signal: Default::default(),
+            word_out_single: Default::default(),
+            continue_at_errors: true,
+        }
+    }
+}
+
+impl Ff800Config {
+    const QUADLET_COUNT: usize = 3;
+
+    fn build(&self, quads: &mut [u32]) {
+        assert_eq!(quads.len(), Self::QUADLET_COUNT);
+
+        self.clk.build(quads);
+        self.analog_in.build(quads);
+
+        match self.line_out_level {
+            LineOutNominalLevel::High => {
+                quads[0] |= Q0_LINE_OUT_LEVEL_HIGH_FLAG;
+                quads[1] |= Q1_LINE_OUT_LEVEL_HIGH_FLAG;
+            }
+            LineOutNominalLevel::Consumer => {
+                quads[0] |= Q0_LINE_OUT_LEVEL_CON_FLAG;
+                quads[1] |= Q1_LINE_OUT_LEVEL_CON_FLAG;
+            }
+            LineOutNominalLevel::Professional => {
+                quads[0] |= Q0_LINE_OUT_LEVEL_PRO_FLAG;
+                quads[1] |= Q1_LINE_OUT_LEVEL_PRO_FLAG;
+            }
+        }
+
+        if self.spdif_in.iface == SpdifIface::Optical {
+            quads[2] |= Q2_SPDIF_IN_IFACE_OPT_MASK;
+        }
+        if self.spdif_in.use_preemble {
+            quads[2] |= Q2_SPDIF_IN_USE_PREEMBLE;
+        }
+
+        if self.opt_out_signal == OpticalOutputSignal::Spdif {
+            quads[2] |= Q2_OPT_OUT_SIGNAL_MASK;
+        }
+        if self.spdif_out.format == SpdifFormat::Professional {
+            quads[2] |= Q2_SPDIF_OUT_FMT_PRO_MASK;
+        }
+        if self.spdif_out.emphasis {
+            quads[2] |= Q2_SPDIF_OUT_EMPHASIS_MASK;
+        }
+        if self.spdif_out.non_audio {
+            quads[2] |= Q2_SPDIF_OUT_NON_AUDIO_MASK;
+        }
+
+        if self.word_out_single {
+            quads[2] |= Q2_WORD_OUT_SINGLE_SPEED_MASK;
+        }
+
+        if self.continue_at_errors {
+            quads[2] |= Q2_CONTINUE_AT_ERRORS;
+        }
+    }
+
+    #[allow(dead_code)]
+    fn parse(&mut self, quads: &[u32]) {
+        assert_eq!(quads.len(), Self::QUADLET_COUNT);
+
+        self.clk.parse(quads);
+        self.analog_in.parse(quads);
+
+        let pair = (quads[0] & Q0_LINE_OUT_LEVEL_MASK, quads[1] & Q1_LINE_OUT_LEVEL_MASK);
+        self.line_out_level = match pair {
+            (Q0_LINE_OUT_LEVEL_HIGH_FLAG, Q1_LINE_OUT_LEVEL_HIGH_FLAG) => LineOutNominalLevel::High,
+            (Q0_LINE_OUT_LEVEL_CON_FLAG, Q1_LINE_OUT_LEVEL_CON_FLAG) => LineOutNominalLevel::Consumer,
+            (Q0_LINE_OUT_LEVEL_PRO_FLAG, Q1_LINE_OUT_LEVEL_PRO_FLAG) => LineOutNominalLevel::Professional,
+            _ => unreachable!(),
+        };
+
+        self.spdif_in.iface = if quads[2] & Q2_SPDIF_IN_IFACE_OPT_MASK > 0 {
+            SpdifIface::Optical
+        } else {
+            SpdifIface::Coaxial
+        };
+        self.spdif_in.use_preemble = quads[2] & Q2_SPDIF_IN_USE_PREEMBLE > 0;
+
+        self.spdif_out.format = if quads[2] & Q2_SPDIF_OUT_FMT_PRO_MASK > 0 {
+            SpdifFormat::Professional
+        } else {
+            SpdifFormat::Consumer
+        };
+        self.spdif_out.emphasis = quads[2] & Q2_SPDIF_OUT_EMPHASIS_MASK > 0;
+        self.spdif_out.non_audio = quads[2] & Q2_SPDIF_OUT_NON_AUDIO_MASK > 0;
+
+        self.opt_out_signal = if quads[2] & Q2_OPT_OUT_SIGNAL_MASK > 0 {
+            OpticalOutputSignal::Spdif
+        } else {
+            OpticalOutputSignal::Adat
+        };
+
+        self.word_out_single = quads[2] & Q2_WORD_OUT_SINGLE_SPEED_MASK > 0;
+        self.continue_at_errors = quads[2] & Q2_CONTINUE_AT_ERRORS > 0;
+    }
+
+    /// Although the configuration registers are write-only, some of them are available in status
+    /// registers.
+    pub fn init(&mut self, status: &Ff800Status) {
+        self.clk.primary_src = status.configured_clk_src;
+        self.spdif_in = status.spdif_in;
+        self.spdif_out = status.spdif_out;
+        self.opt_out_signal = status.opt_out_signal;
+        self.word_out_single = status.word_out_single;
+    }
+}
+
+/// The trait to represent configuration protocol specific to RME Fireface 800.
+pub trait RmeFf800ConfigProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
+    fn write_cfg(&self, node: &T, cfg: &Ff800Config, timeout_ms: u32) -> Result<(), Error> {
+        let mut quads = [0u32;3];
+        cfg.build(&mut quads);
+
+        let mut raw = [0;12];
+        quads.iter()
+            .enumerate()
+            .for_each(|(i, quad)| {
+                let pos = i * 4;
+                raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
+            });
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest, CFG_OFFSET as u64,
+                                       raw.len(), &mut raw, timeout_ms)
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFf800ConfigProtocol<T> for Ff800Protocol {}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -627,5 +1057,234 @@ mod test {
         let quads = [0x02000000, 0x00000000];
         status.parse(&quads);
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::AdatA);
+    }
+
+    #[test]
+    fn test_clk_cfg() {
+        let mut orig = Ff800ClkConfig::default();
+        let mut cfg = Ff800ClkConfig::default();
+
+        orig.primary_src = Ff800ClkSrc::Internal;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x0000001f);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.primary_src = Ff800ClkSrc::WordClock;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x0000141e);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.primary_src = Ff800ClkSrc::AdatA;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x0000001e);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.primary_src = Ff800ClkSrc::AdatB;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x0000041e);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.primary_src = Ff800ClkSrc::Spdif;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x00000c1e);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.primary_src = Ff800ClkSrc::Tco;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(quads[2], 0x00001c1e);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+    }
+
+    #[test]
+    fn test_inst_cfg() {
+        let mut orig = Ff800InstConfig::default();
+        let mut cfg = Ff800InstConfig::default();
+
+        orig.drive = false;
+        orig.limitter = false;
+        orig.speaker_emulation = false;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000000, 0x00000000, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.drive = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000200, 0x00000200, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.limitter = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000200, 0x00000200, 0x00010000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.speaker_emulation = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000204, 0x00000200, 0x00010000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+    }
+
+    #[test]
+    fn test_analog_in_cfg() {
+        let mut orig = Ff800AnalogInConfig::default();
+        let mut cfg = Ff800AnalogInConfig::default();
+
+        orig.jacks[0] = Ff800AnalogInputJack::FrontRear;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000008, 0x000008a4, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.jacks[1] = Ff800AnalogInputJack::FrontRear;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000008, 0x000008e4, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.jacks[2] = Ff800AnalogInputJack::FrontRear;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000008, 0x000009e4, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.line_level = FormerLineInNominalLevel::Consumer;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000020, 0x000009e7, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.line_level = FormerLineInNominalLevel::Professional;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000010, 0x000009e6, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.phantom_powering[0] = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000011, 0x000009e6, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.phantom_powering[1] = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000091, 0x000009e6, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.phantom_powering[2] = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000093, 0x000009e6, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.phantom_powering[3] = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000193, 0x000009e6, 0x00000000]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+    }
+
+    #[test]
+    fn test_cfg() {
+        let mut orig = Ff800Config::default();
+        let mut cfg = Ff800Config::default();
+
+        orig.line_out_level = LineOutNominalLevel::High;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000408, 0x000008b0, 0x8000001e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.line_out_level = LineOutNominalLevel::Consumer;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00001008, 0x000008a8, 0x8000001e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.line_out_level = LineOutNominalLevel::Professional;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0x8000001e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.spdif_in.iface = SpdifIface::Optical;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0x8000021e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.spdif_in.use_preemble = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc000021e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.opt_out_signal = OpticalOutputSignal::Spdif;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc000031e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.spdif_out.format = SpdifFormat::Professional;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc000033e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.spdif_out.emphasis = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc000037e]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.spdif_out.non_audio = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc00003fe]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
+
+        orig.word_out_single = true;
+        let mut quads = [0u32;3];
+        orig.build(&mut quads);
+        assert_eq!(&quads[..], &[0x00000808, 0x000008b8, 0xc00023fe]);
+        cfg.parse(&quads);
+        assert_eq!(cfg, orig);
     }
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -17,6 +17,7 @@ impl AsRef<FwReq> for Ff800Protocol {
 }
 
 
+const MIXER_OFFSET: usize       = 0x000080080000;
 const OUTPUT_OFFSET: usize      = 0x000080081f80;
 const METER_OFFSET: usize       = 0x000080100000;
 
@@ -96,4 +97,45 @@ impl<T: AsRef<FwNode>> RmeFormerOutputProtocol<T, Ff800OutputVolumeState> for Ff
                                        (OUTPUT_OFFSET + ch * 4) as u64, raw.len(), &mut raw,
                                        timeout_ms)
     }
+}
+
+/// The structure to represent state of mixer for RME Fireface 800.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff800MixerState(pub Vec<FormerMixerSrc>);
+
+impl AsRef<[FormerMixerSrc]> for Ff800MixerState {
+    fn as_ref(&self) -> &[FormerMixerSrc] {
+        &self.0
+    }
+}
+
+impl AsMut<[FormerMixerSrc]> for Ff800MixerState {
+    fn as_mut(&mut self) -> &mut [FormerMixerSrc] {
+        &mut self.0
+    }
+}
+
+impl RmeFormerMixerSpec for Ff800MixerState {
+    const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff800MixerState {
+    fn default() -> Self {
+        Self(Self::create_mixer_state())
+    }
+}
+
+impl<T, U> RmeFormerMixerProtocol<T, U> for Ff800Protocol
+    where T: AsRef<FwNode>,
+          U: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
+{
+    const MIXER_OFFSET: usize = MIXER_OFFSET;
+    const AVAIL_COUNT: usize = 32;
 }

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -294,6 +294,7 @@ pub trait RmeFfLatterMeterProtocol<T, U> : AsRef<FwReq>
 pub struct FfLatterDspState{
     pub input: FfLatterInputState,
     pub output: FfLatterOutputState,
+    pub mixer: Vec<FfLatterMixerState>,
 }
 
 /// The trait to represent specification of input and output of DSP.
@@ -335,6 +336,13 @@ pub trait RmeFfLatterDspSpec {
                 invert_phases: vec![Default::default();Self::OUTPUT_COUNT],
                 line_levels: vec![Default::default();Self::LINE_OUTPUT_COUNT],
             },
+            mixer: vec![FfLatterMixerState{
+                line_gains: vec![Default::default();Self::LINE_INPUT_COUNT],
+                mic_gains: vec![Default::default();Self::MIC_INPUT_COUNT],
+                spdif_gains: vec![Default::default();Self::SPDIF_INPUT_COUNT],
+                adat_gains: vec![Default::default();Self::ADAT_INPUT_COUNT],
+                stream_gains: vec![Default::default();Self::STREAM_INPUT_COUNT],
+            };Self::OUTPUT_COUNT],
         }
     }
 }
@@ -612,6 +620,79 @@ pub trait RmeFfLatterOutputProtocol<T, U> : RmeFfLatterDspProtocol<T, U>
 }
 
 impl<T, U, O> RmeFfLatterOutputProtocol<T, U> for O
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+          O: RmeFfLatterDspProtocol<T, U>,
+{}
+
+/// The structure to represent state of mixer.
+///
+/// Each value is between 0x0000 and 0xa000 through 0x9000 to represent -65.00 dB and 6.00 dB
+/// through 0.00 dB.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FfLatterMixerState{
+    pub line_gains: Vec<u16>,
+    pub mic_gains: Vec<u16>,
+    pub spdif_gains: Vec<u16>,
+    pub adat_gains: Vec<u16>,
+    pub stream_gains: Vec<u16>,
+}
+
+fn mixer_state_to_cmds<T: RmeFfLatterDspSpec>(state: &FfLatterMixerState, index: u16, _: &T)
+    -> Vec<u32>
+{
+    let mut cmds = Vec::new();
+
+    state.line_gains.iter()
+        .chain(state.mic_gains.iter())
+        .chain(state.spdif_gains.iter())
+        .chain(state.adat_gains.iter())
+        .enumerate()
+        .for_each(|(i, &gain)| {
+            let ch = i as u16;
+            cmds.push(create_virt_port_cmd(T::MIXER_STEP, index, ch, gain));
+        });
+
+    state.stream_gains.iter()
+        .enumerate()
+        .for_each(|(i, &gain)| {
+            let ch = (T::STREAM_OFFSET as u16) + i as u16;
+            cmds.push(create_virt_port_cmd(T::MIXER_STEP, index, ch, gain));
+        });
+
+    cmds
+}
+
+/// The trait to represent mixer protocol.
+pub trait RmeFfLatterMixerProtocol<T, U> : RmeFfLatterDspProtocol<T, U>
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+{
+    fn init_mixers(&self, node: &T, state: &U, timeout_ms: u32) -> Result<(), Error> {
+        let mixers = &state.as_ref().mixer;
+
+        mixers.iter()
+            .enumerate()
+            .try_for_each(|(i, mixer)| {
+                let ch = i as u16;
+                let cmds = mixer_state_to_cmds(&mixer, ch, state);
+                cmds.iter()
+                    .try_for_each(|&cmd| self.write_dsp_cmd(node, cmd, timeout_ms))
+            })
+    }
+
+    fn write_mixer(&self, node: &T, state: &mut U, index: usize, mixer: FfLatterMixerState, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let old = mixer_state_to_cmds(&state.as_ref().mixer[index], index as u16, state);
+        let new = mixer_state_to_cmds(&mixer, index as u16, state);
+
+        self.write_dsp_cmds(node, &old, &new, timeout_ms)
+            .map(|_| state.as_mut().mixer[index] = mixer)
+    }
+}
+
+impl<T, U, O> RmeFfLatterMixerProtocol<T, U> for O
     where T: AsRef<FwNode>,
           U: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
           O: RmeFfLatterDspProtocol<T, U>,

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -8,10 +8,11 @@ pub mod ff802;
 use glib::Error;
 use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
 
-use crate::*;
+use super::*;
 
 const CFG_OFFSET: usize = 0xffff00000014;
 const DSP_OFFSET: usize = 0xffff0000001c;
+const METER_OFFSET: usize = 0xffffff000000;
 
 // For configuration register (0x'ffff'0000'0014).
 const CFG_MIDI_TX_LOW_OFFSET_MASK: u32          = 0x0001e000;
@@ -155,5 +156,135 @@ pub trait RmeFfLatterStatusProtocol<T, U> : AsRef<FwReq>
                 let quad = u32::from_le_bytes(raw);
                 status.parse(&quad)
             })
+    }
+}
+
+/// The structure to represent state of meters.
+///
+/// Each value is between 0x'0000'0000'0000'0000 and 0x'3fff'ffff'ffff'ffff. 0x'0000'0000'0000'001f
+/// represents negative infinite.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FfLatterMeterState{
+    pub line_inputs: Vec<i32>,
+    pub mic_inputs: Vec<i32>,
+    pub spdif_inputs: Vec<i32>,
+    pub adat_inputs: Vec<i32>,
+    pub stream_inputs: Vec<i32>,
+    pub line_outputs: Vec<i32>,
+    pub hp_outputs: Vec<i32>,
+    pub spdif_outputs: Vec<i32>,
+    pub adat_outputs: Vec<i32>,
+}
+
+const METER32_MASK: i32 = 0x07fffff0;
+
+// Read data retrieved by each block read transaction consists of below chunks in the order:
+//  32 octlets for meters detected by DSP.
+//  32 quadlets for meters detected by DSP.
+//  2 quadlets for unknown meters.
+//  2 quadlets for tags.
+//
+// The first tag represents the set of content:
+//  0x11111111 - hardware outputs
+//  0x22222222 - channel strip for hardware inputs
+//  0x33333333 - stream inputs
+//  0x55555555 - fx bus
+//  0x66666666 - hardware inputs
+//
+//  The maximum value for quadlet is 0x07fffff0. The byte in LSB is 0xf at satulated.
+fn parse_meter<U: RmeFfLatterMeterSpec>(s: &mut FfLatterMeterState, raw: &[u8]) {
+    let mut quadlet = [0;4];
+    quadlet.copy_from_slice(&raw[388..]);
+    let target = u32::from_le_bytes(quadlet);
+
+    match target {
+        // For phys outputs.
+        0x11111111 => {
+            [
+                (s.line_outputs.iter_mut(), 0),
+                (s.hp_outputs.iter_mut(), U::LINE_OUTPUT_COUNT),
+                (s.spdif_outputs.iter_mut(), U::LINE_OUTPUT_COUNT + U::HP_OUTPUT_COUNT),
+                (s.adat_outputs.iter_mut(), U::LINE_OUTPUT_COUNT + U::HP_OUTPUT_COUNT + U::SPDIF_OUTPUT_COUNT),
+            ].iter_mut()
+                .for_each(|(iter, offset)| {
+                    iter.enumerate()
+                        .for_each(|(i, meter)| {
+                            let pos = 256 + (*offset + i) * 4;
+                            quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                            *meter = i32::from_le_bytes(quadlet) & METER32_MASK;
+                        });
+                });
+        }
+        // For stream inputs.
+        0x33333333 => {
+            s.stream_inputs.iter_mut()
+                .enumerate()
+                .for_each(|(i, meter)| {
+                    let pos = 256 + i * 4;
+                    quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                    *meter = i32::from_le_bytes(quadlet) & METER32_MASK;
+                });
+        }
+        // For phys inputs.
+        0x66666666 => {
+            [
+                (s.line_inputs.iter_mut(), 0),
+                (s.mic_inputs.iter_mut(), U::LINE_INPUT_COUNT),
+                (s.spdif_inputs.iter_mut(), U::LINE_INPUT_COUNT + U::MIC_INPUT_COUNT),
+                (s.adat_inputs.iter_mut(), U::LINE_INPUT_COUNT + U::MIC_INPUT_COUNT + U::SPDIF_INPUT_COUNT),
+            ].iter_mut()
+                .for_each(|(iter, offset)| {
+                    iter.enumerate()
+                        .for_each(|(i, meter)| {
+                            let pos = 256 + (*offset + i) * 4;
+                            quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+                            *meter = i32::from_le_bytes(quadlet) & METER32_MASK;
+                        });
+                });
+        }
+        _ => (),
+    }
+}
+
+/// The trait to represent meter protocol.
+pub trait RmeFfLatterMeterSpec {
+    const LINE_INPUT_COUNT: usize;
+    const MIC_INPUT_COUNT: usize;
+    const SPDIF_INPUT_COUNT: usize;
+    const ADAT_INPUT_COUNT: usize;
+    const STREAM_INPUT_COUNT: usize;
+
+    const LINE_OUTPUT_COUNT: usize;
+    const HP_OUTPUT_COUNT: usize;
+    const SPDIF_OUTPUT_COUNT: usize;
+    const ADAT_OUTPUT_COUNT: usize;
+
+    fn create_meter_state() -> FfLatterMeterState {
+        FfLatterMeterState{
+            line_inputs: vec![Default::default();Self::LINE_INPUT_COUNT],
+            mic_inputs: vec![Default::default();Self::MIC_INPUT_COUNT],
+            spdif_inputs: vec![Default::default();Self::SPDIF_INPUT_COUNT],
+            adat_inputs: vec![Default::default();Self::ADAT_INPUT_COUNT],
+            stream_inputs: vec![Default::default();Self::STREAM_INPUT_COUNT],
+            line_outputs: vec![Default::default();Self::LINE_OUTPUT_COUNT],
+            hp_outputs: vec![Default::default();Self::HP_OUTPUT_COUNT],
+            spdif_outputs: vec![Default::default();Self::SPDIF_OUTPUT_COUNT],
+            adat_outputs: vec![Default::default();Self::ADAT_OUTPUT_COUNT],
+        }
+    }
+}
+
+/// The trait to represent meter protocol.
+pub trait RmeFfLatterMeterProtocol<T, U> : AsRef<FwReq>
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
+{
+    fn read_meter(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        (0..5).try_for_each(|_| {
+            let mut raw = vec![0;392];
+            self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, METER_OFFSET as u64,
+                                           raw.len(), &mut raw, timeout_ms)
+                .map(|_| parse_meter::<U>(state.as_mut(), &raw))
+        })
     }
 }

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -296,6 +296,7 @@ pub struct FfLatterDspState{
     pub output: FfLatterOutputState,
     pub mixer: Vec<FfLatterMixerState>,
     pub input_ch_strip: FfLatterInputChStripState,
+    pub output_ch_strip: FfLatterOutputChStripState,
 }
 
 /// The trait to represent specification of input and output of DSP.
@@ -379,6 +380,43 @@ pub trait RmeFfLatterDspSpec {
                     max_gains: vec![Default::default();Self::PHYS_INPUT_COUNT],
                     headrooms: vec![Default::default();Self::PHYS_INPUT_COUNT],
                     rise_times: vec![Default::default();Self::PHYS_INPUT_COUNT],
+                },
+            }),
+            output_ch_strip: FfLatterOutputChStripState(FfLatterChStripState{
+                hpf: FfLatterHpfState{
+                    activates: vec![Default::default();Self::OUTPUT_COUNT],
+                    cut_offs: vec![Default::default();Self::OUTPUT_COUNT],
+                    roll_offs: vec![Default::default();Self::OUTPUT_COUNT],
+                },
+                eq: FfLatterEqState{
+                    activates: vec![Default::default();Self::OUTPUT_COUNT],
+                    low_types: vec![Default::default();Self::OUTPUT_COUNT],
+                    low_gains: vec![Default::default();Self::OUTPUT_COUNT],
+                    low_freqs: vec![Default::default();Self::OUTPUT_COUNT],
+                    low_qualities: vec![Default::default();Self::OUTPUT_COUNT],
+                    middle_gains: vec![Default::default();Self::OUTPUT_COUNT],
+                    middle_freqs: vec![Default::default();Self::OUTPUT_COUNT],
+                    middle_qualities: vec![Default::default();Self::OUTPUT_COUNT],
+                    high_types: vec![Default::default();Self::OUTPUT_COUNT],
+                    high_gains: vec![Default::default();Self::OUTPUT_COUNT],
+                    high_freqs: vec![Default::default();Self::OUTPUT_COUNT],
+                    high_qualities: vec![Default::default();Self::OUTPUT_COUNT],
+                },
+                dynamics: FfLatterDynState{
+                    activates: vec![Default::default();Self::OUTPUT_COUNT],
+                    gains: vec![Default::default();Self::OUTPUT_COUNT],
+                    attacks: vec![Default::default();Self::OUTPUT_COUNT],
+                    releases: vec![Default::default();Self::OUTPUT_COUNT],
+                    compressor_thresholds: vec![Default::default();Self::OUTPUT_COUNT],
+                    compressor_ratios: vec![Default::default();Self::OUTPUT_COUNT],
+                    expander_thresholds: vec![Default::default();Self::OUTPUT_COUNT],
+                    expander_ratios: vec![Default::default();Self::OUTPUT_COUNT],
+                },
+                autolevel: FfLatterAutolevelState{
+                    activates: vec![Default::default();Self::OUTPUT_COUNT],
+                    max_gains: vec![Default::default();Self::OUTPUT_COUNT],
+                    headrooms: vec![Default::default();Self::OUTPUT_COUNT],
+                    rise_times: vec![Default::default();Self::OUTPUT_COUNT],
                 },
             }),
         }
@@ -1081,4 +1119,29 @@ impl<T, U, O> RmeFfLatterChStripProtocol<T, U, FfLatterInputChStripState> for O
           O: RmeFfLatterDspProtocol<T, U>,
 {
     const CH_OFFSET: u8 = 0x00;
+}
+
+/// The structure to represent state of output channel strip effect.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FfLatterOutputChStripState(pub FfLatterChStripState);
+
+impl AsMut<FfLatterChStripState> for FfLatterOutputChStripState {
+    fn as_mut(&mut self) -> &mut FfLatterChStripState {
+        &mut self.0
+    }
+}
+
+impl AsRef<FfLatterChStripState> for FfLatterOutputChStripState {
+    fn as_ref(&self) -> &FfLatterChStripState {
+        &self.0
+    }
+}
+
+impl<T, U, O> RmeFfLatterChStripProtocol<T, U, FfLatterOutputChStripState> for O
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterDspSpec + AsMut<FfLatterDspState> + AsRef<FfLatterDspState>,
+          O: RmeFfLatterDspProtocol<T, U>,
+{
+    const CH_OFFSET: u8 =
+        (U::LINE_INPUT_COUNT + U::MIC_INPUT_COUNT + U::SPDIF_INPUT_COUNT + U::ADAT_INPUT_COUNT) as u8;
 }

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol defined by RME GmbH for latter models of Fireface series.
+
+pub mod ff802;

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -3,6 +3,7 @@
 
 //! Protocol defined by RME GmbH for latter models of Fireface series.
 
+pub mod ucx;
 pub mod ff802;
 
 use glib::Error;

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -4,3 +4,156 @@
 //! Protocol defined by RME GmbH for latter models of Fireface series.
 
 pub mod ff802;
+
+use glib::Error;
+use hinawa::{FwNode, FwTcode, FwReq, FwReqExtManual};
+
+use crate::*;
+
+const CFG_OFFSET: usize = 0xffff00000014;
+const DSP_OFFSET: usize = 0xffff0000001c;
+
+// For configuration register (0x'ffff'0000'0014).
+const CFG_MIDI_TX_LOW_OFFSET_MASK: u32          = 0x0001e000;
+const   CFG_MIDI_TX_LOW_OFFSET_0180_FLAG: u32   = 0x00010000;
+const   CFG_MIDI_TX_LOW_OFFSET_0100_FLAG: u32   = 0x00008000;
+const   CFG_MIDI_TX_LOW_OFFSET_0080_FLAG: u32   = 0x00004000;
+const   CFG_MIDI_TX_LOW_OFFSET_0000_FLAG: u32   = 0x00002000;
+
+/// The enumeration to represent low offset of destination address for MIDI messages.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum FfLatterMidiTxLowOffset {
+    /// Between 0x0000 to 0x007c.
+    A0000,
+    /// Between 0x0080 to 0x00fc.
+    A0080,
+    /// Between 0x0100 to 0x017c.
+    A0100,
+    /// Between 0x0180 to 0x01fc.
+    A0180,
+}
+
+impl Default for FfLatterMidiTxLowOffset {
+    fn default() -> Self {
+        Self::A0000
+    }
+}
+
+impl FfLatterMidiTxLowOffset {
+    fn build(&self, quad: &mut u32) {
+        *quad |= match self {
+            Self::A0000 => CFG_MIDI_TX_LOW_OFFSET_0000_FLAG,
+            Self::A0080 => CFG_MIDI_TX_LOW_OFFSET_0080_FLAG,
+            Self::A0100 => CFG_MIDI_TX_LOW_OFFSET_0100_FLAG,
+            Self::A0180 => CFG_MIDI_TX_LOW_OFFSET_0180_FLAG,
+        };
+    }
+
+    fn parse(&mut self, quad: &u32) {
+        *self = match *quad & CFG_MIDI_TX_LOW_OFFSET_MASK {
+            CFG_MIDI_TX_LOW_OFFSET_0180_FLAG => Self::A0180,
+            CFG_MIDI_TX_LOW_OFFSET_0100_FLAG => Self::A0100,
+            CFG_MIDI_TX_LOW_OFFSET_0080_FLAG => Self::A0080,
+            CFG_MIDI_TX_LOW_OFFSET_0000_FLAG => Self::A0000,
+            _ => unreachable!(),
+        }
+    }
+}
+
+/// The trait to represent operation for configuration structure.
+pub trait RmeFfLatterRegisterValueOperation {
+    fn build(&self, quad: &mut u32);
+    fn parse(&mut self, quad: &u32);
+}
+
+/// The trait to represent configuration protocol.
+pub trait RmeFfLatterConfigProtocol<T, U> : AsRef<FwReq>
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterRegisterValueOperation,
+{
+    fn write_cfg(&self, node: &T, cfg: &U, timeout_ms: u32) -> Result<(), Error> {
+        let mut quad = 0u32;
+        cfg.build(&mut quad);
+
+        let mut raw = [0;4];
+        raw.copy_from_slice(&quad.to_le_bytes());
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteQuadletRequest, CFG_OFFSET as u64,
+                                       raw.len(), &mut raw, timeout_ms)
+    }
+}
+
+// For status register (0x'ffff'0000'001c).
+const STATUS_CLK_RATE_32000: u32 = 0x00;
+const STATUS_CLK_RATE_44100: u32 = 0x01;
+const STATUS_CLK_RATE_48000: u32 = 0x02;
+const STATUS_CLK_RATE_64000: u32 = 0x04;
+const STATUS_CLK_RATE_88200: u32 = 0x05;
+const STATUS_CLK_RATE_96000: u32 = 0x06;
+const STATUS_CLK_RATE_128000: u32 = 0x08;
+const STATUS_CLK_RATE_176400: u32 = 0x09;
+const STATUS_CLK_RATE_192000: u32 = 0x0a;
+const STATUS_CLK_RATE_NONE: u32 = 0x0f;
+
+fn val_from_clk_rate(clk_rate: &ClkNominalRate, quad: &mut u32, shift: usize) {
+    let val = match clk_rate {
+        ClkNominalRate::R32000 => STATUS_CLK_RATE_32000,
+        ClkNominalRate::R44100 => STATUS_CLK_RATE_44100,
+        ClkNominalRate::R48000 => STATUS_CLK_RATE_48000,
+        ClkNominalRate::R64000 => STATUS_CLK_RATE_64000,
+        ClkNominalRate::R88200 => STATUS_CLK_RATE_88200,
+        ClkNominalRate::R96000 => STATUS_CLK_RATE_96000,
+        ClkNominalRate::R128000 => STATUS_CLK_RATE_128000,
+        ClkNominalRate::R176400 => STATUS_CLK_RATE_176400,
+        ClkNominalRate::R192000 => STATUS_CLK_RATE_192000,
+    };
+    *quad |= val << shift;
+}
+
+fn val_to_clk_rate(clk_rate: &mut ClkNominalRate, quad: &u32, shift: usize) {
+        *clk_rate = match (*quad >> shift) & 0x0000000f {
+            STATUS_CLK_RATE_32000 => ClkNominalRate::R32000,
+            STATUS_CLK_RATE_44100 => ClkNominalRate::R44100,
+            STATUS_CLK_RATE_48000 => ClkNominalRate::R48000,
+            STATUS_CLK_RATE_64000 => ClkNominalRate::R64000,
+            STATUS_CLK_RATE_88200 => ClkNominalRate::R88200,
+            STATUS_CLK_RATE_96000 => ClkNominalRate::R96000,
+            STATUS_CLK_RATE_128000 => ClkNominalRate::R128000,
+            STATUS_CLK_RATE_176400 => ClkNominalRate::R176400,
+            STATUS_CLK_RATE_192000 => ClkNominalRate::R192000,
+            _ => unreachable!(),
+        };
+}
+
+fn optional_val_from_clk_rate(clk_rate: &Option<ClkNominalRate>, quad: &mut u32, shift: usize) {
+    if let Some(r) = clk_rate {
+        val_from_clk_rate(r, quad, shift)
+    } else {
+        *quad |= STATUS_CLK_RATE_NONE << shift;
+    }
+}
+
+fn optional_val_to_clk_rate(clk_rate: &mut Option<ClkNominalRate>, quad: &u32, shift: usize) {
+    if (*quad >> shift) & 0x0000000f != STATUS_CLK_RATE_NONE {
+        let mut r = ClkNominalRate::default();
+        val_to_clk_rate(&mut r, quad, shift);
+        *clk_rate = Some(r);
+    } else {
+        *clk_rate = None;
+    };
+}
+
+/// The trait to represent status protocol.
+pub trait RmeFfLatterStatusProtocol<T, U> : AsRef<FwReq>
+    where T: AsRef<FwNode>,
+          U: RmeFfLatterRegisterValueOperation,
+{
+    fn read_status(&self, node: &T, status: &mut U, timeout_ms: u32) -> Result<(), Error> {
+        let mut raw = [0;4];
+        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadQuadletRequest, DSP_OFFSET as u64,
+                                       raw.len(), &mut raw, timeout_ms)
+            .map(|_| {
+                let quad = u32::from_le_bytes(raw);
+                status.parse(&quad)
+            })
+    }
+}

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -781,7 +781,7 @@ pub struct FfLatterMixerState{
     pub stream_gains: Vec<u16>,
 }
 
-fn mixer_state_to_cmds<T: RmeFfLatterDspSpec>(state: &FfLatterMixerState, index: u16, _: &T)
+fn mixer_state_to_cmds<T: RmeFfLatterDspSpec>(state: &FfLatterMixerState, index: u16)
     -> Vec<u32>
 {
     let mut cmds = Vec::new();
@@ -818,7 +818,7 @@ pub trait RmeFfLatterMixerProtocol<T, U> : RmeFfLatterDspProtocol<T, U>
             .enumerate()
             .try_for_each(|(i, mixer)| {
                 let ch = i as u16;
-                let cmds = mixer_state_to_cmds(&mixer, ch, state);
+                let cmds = mixer_state_to_cmds::<U>(&mixer, ch);
                 cmds.iter()
                     .try_for_each(|&cmd| self.write_dsp_cmd(node, cmd, timeout_ms))
             })
@@ -827,8 +827,8 @@ pub trait RmeFfLatterMixerProtocol<T, U> : RmeFfLatterDspProtocol<T, U>
     fn write_mixer(&self, node: &T, state: &mut U, index: usize, mixer: FfLatterMixerState, timeout_ms: u32)
         -> Result<(), Error>
     {
-        let old = mixer_state_to_cmds(&state.as_ref().mixer[index], index as u16, state);
-        let new = mixer_state_to_cmds(&mixer, index as u16, state);
+        let old = mixer_state_to_cmds::<U>(&state.as_ref().mixer[index], index as u16);
+        let new = mixer_state_to_cmds::<U>(&mixer, index as u16);
 
         self.write_dsp_cmds(node, &old, &new, timeout_ms)
             .map(|_| state.as_mut().mixer[index] = mixer)

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -384,3 +384,40 @@ impl Default for Ff802MeterState {
 }
 
 impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, Ff802MeterState> for Ff802Protocol {}
+
+/// The structure to represent state of DSP.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff802DspState(FfLatterDspState);
+
+impl AsRef<FfLatterDspState> for Ff802DspState {
+    fn as_ref(&self) -> &FfLatterDspState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterDspState> for Ff802DspState {
+    fn as_mut(&mut self) -> &mut FfLatterDspState {
+        &mut self.0
+    }
+}
+
+impl RmeFfLatterDspSpec for Ff802DspState {
+    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
+    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
+    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff802DspState {
+    fn default() -> Self {
+        Self(Self::create_dsp_state())
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterDspProtocol<T, Ff802DspState> for Ff802Protocol {}

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol defined by RME GmbH for Fireface 802.
+
+use hinawa::FwReq;
+
+/// The structure to represent unique protocol for Fireface 802.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct Ff802Protocol(FwReq);
+
+impl AsRef<FwReq> for Ff802Protocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -5,6 +5,9 @@
 
 use hinawa::FwReq;
 
+use super::*;
+use crate::*;
+
 /// The structure to represent unique protocol for Fireface 802.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Ff802Protocol(FwReq);
@@ -14,3 +17,141 @@ impl AsRef<FwReq> for Ff802Protocol {
         &self.0
     }
 }
+
+// For configuration register (0x'ffff'0000'0014).
+const CFG_CLK_SRC_MASK: u32                     = 0x00001c00;
+const   CFG_CLK_SRC_ADAT_B_FLAG: u32            = 0x00001000;
+const   CFG_CLK_SRC_ADAT_A_FLAG: u32            = 0x00000c00;
+const   CFG_CLK_SRC_AESEBU_FLAG: u32            = 0x00000800;
+const   CFG_CLK_SRC_WORD_CLK_FLAG: u32          = 0x00000400;
+const   CFG_CLK_SRC_INTERNAL_FLAG: u32          = 0x00000000;
+const CFG_AESEBU_INPUT_FROM_OPT_IFACE_MASK: u32 = 0x00000200;
+const CFG_AESEBU_OUTPUT_TO_OPT_IFACE_MASK: u32  = 0x00000100;
+const CFG_DSP_EFFECT_ON_INPUT_MASK: u32         = 0x00000040;
+const CFG_AESEBU_OUT_PRO_MASK: u32              = 0x00000020;
+const CFG_WORD_OUT_SINGLE_MASK: u32             = 0x00000010;
+
+/// The enumeration to represent source of sampling clock.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum Ff802ClkSrc {
+    Internal,
+    AdatA,
+    AdatB,
+    AesEbu,
+    WordClk,
+}
+
+impl Default for Ff802ClkSrc {
+    fn default() -> Self {
+        Self::Internal
+    }
+}
+
+impl Ff802ClkSrc {
+    fn build(&self, quad: &mut u32) {
+        *quad |= match self {
+            Self::AdatB => CFG_CLK_SRC_ADAT_B_FLAG,
+            Self::AdatA => CFG_CLK_SRC_ADAT_A_FLAG,
+            Self::AesEbu => CFG_CLK_SRC_AESEBU_FLAG,
+            Self::WordClk => CFG_CLK_SRC_WORD_CLK_FLAG,
+            Self::Internal => CFG_CLK_SRC_INTERNAL_FLAG,
+        };
+    }
+
+    fn parse(&mut self, quad: &u32) {
+        match *quad & CFG_CLK_SRC_MASK {
+            CFG_CLK_SRC_ADAT_B_FLAG => Self::AdatB,
+            CFG_CLK_SRC_ADAT_A_FLAG => Self::AdatA,
+            CFG_CLK_SRC_AESEBU_FLAG => Self::AesEbu,
+            CFG_CLK_SRC_WORD_CLK_FLAG => Self::WordClk,
+            CFG_CLK_SRC_INTERNAL_FLAG => Self::Internal,
+            _ => unreachable!(),
+        };
+    }
+}
+
+/// The enumeration to represent interface of S/PDIF signal for Fireface 802.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Ff802SpdifIface {
+    Xlr,
+    Optical,
+}
+
+impl Default for Ff802SpdifIface {
+    fn default() -> Self {
+        Self::Xlr
+    }
+}
+
+/// The structure to represent unique protocol for Fireface 802.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct Ff802Config{
+    /// The low offset of destination address for MIDI messages.
+    midi_tx_low_offset: FfLatterMidiTxLowOffset,
+    /// The source of sampling clock.
+    pub clk_src: Ff802ClkSrc,
+    /// The input interface of S/PDIF signal.
+    pub spdif_in_iface: Ff802SpdifIface,
+    /// The type of signal to optical output interface.
+    pub opt_out_signal: OpticalOutputSignal,
+    /// Whether to enable DSP effect on inputs.
+    pub effect_on_inputs: bool,
+    /// For signal format of S/PDIF output.
+    pub spdif_out_format: SpdifFormat,
+    /// Whether to fix speed to single even if at double/quadruple rate.
+    pub word_out_single: bool,
+}
+
+impl RmeFfLatterRegisterValueOperation for Ff802Config{
+    fn build(&self, quad: &mut u32) {
+        self.midi_tx_low_offset.build(quad);
+        self.clk_src.build(quad);
+
+        if self.spdif_in_iface == Ff802SpdifIface::Optical {
+            *quad |= CFG_AESEBU_INPUT_FROM_OPT_IFACE_MASK;
+        }
+
+        if self.opt_out_signal == OpticalOutputSignal::Spdif {
+            *quad |= CFG_AESEBU_OUTPUT_TO_OPT_IFACE_MASK;
+        }
+
+        if self.effect_on_inputs {
+            *quad |= CFG_DSP_EFFECT_ON_INPUT_MASK;
+        }
+
+        if self.spdif_out_format == SpdifFormat::Professional {
+            *quad |= CFG_AESEBU_OUT_PRO_MASK;
+        }
+
+        if self.word_out_single {
+            *quad |= CFG_WORD_OUT_SINGLE_MASK;
+        }
+    }
+
+    fn parse(&mut self, quad: &u32) {
+        self.midi_tx_low_offset.parse(quad);
+        self.clk_src.parse(quad);
+
+        self.spdif_in_iface = if *quad & CFG_AESEBU_INPUT_FROM_OPT_IFACE_MASK > 0 {
+            Ff802SpdifIface::Optical
+        } else {
+            Ff802SpdifIface::Xlr
+        };
+
+        self.opt_out_signal = if *quad & CFG_AESEBU_OUTPUT_TO_OPT_IFACE_MASK > 0 {
+            OpticalOutputSignal::Spdif
+        } else {
+            OpticalOutputSignal::Adat
+        };
+
+        self.effect_on_inputs = *quad & CFG_DSP_EFFECT_ON_INPUT_MASK > 0;
+        self.spdif_out_format = if *quad & CFG_AESEBU_OUT_PRO_MASK > 0 {
+            SpdifFormat::Professional
+        } else {
+            SpdifFormat::Consumer
+        };
+        self.word_out_single = *quad & CFG_WORD_OUT_SINGLE_MASK > 0;
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterConfigProtocol<T, Ff802Config> for Ff802Protocol {}

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -336,3 +336,51 @@ impl RmeFfLatterRegisterValueOperation for Ff802Status {
 }
 
 impl<T: AsRef<FwNode>> RmeFfLatterStatusProtocol<T, Ff802Status> for Ff802Protocol {}
+
+const LINE_INPUT_COUNT: usize = 8;
+const MIC_INPUT_COUNT: usize = 4;
+const SPDIF_INPUT_COUNT: usize = 2;
+const ADAT_INPUT_COUNT: usize = 16;
+const STREAM_INPUT_COUNT: usize = 30;
+
+const LINE_OUTPUT_COUNT: usize = 8;
+const HP_OUTPUT_COUNT: usize = 4;
+const SPDIF_OUTPUT_COUNT: usize = 2;
+const ADAT_OUTPUT_COUNT: usize = 16;
+
+/// The structure to represent state of meter.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Ff802MeterState(FfLatterMeterState);
+
+impl AsRef<FfLatterMeterState> for Ff802MeterState {
+    fn as_ref(&self) -> &FfLatterMeterState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterMeterState> for Ff802MeterState {
+    fn as_mut(&mut self) -> &mut FfLatterMeterState {
+        &mut self.0
+    }
+}
+
+impl RmeFfLatterMeterSpec for Ff802MeterState {
+    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
+    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
+    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for Ff802MeterState {
+    fn default() -> Self {
+        Self(Self::create_meter_state())
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, Ff802MeterState> for Ff802Protocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -5,6 +5,9 @@
 
 use hinawa::FwReq;
 
+use super::*;
+use crate::*;
+
 /// The structure to represent unique protocol for Fireface UCX.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfUcxProtocol(FwReq);
@@ -14,3 +17,119 @@ impl AsRef<FwReq> for FfUcxProtocol {
         &self.0
     }
 }
+
+// For configuration register (0x'ffff'0000'0014).
+const CFG_CLK_SRC_MASK: u32                         = 0x00000c00;
+const   CFG_CLK_SRC_WORD_CLK_FLAG: u32              = 0x00000c00;
+const   CFG_CLK_SRC_OPT_IFACE_FLAG: u32             = 0x00000800;
+const   CFG_CLK_SRC_COAX_IFACE_FLAG: u32            = 0x00000400;
+const   CFG_CLK_SRC_INTERNAL_FLAG: u32              = 0x00000000;
+const CFG_SPDIF_OUT_TO_OPT_IFACE_MASK: u32          = 0x00000100;
+const CFG_WORD_OUT_SINGLE_MASK: u32                 = 0x00000010;
+const CFG_DSP_EFFECT_ON_INPUT_MASK: u32             = 0x00000040;
+const CFG_WORD_INPUT_TERMINATE_MASK: u32        = 0x00000008;
+const CFG_SPDIF_OUT_PRO_MASK: u32                   = 0x00000020;
+
+/// The enumeration to represent source of sampling clock.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum FfUcxClkSrc {
+    Internal,
+    Coax,
+    Opt,
+    WordClk,
+}
+
+impl Default for FfUcxClkSrc {
+    fn default() -> Self {
+        Self::Internal
+    }
+}
+
+impl FfUcxClkSrc {
+    fn build(&self, quad: &mut u32) {
+        *quad |= match self {
+            Self::WordClk => CFG_CLK_SRC_WORD_CLK_FLAG,
+            Self::Opt => CFG_CLK_SRC_OPT_IFACE_FLAG,
+            Self::Coax => CFG_CLK_SRC_COAX_IFACE_FLAG,
+            Self::Internal => CFG_CLK_SRC_INTERNAL_FLAG,
+        };
+    }
+
+    fn parse(&mut self, quad: &u32) {
+        match *quad & CFG_CLK_SRC_MASK {
+            CFG_CLK_SRC_WORD_CLK_FLAG => Self::WordClk,
+            CFG_CLK_SRC_OPT_IFACE_FLAG => Self::Opt,
+            CFG_CLK_SRC_COAX_IFACE_FLAG => Self::Coax,
+            CFG_CLK_SRC_INTERNAL_FLAG => Self::Internal,
+            _ => unreachable!(),
+        };
+    }
+}
+
+/// The structure to represent unique protocol for Fireface UCX.
+#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+pub struct FfUcxConfig{
+    /// The low offset of destination address for MIDI messages.
+    midi_tx_low_offset: FfLatterMidiTxLowOffset,
+    /// The source of sampling clock.
+    pub clk_src: FfUcxClkSrc,
+    /// The type of signal to optical output interface.
+    pub opt_out_signal: OpticalOutputSignal,
+    /// Whether to fix speed to single even if at double/quadruple rate.
+    pub word_out_single: bool,
+    /// Whether to enable DSP effect on inputs.
+    pub effect_on_inputs: bool,
+    /// Whether to terminate word clock input.
+    pub word_in_terminate: bool,
+    /// For signal format of S/PDIF output.
+    pub spdif_out_format: SpdifFormat,
+}
+
+impl RmeFfLatterRegisterValueOperation for FfUcxConfig{
+    fn build(&self, quad: &mut u32) {
+        self.midi_tx_low_offset.build(quad);
+        self.clk_src.build(quad);
+
+        if self.opt_out_signal == OpticalOutputSignal::Spdif {
+            *quad |= CFG_SPDIF_OUT_TO_OPT_IFACE_MASK;
+        }
+
+        if self.word_out_single {
+            *quad |= CFG_WORD_OUT_SINGLE_MASK;
+        }
+
+        if self.effect_on_inputs {
+            *quad |= CFG_DSP_EFFECT_ON_INPUT_MASK;
+        }
+
+        if self.word_in_terminate {
+            *quad |= CFG_WORD_INPUT_TERMINATE_MASK;
+        }
+
+        if self.spdif_out_format == SpdifFormat::Professional {
+            *quad |= CFG_SPDIF_OUT_PRO_MASK;
+        }
+    }
+
+    fn parse(&mut self, quad: &u32) {
+        self.midi_tx_low_offset.parse(quad);
+        self.clk_src.parse(quad);
+
+        self.opt_out_signal = if *quad & CFG_SPDIF_OUT_TO_OPT_IFACE_MASK > 0 {
+            OpticalOutputSignal::Spdif
+        } else {
+            OpticalOutputSignal::Adat
+        };
+
+        self.word_out_single = *quad & CFG_WORD_OUT_SINGLE_MASK > 0;
+        self.effect_on_inputs = *quad & CFG_DSP_EFFECT_ON_INPUT_MASK > 0;
+        self.word_in_terminate = *quad & CFG_WORD_INPUT_TERMINATE_MASK > 0;
+        self.spdif_out_format = if *quad & CFG_SPDIF_OUT_PRO_MASK > 0 {
+            SpdifFormat::Professional
+        } else {
+            SpdifFormat::Consumer
+        };
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterConfigProtocol<T, FfUcxConfig> for FfUcxProtocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol defined by RME GmbH for Fireface UCX.
+
+use hinawa::FwReq;
+
+/// The structure to represent unique protocol for Fireface UCX.
+#[derive(Default, Debug, Clone, Eq, PartialEq)]
+pub struct FfUcxProtocol(FwReq);
+
+impl AsRef<FwReq> for FfUcxProtocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -302,3 +302,51 @@ impl RmeFfLatterRegisterValueOperation for FfUcxStatus {
 }
 
 impl<T: AsRef<FwNode>> RmeFfLatterStatusProtocol<T, FfUcxStatus> for FfUcxProtocol {}
+
+const LINE_INPUT_COUNT: usize = 6;
+const MIC_INPUT_COUNT: usize = 2;
+const SPDIF_INPUT_COUNT: usize = 2;
+const ADAT_INPUT_COUNT: usize = 8;
+const STREAM_INPUT_COUNT: usize = 18;
+
+const LINE_OUTPUT_COUNT: usize = 6;
+const HP_OUTPUT_COUNT: usize = 2;
+const SPDIF_OUTPUT_COUNT: usize = 2;
+const ADAT_OUTPUT_COUNT: usize = 8;
+
+/// The structure to represent state of meter.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FfUcxMeterState(FfLatterMeterState);
+
+impl AsRef<FfLatterMeterState> for FfUcxMeterState {
+    fn as_ref(&self) -> &FfLatterMeterState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterMeterState> for FfUcxMeterState {
+    fn as_mut(&mut self) -> &mut FfLatterMeterState {
+        &mut self.0
+    }
+}
+
+impl RmeFfLatterMeterSpec for FfUcxMeterState {
+    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
+    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
+    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for FfUcxMeterState {
+    fn default() -> Self {
+        Self(Self::create_meter_state())
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, FfUcxMeterState> for FfUcxProtocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -350,3 +350,40 @@ impl Default for FfUcxMeterState {
 }
 
 impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, FfUcxMeterState> for FfUcxProtocol {}
+
+/// The structure to represent state of DSP.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FfUcxDspState(FfLatterDspState);
+
+impl AsRef<FfLatterDspState> for FfUcxDspState {
+    fn as_ref(&self) -> &FfLatterDspState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterDspState> for FfUcxDspState {
+    fn as_mut(&mut self) -> &mut FfLatterDspState {
+        &mut self.0
+    }
+}
+
+impl RmeFfLatterDspSpec for FfUcxDspState {
+    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
+    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
+    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
+    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
+    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
+
+    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
+    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+}
+
+impl Default for FfUcxDspState {
+    fn default() -> Self {
+        Self(Self::create_dsp_state())
+    }
+}
+
+impl<T: AsRef<FwNode>> RmeFfLatterDspProtocol<T, FfUcxDspState> for FfUcxProtocol {}

--- a/libs/ff/protocols/src/lib.rs
+++ b/libs/ff/protocols/src/lib.rs
@@ -7,6 +7,7 @@
 //! series. The protocols are categorized by two generations; i.e. former and latter.
 
 pub mod former;
+pub mod latter;
 
 use ieee1212_config_rom::{*, entry::*};
 

--- a/libs/ff/protocols/src/lib.rs
+++ b/libs/ff/protocols/src/lib.rs
@@ -35,3 +35,71 @@ impl<'a> FfConfigRom for ConfigRom<'a> {
         })
     }
 }
+
+/// The enumeration to represent nominal frequency of sampling clock.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum ClkNominalRate {
+    R32000,
+    R44100,
+    R48000,
+    R64000,
+    R88200,
+    R96000,
+    R128000,
+    R176400,
+    R192000,
+}
+
+impl Default for ClkNominalRate {
+    fn default() -> Self {
+        Self::R44100
+    }
+}
+
+/// The enumeration to represent format of S/PDIF signal.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SpdifFormat {
+    Consumer,
+    Professional,
+}
+
+impl Default for SpdifFormat {
+    fn default() -> Self {
+        Self::Consumer
+    }
+}
+
+/// The enumeration to represent interface of S/PDIF signal.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum SpdifIface {
+    Coaxial,
+    Optical,
+}
+
+impl Default for SpdifIface {
+    fn default() -> Self {
+        Self::Coaxial
+    }
+}
+
+/// The structure to represent configuration of S/PDIF input.
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+pub struct SpdifInput {
+    /// The interface of S/PDIF signal.
+    pub iface: SpdifIface,
+    /// Whether to deliver preamble information by corresponding audio data channel of tx stream.
+    pub use_preemble: bool,
+}
+
+/// The enumeration to represent the type of signal to optical output interface.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum OpticalOutputSignal {
+    Adat,
+    Spdif,
+}
+
+impl Default for OpticalOutputSignal {
+    fn default() -> Self {
+        Self::Adat
+    }
+}

--- a/libs/ff/protocols/src/lib.rs
+++ b/libs/ff/protocols/src/lib.rs
@@ -103,3 +103,19 @@ impl Default for OpticalOutputSignal {
         Self::Adat
     }
 }
+
+/// The enumeration to represent nominal level of line outputs.
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LineOutNominalLevel {
+    High,
+    /// -10 dBV.
+    Consumer,
+    /// +4 dBu.
+    Professional,
+}
+
+impl Default for LineOutNominalLevel {
+    fn default() -> Self {
+        Self::High
+    }
+}

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -15,5 +15,6 @@ nix = "0.17"
 core = { path = "../../core" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
+alsa-ctl-tlv-codec = { path = "../../alsa-ctl-tlv-codec" }
 ieee1212-config-rom = { path = "../../ieee1212-config-rom" }
 ff-protocols = { path = "../protocols" }

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -15,3 +15,5 @@ nix = "0.17"
 core = { path = "../../core" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
 alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }
+ieee1212-config-rom = { path = "../../ieee1212-config-rom" }
+ff-protocols = { path = "../protocols" }

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -11,4 +11,5 @@ Implementation of service runtime for models in RME Fireface series.
 
 [dependencies]
 glib = "0.10"
+nix = "0.17"
 core = { path = "../../core" }

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -13,3 +13,4 @@ Implementation of service runtime for models in RME Fireface series.
 glib = "0.10"
 nix = "0.17"
 core = { path = "../../core" }
+hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -14,3 +14,4 @@ glib = "0.10"
 nix = "0.17"
 core = { path = "../../core" }
 hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.3.0", version = "0.3" }
+alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.2.0", version = "0.2" }

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ff-runtime"
+version = "0.1.0"
+authors = ["Takashi Sakamoto <o-takashi@sakamocchi.jp>"]
+edition = "2018"
+license = "GPL-3.0-or-later"
+publish = false
+description = """
+Implementation of service runtime for models in RME Fireface series.
+"""
+
+[dependencies]
+glib = "0.10"
+core = { path = "../../core" }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -8,11 +8,21 @@ use hinawa::SndUnit;
 
 use core::card_cntr::*;
 
+use ff_protocols::former::ff400::*;
+
+use super::former_ctls::*;
+
 #[derive(Default, Debug)]
-pub struct Ff400Model;
+pub struct Ff400Model{
+    proto: Ff400Protocol,
+    meter_ctl: FormerMeterCtl<Ff400MeterState>,
+}
+
+const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff400Model {
-    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.meter_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -30,16 +40,17 @@ impl CtlModel<SndUnit> for Ff400Model {
 }
 
 impl MeasureModel<SndUnit> for Ff400Model {
-    fn get_measure_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        self.meter_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, _: &SndUnit) -> Result<(), Error> {
-        Ok(())
+    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+        self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)
     }
 
-    fn measure_elem(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn measure_elem(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.meter_ctl.measure_elem(elem_id, elem_value)
     }
 }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
 use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
@@ -9,10 +9,13 @@ use hinawa::{SndUnit, SndUnitExt};
 use alsa_ctl_tlv_codec::items::DbInterval;
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
-use ff_protocols::former::ff400::*;
+use ff_protocols::{*, former::{*, ff400::*}};
 
 use super::former_ctls::*;
+
+use super::model::*;
 
 #[derive(Default, Debug)]
 pub struct Ff400Model{
@@ -21,6 +24,7 @@ pub struct Ff400Model{
     out_ctl: FormerOutCtl<Ff400OutputVolumeState>,
     input_gain_ctl: InputGainCtl,
     mixer_ctl: FormerMixerCtl<Ff400MixerState>,
+    cfg_ctl: CfgCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -31,6 +35,7 @@ impl CtlModel<SndUnit> for Ff400Model {
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.mixer_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.input_gain_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+        self.cfg_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -43,12 +48,14 @@ impl CtlModel<SndUnit> for Ff400Model {
             Ok(true)
         } else if self.input_gain_ctl.read(elem_id, elem_value)? {
             Ok(true)
+        } else if self.cfg_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
@@ -56,6 +63,8 @@ impl CtlModel<SndUnit> for Ff400Model {
         } else if self.mixer_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.input_gain_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.cfg_ctl.write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -156,6 +165,433 @@ impl<'a> InputGainCtl {
                     .collect();
                 proto.write_input_line_gains(&unit.get_node(), &mut self.status, &gains, timeout_ms)
                     .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+fn clk_src_to_string(src: &Ff400ClkSrc) -> String {
+    match src {
+        Ff400ClkSrc::Internal => "Internal",
+        Ff400ClkSrc::WordClock => "Word-clock",
+        Ff400ClkSrc::Adat => "ADAT",
+        Ff400ClkSrc::Spdif => "S/PDIF",
+        Ff400ClkSrc::Ltc => "LTC",
+    }.to_string()
+}
+
+fn update_cfg<F>(unit: &SndUnit, proto: &Ff400Protocol, cfg: &mut Ff400Config, timeout_ms: u32, cb: F)
+    -> Result<(), Error>
+    where F: Fn(&mut Ff400Config) -> Result<(), Error>,
+{
+    let mut cache = cfg.clone();
+    cb(&mut cache)?;
+    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+        .map(|_| *cfg = cache)
+}
+
+#[derive(Default, Debug)]
+struct CfgCtl(Ff400Config);
+
+impl<'a> CfgCtl {
+    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
+    const LINE_INPUT_LEVEL_NAME: &'a str = "line-input-level";
+    const MIC_POWER_NAME: &'a str = "mic-1/2-powering";
+    const LINE_INST_NAME: &'a str = "line-3/4-inst";
+    const LINE_PAD_NAME: &'a str = "line-3/4-pad";
+    const LINE_OUTPUT_LEVEL_NAME: &'a str = "line-output-level";
+    const HP_OUTPUT_LEVEL_NAME: &'a str = "headphone-output-level";
+    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
+    const SPDIF_INPUT_USE_PREEMBLE_NAME: &'a str = "spdif-input-use-preemble";
+    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
+    const SPDIF_OUTPUT_EMPHASIS_NAME: &'a str = "spdif-output-emphasis";
+    const SPDIF_OUTPUT_NON_AUDIO_NAME: &'a str = "spdif-output-non-audio";
+    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
+    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+
+    const CLK_SRCS: [Ff400ClkSrc;5] = [
+        Ff400ClkSrc::Internal,
+        Ff400ClkSrc::WordClock,
+        Ff400ClkSrc::Adat,
+        Ff400ClkSrc::Spdif,
+        Ff400ClkSrc::Ltc,
+    ];
+
+    const LINE_INPUT_LEVELS: [FormerLineInNominalLevel;3] = [
+        FormerLineInNominalLevel::Low,
+        FormerLineInNominalLevel::Consumer,
+        FormerLineInNominalLevel::Professional,
+    ];
+
+    const LINE_OUTPUT_LEVELS: [LineOutNominalLevel;3] = [
+        LineOutNominalLevel::High,
+        LineOutNominalLevel::Consumer,
+        LineOutNominalLevel::Professional,
+    ];
+
+    const SPDIF_IFACES: [SpdifIface;2] = [
+        SpdifIface::Coaxial,
+        SpdifIface::Optical,
+    ];
+
+    const SPDIF_FMTS: [SpdifFormat;2] = [
+        SpdifFormat::Consumer,
+        SpdifFormat::Professional,
+    ];
+
+    const OPT_OUT_SIGNALS: [OpticalOutputSignal;2] = [
+        OpticalOutputSignal::Adat,
+        OpticalOutputSignal::Spdif,
+    ];
+
+    fn load(&mut self, unit: &SndUnit, proto: &Ff400Protocol, card_cntr: &mut CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+
+        let labels: Vec<String> = Self::CLK_SRCS.iter()
+            .map(|s| clk_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::LINE_INPUT_LEVELS.iter()
+            .map(|l| former_line_in_nominal_level_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_INPUT_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_POWER_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_INST_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_PAD_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
+
+        let labels: Vec<String> = Self::LINE_OUTPUT_LEVELS.iter()
+            .map(|l| line_out_nominal_level_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_OUTPUT_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::HP_OUTPUT_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_IFACES.iter()
+            .map(|i| spdif_iface_to_string(i))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_FMTS.iter()
+            .map(|f| spdif_format_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
+            .map(|f| optical_output_signal_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_IFACES.iter()
+            .map(|i| spdif_iface_to_string(i))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_FMTS.iter()
+            .map(|f| spdif_format_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
+            .map(|f| optical_output_signal_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                let pos = Self::CLK_SRCS.iter()
+                    .position(|s| s.eq(&self.0.clk.primary_src))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::LINE_INPUT_LEVEL_NAME => {
+                let pos = Self::LINE_INPUT_LEVELS.iter()
+                    .position(|l| l.eq(&self.0.analog_in.line_level))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::MIC_POWER_NAME => {
+                elem_value.set_bool(&self.0.analog_in.phantom_powering);
+                Ok(true)
+            }
+            Self::LINE_INST_NAME => {
+                elem_value.set_bool(&self.0.analog_in.insts);
+                Ok(true)
+            }
+            Self::LINE_PAD_NAME => {
+                elem_value.set_bool(&self.0.analog_in.pad);
+                Ok(true)
+            }
+            Self::LINE_OUTPUT_LEVEL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::LINE_OUTPUT_LEVELS.iter()
+                        .position(|l| l.eq(&self.0.line_out_level))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::HP_OUTPUT_LEVEL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::LINE_OUTPUT_LEVELS.iter()
+                        .position(|l| l.eq(&self.0.line_out_level))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_IFACES.iter()
+                        .position(|i| i.eq(&self.0.spdif_in.iface))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+                elem_value.set_bool(&[self.0.spdif_in.use_preemble]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_FMTS.iter()
+                        .position(|f| f.eq(&self.0.spdif_out.format))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+                elem_value.set_bool(&[self.0.spdif_out.emphasis]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+                elem_value.set_bool(&[self.0.spdif_out.non_audio]);
+                Ok(true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::OPT_OUT_SIGNALS.iter()
+                        .position(|f| f.eq(&self.0.opt_out_signal))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                elem_value.set_bool(&[self.0.word_out_single]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndUnit, proto: &Ff400Protocol, elem_id: &ElemId,
+             _: &alsactl::ElemValue, new: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    Self::CLK_SRCS.iter()
+                        .nth(val as usize)
+                        .ok_or_else(|| {
+                            let msg = format!("Invalid value for index of clock source: {}", val);
+                            Error::new(FileError::Inval, &msg)
+                        })
+                        .and_then(|&src| {
+                            update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| Ok(cfg.clk.primary_src = src))
+                        })
+                })
+                .map(|_| true)
+            }
+            Self::LINE_INPUT_LEVEL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::LINE_INPUT_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of line input level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| cfg.analog_in.line_level = l)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::MIC_POWER_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    Ok(new.get_bool(&mut cfg.analog_in.phantom_powering))
+                })
+                .map(|_| true)
+            }
+            Self::LINE_INST_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    Ok(new.get_bool(&mut cfg.analog_in.insts))
+                })
+                .map(|_| true)
+            }
+            Self::LINE_PAD_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    Ok(new.get_bool(&mut cfg.analog_in.pad))
+                })
+                .map(|_| true)
+            }
+            Self::LINE_OUTPUT_LEVEL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::LINE_OUTPUT_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of line output level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| cfg.line_out_level = l)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::HP_OUTPUT_LEVEL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::LINE_OUTPUT_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of line output level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| cfg.line_out_level = l)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::SPDIF_IFACES.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF iface: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&i| cfg.spdif_in.iface = i)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_in.use_preemble = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::SPDIF_FMTS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF format: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&f| cfg.spdif_out.format = f)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_out.emphasis = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_out.non_audio = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::OPT_OUT_SIGNALS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of optical output signal: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&s| cfg.opt_out_signal = s)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.word_out_single = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
             }
             _ => Ok(false),
         }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -17,6 +17,7 @@ pub struct Ff400Model{
     proto: Ff400Protocol,
     meter_ctl: FormerMeterCtl<Ff400MeterState>,
     out_ctl: FormerOutCtl<Ff400OutputVolumeState>,
+    mixer_ctl: FormerMixerCtl<Ff400MixerState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -25,6 +26,7 @@ impl CtlModel<SndUnit> for Ff400Model {
     fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+        self.mixer_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -32,6 +34,8 @@ impl CtlModel<SndUnit> for Ff400Model {
         -> Result<bool, Error>
     {
         if self.out_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -42,6 +46,8 @@ impl CtlModel<SndUnit> for Ff400Model {
         -> Result<bool, Error>
     {
         if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -16,6 +16,7 @@ use super::former_ctls::*;
 pub struct Ff400Model{
     proto: Ff400Protocol,
     meter_ctl: FormerMeterCtl<Ff400MeterState>,
+    out_ctl: FormerOutCtl<Ff400OutputVolumeState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -23,19 +24,28 @@ const TIMEOUT_MS: u32 = 100;
 impl CtlModel<SndUnit> for Ff400Model {
     fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+        self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.out_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -2,9 +2,11 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::Error;
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
-use hinawa::SndUnit;
+use hinawa::{SndUnit, SndUnitExt};
+
+use alsa_ctl_tlv_codec::items::DbInterval;
 
 use core::card_cntr::*;
 
@@ -17,6 +19,7 @@ pub struct Ff400Model{
     proto: Ff400Protocol,
     meter_ctl: FormerMeterCtl<Ff400MeterState>,
     out_ctl: FormerOutCtl<Ff400OutputVolumeState>,
+    input_gain_ctl: InputGainCtl,
     mixer_ctl: FormerMixerCtl<Ff400MixerState>,
 }
 
@@ -27,6 +30,7 @@ impl CtlModel<SndUnit> for Ff400Model {
         self.meter_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.mixer_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+        self.input_gain_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -36,6 +40,8 @@ impl CtlModel<SndUnit> for Ff400Model {
         if self.out_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_gain_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -48,6 +54,8 @@ impl CtlModel<SndUnit> for Ff400Model {
         if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.mixer_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.input_gain_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -68,5 +76,88 @@ impl MeasureModel<SndUnit> for Ff400Model {
         -> Result<bool, Error>
     {
         self.meter_ctl.measure_elem(elem_id, elem_value)
+    }
+}
+
+#[derive(Default, Debug)]
+struct InputGainCtl{
+    status: Ff400InputGainStatus,
+}
+
+impl<'a> InputGainCtl {
+    const MIC_GAIN_NAME: &'a str = "mic-input-gain";
+    const LINE_GAIN_NAME: &'a str = "line-input-gain";
+
+    const MIC_GAIN_MIN: i32 = 0;
+    const MIC_GAIN_MAX: i32 = 65;
+    const MIC_GAIN_STEP: i32 = 1;
+    const MIC_GAIN_TLV: DbInterval = DbInterval{min: 0, max: 6500, linear: false, mute_avail: false};
+
+    const LINE_GAIN_MIN: i32 = 0;
+    const LINE_GAIN_MAX: i32 = 36;
+    const LINE_GAIN_STEP: i32 = 1;
+    const LINE_GAIN_TLV: DbInterval = DbInterval{min: 0, max: 18000, linear: false, mute_avail: false};
+
+    fn load(&mut self, unit: &SndUnit, proto: &Ff400Protocol, card_cntr: &mut CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.init_input_gains(&unit.get_node(), &mut self.status, timeout_ms)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_GAIN_NAME, 0);
+        card_cntr.add_int_elems(&elem_id, 1, Self::MIC_GAIN_MIN, Self::MIC_GAIN_MAX, Self::MIC_GAIN_STEP,
+                                2, Some(&Vec::<u32>::from(&Self::MIC_GAIN_TLV)), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_GAIN_NAME, 0);
+        card_cntr.add_int_elems(&elem_id, 1, Self::LINE_GAIN_MIN, Self::LINE_GAIN_MAX, Self::LINE_GAIN_STEP,
+                                2, Some(&Vec::<u32>::from(&Self::LINE_GAIN_TLV)), true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::MIC_GAIN_NAME => {
+                let vals: Vec<i32> = self.status.mic.iter()
+                    .map(|&gain| gain as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::LINE_GAIN_NAME => {
+                let vals: Vec<i32> = self.status.line.iter()
+                    .map(|&gain| gain as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndUnit, proto: &Ff400Protocol, elem_id: &ElemId,
+             elem_value: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::MIC_GAIN_NAME => {
+                let mut vals = [0;2];
+                elem_value.get_int(&mut vals);
+                let gains: Vec<i8> = vals.iter()
+                    .map(|&val| val as i8)
+                    .collect();
+                proto.write_input_mic_gains(&unit.get_node(), &mut self.status, &gains, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::LINE_GAIN_NAME => {
+                let mut vals = [0;2];
+                elem_value.get_int(&mut vals);
+                let gains: Vec<i8> = vals.iter()
+                    .map(|&val| val as i8)
+                    .collect();
+                proto.write_input_line_gains(&unit.get_node(), &mut self.status, &gains, timeout_ms)
+                    .map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::SndUnit;
+
+use core::card_cntr::*;
+
+#[derive(Default, Debug)]
+pub struct Ff400Model;
+
+impl CtlModel<SndUnit> for Ff400Model {
+    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<SndUnit> for Ff400Model {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -21,6 +21,7 @@ pub struct Ff800Model{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     out_ctl: FormerOutCtl<Ff800OutputVolumeState>,
+    mixer_ctl: FormerMixerCtl<Ff800MixerState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -30,6 +31,7 @@ impl CtlModel<SndUnit> for Ff800Model {
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.cfg_ctl.load(unit, &self.proto, &self.status_ctl.status, card_cntr, TIMEOUT_MS)?;
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+        self.mixer_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -40,6 +42,8 @@ impl CtlModel<SndUnit> for Ff800Model {
         if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -52,6 +56,8 @@ impl CtlModel<SndUnit> for Ff800Model {
         if self.cfg_ctl.write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.mixer_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -1,30 +1,504 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
-use hinawa::SndUnit;
+use hinawa::{SndUnit, SndUnitExt};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
+
+use super::model::*;
+
+use ff_protocols::{*, former::{*, ff800::*}};
 
 #[derive(Default, Debug)]
-pub struct Ff800Model;
+pub struct Ff800Model{
+    proto: Ff800Protocol,
+    cfg_ctl: CfgCtl,
+}
+
+const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff800Model {
-    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.cfg_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
+
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.read(elem_id, elem_value)
     }
 
-    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)
+    }
+}
+
+fn update_cfg<F>(unit: &SndUnit, proto: &Ff800Protocol, cfg: &mut Ff800Config, timeout_ms: u32, cb: F)
+    -> Result<(), Error>
+    where F: Fn(&mut Ff800Config) -> Result<(), Error>,
+{
+    let mut cache = cfg.clone();
+    cb(&mut cache)?;
+    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+        .map(|_| *cfg = cache)
+}
+
+fn clk_src_to_string(src: &Ff800ClkSrc) -> String {
+    match src {
+        Ff800ClkSrc::Internal => "Internal",
+        Ff800ClkSrc::WordClock => "Word-clock",
+        Ff800ClkSrc::AdatA => "ADAT-A",
+        Ff800ClkSrc::AdatB => "ADAT-B",
+        Ff800ClkSrc::Spdif => "S/PDIF",
+        Ff800ClkSrc::Tco => "TCO",
+    }.to_string()
+}
+
+fn line_in_jack_to_string(jack: &Ff800AnalogInputJack) -> String {
+    match jack {
+        Ff800AnalogInputJack::Front => "Front",
+        Ff800AnalogInputJack::Rear => "Rear",
+        Ff800AnalogInputJack::FrontRear => "Front+Rear",
+    }.to_string()
+}
+
+#[derive(Default, Debug)]
+struct CfgCtl(cfg: Ff800Config);
+
+impl<'a> CfgCtl {
+    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
+    const INPUT_JACK_NAME: &'a str = "input-1/7/8-jack";
+    const INPUT_LINE_LEVEL_NAME: &'a str = "input-line-level";
+    const INPUT_POWER_NAME: &'a str = "input-7/8/9/10-powering";
+    const INPUT_INST_DRIVE_NAME: &'a str = "input-1-inst-drive";
+    const INPUT_INST_LIMITTER_NAME: &'a str = "input-1-inst-limitter";
+    const INPUT_INST_SPKR_EMU_NAME: &'a str = "input-1-inst-speaker-emu";
+    const OUTPUT_LINE_LEVEL_NAME: &'a str = "output-line-level";
+    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
+    const SPDIF_INPUT_USE_PREEMBLE_NAME: &'a str = "spdif-input-use-preemble";
+    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
+    const SPDIF_OUTPUT_EMPHASIS_NAME: &'a str = "spdif-output-emphasis";
+    const SPDIF_OUTPUT_NON_AUDIO_NAME: &'a str = "spdif-output-non-audio";
+    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
+    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+
+    const CLK_SRCS: [Ff800ClkSrc;6] = [
+        Ff800ClkSrc::Internal,
+        Ff800ClkSrc::WordClock,
+        Ff800ClkSrc::AdatA,
+        Ff800ClkSrc::AdatB,
+        Ff800ClkSrc::Spdif,
+        Ff800ClkSrc::Tco,
+    ];
+
+    const INPUT_INPUT_JACK_TARGETS: [&'a str;3] = [
+        "analog-1",
+        "analog-7",
+        "analog-8",
+    ];
+
+    const INPUT_POWER_TARGETS: [&'a str;4] = [
+        "analog-7",
+        "analog-8",
+        "analog-9",
+        "analog-10",
+    ];
+
+    const INPUT_JACKS: [Ff800AnalogInputJack;3] = [
+        Ff800AnalogInputJack::Front,
+        Ff800AnalogInputJack::Rear,
+        Ff800AnalogInputJack::FrontRear,
+    ];
+
+    const INPUT_LINE_LEVELS: [FormerLineInNominalLevel;3] = [
+        FormerLineInNominalLevel::Low,
+        FormerLineInNominalLevel::Consumer,
+        FormerLineInNominalLevel::Professional,
+    ];
+
+    const OUTPUT_LINE_LEVELS: [LineOutNominalLevel;3] = [
+        LineOutNominalLevel::High,
+        LineOutNominalLevel::Consumer,
+        LineOutNominalLevel::Professional,
+    ];
+
+    const SPDIF_IFACES: [SpdifIface;2] = [
+        SpdifIface::Coaxial,
+        SpdifIface::Optical,
+    ];
+
+    const SPDIF_FMTS: [SpdifFormat;2] = [
+        SpdifFormat::Consumer,
+        SpdifFormat::Professional,
+    ];
+
+    const OPT_OUT_SIGNALS: [OpticalOutputSignal;2] = [
+        OpticalOutputSignal::Adat,
+        OpticalOutputSignal::Spdif,
+    ];
+
+    fn load(&mut self, unit: &SndUnit, proto: &Ff800Protocol, card_cntr: &mut CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        let node = unit.get_node();
+
+        //proto.read_status(&node, &mut self.status, timeout_ms)?;
+        //self.cfg.init(&self.status);
+        proto.write_cfg(&node, &self.0, timeout_ms)?;
+
+        let labels: Vec<String> = Self::CLK_SRCS.iter()
+            .map(|s| clk_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::INPUT_JACKS.iter()
+            .map(|l| line_in_jack_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_JACK_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, Self::INPUT_INPUT_JACK_TARGETS.len(), &labels,
+                                         None, true)?;
+
+        let labels: Vec<String> = Self::INPUT_LINE_LEVELS.iter()
+            .map(|l| former_line_in_nominal_level_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_LINE_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_POWER_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::INPUT_POWER_TARGETS.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_DRIVE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_LIMITTER_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_SPKR_EMU_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::OUTPUT_LINE_LEVELS.iter()
+            .map(|l| line_out_nominal_level_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OUTPUT_LINE_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_IFACES.iter()
+            .map(|i| spdif_iface_to_string(i))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_FMTS.iter()
+            .map(|f| spdif_format_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
+            .map(|f| optical_output_signal_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::CLK_SRCS.iter()
+                        .position(|s| s.eq(&self.0.clk.primary_src))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_JACK_NAME => {
+                ElemValueAccessor::<u32>::set_vals(elem_value, 3, |idx| {
+                    let pos = Self::INPUT_JACKS.iter()
+                        .position(|j| j.eq(&self.0.analog_in.jacks[idx]))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_LINE_LEVEL_NAME => {
+                let pos = Self::INPUT_LINE_LEVELS.iter()
+                    .position(|l| l.eq(&self.0.analog_in.line_level))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::INPUT_POWER_NAME => {
+                elem_value.set_bool(&self.0.analog_in.phantom_powering);
+                Ok(true)
+            }
+            Self::INPUT_INST_DRIVE_NAME => {
+                elem_value.set_bool(&[self.0.analog_in.inst.drive]);
+                Ok(true)
+            }
+            Self::INPUT_INST_LIMITTER_NAME => {
+                elem_value.set_bool(&[self.0.analog_in.inst.limitter]);
+                Ok(true)
+            }
+            Self::INPUT_INST_SPKR_EMU_NAME => {
+                elem_value.set_bool(&[self.0.analog_in.inst.speaker_emulation]);
+                Ok(true)
+            }
+            Self::OUTPUT_LINE_LEVEL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::OUTPUT_LINE_LEVELS.iter()
+                        .position(|l| l.eq(&self.0.line_out_level))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_IFACES.iter()
+                        .position(|i| i.eq(&self.0.spdif_in.iface))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+                elem_value.set_bool(&[self.0.spdif_in.use_preemble]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_FMTS.iter()
+                        .position(|f| f.eq(&self.0.spdif_out.format))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+                elem_value.set_bool(&[self.0.spdif_out.emphasis]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+                elem_value.set_bool(&[self.0.spdif_out.non_audio]);
+                Ok(true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::OPT_OUT_SIGNALS.iter()
+                        .position(|f| f.eq(&self.0.opt_out_signal))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                elem_value.set_bool(&[self.0.word_out_single]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndUnit, proto: &Ff800Protocol, elem_id: &ElemId,
+             old: &alsactl::ElemValue, new: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        let src = Self::CLK_SRCS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of clock source: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })?;
+                        cfg.clk.primary_src = *src;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_JACK_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_vals(new, old, 3, |idx, val| {
+                        let jack = Self::INPUT_JACKS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of jack: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })?;
+                        cfg.analog_in.jacks[idx] = *jack;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_LINE_LEVEL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::INPUT_LINE_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of line input level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| cfg.analog_in.line_level = l)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_POWER_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    new.get_bool(&mut cfg.analog_in.phantom_powering);
+                    Ok(())
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_INST_DRIVE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.analog_in.inst.drive = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_INST_LIMITTER_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.analog_in.inst.limitter = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::INPUT_INST_SPKR_EMU_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.analog_in.inst.speaker_emulation = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::OUTPUT_LINE_LEVEL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::OUTPUT_LINE_LEVELS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of line output level: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| cfg.line_out_level = l)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::SPDIF_IFACES.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF iface: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&i| cfg.spdif_in.iface = i)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_in.use_preemble = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::SPDIF_FMTS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF format: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&f| cfg.spdif_out.format = f)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_out.emphasis = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.spdif_out.non_audio = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(new, |val| {
+                        Self::OPT_OUT_SIGNALS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of optical output signal: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&s| cfg.opt_out_signal = s)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(new, |val| {
+                        cfg.word_out_single = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::SndUnit;
+
+use core::card_cntr::*;
+
+#[derive(Default, Debug)]
+pub struct Ff800Model;
+
+impl CtlModel<SndUnit> for Ff800Model {
+    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -1,35 +1,42 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExtManual};
 
-use hinawa::SndUnit;
+use hinawa::{SndUnit, SndUnitExt};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
-use ff_protocols::latter::ff802::*;
+use ff_protocols::{*, latter::{*, ff802::*}};
+
+use super::model::*;
 
 #[derive(Default, Debug)]
 pub struct Ff802Model{
     proto: Ff802Protocol,
+    cfg_ctl: CfgCtl,
 }
 
+const TIMEOUT_MS: u32 = 100;
+
 impl CtlModel<SndUnit> for Ff802Model {
-    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.read(elem_id, elem_value)
     }
 
-    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)
     }
 }
 
@@ -45,5 +52,239 @@ impl MeasureModel<SndUnit> for Ff802Model {
         -> Result<bool, Error>
     {
         Ok(false)
+    }
+}
+
+fn clk_src_to_string(src: &Ff802ClkSrc) -> String {
+    match src {
+        Ff802ClkSrc::Internal => "Internal",
+        Ff802ClkSrc::AdatA => "ADAT-A",
+        Ff802ClkSrc::AdatB => "ADAT-B",
+        Ff802ClkSrc::AesEbu => "AES/EBU",
+        Ff802ClkSrc::WordClk => "Word-clock",
+    }.to_string()
+}
+
+fn ff802_spdif_iface_to_string(iface: &Ff802SpdifIface) -> String {
+    match iface {
+        Ff802SpdifIface::Xlr => "XLR",
+        Ff802SpdifIface::Optical => "Optical",
+    }.to_string()
+}
+
+fn update_cfg<F>(unit: &SndUnit, proto: &Ff802Protocol, cfg: &mut Ff802Config, timeout_ms: u32, cb: F)
+    -> Result<(), Error>
+    where F: Fn(&mut Ff802Config) -> Result<(), Error>,
+{
+    let mut cache = cfg.clone();
+    cb(&mut cache)?;
+    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+        .map(|_| *cfg = cache)
+}
+
+#[derive(Default, Debug)]
+struct CfgCtl(Ff802Config);
+
+impl<'a> CfgCtl {
+    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
+    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
+    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
+    const EFFECT_ON_INPUT_NAME: &'a str = "effect-on-input";
+    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
+    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+
+    const SPDIF_IFACES: [Ff802SpdifIface;2] = [
+        Ff802SpdifIface::Xlr,
+        Ff802SpdifIface::Optical,
+    ];
+
+    const CLK_SRCS: [Ff802ClkSrc;5] = [
+        Ff802ClkSrc::Internal,
+        Ff802ClkSrc::AdatA,
+        Ff802ClkSrc::AdatB,
+        Ff802ClkSrc::AesEbu,
+        Ff802ClkSrc::WordClk,
+    ];
+
+    const OPT_OUT_SIGNALS: [OpticalOutputSignal;2] = [
+        OpticalOutputSignal::Adat,
+        OpticalOutputSignal::Spdif,
+    ];
+
+    const SPDIF_FMTS: [SpdifFormat;2] = [
+        SpdifFormat::Consumer,
+        SpdifFormat::Professional,
+    ];
+
+    fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+
+        let labels: Vec<String> = Self::CLK_SRCS.iter()
+            .map(|s| clk_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_IFACES.iter()
+            .map(|i| ff802_spdif_iface_to_string(i))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
+            .map(|f| optical_output_signal_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::EFFECT_ON_INPUT_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_FMTS.iter()
+            .map(|f| spdif_format_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::CLK_SRCS.iter()
+                        .position(|s| s.eq(&self.0.clk_src))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_IFACES.iter()
+                        .position(|i| i.eq(&self.0.spdif_in_iface))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::OPT_OUT_SIGNALS.iter()
+                        .position(|f| f.eq(&self.0.opt_out_signal))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::EFFECT_ON_INPUT_NAME => {
+                elem_value.set_bool(&[self.0.effect_on_inputs]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_FMTS.iter()
+                        .position(|f| f.eq(&self.0.spdif_out_format))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                elem_value.set_bool(&[self.0.word_out_single]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndUnit, proto: &Ff802Protocol, elem_id: &ElemId,
+             elem_value: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        let src = Self::CLK_SRCS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of clock source: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })?;
+                        cfg.clk_src = *src;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_INPUT_IFACE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        Self::SPDIF_IFACES.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF iface: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&i| cfg.spdif_in_iface = i)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        Self::OPT_OUT_SIGNALS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of optical output signal: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&s| cfg.opt_out_signal = s)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::EFFECT_ON_INPUT_NAME => {
+                let mut vals = [false];
+                elem_value.get_bool(&mut vals);
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    cfg.effect_on_inputs = vals[0];
+                    Ok(())
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        Self::SPDIF_FMTS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF format: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&f| cfg.spdif_out_format = f)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(elem_value, |val| {
+                        cfg.word_out_single = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -13,11 +13,14 @@ use ff_protocols::{*, latter::{*, ff802::*}};
 
 use super::model::*;
 
+use super::latter_ctls::*;
+
 #[derive(Default, Debug)]
 pub struct Ff802Model{
     proto: Ff802Protocol,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
+    meter_ctl: FfLatterMeterCtl<Ff802MeterState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -26,13 +29,18 @@ impl CtlModel<SndUnit> for Ff802Model {
     fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
+        self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
     fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.cfg_ctl.read(elem_id, elem_value)
+        if self.cfg_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
@@ -45,16 +53,25 @@ impl CtlModel<SndUnit> for Ff802Model {
 impl MeasureModel<SndUnit> for Ff802Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
+        self.meter_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
-        self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)
+        self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
+        self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
+        Ok(())
     }
 
     fn measure_elem(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.status_ctl.read_measured_elem(elem_id, elem_value)
+        if self.status_ctl.read_measured_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read_measured_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -21,6 +21,7 @@ pub struct Ff802Model{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: FfLatterMeterCtl<Ff802MeterState>,
+    dsp_ctl: FfLatterDspCtl<Ff802DspState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -30,6 +31,7 @@ impl CtlModel<SndUnit> for Ff802Model {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
+        self.dsp_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
@@ -37,6 +39,8 @@ impl CtlModel<SndUnit> for Ff802Model {
         -> Result<bool, Error>
     {
         if self.cfg_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -46,7 +50,13 @@ impl CtlModel<SndUnit> for Ff802Model {
     fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)
+        if self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.dsp_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::SndUnit;
+
+use core::card_cntr::*;
+
+use ff_protocols::latter::ff802::*;
+
+#[derive(Default, Debug)]
+pub struct Ff802Model{
+    proto: Ff802Protocol,
+}
+
+impl CtlModel<SndUnit> for Ff802Model {
+    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<SndUnit> for Ff802Model {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExtManual};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use hinawa::{SndUnit, SndUnitExt};
 
@@ -17,6 +17,7 @@ use super::model::*;
 pub struct Ff802Model{
     proto: Ff802Protocol,
     cfg_ctl: CfgCtl,
+    status_ctl: StatusCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -24,6 +25,7 @@ const TIMEOUT_MS: u32 = 100;
 impl CtlModel<SndUnit> for Ff802Model {
     fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
+        self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
@@ -41,17 +43,18 @@ impl CtlModel<SndUnit> for Ff802Model {
 }
 
 impl MeasureModel<SndUnit> for Ff802Model {
-    fn get_measure_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, _: &SndUnit) -> Result<(), Error> {
-        Ok(())
+    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+        self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)
     }
 
-    fn measure_elem(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn measure_elem(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.status_ctl.read_measured_elem(elem_id, elem_value)
     }
 }
 
@@ -104,6 +107,18 @@ impl<'a> CfgCtl {
         Ff802ClkSrc::AdatB,
         Ff802ClkSrc::AesEbu,
         Ff802ClkSrc::WordClk,
+    ];
+
+    const CLK_RATES: [ClkNominalRate;9] = [
+        ClkNominalRate::R32000,
+        ClkNominalRate::R44100,
+        ClkNominalRate::R48000,
+        ClkNominalRate::R64000,
+        ClkNominalRate::R88200,
+        ClkNominalRate::R96000,
+        ClkNominalRate::R128000,
+        ClkNominalRate::R176400,
+        ClkNominalRate::R192000,
     ];
 
     const OPT_OUT_SIGNALS: [OpticalOutputSignal;2] = [
@@ -283,6 +298,141 @@ impl<'a> CfgCtl {
                     })
                 })
                 .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct StatusCtl{
+    status: Ff802Status,
+    measured_elem_list: Vec<ElemId>,
+}
+
+impl<'a> StatusCtl {
+    const EXT_SRC_LOCK_NAME: &'a str = "external-source-lock";
+    const EXT_SRC_SYNC_NAME: &'a str = "external-source-sync";
+    const EXT_SRC_RATE_NAME: &'a str = "external-source-rate";
+    const ACTIVE_CLK_RATE_NAME: &'a str = "active-clock-rate";
+    const ACTIVE_CLK_SRC_NAME: &'a str = "active-clock-source";
+
+    const EXT_CLK_SRCS: [Ff802ClkSrc;4] = [
+        Ff802ClkSrc::AdatA,
+        Ff802ClkSrc::AdatB,
+        Ff802ClkSrc::AesEbu,
+        Ff802ClkSrc::WordClk,
+    ];
+
+    const EXT_CLK_RATES: [Option<ClkNominalRate>;10] = [
+        None,
+        Some(ClkNominalRate::R32000),
+        Some(ClkNominalRate::R44100),
+        Some(ClkNominalRate::R48000),
+        Some(ClkNominalRate::R64000),
+        Some(ClkNominalRate::R88200),
+        Some(ClkNominalRate::R96000),
+        Some(ClkNominalRate::R128000),
+        Some(ClkNominalRate::R176400),
+        Some(ClkNominalRate::R192000),
+    ];
+
+    fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)?;
+
+        [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
+            .try_for_each(|name| {
+                let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
+                card_cntr.add_bool_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), false)
+                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+            })?;
+
+        let labels: Vec<String> = Self::EXT_CLK_RATES.iter()
+            .map(|r| optional_clk_nominal_rate_to_string(r))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::EXT_SRC_RATE_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), &labels, None, false)
+            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+
+        let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
+            .map(|r| clk_src_to_string(r))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_SRC_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
+            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+
+        let labels: Vec<String> = CfgCtl::CLK_RATES.iter()
+            .map(|r| clk_nominal_rate_to_string(r))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_RATE_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
+            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+
+        Ok(())
+    }
+
+    fn measure_states(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32)
+        -> Result<(), Error>
+    {
+        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)
+    }
+
+    fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::EXT_SRC_LOCK_NAME => {
+                let vals = [
+                    self.status.ext_lock.adat_a,
+                    self.status.ext_lock.adat_b,
+                    self.status.ext_lock.spdif,
+                    self.status.ext_lock.word_clk,
+                ];
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::EXT_SRC_SYNC_NAME => {
+                let vals = [
+                    self.status.ext_sync.adat_a,
+                    self.status.ext_sync.adat_b,
+                    self.status.ext_sync.spdif,
+                    self.status.ext_sync.word_clk,
+                ];
+                elem_value.set_bool(&vals);
+                Ok(true)
+            }
+            Self::EXT_SRC_RATE_NAME => {
+                let vals: Vec<u32> = [
+                    self.status.ext_rate.adat_a,
+                    self.status.ext_rate.adat_b,
+                    self.status.ext_rate.spdif,
+                    self.status.ext_rate.word_clk,
+                ].iter()
+                    .map(|rate| {
+                        Self::EXT_CLK_RATES.iter()
+                            .position(|r| r.eq(rate))
+                            .map(|pos| pos as u32)
+                            .unwrap()
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::ACTIVE_CLK_SRC_NAME => {
+                let pos = CfgCtl::CLK_SRCS.iter()
+                    .position(|r| r.eq(&self.status.active_clk_src))
+                    .map(|p| p as u32)
+                    .unwrap();
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            Self::ACTIVE_CLK_RATE_NAME => {
+                let pos = CfgCtl::CLK_RATES.iter()
+                    .position(|r| r.eq(&self.status.active_clk_rate))
+                    .map(|p| p as u32)
+                    .unwrap();
+                elem_value.set_enum(&[pos]);
+                Ok(true)
             }
             _ => Ok(false),
         }

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
+use hinawa::{FwNode, SndUnit, SndUnitExt};
+
+use alsa_ctl_tlv_codec::items::DbInterval;
+
+use core::card_cntr::*;
+
+use ff_protocols::former::*;
+
+const VOL_MIN: i32 = 0x00000000;
+const VOL_ZERO: i32 = 0x00008000;
+const VOL_MAX: i32 = 0x00010000;
+const VOL_STEP: i32 = 1;
+const VOL_TLV: DbInterval = DbInterval{min: -9000, max: 600, linear: false, mute_avail: false};
+
+#[derive(Default, Debug)]
+pub struct FormerOutCtl<V>
+    where V: AsRef<[i32]> + AsMut<[i32]>,
+{
+    state: V,
+}
+
+impl<'a, V> FormerOutCtl<V>
+    where V: AsRef<[i32]> + AsMut<[i32]>,
+{
+    const VOL_NAME: &'a str = "output-volume";
+
+    pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, card_cntr: &mut CardCntr, timeout_ms: u32)
+        -> Result<(), Error>
+        where U: RmeFormerOutputProtocol<FwNode, V>,
+              V: AsRef<[i32]> + AsMut<[i32]>,
+    {
+        self.state.as_mut().iter_mut()
+            .for_each(|vol| *vol = VOL_ZERO);
+        proto.init_output_vols(&unit.get_node(), &self.state, timeout_ms)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::VOL_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1, VOL_MIN, VOL_MAX, VOL_STEP,
+                                        self.state.as_ref().len(), Some(&Vec::<u32>::from(&VOL_TLV)), true)?;
+
+        Ok(())
+    }
+
+    pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::VOL_NAME => {
+                elem_value.set_int(&self.state.as_ref());
+                Ok(true)
+            },
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write<U>(&mut self, unit: &SndUnit, proto: &U, elem_id: &ElemId, new: &alsactl::ElemValue,
+                    timeout_ms: u32)
+        -> Result<bool, Error>
+        where U: RmeFormerOutputProtocol<FwNode, V>,
+              V: AsRef<[i32]> + AsMut<[i32]>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::VOL_NAME => {
+                let mut vals = self.state.as_ref().to_vec();
+                new.get_int(&mut vals);
+                proto.write_output_vols(&unit.get_node(), &mut self.state, &vals, timeout_ms)
+                    .map(|_| true)
+            },
+            _ => Ok(false),
+        }
+    }
+}

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt};
+use hinawa::{FwNode, SndUnit, SndUnitExt};
+
+use alsa_ctl_tlv_codec::items::DbInterval;
+
+use core::card_cntr::*;
+
+use ff_protocols::latter::*;
+
+#[derive(Default, Debug)]
+pub struct FfLatterMeterCtl<V>
+    where V: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
+{
+    state: V,
+    measured_elem_list: Vec<ElemId>,
+}
+
+impl<'a, V> FfLatterMeterCtl<V>
+    where V: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
+{
+    const LINE_INPUT_METER: &'a str = "meter:line-input";
+    const MIC_INPUT_METER: &'a str = "meter:mic-input";
+    const SPDIF_INPUT_METER: &'a str = "meter:spdif-input";
+    const ADAT_INPUT_METER: &'a str = "meter:adat-input";
+    const STREAM_INPUT_METER: &'a str = "meter:stream-input";
+    const LINE_OUTPUT_METER: &'a str = "meter:line-output";
+    const HP_OUTPUT_METER: &'a str = "meter:hp-output";
+    const SPDIF_OUTPUT_METER: &'a str = "meter:spdif-output";
+    const ADAT_OUTPUT_METER: &'a str = "meter:adat-output";
+
+    const LEVEL_MIN: i32 = 0x0;
+    const LEVEL_MAX: i32 = 0x07fffff0;
+    const LEVEL_STEP: i32 = 0x10;
+    const LEVEL_TLV: DbInterval = DbInterval{min: -9003, max: 600, linear: false, mute_avail: false};
+
+    pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+        where U: RmeFfLatterMeterProtocol<FwNode, V>,
+    {
+        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)?;
+
+        [
+            (Self::LINE_INPUT_METER, V::LINE_INPUT_COUNT),
+            (Self::MIC_INPUT_METER, V::MIC_INPUT_COUNT),
+            (Self::SPDIF_INPUT_METER, V::SPDIF_INPUT_COUNT),
+            (Self::ADAT_INPUT_METER, V::ADAT_INPUT_COUNT),
+            (Self::STREAM_INPUT_METER, V::STREAM_INPUT_COUNT),
+            (Self::LINE_OUTPUT_METER, V::LINE_OUTPUT_COUNT),
+            (Self::HP_OUTPUT_METER, V::HP_OUTPUT_COUNT),
+            (Self::SPDIF_OUTPUT_METER, V::SPDIF_OUTPUT_COUNT),
+            (Self::ADAT_OUTPUT_METER, V::ADAT_OUTPUT_COUNT),
+        ].iter()
+            .try_for_each(|(name, count)| {
+                let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
+                card_cntr.add_int_elems(&elem_id, 1, Self::LEVEL_MIN, Self::LEVEL_MAX, Self::LEVEL_STEP, *count,
+                                        Some(&Vec::<u32>::from(&Self::LEVEL_TLV)), false)
+                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+            })?;
+
+        Ok(())
+    }
+
+    pub fn get_measured_elem_list(&self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.measured_elem_list);
+    }
+
+    pub fn measure_states<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32)
+        -> Result<(), Error>
+        where U: RmeFfLatterMeterProtocol<FwNode, V>,
+    {
+        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)
+    }
+
+    pub fn read_measured_elem(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::LINE_INPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().line_inputs);
+                Ok(true)
+            }
+            Self::MIC_INPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().mic_inputs);
+                Ok(true)
+            }
+            Self::SPDIF_INPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().spdif_inputs);
+                Ok(true)
+            }
+            Self::ADAT_INPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().adat_inputs);
+                Ok(true)
+            }
+            Self::STREAM_INPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().stream_inputs);
+                Ok(true)
+            }
+            Self::LINE_OUTPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().line_outputs);
+                Ok(true)
+            }
+            Self::HP_OUTPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().hp_outputs);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().spdif_outputs);
+                Ok(true)
+            }
+            Self::ADAT_OUTPUT_METER => {
+                elem_value.set_int(&self.state.as_ref().adat_outputs);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 use hinawa::{FwNode, SndUnit, SndUnitExt};
 
 use alsa_ctl_tlv_codec::items::DbInterval;
@@ -10,6 +10,8 @@ use alsa_ctl_tlv_codec::items::DbInterval;
 use core::card_cntr::*;
 
 use ff_protocols::latter::*;
+
+use super::model::*;
 
 #[derive(Default, Debug)]
 pub struct FfLatterMeterCtl<V>
@@ -125,26 +127,202 @@ pub struct FfLatterDspCtl<V>
     where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
 {
     state: V,
+    input_ctl: FfLatterInputCtl,
 }
 
 impl<'a, V> FfLatterDspCtl<V>
     where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
 {
-    pub fn load<U>(&mut self, _: &SndUnit, _: &U, _: u32, _: &mut CardCntr)
+    pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where U: RmeFfLatterDspProtocol<FwNode, V>,
+        where U: RmeFfLatterDspProtocol<FwNode, V> + RmeFfLatterInputProtocol<FwNode, V> +
     {
+        self.input_ctl.load(unit, proto, &mut self.state, timeout_ms, card_cntr)?;
         Ok(())
     }
 
-    pub fn read(&mut self, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
-        Ok(false)
+    pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        if self.input_ctl.read(&self.state, elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
-    pub fn write<U>(&mut self, _: &SndUnit, _: &U, _: &ElemId, _: &ElemValue, _: u32)
+    pub fn write<U>(&mut self, unit: &SndUnit, proto: &U, elem_id: &ElemId, elem_value: &ElemValue,
+                    timeout_ms: u32)
         -> Result<bool, Error>
-        where U: RmeFfLatterDspProtocol<FwNode, V>,
+        where U: RmeFfLatterDspProtocol<FwNode, V> + RmeFfLatterInputProtocol<FwNode, V> +
     {
-        Ok(false)
+        if self.input_ctl.write(unit, proto, &mut self.state, elem_id, elem_value, timeout_ms)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct FfLatterInputCtl;
+
+impl<'a> FfLatterInputCtl {
+    const STEREO_LINK_NAME: &'a str = "input:stereo-link";
+    const LINE_GAIN_NAME: &'a str = "input:line-gain";
+    const LINE_LEVEL_NAME: &'a str = "input:line-level";
+    const MIC_POWER_NAME: &'a str = "input:mic-power";
+    const MIC_INST_NAME: &'a str = "input:mic-instrument";
+    const INVERT_PHASE_NAME: &'a str = "input:invert-phase";
+
+    const GAIN_MIN: i32 = 0;
+    const GAIN_MAX: i32 = 120;
+    const GAIN_STEP: i32 = 1;
+    const GAIN_TLV: DbInterval = DbInterval{min: 0, max: 1200, linear: false, mute_avail: false};
+
+    const LINE_LEVELS: [LatterInNominalLevel;2] = [
+        LatterInNominalLevel::Low,
+        LatterInNominalLevel::Professional,
+    ];
+
+    fn load<U, V>(&mut self, unit: &SndUnit, proto: &U, state: &mut V, timeout_ms: u32,
+                  card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+        where U: RmeFfLatterInputProtocol<FwNode, V>,
+              V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+    {
+        proto.init_input(&unit.get_node(), state, timeout_ms)?;
+
+        let s = &state.as_ref().input;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STEREO_LINK_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, s.stereo_links.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1, Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
+                                        s.line_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
+                                        true)?;
+
+        let labels: Vec<String> = Self::LINE_LEVELS.iter()
+            .map(|l| latter_line_in_nominal_level_to_string(l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::LINE_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, s.line_levels.len(), &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIC_POWER_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, s.mic_powers.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIC_INST_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, s.mic_insts.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::INVERT_PHASE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, s.invert_phases.len(), true)?;
+
+        Ok(())
+    }
+
+    fn read<V>(&mut self, state: &V, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+        where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::STEREO_LINK_NAME => {
+                elem_value.set_bool(&state.as_ref().input.stereo_links);
+                Ok(true)
+            }
+            Self::LINE_GAIN_NAME => {
+                let vals: Vec<i32> = state.as_ref().input.line_gains.iter()
+                    .map(|&gain| gain as i32)
+                    .collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::LINE_LEVEL_NAME => {
+                let vals: Vec<u32> = state.as_ref().input.line_levels.iter()
+                    .map(|level| {
+                        let pos = Self::LINE_LEVELS.iter()
+                            .position(|l| l.eq(level))
+                            .unwrap();
+                        pos as u32
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            Self::MIC_POWER_NAME => {
+                elem_value.set_bool(&state.as_ref().input.mic_powers);
+                Ok(true)
+            }
+            Self::MIC_INST_NAME => {
+                elem_value.set_bool(&state.as_ref().input.mic_insts);
+                Ok(true)
+            }
+            Self::INVERT_PHASE_NAME => {
+                elem_value.set_bool(&state.as_ref().input.invert_phases);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write<U, V>(&mut self, unit: &SndUnit, proto: &U, state: &mut V, elem_id: &ElemId,
+                   elem_value: &ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+        where U: RmeFfLatterInputProtocol<FwNode, V>,
+              V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::STEREO_LINK_NAME => {
+                let mut s = state.as_ref().input.clone();
+                elem_value.get_bool(&mut s.stereo_links);
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::LINE_GAIN_NAME => {
+                let mut s = state.as_ref().input.clone();
+                let mut vals = vec![0;s.line_gains.len()];
+                elem_value.get_int(&mut vals);
+                s.line_gains.iter_mut()
+                    .zip(vals.iter())
+                    .for_each(|(d, s)| *d = *s as i16);
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::LINE_LEVEL_NAME => {
+                let mut s = state.as_mut().input.clone();
+                let mut vals = vec![0;s.line_levels.len()];
+                elem_value.get_enum(&mut vals);
+                vals.iter()
+                    .enumerate()
+                    .try_for_each(|(i, &pos)| {
+                        Self::LINE_LEVELS.iter()
+                            .nth(pos as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of input nominal level: {}", pos);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| s.line_levels[i] = l)
+                    })?;
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::MIC_POWER_NAME => {
+                let mut s = state.as_ref().input.clone();
+                elem_value.get_bool(&mut s.mic_powers);
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::MIC_INST_NAME => {
+                let mut s = state.as_ref().input.clone();
+                elem_value.get_bool(&mut s.mic_insts);
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            Self::INVERT_PHASE_NAME => {
+                let mut s = state.as_ref().input.clone();
+                elem_value.get_bool(&mut s.invert_phases);
+                proto.write_input(&unit.get_node(), state, s, timeout_ms)
+                    .map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -119,3 +119,32 @@ impl<'a, V> FfLatterMeterCtl<V>
         }
     }
 }
+
+#[derive(Default, Debug)]
+pub struct FfLatterDspCtl<V>
+    where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+{
+    state: V,
+}
+
+impl<'a, V> FfLatterDspCtl<V>
+    where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
+{
+    pub fn load<U>(&mut self, _: &SndUnit, _: &U, _: u32, _: &mut CardCntr)
+        -> Result<(), Error>
+        where U: RmeFfLatterDspProtocol<FwNode, V>,
+    {
+        Ok(())
+    }
+
+    pub fn read(&mut self, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    pub fn write<U>(&mut self, _: &SndUnit, _: &U, _: &ElemId, _: &ElemValue, _: u32)
+        -> Result<bool, Error>
+        where U: RmeFfLatterDspProtocol<FwNode, V>,
+    {
+        Ok(false)
+    }
+}

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -6,6 +6,7 @@ mod ff800_model;
 mod ff400_model;
 
 mod ff802_model;
+mod ucx_model;
 
 mod former_ctls;
 mod latter_ctls;

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -4,6 +4,8 @@ mod model;
 
 mod ff800_model;
 
+mod former_ctls;
+
 use glib::Error;
 use glib::source;
 

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -2,6 +2,8 @@
 // Copyright (c) 2021 Takashi Sakamoto
 mod model;
 
+mod ff800_model;
+
 use glib::Error;
 use glib::source;
 

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -5,6 +5,8 @@ mod model;
 mod ff800_model;
 mod ff400_model;
 
+mod ff802_model;
+
 mod former_ctls;
 
 use glib::Error;

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use core::RuntimeOperation;
+
+pub struct FfRuntime;
+
+impl RuntimeOperation<u32> for FfRuntime {
+    fn new(_: u32) -> Result<Self, Error> {
+        Ok(FfRuntime{})
+    }
+
+    fn listen(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn run(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -8,6 +8,7 @@ mod ff400_model;
 mod ff802_model;
 
 mod former_ctls;
+mod latter_ctls;
 
 use glib::Error;
 use glib::source;

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -14,7 +14,7 @@ use std::sync::mpsc;
 use hinawa::FwNodeExt;
 use hinawa::{SndUnit, SndUnitExt, SndUnitExtManual};
 
-use alsactl::CardExt;
+use alsactl::{CardExt, CardExtManual, ElemId, ElemIfaceType, ElemValueExtManual};
 
 use core::RuntimeOperation;
 use core::dispatcher;
@@ -27,6 +27,7 @@ enum Event {
     Disconnected,
     BusReset(u32),
     Elem(alsactl::ElemId, alsactl::ElemEventMask),
+    Timer,
 }
 
 pub struct FfRuntime{
@@ -36,6 +37,7 @@ pub struct FfRuntime{
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
+    timer: Option<dispatcher::Dispatcher>,
 }
 
 impl RuntimeOperation<u32> for FfRuntime {
@@ -54,7 +56,9 @@ impl RuntimeOperation<u32> for FfRuntime {
 
         let dispatchers = Vec::new();
 
-        Ok(FfRuntime{unit, model, card_cntr, rx, tx, dispatchers})
+        let timer = None;
+
+        Ok(FfRuntime{unit, model, card_cntr, rx, tx, dispatchers, timer})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
@@ -62,6 +66,11 @@ impl RuntimeOperation<u32> for FfRuntime {
         self.launch_system_event_dispatcher()?;
 
         self.model.load(&self.unit, &mut self.card_cntr)?;
+
+        if self.model.measured_elem_list.len() > 0 {
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::TIMER_NAME, 0);
+            let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        }
 
         Ok(())
     }
@@ -76,8 +85,25 @@ impl RuntimeOperation<u32> for FfRuntime {
                         println!("IEEE 1394 bus is updated: {}", generation);
                     }
                     Event::Elem(elem_id, events) => {
-                        let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
-                                                               &elem_id, &events);
+                        if elem_id.get_name() != Self::TIMER_NAME {
+                            let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                                                                   &elem_id, &events);
+                        } else {
+                            let mut elem_value = alsactl::ElemValue::new();
+                            let _ = self.card_cntr.card.read_elem_value(&elem_id, &mut elem_value)
+                                .map(|_| {
+                                    let mut vals = [false];
+                                    elem_value.get_bool(&mut vals);
+                                    if vals[0] {
+                                        let _ = self.start_interval_timer();
+                                    } else {
+                                        self.stop_interval_timer();
+                                    }
+                                });
+                        }
+                    }
+                    Event::Timer => {
+                        let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
                     }
                 }
             }
@@ -96,6 +122,10 @@ impl Drop for FfRuntime {
 impl<'a> FfRuntime {
     const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
     const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+
+    const TIMER_NAME: &'a str = "metering";
+    const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
         let name = Self::NODE_DISPATCHER_NAME.to_string();
@@ -141,5 +171,25 @@ impl<'a> FfRuntime {
         self.dispatchers.push(dispatcher);
 
         Ok(())
+    }
+
+    fn start_interval_timer(&mut self) -> Result<(), Error> {
+        let mut dispatcher = dispatcher::Dispatcher::run(Self::TIMER_DISPATCHER_NAME.to_string())?;
+        let tx = self.tx.clone();
+        dispatcher.attach_interval_handler(Self::TIMER_INTERVAL, move || {
+            let _ = tx.send(Event::Timer);
+            source::Continue(true)
+        });
+
+        self.timer = Some(dispatcher);
+
+        Ok(())
+    }
+
+    fn stop_interval_timer(&mut self) {
+        if let Some(dispatcher) = &self.timer {
+            drop(dispatcher);
+            self.timer = None;
+        }
     }
 }

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -7,27 +7,37 @@ use nix::sys::signal;
 
 use std::sync::mpsc;
 
+use hinawa::FwNodeExt;
+use hinawa::{SndUnit, SndUnitExt, SndUnitExtManual};
+
 use core::RuntimeOperation;
 use core::dispatcher;
 
 enum Event {
     Shutdown,
+    Disconnected,
+    BusReset(u32),
 }
 
 pub struct FfRuntime{
+    unit: SndUnit,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<dispatcher::Dispatcher>,
 }
 
 impl RuntimeOperation<u32> for FfRuntime {
-    fn new(_: u32) -> Result<Self, Error> {
+    fn new(card_id: u32) -> Result<Self, Error> {
+        let unit = SndUnit::new();
+        let path = format!("/dev/snd/hwC{}D0", card_id);
+        unit.open(&path)?;
+
         // Use uni-directional channel for communication to child threads.
         let (tx, rx) = mpsc::sync_channel(32);
 
         let dispatchers = Vec::new();
 
-        Ok(FfRuntime{rx, tx, dispatchers})
+        Ok(FfRuntime{unit, rx, tx, dispatchers})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
@@ -42,6 +52,10 @@ impl RuntimeOperation<u32> for FfRuntime {
             if let Ok(ev) = self.rx.recv() {
                 match ev {
                     Event::Shutdown => break,
+                    Event::Disconnected => break,
+                    Event::BusReset(generation) => {
+                        println!("IEEE 1394 bus is updated: {}", generation);
+                    }
                 }
             }
         }
@@ -62,7 +76,22 @@ impl<'a> FfRuntime {
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
         let name = Self::NODE_DISPATCHER_NAME.to_string();
-        let dispatcher = dispatcher::Dispatcher::run(name)?;
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_snd_unit(&self.unit, move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_fw_node(&self.unit.get_node(), move |_| {
+            let _ = tx.send(Event::Disconnected);
+        })?;
+
+        let tx = self.tx.clone();
+        self.unit.get_node().connect_bus_update(move |node| {
+            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+        });
 
         self.dispatchers.push(dispatcher);
 

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
+mod model;
+
 use glib::Error;
 use glib::source;
 
@@ -16,6 +18,8 @@ use core::RuntimeOperation;
 use core::dispatcher;
 use core::card_cntr;
 
+use model::FfModel;
+
 enum Event {
     Shutdown,
     Disconnected,
@@ -25,6 +29,7 @@ enum Event {
 
 pub struct FfRuntime{
     unit: SndUnit,
+    model: FfModel,
     card_cntr: card_cntr::CardCntr,
     rx: mpsc::Receiver<Event>,
     tx: mpsc::SyncSender<Event>,
@@ -37,6 +42,8 @@ impl RuntimeOperation<u32> for FfRuntime {
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path)?;
 
+        let model = FfModel::new(&unit)?;
+
         let card_cntr = card_cntr::CardCntr::new();
         card_cntr.card.open(card_id, 0)?;
 
@@ -45,12 +52,14 @@ impl RuntimeOperation<u32> for FfRuntime {
 
         let dispatchers = Vec::new();
 
-        Ok(FfRuntime{unit, card_cntr, rx, tx, dispatchers})
+        Ok(FfRuntime{unit, model, card_cntr, rx, tx, dispatchers})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
+
+        self.model.load(&self.unit, &mut self.card_cntr)?;
 
         Ok(())
     }
@@ -64,8 +73,9 @@ impl RuntimeOperation<u32> for FfRuntime {
                     Event::BusReset(generation) => {
                         println!("IEEE 1394 bus is updated: {}", generation);
                     }
-                    Event::Elem(_, _) => {
-                        ()
+                    Event::Elem(elem_id, events) => {
+                        let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                                                               &elem_id, &events);
                     }
                 }
             }

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -3,6 +3,7 @@
 mod model;
 
 mod ff800_model;
+mod ff400_model;
 
 mod former_ctls;
 

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -1,21 +1,86 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::Error;
+use glib::source;
+
+use nix::sys::signal;
+
+use std::sync::mpsc;
 
 use core::RuntimeOperation;
+use core::dispatcher;
 
-pub struct FfRuntime;
+enum Event {
+    Shutdown,
+}
+
+pub struct FfRuntime{
+    rx: mpsc::Receiver<Event>,
+    tx: mpsc::SyncSender<Event>,
+    dispatchers: Vec<dispatcher::Dispatcher>,
+}
 
 impl RuntimeOperation<u32> for FfRuntime {
     fn new(_: u32) -> Result<Self, Error> {
-        Ok(FfRuntime{})
+        // Use uni-directional channel for communication to child threads.
+        let (tx, rx) = mpsc::sync_channel(32);
+
+        let dispatchers = Vec::new();
+
+        Ok(FfRuntime{rx, tx, dispatchers})
     }
 
     fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
         Ok(())
     }
 
     fn run(&mut self) -> Result<(), Error> {
+        loop {
+            if let Ok(ev) = self.rx.recv() {
+                match ev {
+                    Event::Shutdown => break,
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for FfRuntime {
+    fn drop(&mut self) {
+        // Finish I/O threads.
+        self.dispatchers.clear();
+    }
+}
+
+impl<'a> FfRuntime {
+    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
+
+    fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        self.dispatchers.push(dispatcher);
+
+        Ok(())
+    }
+
+    fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
+        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let mut dispatcher = dispatcher::Dispatcher::run(name)?;
+
+        let tx = self.tx.clone();
+        dispatcher.attach_signal_handler(signal::Signal::SIGINT, move || {
+            let _ = tx.send(Event::Shutdown);
+            source::Continue(false)
+        });
+
+        self.dispatchers.push(dispatcher);
+
         Ok(())
     }
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -9,7 +9,7 @@ use core::card_cntr::*;
 
 use ieee1212_config_rom::*;
 
-use ff_protocols::*;
+use ff_protocols::{*, former::*};
 
 use super::ff800_model::*;
 
@@ -56,4 +56,41 @@ impl FfModel {
             Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
+}
+
+pub fn spdif_iface_to_string(iface: &SpdifIface) -> String {
+    match iface {
+        SpdifIface::Coaxial => "Coaxial",
+        SpdifIface::Optical => "Optical",
+    }.to_string()
+}
+
+pub fn spdif_format_to_string(fmt: &SpdifFormat) -> String {
+    match fmt {
+        SpdifFormat::Consumer => "Consumer",
+        SpdifFormat::Professional => "Professional",
+    }.to_string()
+}
+
+pub fn optical_output_signal_to_string(sig: &OpticalOutputSignal) -> String {
+    match sig {
+        OpticalOutputSignal::Adat => "ADAT",
+        OpticalOutputSignal::Spdif => "S/PDIF",
+    }.to_string()
+}
+
+pub fn former_line_in_nominal_level_to_string(level: &FormerLineInNominalLevel) -> String {
+    match level {
+        FormerLineInNominalLevel::Low => "Low",
+        FormerLineInNominalLevel::Consumer => "-10dBV",
+        FormerLineInNominalLevel::Professional => "+4dBu",
+    }.to_string()
+}
+
+pub fn line_out_nominal_level_to_string(level: &LineOutNominalLevel) -> String {
+    match level {
+        LineOutNominalLevel::High => "High",
+        LineOutNominalLevel::Consumer => "-10dBV",
+        LineOutNominalLevel::Professional => "+4dBu",
+    }.to_string()
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -13,12 +13,14 @@ use ff_protocols::{*, former::*};
 
 use super::ff800_model::*;
 use super::ff400_model::*;
+use super::ff802_model::*;
 
 use std::convert::TryFrom;
 
 pub enum Model {
     Ff800(Ff800Model),
     Ff400(Ff400Model),
+    Ff802(Ff802Model),
 }
 
 pub struct FfModel{
@@ -41,6 +43,7 @@ impl FfModel {
         let model = match model_id {
             0x00000001 => Model::Ff800(Ff800Model::default()),
             0x00000002 => Model::Ff400(Ff400Model::default()),
+            0x00000005 => Model::Ff802(Ff802Model::default()),
             _ => Err(Error::new(FileError::Nxio, "Not supported."))?,
         };
 
@@ -53,11 +56,13 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => m.load(unit, card_cntr),
             Model::Ff400(m) => m.load(unit, card_cntr),
+            Model::Ff802(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
             Model::Ff800(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Ff400(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::Ff802(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -70,6 +75,7 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Ff400(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::Ff802(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -79,6 +85,7 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Ff400(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::Ff802(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -21,6 +21,7 @@ pub enum Model {
 
 pub struct FfModel{
     model: Model,
+    pub measured_elem_list: Vec<alsactl::ElemId>,
 }
 
 impl FfModel {
@@ -40,12 +41,21 @@ impl FfModel {
             _ => Err(Error::new(FileError::Nxio, "Not supported."))?,
         };
 
-        Ok(FfModel{model})
+        let measured_elem_list = Vec::new();
+
+        Ok(FfModel{model, measured_elem_list})
     }
+
     pub fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         match &mut self.model {
             Model::Ff800(m) => m.load(unit, card_cntr),
+        }?;
+
+        match &mut self.model {
+            Model::Ff800(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
+
+        Ok(())
     }
 
     pub fn dispatch_elem_event(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr,
@@ -54,6 +64,14 @@ impl FfModel {
     {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+        }
+    }
+
+    pub fn measure_elems(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        match &mut self.model {
+            Model::Ff800(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+use glib::Error;
+
+use hinawa::SndUnit;
+
+use core::card_cntr::*;
+
+pub struct FfModel;
+
+impl FfModel {
+    pub fn new(_: &SndUnit) -> Result<FfModel, Error> {
+        Ok(FfModel{})
+    }
+    pub fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn dispatch_elem_event(&mut self, _: &SndUnit, _: &mut CardCntr,
+                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+        -> Result<(), Error>
+    {
+        Ok(())
+    }
+}

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -112,3 +112,25 @@ pub fn line_out_nominal_level_to_string(level: &LineOutNominalLevel) -> String {
         LineOutNominalLevel::Professional => "+4dBu",
     }.to_string()
 }
+
+pub fn clk_nominal_rate_to_string(rate: &ClkNominalRate) -> String {
+    match rate {
+        ClkNominalRate::R32000 => "32000",
+        ClkNominalRate::R44100 => "44100",
+        ClkNominalRate::R48000 => "48000",
+        ClkNominalRate::R64000 => "64000",
+        ClkNominalRate::R88200 => "88200",
+        ClkNominalRate::R96000 => "96000",
+        ClkNominalRate::R128000 => "128000",
+        ClkNominalRate::R176400 => "176400",
+        ClkNominalRate::R192000 => "192000",
+    }.to_string()
+}
+
+pub fn optional_clk_nominal_rate_to_string(rate: &Option<ClkNominalRate>) -> String {
+    if let Some(r) = rate {
+        clk_nominal_rate_to_string(r)
+    } else {
+        "not-detected".to_string()
+    }
+}

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -14,12 +14,14 @@ use ff_protocols::{*, former::*, latter::*};
 use super::ff800_model::*;
 use super::ff400_model::*;
 use super::ff802_model::*;
+use super::ucx_model::*;
 
 use std::convert::TryFrom;
 
 pub enum Model {
     Ff800(Ff800Model),
     Ff400(Ff400Model),
+    Ucx(UcxModel),
     Ff802(Ff802Model),
 }
 
@@ -43,6 +45,7 @@ impl FfModel {
         let model = match model_id {
             0x00000001 => Model::Ff800(Ff800Model::default()),
             0x00000002 => Model::Ff400(Ff400Model::default()),
+            0x00000004 => Model::Ucx(UcxModel::default()),
             0x00000005 => Model::Ff802(Ff802Model::default()),
             _ => Err(Error::new(FileError::Nxio, "Not supported."))?,
         };
@@ -56,12 +59,14 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => m.load(unit, card_cntr),
             Model::Ff400(m) => m.load(unit, card_cntr),
+            Model::Ucx(m) => m.load(unit, card_cntr),
             Model::Ff802(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
             Model::Ff800(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Ff400(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::Ucx(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::Ff802(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
@@ -75,6 +80,7 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Ff400(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::Ucx(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::Ff802(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
@@ -85,6 +91,7 @@ impl FfModel {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Ff400(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::Ucx(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::Ff802(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -1,26 +1,59 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
+use glib::{Error, FileError};
 
-use glib::Error;
-
-use hinawa::SndUnit;
+use hinawa::FwNodeExtManual;
+use hinawa::{SndUnit, SndUnitExt};
 
 use core::card_cntr::*;
 
-pub struct FfModel;
+use ieee1212_config_rom::*;
+
+use ff_protocols::*;
+
+use super::ff800_model::*;
+
+use std::convert::TryFrom;
+
+pub enum Model {
+    Ff800(Ff800Model),
+}
+
+pub struct FfModel{
+    model: Model,
+}
 
 impl FfModel {
-    pub fn new(_: &SndUnit) -> Result<FfModel, Error> {
-        Ok(FfModel{})
+    pub fn new(unit: &SndUnit) -> Result<FfModel, Error> {
+        let node = unit.get_node();
+        let raw = node.get_config_rom()?;
+        let config_rom = ConfigRom::try_from(&raw[..])
+            .map_err(|e| {
+                let msg = format!("Malformed configuration ROM detected: {}", e);
+                Error::new(FileError::Nxio, &msg)
+            })?;
+        let model_id = config_rom.get_model_id()
+            .ok_or_else(|| Error::new(FileError::Nxio, "Unexpected format of configuration ROM"))?;
+
+        let model = match model_id {
+            0x00000001 => Model::Ff800(Ff800Model::default()),
+            _ => Err(Error::new(FileError::Nxio, "Not supported."))?,
+        };
+
+        Ok(FfModel{model})
     }
-    pub fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
-        Ok(())
+    pub fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        match &mut self.model {
+            Model::Ff800(m) => m.load(unit, card_cntr),
+        }
     }
 
-    pub fn dispatch_elem_event(&mut self, _: &SndUnit, _: &mut CardCntr,
-                               _: &alsactl::ElemId, _: &alsactl::ElemEventMask)
+    pub fn dispatch_elem_event(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr,
+                               elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {
-        Ok(())
+        match &mut self.model {
+            Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+        }
     }
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -9,7 +9,7 @@ use core::card_cntr::*;
 
 use ieee1212_config_rom::*;
 
-use ff_protocols::{*, former::*};
+use ff_protocols::{*, former::*, latter::*};
 
 use super::ff800_model::*;
 use super::ff400_model::*;
@@ -147,4 +147,11 @@ pub fn optional_clk_nominal_rate_to_string(rate: &Option<ClkNominalRate>) -> Str
     } else {
         "not-detected".to_string()
     }
+}
+
+pub fn latter_line_in_nominal_level_to_string(level: &LatterInNominalLevel) -> String {
+    match level {
+        LatterInNominalLevel::Low => "Low",
+        LatterInNominalLevel::Professional => "+4dBu",
+    }.to_string()
 }

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -12,11 +12,13 @@ use ieee1212_config_rom::*;
 use ff_protocols::{*, former::*};
 
 use super::ff800_model::*;
+use super::ff400_model::*;
 
 use std::convert::TryFrom;
 
 pub enum Model {
     Ff800(Ff800Model),
+    Ff400(Ff400Model),
 }
 
 pub struct FfModel{
@@ -38,6 +40,7 @@ impl FfModel {
 
         let model = match model_id {
             0x00000001 => Model::Ff800(Ff800Model::default()),
+            0x00000002 => Model::Ff400(Ff400Model::default()),
             _ => Err(Error::new(FileError::Nxio, "Not supported."))?,
         };
 
@@ -49,10 +52,12 @@ impl FfModel {
     pub fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         match &mut self.model {
             Model::Ff800(m) => m.load(unit, card_cntr),
+            Model::Ff400(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.model {
             Model::Ff800(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::Ff400(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -64,6 +69,7 @@ impl FfModel {
     {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::Ff400(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -72,6 +78,7 @@ impl FfModel {
     {
         match &mut self.model {
             Model::Ff800(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::Ff400(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
         }
     }
 }

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -21,6 +21,7 @@ pub struct UcxModel{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: FfLatterMeterCtl<FfUcxMeterState>,
+    dsp_ctl: FfLatterDspCtl<FfUcxDspState>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -30,6 +31,7 @@ impl CtlModel<SndUnit> for UcxModel {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
+        self.dsp_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
@@ -37,6 +39,8 @@ impl CtlModel<SndUnit> for UcxModel {
         -> Result<bool, Error>
     {
         if self.cfg_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -46,7 +50,13 @@ impl CtlModel<SndUnit> for UcxModel {
     fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)
+        if self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.dsp_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use alsactl::{ElemId, ElemValue};
+
+use hinawa::SndUnit;
+
+use core::card_cntr::*;
+
+use ff_protocols::latter::ucx::*;
+
+#[derive(Default, Debug)]
+pub struct UcxModel{
+    proto: FfUcxProtocol,
+}
+
+impl CtlModel<SndUnit> for UcxModel {
+    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+
+    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+
+impl MeasureModel<SndUnit> for UcxModel {
+    fn get_measure_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    }
+
+    fn measure_states(&mut self, _: &SndUnit) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        Ok(false)
+    }
+}
+

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -1,35 +1,42 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::Error;
+use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExtManual};
 
-use hinawa::SndUnit;
+use hinawa::{SndUnit, SndUnitExt};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::*;
 
-use ff_protocols::latter::ucx::*;
+use ff_protocols::{*, latter::{*, ucx::*}};
+
+use super::model::*;
 
 #[derive(Default, Debug)]
 pub struct UcxModel{
     proto: FfUcxProtocol,
+    cfg_ctl: CfgCtl,
 }
 
+const TIMEOUT_MS: u32 = 100;
+
 impl CtlModel<SndUnit> for UcxModel {
-    fn load(&mut self, _: &SndUnit, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, _: &ElemId, _: &mut ElemValue)
+    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.read(elem_id, elem_value)
     }
 
-    fn write(&mut self, _: &SndUnit, _: &ElemId, _: &ElemValue, _: &ElemValue)
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        Ok(false)
+        self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)
     }
 }
 
@@ -48,3 +55,209 @@ impl MeasureModel<SndUnit> for UcxModel {
     }
 }
 
+fn clk_src_to_string(src: &FfUcxClkSrc) -> String {
+    match src {
+        FfUcxClkSrc::Internal => "Internal",
+        FfUcxClkSrc::Coax => "Coaxial",
+        FfUcxClkSrc::Opt => "Optical",
+        FfUcxClkSrc::WordClk => "Word-clock",
+    }.to_string()
+}
+
+fn update_cfg<F>(unit: &SndUnit, proto: &FfUcxProtocol, cfg: &mut FfUcxConfig, timeout_ms: u32, cb: F)
+    -> Result<(), Error>
+    where F: Fn(&mut FfUcxConfig) -> Result<(), Error>,
+{
+    let mut cache = cfg.clone();
+    cb(&mut cache)?;
+    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+        .map(|_| *cfg = cache)
+}
+
+#[derive(Default, Debug)]
+struct CfgCtl(FfUcxConfig);
+
+impl<'a> CfgCtl {
+    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
+    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
+    const EFFECT_ON_INPUT_NAME: &'a str = "effect-on-input";
+    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
+    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+    const WORD_CLOCK_IN_TERMINATE_NAME: &'a str = "word-clock-input-terminate";
+
+    const CLK_SRCS: [FfUcxClkSrc;4] = [
+        FfUcxClkSrc::Internal,
+        FfUcxClkSrc::Coax,
+        FfUcxClkSrc::Opt,
+        FfUcxClkSrc::WordClk,
+    ];
+
+    const OPT_OUT_SIGNALS: [OpticalOutputSignal;2] = [
+        OpticalOutputSignal::Adat,
+        OpticalOutputSignal::Spdif,
+    ];
+
+    const SPDIF_FMTS: [SpdifFormat;2] = [
+        SpdifFormat::Consumer,
+        SpdifFormat::Professional,
+    ];
+
+    fn load(&mut self, unit: &SndUnit, proto: &FfUcxProtocol, timeout_ms: u32, card_cntr: &mut CardCntr)
+        -> Result<(), Error>
+    {
+        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+
+        let labels: Vec<String> = Self::CLK_SRCS.iter()
+            .map(|s| clk_src_to_string(s))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
+            .map(|f| optical_output_signal_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::EFFECT_ON_INPUT_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<String> = Self::SPDIF_FMTS.iter()
+            .map(|f| spdif_format_to_string(f))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_IN_TERMINATE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::CLK_SRCS.iter()
+                        .position(|s| s.eq(&self.0.clk_src))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::OPT_OUT_SIGNALS.iter()
+                        .position(|f| f.eq(&self.0.opt_out_signal))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::EFFECT_ON_INPUT_NAME => {
+                elem_value.set_bool(&[self.0.effect_on_inputs]);
+                Ok(true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    let pos = Self::SPDIF_FMTS.iter()
+                        .position(|f| f.eq(&self.0.spdif_out_format))
+                        .unwrap();
+                    Ok(pos as u32)
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                elem_value.set_bool(&[self.0.word_out_single]);
+                Ok(true)
+            }
+            Self::WORD_CLOCK_IN_TERMINATE_NAME => {
+                elem_value.set_bool(&[self.0.word_in_terminate]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, unit: &SndUnit, proto: &FfUcxProtocol, elem_id: &ElemId,
+             elem_value: &alsactl::ElemValue, timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            Self::PRIMARY_CLK_SRC_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        let src = Self::CLK_SRCS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of clock source: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })?;
+                        cfg.clk_src = *src;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::OPT_OUTPUT_SIGNAL_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        Self::OPT_OUT_SIGNALS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of optical output signal: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&s| cfg.opt_out_signal = s)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::EFFECT_ON_INPUT_NAME => {
+                let mut vals = [false];
+                elem_value.get_bool(&mut vals);
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    cfg.effect_on_inputs = vals[0];
+                    Ok(())
+                })
+                .map(|_| true)
+            }
+            Self::SPDIF_OUTPUT_FMT_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<u32>::get_val(elem_value, |val| {
+                        Self::SPDIF_FMTS.iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of S/PDIF format: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&f| cfg.spdif_out_format = f)
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(elem_value, |val| {
+                        cfg.word_out_single = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            Self::WORD_CLOCK_IN_TERMINATE_NAME => {
+                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                    ElemValueAccessor::<bool>::get_val(elem_value, |val| {
+                        cfg.word_in_terminate = val;
+                        Ok(())
+                    })
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/services/Cargo.toml
+++ b/services/Cargo.toml
@@ -22,3 +22,4 @@ motu = { path = "../libs/motu" }
 oxfw = { path = "../libs/oxfw" }
 bebob = { path = "../libs/bebob" }
 dice-runtime = { path = "../libs/dice/runtime" }
+ff-runtime = { path = "../libs/ff/runtime" }

--- a/services/src/bin/snd-fireface-ctl-service.rs
+++ b/services/src/bin/snd-fireface-ctl-service.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use snd_firewire_ctl_services::*;
+use ff_runtime::FfRuntime;
+
+struct FfServiceCmd;
+
+impl<'a> ServiceCmd<'a, u32, FfRuntime> for FfServiceCmd {
+    const CMD_NAME: &'a str = "snd-fireface-ctl-service";
+    const ARGS: &'a [(&'a str, &'a str)] = &[("CARD_ID", "The numeric ID of sound card")];
+
+    fn parse_args(args: &[String]) -> Result<u32, String> {
+        parse_arg_as_u32(&args[0])
+    }
+}
+
+fn main() {
+    FfServiceCmd::run()
+}


### PR DESCRIPTION
RME GmbH shipped some models in its Fireface series 2004 to 2014. The models are categorized to former and latter generation by protocol specification, programmed for FPGA. The latter models supports channel strip effect and reverb/echo fx effect.

This patchset adds support for the former and latter models. As a result, below models are controllable via ALSA control interface.

 * Fireface 400
 * Fireface 800
 * Fireface UCX
 * Fireface 802

```
Takashi Sakamoto (70):
  ff-protocols: add crate for protocol implementation of RME Fireface series
  ff-protocols: add trait implementation for parser of configuration rom by unique protocol
  ff-protocols: add parser of configuration rom
  ff-protocols: former: add module for protocol specific to former models of Fireface series
  ff-protocols: former: add protocol structure for Fireface 800
  ff-protocols: former: add trait implementation for meter protocol of Fireface 800
  ff-protocols: former: add trait implementation for output protocol of Fireface 800
  ff-protocols: former: add trait implementation for mixer protocol of Fireface 800
  ff-protocols: former: add trait implementation for status protocol of Fireface 800
  ff-protocols: former: add trait implementation for configuration protocol of Fireface 800
  ff-runtime: add runtime crate for RME Fireface series
  services: add service program for models of RME Fireface series
  ff-runtime: launch I/O threads to dispatch event
  ff-runtime: open ALSA hwdep character device and Linux firewire character device
  ff-runtime: open ALSA control character device
  ff-runtime: add model module
  ff-runtime: add support for Fireface 800
  ff-runtime: add configuration controls for Fireface 800
  ff-runtime: add interval timer to measure control elements
  ff-runtime: add status control for 800
  ff-runtime: add output controls for Fireface 800
  ff-runtime: add mixer controls for Fireface 800
  ff-runtime: add meter controls for Fireface 800
  ff-protocols: former: add protocol structure for Fireface 400
  ff-protocols: former: add trait implementation of meter protocol for Fireface 400
  ff-protocols: former: add trait implementation for amplifier protocol of Fireface 400
  ff-protocols: former: add trait implementation for input amplifier protocol of Fireface 400
  ff-protocols: former: add trait implementation for output protocol of Fireface 400
  ff-protocols: former: add trait implementation for mixer protocol of Fireface 400
  ff-protocols: former: add trait implementation for status protocol of Fireface 400
  ff-protocols: former: add trait implementation for configuration protocol of Fireface 400
  ff-runtime: add support for Fireface 400
  ff-runtime: add meter controls for Fireface 400
  ff-runtime: add output controls for Fireface 400
  ff-runtime: add mixer control for Fireface 400
  ff-runtime: add input gain controls for Fireface 400
  ff-runtime: add configuration controls for Fireface 400
  ff-runtime: add status controls for Fireface 400
  ff-protocols: latter: add protocol structure for 802
  ff-protocols: latter: add trait implementation for configuration protocol of 802
  ff-protocols: latter: add trait implementation for status protocol of 802
  ff-protocols: latter: add trait implementation of meter protocol for 802
  ff-protocols: latter: add trait implementation of DSP protocol for 802
  ff-protocols: latter: add trait implementation for input protocol
  ff-protocols: latter: add trait implementation for output protocol
  ff-protocols: latter: add trait implementation for mixer protocol
  ff-protocols: latter: add trait for channel strip protocol
  ff-protocols; latter: add trait implementation for input channel strip protocol
  ff-protocols: latter: add trait implementation for output channel strip protocol
  ff-protocols: latter: add trait implementation for fx protocol
  ff-runtime: add support for 802
  ff-runtime: add configuration controls for 802
  ff-runtime: add status controls for 802
  ff-runtime: add meter controls for 802
  ff-runtime: add DSP controls for 802
  ff-runtime: add DSP input controls for 802
  ff-runtime: add DSP output controls for 802
  ff-runtime: add DSP mixer controls for 802
  ff-runtime: add DSP input and output channel strip controls for 802
  ff-runtime: add DSP fx controls for 802
  ff-protocols: latter: add protocol structure for UCX
  ff-protocols: latter: add trait implementation for configuration protocol of UCX
  ff-protocols: latter: add trait implementation of status protocol for UCX
  ff-protocols: latter: add trait implementation of meter protocol for UCX
  ff-protocols: latter: add trait implementation of DSP protocol for UCX
  ff-runtime: add support for Fireface UCX
  ff-runtime: add configuration controls for UCX
  ff-runtime: add status controls for UCX
  ff-runtime: add meter controls for UCX
  ff-runtime: add DSP controls for UCX

 Cargo.toml                                    |    2 +
 README.rst                                    |   11 +
 libs/ff/protocols/Cargo.toml                  |   18 +
 .../protocols/src/bin/ff-config-rom-parser.rs |  103 +
 libs/ff/protocols/src/former.rs               |  275 +++
 libs/ff/protocols/src/former/ff400.rs         |  914 +++++++
 libs/ff/protocols/src/former/ff800.rs         | 1290 ++++++++++
 libs/ff/protocols/src/latter.rs               | 1523 ++++++++++++
 libs/ff/protocols/src/latter/ff802.rs         |  423 ++++
 libs/ff/protocols/src/latter/ucx.rs           |  389 +++
 libs/ff/protocols/src/lib.rs                  |  122 +
 libs/ff/runtime/Cargo.toml                    |   20 +
 libs/ff/runtime/src/ff400_model.rs            |  729 ++++++
 libs/ff/runtime/src/ff800_model.rs            |  675 +++++
 libs/ff/runtime/src/ff802_model.rs            |  467 ++++
 libs/ff/runtime/src/former_ctls.rs            |  305 +++
 libs/ff/runtime/src/latter_ctls.rs            | 2166 +++++++++++++++++
 libs/ff/runtime/src/lib.rs                    |  202 ++
 libs/ff/runtime/src/model.rs                  |  164 ++
 libs/ff/runtime/src/ucx_model.rs              |  436 ++++
 services/Cargo.toml                           |    1 +
 services/src/bin/snd-fireface-ctl-service.rs  |   19 +
 22 files changed, 10254 insertions(+)
 create mode 100644 libs/ff/protocols/Cargo.toml
 create mode 100644 libs/ff/protocols/src/bin/ff-config-rom-parser.rs
 create mode 100644 libs/ff/protocols/src/former.rs
 create mode 100644 libs/ff/protocols/src/former/ff400.rs
 create mode 100644 libs/ff/protocols/src/former/ff800.rs
 create mode 100644 libs/ff/protocols/src/latter.rs
 create mode 100644 libs/ff/protocols/src/latter/ff802.rs
 create mode 100644 libs/ff/protocols/src/latter/ucx.rs
 create mode 100644 libs/ff/protocols/src/lib.rs
 create mode 100644 libs/ff/runtime/Cargo.toml
 create mode 100644 libs/ff/runtime/src/ff400_model.rs
 create mode 100644 libs/ff/runtime/src/ff800_model.rs
 create mode 100644 libs/ff/runtime/src/ff802_model.rs
 create mode 100644 libs/ff/runtime/src/former_ctls.rs
 create mode 100644 libs/ff/runtime/src/latter_ctls.rs
 create mode 100644 libs/ff/runtime/src/lib.rs
 create mode 100644 libs/ff/runtime/src/model.rs
 create mode 100644 libs/ff/runtime/src/ucx_model.rs
 create mode 100644 services/src/bin/snd-fireface-ctl-service.rs
```