### PR TITLE
dice-runtime/efw: fix value for dB interval

### DIFF
--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -467,7 +467,7 @@ impl<'a> MixerCtl {
     const COEF_MIN: i32 = 0;
     const COEF_MAX: i32 = 0x0000ffffi32; // 2:14 Fixed-point.
     const COEF_STEP: i32 = 1;
-    const COEF_TLV: DbInterval = DbInterval{min: -6000, max: 4, linear: false, mute_avail: false};
+    const COEF_TLV: DbInterval = DbInterval{min: -6000, max: 400, linear: false, mute_avail: false};
 
     pub fn load<T>(&mut self, caps: &ExtensionCaps, state: &T, card_cntr: &mut CardCntr)
         -> Result<(), Error>

--- a/libs/efw/src/mixer_ctl.rs
+++ b/libs/efw/src/mixer_ctl.rs
@@ -31,7 +31,7 @@ impl<'a> MixerCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 6, linear: false, mute_avail: false};
+    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 600, linear: false, mute_avail: false};
 
     const PAN_MIN: i32 = 0;
     const PAN_MAX: i32 = 255;

--- a/libs/efw/src/output_ctl.rs
+++ b/libs/efw/src/output_ctl.rs
@@ -22,7 +22,7 @@ impl<'a> OutputCtl {
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
-    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 6, linear: false, mute_avail: false};
+    const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 600, linear: false, mute_avail: false};
 
     const OUT_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "-10dBV"];
     const OUT_NOMINAL_LEVELS: &'a [NominalLevel] = &[NominalLevel::PlusFour, NominalLevel::MinusTen];


### PR DESCRIPTION
In TLV-style data, dB value is in 0.01 unit.