### PR TITLE
[PATCH 0/7] ieee1212-config-rom: add parser for some types of data for leaf entry

### DIFF
--- a/libs/ieee1212-config-rom/README.md
+++ b/libs/ieee1212-config-rom/README.md
@@ -15,7 +15,7 @@ represents directory entry. In the `Entry` structure, `key` member is typed as `
 for the type of key, and `data` member is typed as `EntryData` to dispatch four types
 of data in the entry.
 
-In IEEE 1212, text descriptor of leaf entry includes string information. `Descriptor`
+In IEEE 1212, text descriptor of leaf entry includes string information. `DescriptorLeaf`
 structure is used to parse the descriptor.
 
 For convenience, `EntryDataAccess` trait is available to access several type of data in
@@ -26,7 +26,7 @@ each entry by key.
 ```rust
 use ieee1212_config_rom::ConfigRom;
 use ieee1212_config_rom::entry::{Entry, KeyType, EntryData, EntryDataAccess};
-use ieee1212_config_rom::leaf::{Descriptor, DescriptorData, TextualDescriptorData};
+use ieee1212_config_rom::leaf::{DescriptorLeaf, DescriptorData, TextualDescriptorData};
 use std::convert::TryFrom;
 
 // Prepare raw data of Configuration ROM as array with u8 elements aligned by big endian.
@@ -52,7 +52,7 @@ if let EntryData::Immediate(value) = config_rom.root[1].data {
 } else {
     unreachable!();
 }
-let desc = Descriptor::try_from(&config_rom.root[2]).unwrap();
+let desc = DescriptorLeaf::try_from(&config_rom.root[2]).unwrap();
 if let DescriptorData::Textual(d) = desc.data {
     assert_eq!("Linux Firewire", d.text);
 } else {

--- a/libs/ieee1212-config-rom/README.md
+++ b/libs/ieee1212-config-rom/README.md
@@ -26,7 +26,7 @@ each entry by key.
 ```rust
 use ieee1212_config_rom::ConfigRom;
 use ieee1212_config_rom::entry::{Entry, KeyType, EntryData, EntryDataAccess};
-use ieee1212_config_rom::desc::{Descriptor, DescriptorData, TextualDescriptorData};
+use ieee1212_config_rom::leaf::{Descriptor, DescriptorData, TextualDescriptorData};
 use std::convert::TryFrom;
 
 // Prepare raw data of Configuration ROM as array with u8 elements aligned by big endian.

--- a/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
+++ b/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
@@ -20,7 +20,16 @@ fn print_raw(raw: &[u8], level: usize) {
     println!("");
 }
 
-fn print_leaf(raw: &[u8], level: usize) -> Result<(), String> {
+fn print_eui64_leaf(raw: &[u8], level: usize) -> Result<(), String> {
+    let mut indent = String::new();
+    (0..(level * INDENT_PER_LEVEL)).for_each(|_| indent.push(' '));
+
+    Eui64Leaf::try_from(raw)
+        .map(|data| println!("{}0x{:016x}", indent, data.0))
+        .map_err(|e| e.to_string())
+}
+
+fn print_descriptor_leaf(raw: &[u8], level: usize) -> Result<(), String> {
     let mut indent = String::new();
     (0..(level * INDENT_PER_LEVEL)).for_each(|_| indent.push(' '));
 
@@ -56,7 +65,11 @@ fn print_directory_entries(entries: &[Entry], level: usize) -> Result<(), String
             EntryData::CsrOffset(offset) => println!("{}{:?} (offset): 0x{:024x}", indent, entry.key, offset),
             EntryData::Leaf(leaf) => {
                 println!("{}{:?} (leaf):", indent, entry.key);
-                print_leaf(leaf, level + 1)?;
+                if entry.key == KeyType::Eui64 {
+                    print_eui64_leaf(leaf, level + 1)?;
+                } else {
+                    print_descriptor_leaf(leaf, level + 1)?;
+                }
             }
             EntryData::Directory(raw) => {
                 println!("{}{:?} (directory):", indent, entry.key);

--- a/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
+++ b/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
@@ -29,6 +29,18 @@ fn print_eui64_leaf(raw: &[u8], level: usize) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+fn print_unit_location_leaf(raw: &[u8], level: usize) -> Result<(), String> {
+    let mut indent = String::new();
+    (0..(level * INDENT_PER_LEVEL)).for_each(|_| indent.push(' '));
+
+    UnitLocationLeaf::try_from(raw)
+        .map(|data| {
+            println!("{}base address: 0x{:016x}", indent, data.base_addr);
+            println!("{}upper bound: 0x{:016x}", indent, data.upper_bound);
+        })
+        .map_err(|e| e.to_string())
+}
+
 fn print_descriptor_leaf(raw: &[u8], level: usize) -> Result<(), String> {
     let mut indent = String::new();
     (0..(level * INDENT_PER_LEVEL)).for_each(|_| indent.push(' '));
@@ -67,6 +79,8 @@ fn print_directory_entries(entries: &[Entry], level: usize) -> Result<(), String
                 println!("{}{:?} (leaf):", indent, entry.key);
                 if entry.key == KeyType::Eui64 {
                     print_eui64_leaf(leaf, level + 1)?;
+                } else if entry.key == KeyType::UnitLocation {
+                    print_unit_location_leaf(leaf, level + 1)?;
                 } else {
                     print_descriptor_leaf(leaf, level + 1)?;
                 }

--- a/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
+++ b/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use ieee1212_config_rom::{*, entry::*, desc::*};
+use ieee1212_config_rom::{*, entry::*, leaf::*};
 use std::fs::File;
 use std::io::Read;
 use std::convert::TryFrom;

--- a/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
+++ b/libs/ieee1212-config-rom/src/bin/config-rom-parser.rs
@@ -24,7 +24,7 @@ fn print_leaf(raw: &[u8], level: usize) -> Result<(), String> {
     let mut indent = String::new();
     (0..(level * INDENT_PER_LEVEL)).for_each(|_| indent.push(' '));
 
-    let desc = Descriptor::try_from(raw)
+    let desc = DescriptorLeaf::try_from(raw)
         .map_err(|e| e.to_string())?;
     match &desc.data {
         DescriptorData::Textual(d) => {

--- a/libs/ieee1212-config-rom/src/entry.rs
+++ b/libs/ieee1212-config-rom/src/entry.rs
@@ -139,10 +139,10 @@ impl<'a> EntryDataAccess<'a, usize> for Entry<'a> {
 }
 
 // Via descriptor data.
-impl<'a> EntryDataAccess<'a, Descriptor<'a>> for Entry<'a> {
-    fn get(&'a self, key_type: KeyType) -> Option<Descriptor<'a>> {
+impl<'a> EntryDataAccess<'a, DescriptorLeaf<'a>> for Entry<'a> {
+    fn get(&'a self, key_type: KeyType) -> Option<DescriptorLeaf<'a>> {
         if self.key == key_type {
-            Descriptor::try_from(self)
+            DescriptorLeaf::try_from(self)
                 .ok()
         } else {
             None
@@ -152,7 +152,7 @@ impl<'a> EntryDataAccess<'a, Descriptor<'a>> for Entry<'a> {
 
 impl<'a> EntryDataAccess<'a, TextualDescriptorData<'a>> for Entry<'a> {
     fn get(&'a self, key_type: KeyType) -> Option<TextualDescriptorData<'a>> {
-        EntryDataAccess::<Descriptor<'a>>::get(self, key_type)
+        EntryDataAccess::<DescriptorLeaf<'a>>::get(self, key_type)
             .and_then(|desc| {
                 if let DescriptorData::Textual(d) = desc.data {
                     Some(d)

--- a/libs/ieee1212-config-rom/src/entry.rs
+++ b/libs/ieee1212-config-rom/src/entry.rs
@@ -6,7 +6,7 @@
 //! Entry structure represents directory entry. KeyType enumerations represents key of entry.
 //! EntryData enumeration represents type of directory entry, including its content.
 
-use super::desc::*;
+use super::leaf::*;
 
 use std::convert::TryFrom;
 

--- a/libs/ieee1212-config-rom/src/entry.rs
+++ b/libs/ieee1212-config-rom/src/entry.rs
@@ -195,3 +195,14 @@ impl<'a> EntryDataAccess<'a, u64> for Entry<'a> {
             .map(|data| data.0)
     }
 }
+
+impl<'a> EntryDataAccess<'a, UnitLocationLeaf> for Entry<'a> {
+    fn get(&'a self, key_type: KeyType) -> Option<UnitLocationLeaf> {
+        if self.key == key_type {
+            UnitLocationLeaf::try_from(self)
+                .ok()
+        } else {
+            None
+        }
+    }
+}

--- a/libs/ieee1212-config-rom/src/entry.rs
+++ b/libs/ieee1212-config-rom/src/entry.rs
@@ -176,3 +176,22 @@ impl<'a> EntryDataAccess<'a, String> for Entry<'a> {
             .map(|text| text.to_string())
     }
 }
+
+// Via EUI-64 leaf data.
+impl<'a> EntryDataAccess<'a, Eui64Leaf> for Entry<'a> {
+    fn get(&'a self, key_type: KeyType) -> Option<Eui64Leaf> {
+        if self.key == key_type {
+            Eui64Leaf::try_from(self)
+                .ok()
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> EntryDataAccess<'a, u64> for Entry<'a> {
+    fn get(&'a self, key_type: KeyType) -> Option<u64> {
+        EntryDataAccess::<Eui64Leaf>::get(self, key_type)
+            .map(|data| data.0)
+    }
+}

--- a/libs/ieee1212-config-rom/src/leaf.rs
+++ b/libs/ieee1212-config-rom/src/leaf.rs
@@ -106,12 +106,12 @@ impl<'a> TryFrom<&'a [u8]> for DescriptorData<'a> {
 
 /// The structure represents descriptor in content of leaf.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Descriptor<'a>{
+pub struct DescriptorLeaf<'a>{
     pub spec_id: u32,
     pub data: DescriptorData<'a>,
 }
 
-impl<'a> TryFrom<&'a [u8]> for Descriptor<'a> {
+impl<'a> TryFrom<&'a [u8]> for DescriptorLeaf<'a> {
     type Error = LeafParseError<DescriptorLeafParseCtx>;
 
     fn try_from(raw: &'a [u8]) -> Result<Self, Self::Error> {
@@ -120,16 +120,16 @@ impl<'a> TryFrom<&'a [u8]> for Descriptor<'a> {
         let spec_id = u32::from_be_bytes(quadlet) & 0x00ffffff;
 
         let data = DescriptorData::try_from(raw)?;
-        Ok(Descriptor{spec_id, data})
+        Ok(Self{spec_id, data})
     }
 }
 
-impl<'a> TryFrom<&'a Entry<'a>> for Descriptor<'a> {
+impl<'a> TryFrom<&'a Entry<'a>> for DescriptorLeaf<'a> {
     type Error = LeafParseError<DescriptorLeafParseCtx>;
 
     fn try_from(entry: &'a Entry<'a>) -> Result<Self, Self::Error> {
         if let EntryData::Leaf(leaf) = &entry.data {
-            let desc = Descriptor::try_from(&leaf[..])?;
+            let desc = Self::try_from(&leaf[..])?;
             Ok(desc)
         } else {
             let label = if let EntryData::Immediate(_) = &entry.data {
@@ -176,7 +176,7 @@ mod test {
             0x46, 0x69, 0x72, 0x65, 0x77, 0x69, 0x72, 0x65, 0x00, 0x00,
         ];
         let entry = Entry{key: KeyType::Descriptor, data: EntryData::Leaf(&raw[..])};
-        let desc = Descriptor::try_from(&entry).unwrap();
+        let desc = DescriptorLeaf::try_from(&entry).unwrap();
         assert_eq!(0, desc.spec_id);
         if let DescriptorData::Textual(d) = desc.data {
             assert_eq!(0, d.width);

--- a/libs/ieee1212-config-rom/src/leaf.rs
+++ b/libs/ieee1212-config-rom/src/leaf.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-//! For descriptor in leaf entry, the module includes structure, enumeration and trait implementation.
+//! Leaf entry has structured data. The module includes structure, enumeration and trait
+//! implementation to parse it.
 //!
 //! Descriptor structure represents descriptor itself. The structure implements TryFrom trait to
 //! convert from the content of leaf entry. DescriptorData enumeration represents data of
@@ -159,10 +160,10 @@ impl std::fmt::Display for DescriptorParseCtx {
 
 #[cfg(test)]
 mod test {
-    use super::desc::*;
+    use super::leaf::*;
 
     #[test]
-    fn textual_desc_from_entry() {
+    fn textual_desc_from_leaf_entry() {
         let raw = [
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x4c, 0x69, 0x6e, 0x75, 0x78, 0x20,
             0x46, 0x69, 0x72, 0x65, 0x77, 0x69, 0x72, 0x65, 0x00, 0x00,

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -27,7 +27,7 @@
 //! ```rust
 //! use ieee1212_config_rom::ConfigRom;
 //! use ieee1212_config_rom::entry::{Entry, KeyType, EntryData, EntryDataAccess};
-//! use ieee1212_config_rom::desc::{Descriptor, DescriptorData, TextualDescriptorData};
+//! use ieee1212_config_rom::leaf::{Descriptor, DescriptorData, TextualDescriptorData};
 //! use std::convert::TryFrom;
 //!
 //! // Prepare raw data of Configuration ROM as array with u8 elements aligned by big endian.
@@ -103,7 +103,7 @@
 //! In both cases, the content to be parsed should be aligned to big-endian order.
 
 pub mod entry;
-pub mod desc;
+pub mod leaf;
 
 use entry::*;
 

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -16,7 +16,7 @@
 //! for the type of key, and `data` member is typed as `EntryData` to dispatch four types
 //! of data in the entry.
 //!
-//! In IEEE 1212, text descriptor of leaf entry includes string information. `Descriptor`
+//! In IEEE 1212, text descriptor of leaf entry includes string information. `DescriptorLeaf`
 //! structure is used to parse the descriptor.
 //!
 //! For convenience, `EntryDataAccess` trait is available to access several type of data in
@@ -27,7 +27,7 @@
 //! ```rust
 //! use ieee1212_config_rom::ConfigRom;
 //! use ieee1212_config_rom::entry::{Entry, KeyType, EntryData, EntryDataAccess};
-//! use ieee1212_config_rom::leaf::{Descriptor, DescriptorData, TextualDescriptorData};
+//! use ieee1212_config_rom::leaf::{DescriptorLeaf, DescriptorData, TextualDescriptorData};
 //! use std::convert::TryFrom;
 //!
 //! // Prepare raw data of Configuration ROM as array with u8 elements aligned by big endian.
@@ -53,7 +53,7 @@
 //! } else {
 //!     unreachable!();
 //! }
-//! let desc = Descriptor::try_from(&config_rom.root[2]).unwrap();
+//! let desc = DescriptorLeaf::try_from(&config_rom.root[2]).unwrap();
 //! if let DescriptorData::Textual(d) = desc.data {
 //!     assert_eq!("Linux Firewire", d.text);
 //! } else {


### PR DESCRIPTION
In IEEE 1212, leaf is used for structured data and some types of structured data is defined. Current implementation of ieee1212-config-rom crate just supports descriptor type, however the other types are actually used in configuration ROM for Audio and Music units on IEEE 1394 bus.

This patchset adds support for some types.

```
Takashi Sakamoto (7):
  ieee1212-config-rom: rename desc module to leaf module
  ieee1212-config-rom: use generic structure for error to parse leaf
  ieee1212-config-rom: rename Descriptor structure to DescriptorLeaf
  ieee1212-config-rom: add Eui64 data structure and parser for leaf
  ieee1212-config-rom: bin: parse EUI-64 leaf
  ieee1212-config-rom: add unit location structure and parser for leaf
  ieee1212-config-rom: bin: parse Unit Location leaf

 libs/ieee1212-config-rom/README.md            |   6 +-
 .../src/bin/config-rom-parser.rs              |  35 +-
 libs/ieee1212-config-rom/src/desc.rs          | 180 ---------
 libs/ieee1212-config-rom/src/entry.rs         |  40 +-
 libs/ieee1212-config-rom/src/leaf.rs          | 343 ++++++++++++++++++
 libs/ieee1212-config-rom/src/lib.rs           |   8 +-
 6 files changed, 416 insertions(+), 196 deletions(-)
 delete mode 100644 libs/ieee1212-config-rom/src/desc.rs
 create mode 100644 libs/ieee1212-config-rom/src/leaf.rs
```