### PR TITLE
core: dispatcher: fix thread blocking in shutdown process due to full queue

### DIFF
--- a/libs/bebob/src/runtime.rs
+++ b/libs/bebob/src/runtime.rs
@@ -42,7 +42,15 @@ pub struct BebobRuntime<'a> {
 
 impl<'a> Drop for BebobRuntime<'a> {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/core/src/dispatcher.rs
+++ b/libs/core/src/dispatcher.rs
@@ -59,6 +59,10 @@ impl Dispatcher {
         Ok(Dispatcher{name, th, ev_loop})
     }
 
+    pub fn stop(&mut self) {
+        self.ev_loop.quit();
+    }
+
     fn attach_src_to_ctx(&mut self, src: &Source) {
         let ctx = self.ev_loop.get_context();
         src.attach(Some(&ctx));

--- a/libs/dg00x/src/runtime.rs
+++ b/libs/dg00x/src/runtime.rs
@@ -38,7 +38,15 @@ pub struct Dg00xRuntime {
 
 impl<'a> Drop for Dg00xRuntime {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -131,7 +131,15 @@ impl RuntimeOperation<u32> for DiceRuntime {
 
 impl Drop for DiceRuntime {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/efw/src/runtime.rs
+++ b/libs/efw/src/runtime.rs
@@ -37,7 +37,15 @@ pub struct EfwRuntime {
 
 impl Drop for EfwRuntime {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -121,7 +121,15 @@ impl RuntimeOperation<u32> for FfRuntime {
 
 impl Drop for FfRuntime {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/motu/src/runtime.rs
+++ b/libs/motu/src/runtime.rs
@@ -38,7 +38,15 @@ pub struct MotuRuntime<'a> {
 
 impl<'a> Drop for MotuRuntime<'a> {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -52,7 +52,15 @@ pub struct OxfwRuntime {
 
 impl Drop for OxfwRuntime {
     fn drop(&mut self) {
-        // Finish I/O threads.
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/tascam/src/async_runtime.rs
+++ b/libs/tascam/src/async_runtime.rs
@@ -50,6 +50,16 @@ impl Drop for AsyncRuntime {
         });
         let _ = self.req.enable_notification(&self.node, false);
         self.resp.release();
+
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }

--- a/libs/tascam/src/isoc_rack_runtime.rs
+++ b/libs/tascam/src/isoc_rack_runtime.rs
@@ -37,6 +37,15 @@ pub struct IsocRackRuntime<'a> {
 
 impl<'a> Drop for IsocRackRuntime<'a> {
     fn drop(&mut self) {
+        // At first, stop event loop in all of dispatchers to avoid queueing new events.
+        for dispatcher in &mut self.dispatchers {
+            dispatcher.stop();
+        }
+
+        // Next, consume all events in queue to release blocked thread for sender.
+        for _ in self.rx.try_iter() {}
+
+        // Finally Finish I/O threads.
         self.dispatchers.clear();
     }
 }


### PR DESCRIPTION
When implementation of RuntimeOperation::listen() fails due to ENOMEM
error in call of ioctl(2) with SNDRV_CTL_IOCTL_ELEM_ADD, the process
should be going to shutdown. However, preceding calls already queue
some ALSA control element event in kernel space. Running dispatcher
reads the events and sends to std::sync::mpsc, then possible to reach
the limit of queue in userspace. As a result, the sender thread is
blocked due to the lack of rest in the queue. In this case, the
shutdown corrupts due to thread joining even if glib::MainLoop is set
to quit.

Current implementation gives an internal API for the combination of
glib::MainLoop::quit() and std::Thread::join(). However, to release
the blocked thread, it's required to hollow the queue. This should
be done after scheduling stop of dispatchers in sender side since no
additional events should not be queued.

This commit fixes the bug. The commit adds an independent internal
API to schedule stop of dispatcher. After calling the API, runtime
instance is expected to hollow the queue, then drop dispatcher to
join thread.

I note that Linux kernel v5.13 or later extends the capacity of
user-defined element set. the ioctl error will becomes rare.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>