### PR TITLE
ieee1212-config-rom: fix size check for directory with single leaf/directory entry

### DIFF
--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -243,7 +243,7 @@ fn get_directory_entry_list<'a>(mut directory: &'a [u8], data: &'a [u8])
                 }
                 let doublet = [data[start_offset], data[start_offset + 1]];
                 let length = 4 * u16::from_be_bytes(doublet) as usize;
-                if length < 8 {
+                if length < 4 {
                     let msg = format!("Invalid length of block {}", length);
                     Err(ConfigRomParseError::new(ctx, msg))?
                 }


### PR DESCRIPTION
When directory has single leaf/directory entry, the size of directory is 4
bytes (=1 quadlet). Current implementation expects the size greater than 8
and fail to parse in the case.

This commit fixes the bug.