### PR TITLE
[PATCH 00/11] motu-protocols/motu-runtime: add support for 828/896

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,6 +102,7 @@ your device, please contact to developer.
 
 * snd-firewire-motu-ctl-service
 
+  * MOTU 828
   * MOTU Traveler
   * MOTU 828mkII
   * MOTU UltraLite

--- a/README.rst
+++ b/README.rst
@@ -103,6 +103,7 @@ your device, please contact to developer.
 * snd-firewire-motu-ctl-service
 
   * MOTU 828
+  * MOTU 896
   * MOTU Traveler
   * MOTU 828mkII
   * MOTU UltraLite

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -319,3 +319,219 @@ pub trait AesebuRateConvertProtocol<'a>: CommonProtocol<'a> {
         )
     }
 }
+
+/// The enumeration to express the mode of hold time for clip and peak LEDs.
+pub enum LevelMetersHoldTimeMode {
+    /// off.
+    Off,
+    /// 2 seconds.
+    Sec2,
+    /// 4 seconds.
+    Sec4,
+    /// 10 seconds.
+    Sec10,
+    /// 1 minute.
+    Sec60,
+    /// 5 minutes.
+    Sec300,
+    /// 8 minutes.
+    Sec480,
+    /// Infinite.
+    Infinite,
+}
+
+/// The enumeration to express the mode of programmable meter display.
+pub enum LevelMetersProgrammableMode {
+    AnalogOutput,
+    AdatInput,
+    AdatOutput,
+}
+
+/// The enumeration to express the mode of AES/EBU meter display.
+pub enum LevelMetersAesebuMode {
+    Input,
+    Output,
+}
+
+const LEVEL_METERS_OFFSET: u32 = 0x0b24;
+
+const LEVEL_METERS_PEAK_HOLD_TIME_MASK: u32 = 0x00003800;
+const LEVEL_METERS_PEAK_HOLD_TIME_SHIFT: usize = 11;
+
+const LEVEL_METERS_CLIP_HOLD_TIME_MASK: u32 = 0x00000700;
+const LEVEL_METERS_CLIP_HOLD_TIME_SHIFT: usize = 8;
+
+const LEVEL_METERS_HOLD_TIME_VALS: [u8; 8] = [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+
+const LEVEL_METERS_AESEBU_MASK: u32 = 0x00000004;
+const LEVEL_METERS_AESEBU_SHIFT: usize = 2;
+
+const LEVEL_METERS_AESEBU_VALS: [u8; 2] = [0x00, 0x01];
+
+const LEVEL_METERS_PROGRAMMABLE_MASK: u32 = 0x00000003;
+const LEVEL_METERS_PROGRAMMABLE_SHIFT: usize = 0;
+const LEVEL_METERS_PROGRAMMABLE_VALS: [u8; 3] = [0x00, 0x01, 0x02];
+
+const LEVEL_METERS_PEAK_HOLD_TIME_LABEL: &str = "level-meters-peak-hold-time";
+const LEVEL_METERS_CLIP_HOLD_TIME_LABEL: &str = "level-meters-clip-hold-time";
+const LEVEL_METERS_PROGRAMMABLE_LABEL: &str = "level-meters-programmable";
+const LEVEL_METERS_AESEBU_LABEL: &str = "level-meters-aesebu";
+
+/// The trait for protocol of level meter.
+pub trait LevelMetersProtocol<'a>: CommonProtocol<'a> {
+    const LEVEL_METERS_HOLD_TIME_MODES: [LevelMetersHoldTimeMode; 8] = [
+        LevelMetersHoldTimeMode::Off,
+        LevelMetersHoldTimeMode::Sec2,
+        LevelMetersHoldTimeMode::Sec4,
+        LevelMetersHoldTimeMode::Sec10,
+        LevelMetersHoldTimeMode::Sec60,
+        LevelMetersHoldTimeMode::Sec300,
+        LevelMetersHoldTimeMode::Sec480,
+        LevelMetersHoldTimeMode::Infinite,
+    ];
+
+    const LEVEL_METERS_AESEBU_MODES: [LevelMetersAesebuMode; 2] =
+        [LevelMetersAesebuMode::Output, LevelMetersAesebuMode::Input];
+
+    const LEVEL_METERS_PROGRAMMABLE_MODES: [LevelMetersProgrammableMode; 3] = [
+        LevelMetersProgrammableMode::AnalogOutput,
+        LevelMetersProgrammableMode::AdatInput,
+        LevelMetersProgrammableMode::AdatOutput,
+    ];
+
+    fn get_level_meters_peak_hold_time_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_PEAK_HOLD_TIME_MASK,
+            LEVEL_METERS_PEAK_HOLD_TIME_SHIFT,
+            LEVEL_METERS_PEAK_HOLD_TIME_LABEL,
+            unit,
+            &LEVEL_METERS_HOLD_TIME_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_level_meters_peak_hold_time_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_PEAK_HOLD_TIME_MASK,
+            LEVEL_METERS_PEAK_HOLD_TIME_SHIFT,
+            LEVEL_METERS_PEAK_HOLD_TIME_LABEL,
+            unit,
+            &LEVEL_METERS_HOLD_TIME_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_level_meters_clip_hold_time_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_CLIP_HOLD_TIME_MASK,
+            LEVEL_METERS_CLIP_HOLD_TIME_SHIFT,
+            LEVEL_METERS_CLIP_HOLD_TIME_LABEL,
+            unit,
+            &LEVEL_METERS_HOLD_TIME_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_level_meters_clip_hold_time_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_CLIP_HOLD_TIME_MASK,
+            LEVEL_METERS_CLIP_HOLD_TIME_SHIFT,
+            LEVEL_METERS_CLIP_HOLD_TIME_LABEL,
+            unit,
+            &LEVEL_METERS_HOLD_TIME_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_level_meters_aesebu_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_AESEBU_MASK,
+            LEVEL_METERS_AESEBU_SHIFT,
+            LEVEL_METERS_AESEBU_LABEL,
+            unit,
+            &LEVEL_METERS_AESEBU_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_level_meters_aesebu_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_AESEBU_MASK,
+            LEVEL_METERS_AESEBU_SHIFT,
+            LEVEL_METERS_AESEBU_LABEL,
+            unit,
+            &LEVEL_METERS_AESEBU_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_level_meters_programmable_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_PROGRAMMABLE_MASK,
+            LEVEL_METERS_PROGRAMMABLE_SHIFT,
+            LEVEL_METERS_PROGRAMMABLE_LABEL,
+            unit,
+            &LEVEL_METERS_PROGRAMMABLE_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_level_meters_programmable_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            LEVEL_METERS_OFFSET,
+            LEVEL_METERS_PROGRAMMABLE_MASK,
+            LEVEL_METERS_PROGRAMMABLE_SHIFT,
+            LEVEL_METERS_PROGRAMMABLE_LABEL,
+            unit,
+            &LEVEL_METERS_PROGRAMMABLE_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+}

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -257,3 +257,65 @@ pub trait WordClkProtocol<'a>: CommonProtocol<'a> {
         )
     }
 }
+
+/// The enumeration to express the mode of rate convert for AES/EBU input/output signals.
+pub enum AesebuRateConvertMode {
+    /// Not available.
+    None,
+    /// The rate of input signal is converted to system rate.
+    InputToSystem,
+    /// The rate of output signal is slave to input, ignoring system rate.
+    OutputDependsInput,
+    /// The rate of output signal is double rate than system rate.
+    OutputDoubleSystem,
+}
+
+const AESEBU_RATE_CONVERT_MASK: u32 = 0x00000060;
+const AESEBU_RATE_CONVERT_SHIFT: usize = 5;
+const AESEBU_RATE_CONVERT_VALS: [u8; 4] = [0x00, 0x01, 0x02, 0x03];
+
+const AESEBU_RATE_CONVERT_LABEL: &str = "aesebu-rate-convert";
+
+/// The trait for protocol of rate convert specific to AES/EBU input/output signals.
+pub trait AesebuRateConvertProtocol<'a>: CommonProtocol<'a> {
+    const AESEBU_RATE_CONVERT_MODES: [AesebuRateConvertMode; 4] = [
+        AesebuRateConvertMode::None,
+        AesebuRateConvertMode::InputToSystem,
+        AesebuRateConvertMode::OutputDependsInput,
+        AesebuRateConvertMode::OutputDoubleSystem,
+    ];
+
+    fn get_aesebu_rate_convert_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            Self::OFFSET_CLK,
+            AESEBU_RATE_CONVERT_MASK,
+            AESEBU_RATE_CONVERT_SHIFT,
+            AESEBU_RATE_CONVERT_LABEL,
+            unit,
+            &AESEBU_RATE_CONVERT_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_aesebu_rate_convert_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            Self::OFFSET_CLK,
+            AESEBU_RATE_CONVERT_MASK,
+            AESEBU_RATE_CONVERT_SHIFT,
+            AESEBU_RATE_CONVERT_LABEL,
+            unit,
+            &AESEBU_RATE_CONVERT_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+}

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -6,6 +6,7 @@
 //! The crate includes protocols defined by Mark of the Unicorn for its FireWire series.
 
 pub mod config_rom;
+pub mod version_1;
 pub mod version_2;
 pub mod version_3;
 

--- a/libs/motu/protocols/src/version_1.rs
+++ b/libs/motu/protocols/src/version_1.rs
@@ -1,0 +1,732 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol used in version 1 devices of MOTU FireWire series.
+//!
+//! The modules includes structure, enumeration, and trait and its implementation for protocol
+//! used in version 1 devices of Mark of the Unicorn FireWire series.
+
+use glib::Error;
+
+use hinawa::FwReq;
+use hinawa::SndMotu;
+
+use super::*;
+
+/// The enumeration to express source of sampling clock.
+pub enum V1ClkSrc {
+    /// Internal.
+    Internal,
+    /// S/PDIF on coaxial or optical interface.
+    Spdif,
+    /// Word clock on BNC interface.
+    WordClk,
+    /// ADAT on optical interface.
+    AdatOpt,
+    /// ADAT on D-Sub interface.
+    AdatDsub,
+    /// AES/EBU on XLR interface.
+    AesebuXlr,
+}
+
+/// The enumeration to express mode of optical interface.
+pub enum V1OptIfaceMode {
+    Adat,
+    Spdif,
+}
+
+// 828 registers:
+//
+// 0x'ffff'f000'0b00: configuration for sampling clock and digital interfaces.
+//
+//  0xffff0000: communication control. ALSA firewire-motu driver changes it.
+//  0x00008000: mode of optical input interface.
+//    0x00008000: for S/PDIF signal.
+//    0x00000000: disabled or for ADAT signal.
+//  0x00004000: mode of optical output interface.
+//    0x00004000: for S/PDIF signal.
+//    0x00000000: disabled or for ADAT signal.
+//  0x00003f00: monitor input mode.
+//    0x00000800: analog-1/2
+//    0x00001a00: analog-3/4
+//    0x00002c00: analog-5/6
+//    0x00003e00: analog-7/8
+//    0x00000000: analog-1
+//    0x00000900: analog-2
+//    0x00001200: analog-3
+//    0x00001b00: analog-4
+//    0x00002400: analog-5
+//    0x00002d00: analog-6
+//    0x00003600: analog-7
+//    0x00003f00: analog-8
+//  0x00000080: enable stream input.
+//  0x00000040: disable monitor input.
+//  0x00000008: enable main out.
+//  0x00000004: rate of sampling clock.
+//    0x00000004: 48.0 kHz
+//    0x00000000: 44.1 kHz
+//  0x00000023: source of sampling clock.
+//    0x00000003: source packet header (SPH)
+//    0x00000002: S/PDIF on optical/coaxial interface.
+//    0x00000021: ADAT on optical interface
+//    0x00000001: ADAT on Dsub 9pin
+//    0x00000000: internal
+
+const CONF_828_OFFSET: u32 = 0x00000b00;
+
+const CONF_BOOL_VALS: [u8; 2] = [0x00, 0x01];
+
+const CONF_828_OPT_IN_IFACE_MASK: u32 = 0x00008000;
+const CONF_828_OPT_IN_IFACE_SHIFT: usize = 15;
+
+const CONF_828_OPT_OUT_IFACE_MASK: u32 = 0x00004000;
+const CONF_828_OPT_OUT_IFACE_SHIFT: usize = 14;
+
+const CONF_828_OPT_IFACE_VALS: [u8; 2] = [0x00, 0x01];
+
+const CONF_828_MONITOR_INPUT_CH_MASK: u32 = 0x00003f00;
+const CONF_828_MONITOR_INPUT_CH_SHIFT: usize = 8;
+const CONF_828_MONITOR_INPUT_CH_VALS: [u8; 12] = [
+    0x08, // 0/1
+    0x1a, // 2/3
+    0x2c, // 4/5
+    0x3e, // 6/7
+    0x00, // 0
+    0x09, // 1
+    0x12, // 2
+    0x1b, // 3
+    0x24, // 4
+    0x2d, // 5
+    0x36, // 6
+    0x3f, // 7
+];
+
+const CONF_828_STREAM_INPUT_ENABLE_MASK: u32 = 0x00000080;
+const CONF_828_STREAM_INPUT_ENABLE_SHIFT: usize = 7;
+
+const CONF_828_MONITOR_INPUT_DISABLE_MASK: u32 = 0x00000040;
+const CONF_828_MONITOR_INPUT_DISABLE_SHIFT: usize = 6;
+
+const CONF_828_OUTPUT_ENABLE_MASK: u32 = 0x00000008;
+const CONF_828_OUTPUT_ENABLE_SHIFT: usize = 3;
+
+const CONF_828_CLK_RATE_MASK: u32 = 0x00000004;
+const CONF_828_CLK_RATE_SHIFT: usize = 2;
+
+const CONF_828_CLK_SRC_MASK: u32 = 0x00000023;
+const CONF_828_CLK_SRC_SHIFT: usize = 0;
+
+//
+// 896 registers:
+//
+// 0x'ffff'f000'0b14: configuration for sampling clock and input source for main output.
+//  0xf0000000: enable physical and stream input to DAC.
+//    0x80000000: disable
+//    0x40000000: disable
+//    0x20000000: enable (prior to the other bits)
+//    0x10000000: disable
+//    0x00000000: disable
+//  0x08000000: speed of word clock signal output on BNC interface.
+//    0x00000000: force to low rate (44.1/48.0 kHz).
+//    0x08000000: follow to system clock.
+//  0x04000000: something relevant to clock.
+//  0x03000000: enable output.
+//   0x02000000: enabled irreversibly once standing
+//   0x01000000: enabled irreversibly once standing
+//  0x00ffff00: input to monitor.
+//    0x00000000: none
+//    0x00004800: analog-1/2
+//    0x00005a00: analog-3/4
+//    0x00006c00: analog-5/6
+//    0x00007e00: analog-7/8
+//    0x00104800: AES/EBU-1/2
+//    0x00004000: analog-1
+//    0x00004900: analog-2
+//    0x00005200: analog-3
+//    0x00005b00: analog-4
+//    0x00006400: analog-5
+//    0x00006d00: analog-6
+//    0x00007600: analog-7
+//    0x00007f00: analog-8
+//    0x00104000: AES/EBU-1
+//    0x00104900: AES/EBU-2
+//  0x00000060: sample rate conversion for AES/EBU input/output.
+//    0x00000000: None
+//    0x00000020: input signal is converted to system rate
+//    0x00000040: output is slave to input, ignoring system rate
+//    0x00000060: output is double rate than system rate
+//  0x00000018: nominal rate of sampling clock.
+//    0x00000000: 44.1 kHz
+//    0x00000008: 48.0 kHz
+//    0x00000010: 88.2 kHz
+//    0x00000018: 96.0 kHz
+//  0x00000007: source of sampling clock.
+//    0x00000000: internal
+//    0x00000001: ADAT on optical interface
+//    0x00000002: AES/EBU on XLR
+//    0x00000003: source packet header (SPH)
+//    0x00000004: word clock on BNC
+//    0x00000005: ADAT on Dsub 9pin
+//
+// 0x'ffff'f000'0b24: configuration for meter and stream source for main output.
+//  0x00004000: LED carnival.
+//  0x00003800: peak hold time.
+//   0x00003800: infinite
+//   0x00003000: 480 sec
+//   0x00002800: 300 sec
+//   0x00002000: 60 sec
+//   0x00001800: 10 sec
+//   0x00001000: 4 sec
+//   0x00000800: 2 sec
+//   0x00000000: disabled
+//  0x00000700: clip hold time.
+//   0x00000700: infinite
+//   0x00000600: 480 sec
+//   0x00000500: 300 sec
+//   0x00000400: 60 sec
+//   0x00000300: 10 sec
+//   0x00000200: 4 sec
+//   0x00000100: 2 sec
+//   0x00000000: disabled
+//  0x000000f0: stream source to main output.
+//   0x00000080: Stream-16/17
+//   0x00000080: Stream-16/17
+//   0x00000070: (mute)
+//   0x00000060: (mute)
+//   0x00000050: (mute)
+//   0x00000040: (mute)
+//   0x00000030: Stream-6/7
+//   0x00000020: Stream-4/5
+//   0x00000010: Stream-2/3
+//   0x00000000: Stream-0/1
+//  0x00000004: The target of AES/EBU meter.
+//   0x00000001: AES/EBU input
+//   0x00000000: AES/EBU output.
+//  0x00000003: The target of programmable meter.
+//   0x00000002: ADAT output
+//   0x00000001: ADAT input
+//   0x00000000: Analog output
+
+const CONF_896_MONITOR_INPUT_AESEBU_MASK: u32 = 0x00100000;
+const CONF_896_MONITOR_INPUT_AESEBU_SHIFT: usize = 20;
+const CONF_896_MONITOR_INPUT_CH_VALS: [u8; 13] = [
+    0x00, // disabled
+    0x48, // 1/2
+    0x5a, // 3/4
+    0x6c, // 5/6
+    0x7e, // 7/8
+    0x40, // 1
+    0x49, // 2
+    0x52, // 3
+    0x5b, // 4
+    0x64, // 5
+    0x6d, // 6
+    0x76, // 7
+    0x7f, // 8
+];
+
+const CONF_896_MONITOR_INPUT_CH_MASK: u32 = 0x0000ff00;
+const CONF_896_MONITOR_INPUT_CH_SHIFT: usize = 8;
+const CONF_896_MONITOR_INPUT_VALS: [(usize, usize); 15] = [
+    (0, 0),
+    (1, 0),
+    (2, 0),
+    (3, 0),
+    (4, 0),
+    (1, 1),
+    (5, 0),
+    (6, 0),
+    (7, 0),
+    (8, 0),
+    (9, 0),
+    (10, 0),
+    (11, 0),
+    (12, 0),
+    (5, 1),
+];
+
+const CONF_896_CLK_RATE_MASK: u32 = 0x00000018;
+const CONF_896_CLK_RATE_SHIFT: usize = 3;
+
+const CONF_896_CLK_SRC_MASK: u32 = 0x00000007;
+const CONF_896_CLK_SRC_SHIFT: usize = 0;
+
+const CLK_RATE_LABEL: &str = "clock-rate-v1";
+const CLK_SRC_LABEL: &str = "clock-source-v1";
+
+/// The trait for configuration of sampling clock in version 1 protocol.
+pub trait V1ClkProtocol<'a>: CommonProtocol<'a> {
+    const CLK_OFFSET: u32;
+
+    const CLK_RATE_MASK: u32;
+    const CLK_RATE_SHIFT: usize;
+    const CLK_RATE_VALS: &'a [u8];
+    const CLK_RATE_LABELS: &'a [ClkRate];
+
+    const CLK_SRC_MASK: u32;
+    const CLK_SRC_SHIFT: usize;
+    const CLK_SRC_VALS: &'a [u8];
+    const CLK_SRC_LABELS: &'a [V1ClkSrc];
+
+    fn get_clk_rate(&self, unit: &SndMotu, timeout_ms: u32) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            Self::CLK_OFFSET,
+            Self::CLK_RATE_MASK,
+            Self::CLK_RATE_SHIFT,
+            CLK_RATE_LABEL,
+            unit,
+            Self::CLK_RATE_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_clk_rate(&self, unit: &SndMotu, idx: usize, timeout_ms: u32) -> Result<(), Error> {
+        self.set_idx_to_val(
+            Self::CLK_OFFSET,
+            Self::CLK_RATE_MASK,
+            Self::CLK_RATE_SHIFT,
+            CLK_RATE_LABEL,
+            unit,
+            Self::CLK_RATE_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_clk_src(&self, unit: &SndMotu, timeout_ms: u32) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            Self::CLK_OFFSET,
+            Self::CLK_SRC_MASK,
+            Self::CLK_SRC_SHIFT,
+            CLK_SRC_LABEL,
+            unit,
+            Self::CLK_SRC_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_clk_src(&self, unit: &SndMotu, idx: usize, timeout_ms: u32) -> Result<(), Error> {
+        self.set_idx_to_val(
+            Self::CLK_OFFSET,
+            Self::CLK_SRC_MASK,
+            Self::CLK_SRC_SHIFT,
+            CLK_SRC_LABEL,
+            unit,
+            Self::CLK_SRC_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+}
+
+const MONITOR_INPUT_CH_LABEL: &str = "monitor-input-ch-v1";
+const MONITOR_INPUT_DISABLE_LABEL: &str = "monitor-input-enable-v1";
+const MONITOR_INPUT_AESEBU_LABEL: &str = "monitor-input-aesebu-v1";
+
+/// The trait for configuration of input to monitor in version 1 protocol.
+pub trait V1MonitorInputProtocol<'a>: CommonProtocol<'a> {
+    const MONITOR_INPUT_MODES: &'a [&'a str];
+
+    fn set_monitor_input(&self, unit: &SndMotu, idx: usize, timeout_ms: u32) -> Result<(), Error>;
+    fn get_monitor_input(&self, unit: &SndMotu, timeout_ms: u32) -> Result<usize, Error>;
+}
+
+/// The protocol implementation for 828.
+#[derive(Default)]
+pub struct F828Protocol(FwReq);
+
+impl AsRef<FwReq> for F828Protocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}
+
+impl<'a> CommonProtocol<'a> for F828Protocol {}
+
+impl<'a> V1ClkProtocol<'a> for F828Protocol {
+    const CLK_OFFSET: u32 = CONF_828_OFFSET;
+
+    const CLK_RATE_MASK: u32 = CONF_828_CLK_RATE_MASK;
+    const CLK_RATE_SHIFT: usize = CONF_828_CLK_RATE_SHIFT;
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01];
+    const CLK_RATE_LABELS: &'a [ClkRate] = &[ClkRate::R44100, ClkRate::R48000];
+
+    const CLK_SRC_MASK: u32 = CONF_828_CLK_SRC_MASK;
+    const CLK_SRC_SHIFT: usize = CONF_828_CLK_SRC_SHIFT;
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x21];
+    const CLK_SRC_LABELS: &'a [V1ClkSrc] = &[
+        V1ClkSrc::Internal,
+        V1ClkSrc::AdatDsub,
+        V1ClkSrc::Spdif,
+        V1ClkSrc::AdatOpt,
+    ];
+}
+
+impl<'a> V1MonitorInputProtocol<'a> for F828Protocol {
+    const MONITOR_INPUT_MODES: &'a [&'a str] = &[
+        "Disabled",
+        "Analog-1/2",
+        "Analog-3/4",
+        "Analog-5/6",
+        "Analog-7/8",
+        "Analog-1",
+        "Analog-2",
+        "Analog-3",
+        "Analog-4",
+        "Analog-5",
+        "Analog-6",
+        "Analog-7",
+        "Analog-8",
+    ];
+
+    fn set_monitor_input(&self, unit: &SndMotu, idx: usize, timeout_ms: u32) -> Result<(), Error> {
+        let (disable_idx, ch_idx) = if idx == 0 { (1, 0) } else { (0, idx - 1) };
+
+        self.set_idx_to_val(
+            CONF_828_OFFSET,
+            CONF_828_MONITOR_INPUT_DISABLE_MASK,
+            CONF_828_MONITOR_INPUT_DISABLE_SHIFT,
+            MONITOR_INPUT_DISABLE_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            disable_idx,
+            timeout_ms,
+        )?;
+
+        self.set_idx_to_val(
+            CONF_828_OFFSET,
+            CONF_828_MONITOR_INPUT_CH_MASK,
+            CONF_828_MONITOR_INPUT_CH_SHIFT,
+            MONITOR_INPUT_CH_LABEL,
+            unit,
+            &CONF_828_MONITOR_INPUT_CH_VALS,
+            ch_idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_monitor_input(&self, unit: &SndMotu, timeout_ms: u32) -> Result<usize, Error> {
+        let mut idx = self
+            .get_idx_from_val(
+                CONF_828_OFFSET,
+                CONF_828_MONITOR_INPUT_DISABLE_MASK,
+                CONF_828_MONITOR_INPUT_DISABLE_SHIFT,
+                MONITOR_INPUT_DISABLE_LABEL,
+                unit,
+                &CONF_BOOL_VALS,
+                timeout_ms,
+            )
+            .map(|idx| if idx > 0 { 0 } else { 1 })?;
+        if idx > 0 {
+            idx += self.get_idx_from_val(
+                CONF_828_OFFSET,
+                CONF_828_MONITOR_INPUT_CH_MASK,
+                CONF_828_MONITOR_INPUT_CH_SHIFT,
+                MONITOR_INPUT_CH_LABEL,
+                unit,
+                &CONF_828_MONITOR_INPUT_CH_VALS,
+                timeout_ms,
+            )?;
+        }
+        Ok(idx)
+    }
+}
+
+const CONF_828_OPT_OUT_IFACE_LABEL: &str = "opt-out-iface-v1";
+const CONF_828_OPT_IN_IFACE_LABEL: &str = "opt-in-iface-v1";
+const CONF_828_STREAM_INPUT_ENABLE_LABEL: &str = "stream-input-enable-v1";
+const CONF_828_OUTPUT_ENABLE_LABEL: &str = "output-enable-v1";
+
+impl F828Protocol {
+    pub const OPT_IFACE_MODES: [V1OptIfaceMode; 2] = [V1OptIfaceMode::Adat, V1OptIfaceMode::Spdif];
+
+    fn get_opt_iface_mode(
+        &self,
+        mask: u32,
+        shift: usize,
+        label: &str,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_idx_from_val(
+            CONF_828_OFFSET,
+            mask,
+            shift,
+            label,
+            unit,
+            &CONF_828_OPT_IFACE_VALS,
+            timeout_ms,
+        )
+    }
+
+    fn set_opt_iface_mode(
+        &self,
+        mask: u32,
+        shift: usize,
+        label: &str,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_idx_to_val(
+            CONF_828_OFFSET,
+            mask,
+            shift,
+            label,
+            unit,
+            &CONF_828_OPT_IFACE_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    pub fn get_optical_output_iface_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_opt_iface_mode(
+            CONF_828_OPT_OUT_IFACE_MASK,
+            CONF_828_OPT_OUT_IFACE_SHIFT,
+            CONF_828_OPT_OUT_IFACE_LABEL,
+            unit,
+            timeout_ms,
+        )
+    }
+
+    pub fn set_optical_output_iface_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_opt_iface_mode(
+            CONF_828_OPT_OUT_IFACE_MASK,
+            CONF_828_OPT_OUT_IFACE_SHIFT,
+            CONF_828_OPT_OUT_IFACE_LABEL,
+            unit,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    pub fn get_optical_input_iface_mode(
+        &self,
+        unit: &SndMotu,
+        timeout_ms: u32,
+    ) -> Result<usize, Error> {
+        self.get_opt_iface_mode(
+            CONF_828_OPT_IN_IFACE_MASK,
+            CONF_828_OPT_IN_IFACE_SHIFT,
+            CONF_828_OPT_IN_IFACE_LABEL,
+            unit,
+            timeout_ms,
+        )
+    }
+
+    pub fn set_optical_input_iface_mode(
+        &self,
+        unit: &SndMotu,
+        idx: usize,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_opt_iface_mode(
+            CONF_828_OPT_IN_IFACE_MASK,
+            CONF_828_OPT_IN_IFACE_SHIFT,
+            CONF_828_OPT_IN_IFACE_LABEL,
+            unit,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    pub fn get_stream_input_enable(&self, unit: &SndMotu, timeout_ms: u32) -> Result<bool, Error> {
+        self.get_idx_from_val(
+            CONF_828_OFFSET,
+            CONF_828_STREAM_INPUT_ENABLE_MASK,
+            CONF_828_STREAM_INPUT_ENABLE_SHIFT,
+            CONF_828_STREAM_INPUT_ENABLE_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            timeout_ms,
+        )
+        .map(|val| val > 0)
+    }
+
+    pub fn set_stream_input_enable(
+        &self,
+        unit: &SndMotu,
+        enable: bool,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let idx = match enable {
+            false => 0x00,
+            true => 0x01,
+        };
+        self.set_idx_to_val(
+            CONF_828_OFFSET,
+            CONF_828_STREAM_INPUT_ENABLE_MASK,
+            CONF_828_STREAM_INPUT_ENABLE_SHIFT,
+            CONF_828_STREAM_INPUT_ENABLE_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+
+    pub fn get_output_enable(&self, unit: &SndMotu, timeout_ms: u32) -> Result<bool, Error> {
+        self.get_idx_from_val(
+            CONF_828_OFFSET,
+            CONF_828_OUTPUT_ENABLE_MASK,
+            CONF_828_OUTPUT_ENABLE_SHIFT,
+            CONF_828_OUTPUT_ENABLE_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            timeout_ms,
+        )
+        .map(|val| val > 0)
+    }
+
+    pub fn set_output_enable(
+        &self,
+        unit: &SndMotu,
+        enable: bool,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let idx = match enable {
+            false => 0x00,
+            true => 0x01,
+        };
+        self.set_idx_to_val(
+            CONF_828_OFFSET,
+            CONF_828_OUTPUT_ENABLE_MASK,
+            CONF_828_OUTPUT_ENABLE_SHIFT,
+            CONF_828_OUTPUT_ENABLE_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            idx,
+            timeout_ms,
+        )
+    }
+}
+
+/// The protocol implementation for 896.
+#[derive(Default)]
+pub struct F896Protocol(FwReq);
+
+impl AsRef<FwReq> for F896Protocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}
+
+impl<'a> CommonProtocol<'a> for F896Protocol {}
+
+impl<'a> WordClkProtocol<'a> for F896Protocol {}
+
+impl<'a> V1ClkProtocol<'a> for F896Protocol {
+    const CLK_OFFSET: u32 = Self::OFFSET_CLK;
+
+    const CLK_RATE_MASK: u32 = CONF_896_CLK_RATE_MASK;
+    const CLK_RATE_SHIFT: usize = CONF_896_CLK_RATE_SHIFT;
+    const CLK_RATE_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x03];
+    const CLK_RATE_LABELS: &'a [ClkRate] = &[
+        ClkRate::R44100,
+        ClkRate::R48000,
+        ClkRate::R88200,
+        ClkRate::R96000,
+    ];
+
+    const CLK_SRC_MASK: u32 = CONF_896_CLK_SRC_MASK;
+    const CLK_SRC_SHIFT: usize = CONF_896_CLK_SRC_SHIFT;
+    const CLK_SRC_VALS: &'a [u8] = &[0x00, 0x01, 0x02, 0x04, 0x05];
+    const CLK_SRC_LABELS: &'a [V1ClkSrc] = &[
+        V1ClkSrc::Internal,
+        V1ClkSrc::AdatOpt,
+        V1ClkSrc::AesebuXlr,
+        V1ClkSrc::WordClk,
+        V1ClkSrc::AdatDsub,
+    ];
+}
+
+impl<'a> V1MonitorInputProtocol<'a> for F896Protocol {
+    const MONITOR_INPUT_MODES: &'a [&'a str] = &[
+        "Disabled",
+        "Analog-1/2",
+        "Analog-3/4",
+        "Analog-5/6",
+        "Analog-7/8",
+        "AES/EBU-1/2",
+        "Analog-1",
+        "Analog-2",
+        "Analog-3",
+        "Analog-4",
+        "Analog-5",
+        "Analog-6",
+        "Analog-7",
+        "Analog-8",
+        "AES/EBU-1",
+        "AES/EBU-2",
+    ];
+
+    fn set_monitor_input(&self, unit: &SndMotu, idx: usize, timeout_ms: u32) -> Result<(), Error> {
+        let &(ch_idx, aesebu_idx) =
+            CONF_896_MONITOR_INPUT_VALS.iter().nth(idx).ok_or_else(|| {
+                let label = "Invalid argument for index of monitor input}";
+                Error::new(FileError::Inval, &label)
+            })?;
+        self.set_idx_to_val(
+            Self::OFFSET_CLK,
+            CONF_896_MONITOR_INPUT_CH_MASK,
+            CONF_896_MONITOR_INPUT_CH_SHIFT,
+            MONITOR_INPUT_CH_LABEL,
+            unit,
+            &CONF_896_MONITOR_INPUT_CH_VALS,
+            ch_idx,
+            timeout_ms,
+        )?;
+        self.set_idx_to_val(
+            Self::OFFSET_CLK,
+            CONF_896_MONITOR_INPUT_AESEBU_MASK,
+            CONF_896_MONITOR_INPUT_AESEBU_SHIFT,
+            MONITOR_INPUT_AESEBU_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            aesebu_idx,
+            timeout_ms,
+        )
+    }
+
+    fn get_monitor_input(&self, unit: &SndMotu, timeout_ms: u32) -> Result<usize, Error> {
+        let ch_idx = self.get_idx_from_val(
+            Self::OFFSET_CLK,
+            CONF_896_MONITOR_INPUT_CH_MASK,
+            CONF_896_MONITOR_INPUT_CH_SHIFT,
+            MONITOR_INPUT_CH_LABEL,
+            unit,
+            &CONF_896_MONITOR_INPUT_CH_VALS,
+            timeout_ms,
+        )?;
+        let aesebu_idx = self.get_idx_from_val(
+            Self::OFFSET_CLK,
+            CONF_896_MONITOR_INPUT_AESEBU_MASK,
+            CONF_896_MONITOR_INPUT_AESEBU_SHIFT,
+            MONITOR_INPUT_AESEBU_LABEL,
+            unit,
+            &CONF_BOOL_VALS,
+            timeout_ms,
+        )?;
+        CONF_896_MONITOR_INPUT_VALS
+            .iter()
+            .position(|&e| e == (ch_idx, aesebu_idx))
+            .ok_or_else(|| {
+                let label = "Detect invalid value for monitor input";
+                Error::new(FileError::Io, &label)
+            })
+    }
+}
+
+impl<'a> AesebuRateConvertProtocol<'a> for F896Protocol {}
+
+impl<'a> LevelMetersProtocol<'a> for F896Protocol {}

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -10,29 +10,52 @@ use core::card_cntr::{CardCntr, CtlModel};
 
 use motu_protocols::version_1::*;
 
+use super::v1_ctls::*;
+
 const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default)]
 pub struct F828 {
     proto: F828Protocol,
+    clk_ctls: V1ClkCtl,
 }
 
 impl CtlModel<SndMotu> for F828 {
-    fn load(&mut self, _: &SndMotu, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.clk_ctls.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
-    fn read(&mut self, _: &SndMotu, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
-        Ok(false)
+    fn read(
+        &mut self,
+        unit: &SndMotu,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(
         &mut self,
-        _: &SndMotu,
-        _: &ElemId,
-        _: &ElemValue,
-        _: &ElemValue,
+        unit: &SndMotu,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue,
     ) -> Result<bool, Error> {
-        Ok(false)
+        if self
+            .clk_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndMotu;
+
+use alsactl::{ElemId, ElemValue};
+
+use core::card_cntr::{CardCntr, CtlModel};
+
+use motu_protocols::version_1::*;
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default)]
+pub struct F828 {
+    proto: F828Protocol,
+}
+
+impl CtlModel<SndMotu> for F828 {
+    fn load(&mut self, _: &SndMotu, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndMotu, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    fn write(
+        &mut self,
+        _: &SndMotu,
+        _: &ElemId,
+        _: &ElemValue,
+        _: &ElemValue,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+}

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -2,11 +2,12 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::Error;
 
-use hinawa::SndMotu;
+use hinawa::{SndMotu, SndUnitExt};
 
-use alsactl::{ElemId, ElemValue};
+use alsactl::{ElemId, ElemIfaceType, ElemValue};
 
 use core::card_cntr::{CardCntr, CtlModel};
+use core::elem_value_accessor::ElemValueAccessor;
 
 use motu_protocols::version_1::*;
 
@@ -19,12 +20,14 @@ pub struct F828 {
     proto: F828Protocol,
     clk_ctls: V1ClkCtl,
     monitor_input_ctl: V1MonitorInputCtl,
+    specific_ctls: SpecificCtl,
 }
 
 impl CtlModel<SndMotu> for F828 {
     fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
+        self.specific_ctls.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -41,6 +44,11 @@ impl CtlModel<SndMotu> for F828 {
             Ok(true)
         } else if self
             .monitor_input_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .specific_ctls
             .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
@@ -66,8 +74,107 @@ impl CtlModel<SndMotu> for F828 {
             .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
+        } else if self
+            .specific_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
         } else {
             Ok(false)
+        }
+    }
+}
+
+fn opt_iface_mode_to_label(mode: &V1OptIfaceMode) -> String {
+    match mode {
+        V1OptIfaceMode::Adat => "ADAT",
+        V1OptIfaceMode::Spdif => "SPDIF",
+    }
+    .to_string()
+}
+
+#[derive(Default)]
+pub struct SpecificCtl {}
+
+impl<'a> SpecificCtl {
+    const OPT_IN_IFACE_MODE_NAME: &'a str = "optical-iface-in-mode";
+    const OPT_OUT_IFACE_MODE_NAME: &'a str = "optical-iface-out-mode";
+
+    pub fn load(&mut self, _: &F828Protocol, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let labels: Vec<String> = F828Protocol::OPT_IFACE_MODES
+            .iter()
+            .map(|l| opt_iface_mode_to_label(&l))
+            .collect();
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_IN_IFACE_MODE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUT_IFACE_MODE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read(
+        &mut self,
+        unit: &SndMotu,
+        proto: &F828Protocol,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::OPT_IN_IFACE_MODE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    proto
+                        .get_optical_input_iface_mode(unit, timeout_ms)
+                        .map(|val| val as u32)
+                })?;
+                Ok(true)
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    proto
+                        .get_optical_output_iface_mode(unit, timeout_ms)
+                        .map(|val| val as u32)
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        unit: &SndMotu,
+        proto: &F828Protocol,
+        elem_id: &ElemId,
+        _: &ElemValue,
+        new: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            Self::OPT_IN_IFACE_MODE_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.set_optical_input_iface_mode(unit, val as usize, timeout_ms);
+                    unit.unlock()?;
+                    res
+                })?;
+                Ok(true)
+            }
+            Self::OPT_OUT_IFACE_MODE_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.set_optical_output_iface_mode(unit, val as usize, timeout_ms);
+                    unit.unlock()?;
+                    res
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
         }
     }
 }

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -18,11 +18,13 @@ const TIMEOUT_MS: u32 = 100;
 pub struct F828 {
     proto: F828Protocol,
     clk_ctls: V1ClkCtl,
+    monitor_input_ctl: V1MonitorInputCtl,
 }
 
 impl CtlModel<SndMotu> for F828 {
     fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
+        self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -34,6 +36,11 @@ impl CtlModel<SndMotu> for F828 {
     ) -> Result<bool, Error> {
         if self
             .clk_ctls
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .monitor_input_ctl
             .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
@@ -51,6 +58,11 @@ impl CtlModel<SndMotu> for F828 {
     ) -> Result<bool, Error> {
         if self
             .clk_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .monitor_input_ctl
             .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -22,6 +22,7 @@ pub struct F896 {
     monitor_input_ctl: V1MonitorInputCtl,
     word_clk_ctl: CommonWordClkCtl,
     aesebu_rate_convert_ctl: CommonAesebuRateConvertCtl,
+    level_meters_ctl: CommonLevelMetersCtl,
 }
 
 impl CtlModel<SndMotu> for F896 {
@@ -30,6 +31,7 @@ impl CtlModel<SndMotu> for F896 {
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         self.word_clk_ctl.load(&self.proto, card_cntr)?;
         self.aesebu_rate_convert_ctl.load(&self.proto, card_cntr)?;
+        self.level_meters_ctl.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -61,6 +63,11 @@ impl CtlModel<SndMotu> for F896 {
             elem_value,
             TIMEOUT_MS,
         )? {
+            Ok(true)
+        } else if self
+            .level_meters_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else {
             Ok(false)
@@ -97,6 +104,11 @@ impl CtlModel<SndMotu> for F896 {
             new,
             TIMEOUT_MS,
         )? {
+            Ok(true)
+        } else if self
+            .level_meters_ctl
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -10,29 +10,52 @@ use core::card_cntr::{CardCntr, CtlModel};
 
 use motu_protocols::version_1::*;
 
+use super::v1_ctls::*;
+
 const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default)]
 pub struct F896 {
     proto: F896Protocol,
+    clk_ctls: V1ClkCtl,
 }
 
 impl CtlModel<SndMotu> for F896 {
-    fn load(&mut self, _: &SndMotu, _: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.clk_ctls.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
-    fn read(&mut self, _: &SndMotu, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
-        Ok(false)
+    fn read(
+        &mut self,
+        unit: &SndMotu,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 
     fn write(
         &mut self,
-        _: &SndMotu,
-        _: &ElemId,
-        _: &ElemValue,
-        _: &ElemValue,
+        unit: &SndMotu,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue,
     ) -> Result<bool, Error> {
-        Ok(false)
+        if self
+            .clk_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -18,11 +18,13 @@ const TIMEOUT_MS: u32 = 100;
 pub struct F896 {
     proto: F896Protocol,
     clk_ctls: V1ClkCtl,
+    monitor_input_ctl: V1MonitorInputCtl,
 }
 
 impl CtlModel<SndMotu> for F896 {
     fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
+        self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -34,6 +36,11 @@ impl CtlModel<SndMotu> for F896 {
     ) -> Result<bool, Error> {
         if self
             .clk_ctls
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .monitor_input_ctl
             .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
@@ -51,6 +58,11 @@ impl CtlModel<SndMotu> for F896 {
     ) -> Result<bool, Error> {
         if self
             .clk_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .monitor_input_ctl
             .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -21,6 +21,7 @@ pub struct F896 {
     clk_ctls: V1ClkCtl,
     monitor_input_ctl: V1MonitorInputCtl,
     word_clk_ctl: CommonWordClkCtl,
+    aesebu_rate_convert_ctl: CommonAesebuRateConvertCtl,
 }
 
 impl CtlModel<SndMotu> for F896 {
@@ -28,6 +29,7 @@ impl CtlModel<SndMotu> for F896 {
         self.clk_ctls.load(&self.proto, card_cntr)?;
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         self.word_clk_ctl.load(&self.proto, card_cntr)?;
+        self.aesebu_rate_convert_ctl.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -51,6 +53,14 @@ impl CtlModel<SndMotu> for F896 {
             .word_clk_ctl
             .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
         {
+            Ok(true)
+        } else if self.aesebu_rate_convert_ctl.read(
+            unit,
+            &self.proto,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -78,6 +88,15 @@ impl CtlModel<SndMotu> for F896 {
             .word_clk_ctl
             .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
         {
+            Ok(true)
+        } else if self.aesebu_rate_convert_ctl.write(
+            unit,
+            &self.proto,
+            elem_id,
+            old,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -10,6 +10,7 @@ use core::card_cntr::{CardCntr, CtlModel};
 
 use motu_protocols::version_1::*;
 
+use super::common_ctls::*;
 use super::v1_ctls::*;
 
 const TIMEOUT_MS: u32 = 100;
@@ -19,12 +20,14 @@ pub struct F896 {
     proto: F896Protocol,
     clk_ctls: V1ClkCtl,
     monitor_input_ctl: V1MonitorInputCtl,
+    word_clk_ctl: CommonWordClkCtl,
 }
 
 impl CtlModel<SndMotu> for F896 {
     fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
+        self.word_clk_ctl.load(&self.proto, card_cntr)?;
         Ok(())
     }
 
@@ -41,6 +44,11 @@ impl CtlModel<SndMotu> for F896 {
             Ok(true)
         } else if self
             .monitor_input_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
             .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
@@ -63,6 +71,11 @@ impl CtlModel<SndMotu> for F896 {
             Ok(true)
         } else if self
             .monitor_input_ctl
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
             .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndMotu;
+
+use alsactl::{ElemId, ElemValue};
+
+use core::card_cntr::{CardCntr, CtlModel};
+
+use motu_protocols::version_1::*;
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default)]
+pub struct F896 {
+    proto: F896Protocol,
+}
+
+impl CtlModel<SndMotu> for F896 {
+    fn load(&mut self, _: &SndMotu, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read(&mut self, _: &SndMotu, _: &ElemId, _: &mut ElemValue) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    fn write(
+        &mut self,
+        _: &SndMotu,
+        _: &ElemId,
+        _: &ElemValue,
+        _: &ElemValue,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+}

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -13,6 +13,7 @@ mod f828;
 mod f896;
 
 mod common_ctls;
+mod v1_ctls;
 mod v2_ctls;
 mod v3_ctls;
 

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -9,6 +9,7 @@ mod ultralite;
 mod traveler;
 mod f8pre;
 mod f828mk2;
+mod f828;
 
 mod common_ctls;
 mod v2_ctls;

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -10,6 +10,7 @@ mod traveler;
 mod f8pre;
 mod f828mk2;
 mod f828;
+mod f896;
 
 mod common_ctls;
 mod v2_ctls;

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -6,6 +6,7 @@ use core::card_cntr::{CardCntr, CtlModel, NotifyModel};
 
 use motu_protocols::ClkRate;
 
+use super::f828::F828;
 use super::f828mk2::F828mk2;
 use super::traveler::Traveler;
 use super::ultralite::UltraLite;
@@ -23,6 +24,7 @@ pub struct MotuModel {
 }
 
 enum MotuCtlModel {
+    F828(F828),
     F828mk2(F828mk2),
     Traveler(Traveler),
     UltraLite(UltraLite),
@@ -36,6 +38,7 @@ enum MotuCtlModel {
 impl MotuModel {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
+            0x000001 => MotuCtlModel::F828(Default::default()),
             0x000003 => MotuCtlModel::F828mk2(Default::default()),
             0x000009 => MotuCtlModel::Traveler(Default::default()),
             0x00000d => MotuCtlModel::UltraLite(Default::default()),
@@ -62,6 +65,7 @@ impl MotuModel {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::F828(m) => m.load(unit, card_cntr),
             MotuCtlModel::F828mk2(m) => m.load(unit, card_cntr),
             MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
@@ -89,6 +93,7 @@ impl MotuModel {
         -> Result<(), Error>
     {
         match &mut self.ctl_model {
+            MotuCtlModel::F828(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F828mk2(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -7,6 +7,7 @@ use core::card_cntr::{CardCntr, CtlModel, NotifyModel};
 use motu_protocols::ClkRate;
 
 use super::f828::F828;
+use super::f896::F896;
 use super::f828mk2::F828mk2;
 use super::traveler::Traveler;
 use super::ultralite::UltraLite;
@@ -25,6 +26,7 @@ pub struct MotuModel {
 
 enum MotuCtlModel {
     F828(F828),
+    F896(F896),
     F828mk2(F828mk2),
     Traveler(Traveler),
     UltraLite(UltraLite),
@@ -39,6 +41,7 @@ impl MotuModel {
     pub fn new(model_id: u32, version: u32) -> Result<Self, Error> {
         let ctl_model = match model_id {
             0x000001 => MotuCtlModel::F828(Default::default()),
+            0x000002 => MotuCtlModel::F896(Default::default()),
             0x000003 => MotuCtlModel::F828mk2(Default::default()),
             0x000009 => MotuCtlModel::Traveler(Default::default()),
             0x00000d => MotuCtlModel::UltraLite(Default::default()),
@@ -66,6 +69,7 @@ impl MotuModel {
     {
         match &mut self.ctl_model {
             MotuCtlModel::F828(m) => m.load(unit, card_cntr),
+            MotuCtlModel::F896(m) => m.load(unit, card_cntr),
             MotuCtlModel::F828mk2(m) => m.load(unit, card_cntr),
             MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
@@ -94,6 +98,7 @@ impl MotuModel {
     {
         match &mut self.ctl_model {
             MotuCtlModel::F828(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::F896(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F828mk2(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),

--- a/libs/motu/runtime/src/v1_ctls.rs
+++ b/libs/motu/runtime/src/v1_ctls.rs
@@ -118,7 +118,7 @@ impl<'a> V1ClkCtl {
 }
 
 #[derive(Default)]
-pub struct V1MonitorInputCtl;
+pub struct V1MonitorInputCtl {}
 
 impl<'a> V1MonitorInputCtl {
     const MONITOR_INPUT_NAME: &'a str = "monitor-input";

--- a/libs/motu/runtime/src/v1_ctls.rs
+++ b/libs/motu/runtime/src/v1_ctls.rs
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::{SndMotu, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue};
+
+use core::card_cntr::CardCntr;
+use core::elem_value_accessor::ElemValueAccessor;
+
+use motu_protocols::version_1::*;
+
+use super::model::clk_rate_to_string;
+
+fn clk_src_to_label(src: &V1ClkSrc) -> String {
+    match src {
+        V1ClkSrc::Internal => "Internal",
+        V1ClkSrc::Spdif => "S/PDIF",
+        V1ClkSrc::WordClk => "Word-on-BNC",
+        V1ClkSrc::AdatOpt => "Adat-on-opt",
+        V1ClkSrc::AdatDsub => "Adat-on-Dsub",
+        V1ClkSrc::AesebuXlr => "AES/EBU-on-XLR",
+    }
+    .to_string()
+}
+
+#[derive(Default)]
+pub struct V1ClkCtl {}
+
+impl<'a> V1ClkCtl {
+    const RATE_NAME: &'a str = "sampling- rate";
+    const SRC_NAME: &'a str = "clock-source";
+
+    pub fn load<O>(&mut self, _: &O, card_cntr: &mut CardCntr) -> Result<(), Error>
+    where
+        for<'b> O: V1ClkProtocol<'b>,
+    {
+        let labels: Vec<String> = O::CLK_RATE_LABELS
+            .iter()
+            .map(|l| clk_rate_to_string(&l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::RATE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let labels: Vec<String> = O::CLK_SRC_LABELS
+            .iter()
+            .map(|l| clk_src_to_label(&l))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SRC_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    pub fn read<O>(
+        &mut self,
+        unit: &SndMotu,
+        proto: &O,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error>
+    where
+        for<'b> O: V1ClkProtocol<'b>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    proto.get_clk_rate(unit, timeout_ms).map(|idx| idx as u32)
+                })?;
+                Ok(true)
+            }
+            Self::SRC_NAME => {
+                ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    proto.get_clk_src(unit, timeout_ms).map(|idx| idx as u32)
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write<O>(
+        &mut self,
+        unit: &SndMotu,
+        proto: &O,
+        elem_id: &ElemId,
+        _: &ElemValue,
+        new: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error>
+    where
+        for<'b> O: V1ClkProtocol<'b>,
+    {
+        match elem_id.get_name().as_str() {
+            Self::RATE_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.set_clk_rate(unit, val as usize, timeout_ms);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
+            }
+            Self::SRC_NAME => {
+                ElemValueAccessor::<u32>::get_val(new, |val| {
+                    unit.lock()?;
+                    let res = proto.set_clk_src(unit, val as usize, timeout_ms);
+                    let _ = unit.unlock();
+                    res
+                })?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}


### PR DESCRIPTION
ALSA firewire stack in Linux kernel v5.14 (probably) gains MOTU 828/896 support newly.

This patchset also adds support for the models with protocols to configure its functions
regardless of packet streaming.

```
Takashi Sakamoto (11):
  motu-protocols: add trait for protocol of sample rate convert specific to AES/EBU signals
  motu-protocols: add trait for protocol of level meters
  motu-protocols: add implementation for protocol version 1
  motu-runtime: add support for 828
  motu-runtime: add support for 896
  motu-runtime: add controls of sampling clock for version 1 models
  motu-runtime: add control of monitor input for version 1 models
  motu-runtime: add control of word out speed for 896
  motu-runtime: add control of AES/EBU rate converter for 896
  motu-runtime: add controls of level meters for 896
  motu-runtime: add controls specific to 828

 README.rst                           |   2 +
 libs/motu/protocols/src/lib.rs       | 279 ++++++++++
 libs/motu/protocols/src/version_1.rs | 732 +++++++++++++++++++++++++++
 libs/motu/runtime/src/common_ctls.rs | 248 +++++++++
 libs/motu/runtime/src/f828.rs        | 180 +++++++
 libs/motu/runtime/src/f896.rs        | 117 +++++
 libs/motu/runtime/src/lib.rs         |   3 +
 libs/motu/runtime/src/model.rs       |  10 +
 libs/motu/runtime/src/v1_ctls.rs     | 185 +++++++
 9 files changed, 1756 insertions(+)
 create mode 100644 libs/motu/protocols/src/version_1.rs
 create mode 100644 libs/motu/runtime/src/f828.rs
 create mode 100644 libs/motu/runtime/src/f896.rs
 create mode 100644 libs/motu/runtime/src/v1_ctls.rs
```