### PR TITLE
[PATCH 0/5] bebob: ESI Quatafire 610 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -131,6 +131,7 @@ your device, please contact to developer.
   * M-Audio ProjectMix I/O
   * Behringer FIREPOWER FCA610
   * Stanton ScratchAmp in Final Scratch version 2
+  * ESI Quatafire 610
 
 * snd-dice-ctl-service
 

--- a/libs/bebob/src/apogee/apogee_model.rs
+++ b/libs/bebob/src/apogee/apogee_model.rs
@@ -51,9 +51,11 @@ impl<'a> EnsembleModel<'a> {
         "Optical",
         "Word Clock",
     ];
+}
 
-    pub fn new() -> Self {
-        EnsembleModel{
+impl<'a> Default for EnsembleModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             clk_ctls: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_SRC_LABELS),
             hw_ctls: HwCtl::new(),

--- a/libs/bebob/src/apogee/apogee_model.rs
+++ b/libs/bebob/src/apogee/apogee_model.rs
@@ -56,7 +56,7 @@ impl<'a> EnsembleModel<'a> {
 impl<'a> Default for EnsembleModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
+            avc: Default::default(),
             clk_ctls: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_SRC_LABELS),
             hw_ctls: HwCtl::new(),
             display_ctls: DisplayCtl::new(),

--- a/libs/bebob/src/behringer/firepower_model.rs
+++ b/libs/bebob/src/behringer/firepower_model.rs
@@ -40,7 +40,7 @@ impl<'a> FirepowerModel<'a> {
 impl<'a> Default for FirepowerModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
+            avc: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, &Self::CLK_LABELS),
         }
     }

--- a/libs/bebob/src/behringer/firepower_model.rs
+++ b/libs/bebob/src/behringer/firepower_model.rs
@@ -35,9 +35,11 @@ impl<'a> FirepowerModel<'a> {
         }),
     ];
     const CLK_LABELS: &'a [&'a str] = &["Device Internal Clock", "S/PDIF", "Firewire Bus"];
+}
 
-    pub fn new() -> Self {
-        FirepowerModel{
+impl<'a> Default for FirepowerModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, &Self::CLK_LABELS),
         }

--- a/libs/bebob/src/esi.rs
+++ b/libs/bebob/src/esi.rs
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use glib::Error;
+
+use hinawa::{SndUnit, SndUnitExt, FwFcpExt};
+use alsactl::{ElemId, ElemValue};
+
+use core::card_cntr::*;
+
+use ta1394::{*, ccm::*};
+
+use super::{*, common_ctls::ClkCtl};
+
+pub struct QuatafireModel<'a>{
+    avc: BebobAvc,
+    clk_ctl: ClkCtl<'a>,
+}
+
+impl<'a> QuatafireModel<'a> {
+    const FCP_TIMEOUT_MS: u32 = 100;
+
+    const CLK_DST: SignalAddr = SignalAddr::Subunit(SignalSubunitAddr{
+        subunit: MUSIC_SUBUNIT_0,
+        plug_id: 0x01,
+    });
+    const CLK_SRCS: [SignalAddr;1] = [
+        SignalAddr::Subunit(SignalSubunitAddr{
+            subunit: MUSIC_SUBUNIT_0,
+            plug_id: 0x01,
+        }),
+    ];
+
+    const CLK_LABELS: [&'a str;1] = [
+        "Internal",
+    ];
+}
+
+impl<'a> Default for QuatafireModel<'a> {
+    fn default() -> Self {
+        Self{
+            avc: Default::default(),
+            clk_ctl: ClkCtl::new(&Self::CLK_DST, &Self::CLK_SRCS, &Self::CLK_LABELS),
+        }
+    }
+}
+
+impl<'a> CtlModel<SndUnit> for QuatafireModel<'a> {
+    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.avc.fcp.bind(&unit.get_node())?;
+        self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+
+    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)
+    }
+}
+
+impl<'a> NotifyModel<SndUnit, bool> for QuatafireModel<'a> {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
+    }
+
+    fn parse_notification(&mut self, _: &SndUnit, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}

--- a/libs/bebob/src/esi.rs
+++ b/libs/bebob/src/esi.rs
@@ -4,17 +4,21 @@
 use glib::Error;
 
 use hinawa::{SndUnit, SndUnitExt, FwFcpExt};
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue};
+
+use alsa_ctl_tlv_codec::items::{DbInterval, CTL_VALUE_MUTE};
 
 use core::card_cntr::*;
+use core::elem_value_accessor::ElemValueAccessor;
 
-use ta1394::{*, ccm::*};
+use ta1394::{*, ccm::*, audio::*};
 
 use super::{*, common_ctls::ClkCtl};
 
 pub struct QuatafireModel<'a>{
     avc: BebobAvc,
     clk_ctl: ClkCtl<'a>,
+    input_ctl: InputCtl,
 }
 
 impl<'a> QuatafireModel<'a> {
@@ -41,6 +45,7 @@ impl<'a> Default for QuatafireModel<'a> {
         Self{
             avc: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, &Self::CLK_SRCS, &Self::CLK_LABELS),
+            input_ctl: Default::default(),
         }
     }
 }
@@ -49,19 +54,32 @@ impl<'a> CtlModel<SndUnit> for QuatafireModel<'a> {
     fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
         self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
+        self.input_ctl.load(card_cntr)?;
         Ok(())
     }
 
     fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
-        self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+        if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.input_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)
+        if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.input_ctl.write(&self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -78,5 +96,112 @@ impl<'a> NotifyModel<SndUnit, bool> for QuatafireModel<'a> {
         -> Result<bool, Error>
     {
         self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)
+    }
+}
+
+#[derive(Default, Debug)]
+struct InputCtl;
+
+const INPUT_GAIN_NAME: &str = "input-gain";
+const INPUT_BALANCE_NAME: &str = "input-pan";
+
+const GAIN_MIN: i32 = FeatureCtl::NEG_INFINITY as i32;
+const GAIN_MAX: i32 = 0;
+const GAIN_STEP: i32 = 1;
+const GAIN_TLV: DbInterval = DbInterval{min: -12800, max: 0, linear: false, mute_avail: false};
+
+const BALANCE_MIN: i32 = FeatureCtl::NEG_INFINITY as i32;
+const BALANCE_MAX: i32 = FeatureCtl::INFINITY as i32;
+const BALANCE_STEP: i32 = 1;
+
+const INPUT_LABELS: [&str;6] = [
+    "mic-input-1", "mic-input-2",
+    "line-input-1", "line-input-2",
+    "S/PDIF-input-1", "S/PDIF-input-2",
+];
+
+const INPUT_FB_IDS: [u8;3] = [1, 2, 3];
+
+impl InputCtl {
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_GAIN_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1, GAIN_MIN, GAIN_MAX, GAIN_STEP, INPUT_LABELS.len(),
+                                        Some(&Into::<Vec<u32>>::into(GAIN_TLV)), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_BALANCE_NAME, 0);
+        let _ = card_cntr.add_int_elems(&elem_id, 1, BALANCE_MIN, BALANCE_MAX, BALANCE_STEP, 2,
+                                        None, true)?;
+
+        Ok(())
+    }
+
+    fn read(&mut self, avc: &BebobAvc, elem_id: &ElemId, elem_value: &mut ElemValue,
+            timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            INPUT_GAIN_NAME => {
+                ElemValueAccessor::<i32>::set_vals(elem_value, INPUT_LABELS.len(), |idx| {
+                    let func_blk_id = INPUT_FB_IDS[idx / 2];
+                    let audio_ch_num = AudioCh::Each((idx % 2) as u8);
+                    let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                   FeatureCtl::Volume(vec![-1]));
+                    avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
+                    if let FeatureCtl::Volume(data) = op.ctl {
+                        let val = if data[0] == FeatureCtl::NEG_INFINITY { CTL_VALUE_MUTE } else { data[0] as i32 };
+                        Ok(val)
+                    } else {
+                        unreachable!();
+                    }
+                })
+                .map(|_| true)
+            }
+            INPUT_BALANCE_NAME => {
+                ElemValueAccessor::<i32>::set_vals(elem_value, 2, |idx| {
+                    let func_blk_id = INPUT_FB_IDS[idx / 2];
+                    let audio_ch_num = AudioCh::Each((idx % 2) as u8);
+                    let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                   FeatureCtl::LrBalance(-1));
+                    avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
+                    if let FeatureCtl::LrBalance(val) = op.ctl {
+                        Ok(val as i32)
+                    } else {
+                        unreachable!();
+                    }
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(&mut self, avc: &BebobAvc, elem_id: &ElemId, old: &ElemValue, new: &ElemValue,
+             timeout_ms: u32)
+        -> Result<bool, Error>
+    {
+        match elem_id.get_name().as_str() {
+            INPUT_GAIN_NAME => {
+                ElemValueAccessor::<i32>::get_vals(new, old, INPUT_LABELS.len(), |idx, val| {
+                    let func_blk_id = INPUT_FB_IDS[idx / 2];
+                    let audio_ch_num = AudioCh::Each((idx % 2) as u8);
+                    let v = if val == CTL_VALUE_MUTE { FeatureCtl::NEG_INFINITY } else { val as i16 };
+                    let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                   FeatureCtl::Volume(vec![v]));
+                    avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            INPUT_BALANCE_NAME => {
+                ElemValueAccessor::<i32>::get_vals(new, old, 2, |idx, val| {
+                    let func_blk_id = INPUT_FB_IDS[idx / 2];
+                    let audio_ch_num = AudioCh::Each((idx % 2) as u8);
+                    let mut op = AudioFeature::new(func_blk_id, CtlAttr::Current, audio_ch_num,
+                                                   FeatureCtl::LrBalance(val as i16));
+                    avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+                })
+                .map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/libs/bebob/src/lib.rs
+++ b/libs/bebob/src/lib.rs
@@ -19,6 +19,7 @@ use ta1394::{AvcOp, AvcStatus, AvcControl, AvcNotify};
 use ta1394::general::{InputPlugSignalFormat, OutputPlugSignalFormat};
 use ta1394::ccm::SignalSource;
 
+#[derive(Default, Debug)]
 pub struct BebobAvc{
     pub fcp: hinawa::FwFcp,
     pub company_id: [u8;3],

--- a/libs/bebob/src/lib.rs
+++ b/libs/bebob/src/lib.rs
@@ -11,7 +11,7 @@ mod apogee;
 mod maudio;
 mod behringer;
 mod stanton;
-
+mod esi;
 
 use glib::Error;
 use ta1394::{Ta1394Avc, Ta1394AvcError, AvcCmdType, AvcAddr, AvcRespCode};

--- a/libs/bebob/src/maudio/audiophile_model.rs
+++ b/libs/bebob/src/maudio/audiophile_model.rs
@@ -79,8 +79,8 @@ impl<'a> AudiophileModel<'a> {
 impl<'a> Default for AudiophileModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, &[], Self::OUT_METER_LABELS, true, 2, true),
             mixer_ctl: MixerCtl::new(

--- a/libs/bebob/src/maudio/audiophile_model.rs
+++ b/libs/bebob/src/maudio/audiophile_model.rs
@@ -74,9 +74,11 @@ impl<'a> AudiophileModel<'a> {
 
     const HP_SRC_FB_ID: u8 = 0x04;
     const HP_OUT_FB_ID: u8 = 0x0f;
+}
 
-    pub fn new() -> Self {
-        AudiophileModel{
+impl<'a> Default for AudiophileModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),

--- a/libs/bebob/src/maudio/fw410_model.rs
+++ b/libs/bebob/src/maudio/fw410_model.rs
@@ -86,9 +86,11 @@ impl<'a> Fw410Model<'a> {
 
     const HP_SRC_FB_ID: u8 = 0x07;
     const HP_OUT_FB_ID: u8 = 0x0f;
+}
 
-    pub fn new() -> Self {
-        Fw410Model{
+impl<'a> Default for Fw410Model<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),

--- a/libs/bebob/src/maudio/fw410_model.rs
+++ b/libs/bebob/src/maudio/fw410_model.rs
@@ -91,8 +91,8 @@ impl<'a> Fw410Model<'a> {
 impl<'a> Default for Fw410Model<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, &[], Self::OUT_METER_LABELS, false, 1, true),
             mixer_ctl: MixerCtl::new(

--- a/libs/bebob/src/maudio/ozonic_model.rs
+++ b/libs/bebob/src/maudio/ozonic_model.rs
@@ -60,9 +60,11 @@ impl<'a> OzonicModel<'a> {
 
     const PHYS_IN_FB_IDS: &'a [u8] = &[0x03, 0x04];
     const STREAM_IN_FB_IDS: &'a [u8] = &[0x01, 0x02];
+}
 
-    pub fn new() -> Self {
-        OzonicModel{
+impl<'a> Default for OzonicModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),

--- a/libs/bebob/src/maudio/ozonic_model.rs
+++ b/libs/bebob/src/maudio/ozonic_model.rs
@@ -65,8 +65,8 @@ impl<'a> OzonicModel<'a> {
 impl<'a> Default for OzonicModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, Self::STREAM_METER_LABELS, Self::OUT_METER_LABELS,
                                      false, 0, false),

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -58,8 +58,8 @@ impl<'a> ProfirelightbridgeModel<'a> {
 impl<'a> Default for ProfirelightbridgeModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(),
             input_ctl: InputCtl::new(),

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -53,9 +53,11 @@ impl<'a> ProfirelightbridgeModel<'a> {
         "ADAT-4",
         "Word-clock",
     ];
+}
 
-    pub fn new() -> Self {
-        ProfirelightbridgeModel {
+impl<'a> Default for ProfirelightbridgeModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),

--- a/libs/bebob/src/maudio/solo_model.rs
+++ b/libs/bebob/src/maudio/solo_model.rs
@@ -69,8 +69,8 @@ impl<'a> SoloModel<'a> {
 impl<'a> Default for SoloModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
             meter_ctl: MeterCtl::new(Self::IN_METER_LABELS, Self::STREAM_METER_LABELS, Self::OUT_METER_LABELS,
                                      false, 0, true),

--- a/libs/bebob/src/maudio/solo_model.rs
+++ b/libs/bebob/src/maudio/solo_model.rs
@@ -64,9 +64,11 @@ impl<'a> SoloModel<'a> {
 
     const PHYS_IN_FB_IDS: &'a [u8] = &[0x01, 0x02];
     const STREAM_IN_FB_IDS: &'a [u8] = &[0x03, 0x04];
+}
 
-    pub fn new() -> Self {
-        SoloModel{
+impl<'a> Default for SoloModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             req: hinawa::FwReq::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),

--- a/libs/bebob/src/maudio/special_model.rs
+++ b/libs/bebob/src/maudio/special_model.rs
@@ -21,8 +21,8 @@ pub struct SpecialModel {
 impl SpecialModel {
     pub fn new(is_fw1814: bool) -> Self {
         SpecialModel {
-            avc: BebobAvc::new(),
-            req: hinawa::FwReq::new(),
+            avc: Default::default(),
+            req: Default::default(),
             clk_ctl: ClkCtl::new(is_fw1814),
             meter_ctl: MeterCtl::new(),
             cache: StateCache::new(),

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -14,6 +14,7 @@ use super::maudio::profirelightbridge_model::ProfirelightbridgeModel;
 use super::maudio::special_model::SpecialModel;
 use super::behringer::firepower_model::FirepowerModel;
 use super::stanton::ScratchampModel;
+use super::esi::QuatafireModel;
 
 pub struct BebobModel<'a>{
     ctl_model: BebobCtlModel<'a>,
@@ -31,6 +32,7 @@ enum BebobCtlModel<'a> {
     MaudioSpecial(SpecialModel),
     BehringerFirepower(FirepowerModel<'a>),
     StantonScratchamp(ScratchampModel<'a>),
+    EsiQuatafire(QuatafireModel<'a>),
 }
 
 impl<'a> BebobModel<'a> {
@@ -46,6 +48,7 @@ impl<'a> BebobModel<'a> {
             (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new(false)),
             (0x001564, 0x000610) => BebobCtlModel::BehringerFirepower(Default::default()),
             (0x001260, 0x000001) => BebobCtlModel::StantonScratchamp(Default::default()),
+            (0x000f1b, 0x010064) => BebobCtlModel::EsiQuatafire(Default::default()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }
@@ -73,6 +76,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSpecial(m) => m.load(unit, card_cntr),
             BebobCtlModel::BehringerFirepower(m) => m.load(unit, card_cntr),
             BebobCtlModel::StantonScratchamp(m) => m.load(unit, card_cntr),
+            BebobCtlModel::EsiQuatafire(m) => m.load(unit, card_cntr),
         }?;
 
         match &mut self.ctl_model {
@@ -96,6 +100,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSpecial(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::BehringerFirepower(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             BebobCtlModel::StantonScratchamp(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            BebobCtlModel::EsiQuatafire(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         Ok(())
@@ -115,6 +120,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             BebobCtlModel::StantonScratchamp(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            BebobCtlModel::EsiQuatafire(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -146,6 +152,7 @@ impl<'a> BebobModel<'a> {
             BebobCtlModel::MaudioSpecial(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::BehringerFirepower(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
             BebobCtlModel::StantonScratchamp(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
+            BebobCtlModel::EsiQuatafire(m) => card_cntr.dispatch_notification(unit, &notice, &self.notified_elem_list, m),
         }
     }
 }

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -36,16 +36,16 @@ enum BebobCtlModel<'a> {
 impl<'a> BebobModel<'a> {
     pub fn new(vendor_id: u32, model_id: u32) -> Result<Self, Error> {
         let ctl_model = match (vendor_id, model_id) {
-            (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(EnsembleModel::new()),
-            (0x000d6c, 0x00000a) => BebobCtlModel::MaudioOzonic(OzonicModel::new()),
-            (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(SoloModel::new()),
-            (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(AudiophileModel::new()),
-            (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Fw410Model::new()),
-            (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(ProfirelightbridgeModel::new()),
+            (0x0003db, 0x01eeee) => BebobCtlModel::ApogeeEnsemble(Default::default()),
+            (0x000d6c, 0x00000a) => BebobCtlModel::MaudioOzonic(Default::default()),
+            (0x000d6c, 0x010062) => BebobCtlModel::MaudioSolo(Default::default()),
+            (0x000d6c, 0x010060) => BebobCtlModel::MaudioAudiophile(Default::default()),
+            (0x0007f5, 0x010046) => BebobCtlModel::MaudioFw410(Default::default()),
+            (0x000d6c, 0x0100a1) => BebobCtlModel::MaudioPlb(Default::default()),
             (0x000d6c, 0x010071) => BebobCtlModel::MaudioSpecial(SpecialModel::new(true)),
             (0x000d6c, 0x010091) => BebobCtlModel::MaudioSpecial(SpecialModel::new(false)),
-            (0x001564, 0x000610) => BebobCtlModel::BehringerFirepower(FirepowerModel::new()),
-            (0x001260, 0x000001) => BebobCtlModel::StantonScratchamp(ScratchampModel::new()),
+            (0x001564, 0x000610) => BebobCtlModel::BehringerFirepower(Default::default()),
+            (0x001260, 0x000001) => BebobCtlModel::StantonScratchamp(Default::default()),
             _ => {
                 return Err(Error::new(FileError::Noent, "Not supported"));
             }

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -45,7 +45,7 @@ impl<'a> ScratchampModel<'a> {
 impl<'a> Default for ScratchampModel<'a> {
     fn default() -> Self {
         Self{
-            avc: BebobAvc::new(),
+            avc: Default::default(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }
     }

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -40,9 +40,11 @@ impl<'a> ScratchampModel<'a> {
     const CLK_LABELS: &'a [&'a str] = &[
         "Internal",
     ];
+}
 
-    pub fn new() -> Self {
-        ScratchampModel{
+impl<'a> Default for ScratchampModel<'a> {
+    fn default() -> Self {
+        Self{
             avc: BebobAvc::new(),
             clk_ctl: ClkCtl::new(&Self::CLK_DST, Self::CLK_SRCS, Self::CLK_LABELS),
         }


### PR DESCRIPTION
ESI Audiotechnik GmbH shipped Quatafire 610 2004. The model is based on
DM1000 in BridgeCo. Enhanced Breakout Box (BeBoB) as its communication
functionality.

This patchset adds support for the model.

```
Takashi Sakamoto (5):
  bebob: use Default trait to instantiate each control model
  bebob: implement Default trait for BebobAvc structure
  bebob: add support fir ESI Quatafire 610
  bebob: esi: add input controls for Quatafire
  bebob: esi: add output control for Quatafire

 libs/bebob/src/apogee/apogee_model.rs         |   8 +-
 libs/bebob/src/behringer/firepower_model.rs   |   8 +-
 libs/bebob/src/esi.rs                         | 278 ++++++++++++++++++
 libs/bebob/src/lib.rs                         |   3 +-
 libs/bebob/src/maudio/audiophile_model.rs     |  10 +-
 libs/bebob/src/maudio/fw410_model.rs          |  10 +-
 libs/bebob/src/maudio/ozonic_model.rs         |  10 +-
 .../src/maudio/profirelightbridge_model.rs    |  10 +-
 libs/bebob/src/maudio/solo_model.rs           |  10 +-
 libs/bebob/src/maudio/special_model.rs        |   4 +-
 libs/bebob/src/model.rs                       |  23 +-
 libs/bebob/src/stanton.rs                     |   8 +-
 12 files changed, 342 insertions(+), 40 deletions(-)
 create mode 100644 libs/bebob/src/esi.rs
```