### PR TITLE
core: reafactor to use mutable reference for unit instance

### DIFF
--- a/libs/bebob/src/apogee/apogee_model.rs
+++ b/libs/bebob/src/apogee/apogee_model.rs
@@ -158,7 +158,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndUnit> for EnsembleModel<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctls.measure_elem_list);
     }
 
-    fn measure_states(&mut self, _: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, _: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctls.measure_states(&self.avc, Self::FCP_TIMEOUT_MS)
     }
 

--- a/libs/bebob/src/apogee/apogee_model.rs
+++ b/libs/bebob/src/apogee/apogee_model.rs
@@ -72,7 +72,7 @@ impl<'a> Default for EnsembleModel<'a> {
 }
 
 impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         self.avc.fcp.bind(&unit.get_node())?;
@@ -95,7 +95,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctls.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -123,7 +123,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndUnit> for EnsembleModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/apogee/apogee_model.rs
+++ b/libs/bebob/src/apogee/apogee_model.rs
@@ -174,7 +174,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for EnsembleModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctls.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/behringer/firepower_model.rs
+++ b/libs/bebob/src/behringer/firepower_model.rs
@@ -82,7 +82,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for FirepowerModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/behringer/firepower_model.rs
+++ b/libs/bebob/src/behringer/firepower_model.rs
@@ -47,7 +47,7 @@ impl<'a> Default for FirepowerModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for FirepowerModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -55,7 +55,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for FirepowerModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -65,7 +65,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for FirepowerModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/esi.rs
+++ b/libs/bebob/src/esi.rs
@@ -95,7 +95,7 @@ impl<'a> NotifyModel<SndUnit, bool> for QuatafireModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/esi.rs
+++ b/libs/bebob/src/esi.rs
@@ -53,7 +53,7 @@ impl<'a> Default for QuatafireModel<'a> {
 }
 
 impl<'a> CtlModel<SndUnit> for QuatafireModel<'a> {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
         self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
         self.input_ctl.load(card_cntr)?;
@@ -61,7 +61,7 @@ impl<'a> CtlModel<SndUnit> for QuatafireModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -75,7 +75,7 @@ impl<'a> CtlModel<SndUnit> for QuatafireModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.write(unit, &self.avc, elem_id, old, new, Self::FCP_TIMEOUT_MS)? {

--- a/libs/bebob/src/maudio/audiophile_model.rs
+++ b/libs/bebob/src/maudio/audiophile_model.rs
@@ -176,7 +176,7 @@ impl<'a> MeasureModel<hinawa::SndUnit> for AudiophileModel<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 

--- a/libs/bebob/src/maudio/audiophile_model.rs
+++ b/libs/bebob/src/maudio/audiophile_model.rs
@@ -107,7 +107,7 @@ impl<'a> Default for AudiophileModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
@@ -125,7 +125,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -147,7 +147,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for AudiophileModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/audiophile_model.rs
+++ b/libs/bebob/src/maudio/audiophile_model.rs
@@ -192,7 +192,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for AudiophileModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/fw410_model.rs
+++ b/libs/bebob/src/maudio/fw410_model.rs
@@ -215,7 +215,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for Fw410Model<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/fw410_model.rs
+++ b/libs/bebob/src/maudio/fw410_model.rs
@@ -199,7 +199,7 @@ impl<'a> MeasureModel<hinawa::SndUnit> for Fw410Model<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 

--- a/libs/bebob/src/maudio/fw410_model.rs
+++ b/libs/bebob/src/maudio/fw410_model.rs
@@ -119,7 +119,7 @@ impl<'a> Default for Fw410Model<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
@@ -140,7 +140,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -166,7 +166,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for Fw410Model<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/ozonic_model.rs
+++ b/libs/bebob/src/maudio/ozonic_model.rs
@@ -154,7 +154,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for OzonicModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/ozonic_model.rs
+++ b/libs/bebob/src/maudio/ozonic_model.rs
@@ -138,7 +138,7 @@ impl<'a> MeasureModel<hinawa::SndUnit> for OzonicModel<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 

--- a/libs/bebob/src/maudio/ozonic_model.rs
+++ b/libs/bebob/src/maudio/ozonic_model.rs
@@ -84,7 +84,7 @@ impl<'a> Default for OzonicModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for OzonicModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
@@ -99,7 +99,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for OzonicModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -115,7 +115,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for OzonicModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -109,7 +109,7 @@ impl<'a> MeasureModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.req)
     }
 

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -68,7 +68,7 @@ impl<'a> Default for ProfirelightbridgeModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
@@ -78,7 +78,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -90,7 +90,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ProfirelightbridgeModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/src/maudio/profirelightbridge_model.rs
@@ -216,7 +216,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ProfirelightbridgeMod
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/solo_model.rs
+++ b/libs/bebob/src/maudio/solo_model.rs
@@ -148,7 +148,7 @@ impl<'a> MeasureModel<hinawa::SndUnit> for SoloModel<'a> {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.avc, &self.req)
     }
 

--- a/libs/bebob/src/maudio/solo_model.rs
+++ b/libs/bebob/src/maudio/solo_model.rs
@@ -88,7 +88,7 @@ impl<'a> Default for SoloModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
@@ -105,7 +105,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -123,7 +123,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for SoloModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/solo_model.rs
+++ b/libs/bebob/src/maudio/solo_model.rs
@@ -164,7 +164,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for SoloModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/special_model.rs
+++ b/libs/bebob/src/maudio/special_model.rs
@@ -31,7 +31,7 @@ impl SpecialModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(card_cntr)?;
@@ -48,7 +48,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value)? {
@@ -68,7 +68,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for SpecialModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
              old: &alsactl::ElemValue, new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/bebob/src/maudio/special_model.rs
+++ b/libs/bebob/src/maudio/special_model.rs
@@ -111,7 +111,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for SpecialModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/maudio/special_model.rs
+++ b/libs/bebob/src/maudio/special_model.rs
@@ -95,7 +95,7 @@ impl card_cntr::MeasureModel<hinawa::SndUnit> for SpecialModel {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.req, &self.avc)
     }
 

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -63,7 +63,7 @@ impl<'a> BebobModel<'a> {
         Ok(model)
     }
 
-    pub fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
+    pub fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -124,7 +124,7 @@ impl<'a> BebobModel<'a> {
         }
     }
 
-    pub fn measure_elems(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
+    pub fn measure_elems(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -139,7 +139,7 @@ impl<'a> BebobModel<'a> {
         }
     }
 
-    pub fn dispatch_stream_lock(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr, notice: bool)
+    pub fn dispatch_stream_lock(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr, notice: bool)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/bebob/src/model.rs
+++ b/libs/bebob/src/model.rs
@@ -106,7 +106,7 @@ impl<'a> BebobModel<'a> {
         Ok(())
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
+    pub fn dispatch_elem_event(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
                                elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {

--- a/libs/bebob/src/runtime.rs
+++ b/libs/bebob/src/runtime.rs
@@ -104,7 +104,7 @@ impl<'a> RuntimeOperation<u32> for BebobRuntime<'a> {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measure_elem_list.len() > 0 {
             let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,

--- a/libs/bebob/src/runtime.rs
+++ b/libs/bebob/src/runtime.rs
@@ -130,8 +130,8 @@ impl<'a> RuntimeOperation<u32> for BebobRuntime<'a> {
                 }
                 Event::Elem(elem_id, events) => {
                     if elem_id.get_name() != Self::TIMER_NAME {
-                        let _= self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
-                                                               &elem_id, &events);
+                        let _= self.model.dispatch_elem_event(&mut self.unit, &mut self.card_cntr,
+                                                              &elem_id, &events);
                     } else {
                         let mut elem_value = alsactl::ElemValue::new();
                         if self.card_cntr.card.read_elem_value(&elem_id, &mut elem_value).is_ok() {

--- a/libs/bebob/src/runtime.rs
+++ b/libs/bebob/src/runtime.rs
@@ -149,7 +149,7 @@ impl<'a> RuntimeOperation<u32> for BebobRuntime<'a> {
                     let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                 }
                 Event::StreamLock(locked) => {
-                    let _ = self.model.dispatch_stream_lock(&self.unit, &mut self.card_cntr, locked);
+                    let _ = self.model.dispatch_stream_lock(&mut self.unit, &mut self.card_cntr, locked);
                 }
             }
         }

--- a/libs/bebob/src/runtime.rs
+++ b/libs/bebob/src/runtime.rs
@@ -146,7 +146,7 @@ impl<'a> RuntimeOperation<u32> for BebobRuntime<'a> {
                     }
                 }
                 Event::Timer => {
-                    let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
+                    let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                 }
                 Event::StreamLock(locked) => {
                     let _ = self.model.dispatch_stream_lock(&self.unit, &mut self.card_cntr, locked);

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -92,7 +92,7 @@ impl<'a> card_cntr::NotifyModel<hinawa::SndUnit, bool> for ScratchampModel<'a> {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/bebob/src/stanton.rs
+++ b/libs/bebob/src/stanton.rs
@@ -52,7 +52,7 @@ impl<'a> Default for ScratchampModel<'a> {
 }
 
 impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         self.clk_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -61,7 +61,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.clk_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -73,7 +73,7 @@ impl<'a> CtlModel<hinawa::SndUnit> for ScratchampModel<'a> {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -10,16 +10,16 @@ pub struct CardCntr {
 }
 
 pub trait CtlModel<O: IsA<hinawa::SndUnit>> {
-    fn load(&mut self, unit: &O, card_cntr: &mut CardCntr) -> Result<(), Error>;
+    fn load(&mut self, unit: &mut O, card_cntr: &mut CardCntr) -> Result<(), Error>;
     fn read(
         &mut self,
-        unit: &O,
+        unit: &mut O,
         elem_id: &alsactl::ElemId,
         elem_value: &mut alsactl::ElemValue,
     ) -> Result<bool, Error>;
     fn write(
         &mut self,
-        unit: &O,
+        unit: &mut O,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -279,7 +279,7 @@ impl CardCntr {
 
     pub fn dispatch_elem_event<O, T>(
         &mut self,
-        unit: &O,
+        unit: &mut O,
         elem_id: &alsactl::ElemId,
         events: &alsactl::ElemEventMask,
         ctl_model: &mut T,

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -28,7 +28,7 @@ pub trait CtlModel<O: IsA<hinawa::SndUnit>> {
 
 pub trait MeasureModel<O: IsA<hinawa::SndUnit>> {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>);
-    fn measure_states(&mut self, unit: &O) -> Result<(), Error>;
+    fn measure_states(&mut self, unit: &mut O) -> Result<(), Error>;
     fn measure_elem(&mut self, unit: &O, elem_id: &alsactl::ElemId,
                     elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>;

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -369,7 +369,7 @@ impl CardCntr {
 
     pub fn measure_elems<O, T>(
         &mut self,
-        unit: &O,
+        unit: &mut O,
         elem_id_list: &Vec<alsactl::ElemId>,
         ctl_model: &mut T,
     ) -> Result<(), Error>

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -36,7 +36,7 @@ pub trait MeasureModel<O: IsA<hinawa::SndUnit>> {
 
 pub trait NotifyModel<O: IsA<hinawa::SndUnit>, N> {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>);
-    fn parse_notification(&mut self, unit: &O, notice: &N) -> Result<(), Error>;
+    fn parse_notification(&mut self, unit: &mut O, notice: &N) -> Result<(), Error>;
     fn read_notified_elem(&mut self, unit: &O, elem_id: &alsactl::ElemId,
                           elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>;

--- a/libs/core/src/card_cntr.rs
+++ b/libs/core/src/card_cntr.rs
@@ -400,7 +400,7 @@ impl CardCntr {
 
     pub fn dispatch_notification<O, N, T>(
         &mut self,
-        unit: &O,
+        unit: &mut O,
         notification: &N,
         elem_id_list: &Vec<alsactl::ElemId>,
         ctl_model: &mut T,

--- a/libs/dg00x/src/model.rs
+++ b/libs/dg00x/src/model.rs
@@ -51,7 +51,7 @@ impl card_cntr::NotifyModel<hinawa::SndDg00x, bool> for Dg00xModel {
         elem_id_list.extend_from_slice(&self.monitor.notified_elems);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndDg00x, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndDg00x, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/dg00x/src/model.rs
+++ b/libs/dg00x/src/model.rs
@@ -66,7 +66,7 @@ impl card_cntr::NotifyModel<hinawa::SndDg00x, bool> for Dg00xModel {
 impl card_cntr::CtlModel<hinawa::SndDg00x> for Dg00xModel {
     fn load(
         &mut self,
-        unit: &hinawa::SndDg00x,
+        unit: &mut hinawa::SndDg00x,
         card_cntr: &mut card_cntr::CardCntr,
     ) -> Result<(), Error> {
         self.common.load(&unit, &self.req, card_cntr)?;
@@ -76,7 +76,7 @@ impl card_cntr::CtlModel<hinawa::SndDg00x> for Dg00xModel {
 
     fn read(
         &mut self,
-        unit: &hinawa::SndDg00x,
+        unit: &mut hinawa::SndDg00x,
         elem_id: &alsactl::ElemId,
         elem_value: &mut alsactl::ElemValue,
     ) -> Result<bool, Error> {
@@ -91,7 +91,7 @@ impl card_cntr::CtlModel<hinawa::SndDg00x> for Dg00xModel {
 
     fn write(
         &mut self,
-        unit: &hinawa::SndDg00x,
+        unit: &mut hinawa::SndDg00x,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/dg00x/src/runtime.rs
+++ b/libs/dg00x/src/runtime.rs
@@ -104,7 +104,7 @@ impl RuntimeOperation<u32> for Dg00xRuntime {
                 }
                 Event::Elem((elem_id, events)) => {
                     let _ = self.card_cntr.dispatch_elem_event(
-                        &self.unit,
+                        &mut self.unit,
                         &elem_id,
                         &events,
                         &mut self.model,

--- a/libs/dg00x/src/runtime.rs
+++ b/libs/dg00x/src/runtime.rs
@@ -84,7 +84,7 @@ impl RuntimeOperation<u32> for Dg00xRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
         self.model.get_notified_elem_list(&mut self.notified_elems);
 
         Ok(())

--- a/libs/dg00x/src/runtime.rs
+++ b/libs/dg00x/src/runtime.rs
@@ -111,7 +111,7 @@ impl RuntimeOperation<u32> for Dg00xRuntime {
                     );
                 }
                 Event::StreamLock(locked) => {
-                    let _ = self.card_cntr.dispatch_notification(&self.unit, &locked,
+                    let _ = self.card_cntr.dispatch_notification(&mut self.unit, &locked,
                                                             &self.notified_elems, &mut self.model);
                 }
             }

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -104,7 +104,7 @@ impl MeasureModel<hinawa::SndDice> for BlackbirdModel {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -78,7 +78,7 @@ impl NotifyModel<SndDice, u32> for BlackbirdModel {
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -28,7 +28,7 @@ pub struct BlackbirdModel {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for BlackbirdModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -45,7 +45,7 @@ impl CtlModel<SndDice> for BlackbirdModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -58,7 +58,7 @@ impl CtlModel<SndDice> for BlackbirdModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -78,7 +78,7 @@ impl NotifyModel<SndDice, u32> for ExtensionModel {
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                             &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -28,7 +28,7 @@ pub struct ExtensionModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for ExtensionModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -45,7 +45,7 @@ impl CtlModel<SndDice> for ExtensionModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -58,7 +58,7 @@ impl CtlModel<SndDice> for ExtensionModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -104,7 +104,7 @@ impl MeasureModel<hinawa::SndDice> for ExtensionModel {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -99,7 +99,7 @@ impl NotifyModel<SndDice, u32> for LiquidS56Model {
         self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -33,7 +33,7 @@ pub struct LiquidS56Model {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for LiquidS56Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -54,7 +54,7 @@ impl CtlModel<SndDice> for LiquidS56Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -72,7 +72,7 @@ impl CtlModel<SndDice> for LiquidS56Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -129,7 +129,7 @@ impl MeasureModel<hinawa::SndDice> for LiquidS56Model {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -31,7 +31,7 @@ pub struct SPro26Model {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for SPro26Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -51,7 +51,7 @@ impl CtlModel<SndDice> for SPro26Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -66,7 +66,7 @@ impl CtlModel<SndDice> for SPro26Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -120,7 +120,7 @@ impl MeasureModel<hinawa::SndDice> for SPro26Model {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -90,7 +90,7 @@ impl NotifyModel<SndDice, u32> for SPro26Model {
         self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -128,7 +128,7 @@ impl MeasureModel<hinawa::SndDice> for SPro40Model {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -98,7 +98,7 @@ impl NotifyModel<SndDice, u32> for SPro40Model {
         self.out_grp_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -32,7 +32,7 @@ pub struct SPro40Model {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for SPro40Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -53,7 +53,7 @@ impl CtlModel<SndDice> for SPro40Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -71,7 +71,7 @@ impl CtlModel<SndDice> for SPro40Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -80,7 +80,7 @@ impl NotifyModel<SndDice, u32> for IoFwModel {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
     }
 

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -30,7 +30,7 @@ pub struct IoFwModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for IoFwModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -46,7 +46,7 @@ impl CtlModel<SndDice> for IoFwModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -60,7 +60,7 @@ impl CtlModel<SndDice> for IoFwModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -98,7 +98,7 @@ impl MeasureModel<hinawa::SndDice> for IoFwModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.0);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, &mut self.state, TIMEOUT_MS)?;
         self.mixer_ctl.measure_states(unit, &self.proto, &mut self.state, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -29,7 +29,7 @@ pub struct IonixModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for IonixModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -43,7 +43,7 @@ impl CtlModel<SndDice> for IonixModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -55,7 +55,7 @@ impl CtlModel<SndDice> for IonixModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -90,7 +90,7 @@ impl MeasureModel<hinawa::SndDice> for IonixModel {
         elem_id_list.extend_from_slice(&self.meter_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -73,7 +73,7 @@ impl NotifyModel<SndDice, u32> for IonixModel {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
     }
 

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -120,7 +120,7 @@ impl RuntimeOperation<u32> for DiceRuntime {
                         let _ = self.model.dispatch_msg(&self.unit, &mut self.card_cntr, msg);
                     }
                     Event::Timer => {
-                        let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
+                        let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                     }
                 }
             }

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -78,7 +78,7 @@ impl RuntimeOperation<u32> for DiceRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measured_elem_list.len() > 0 {
             let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -100,7 +100,7 @@ impl RuntimeOperation<u32> for DiceRuntime {
                     }
                     Event::Elem(elem_id, events) => {
                         if elem_id.get_name() != Self::TIMER_NAME {
-                            let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                            let _ = self.model.dispatch_elem_event(&mut self.unit, &mut self.card_cntr,
                                                                    &elem_id, &events);
                         } else {
                             let mut elem_value = alsactl::ElemValue::new();

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -117,7 +117,7 @@ impl RuntimeOperation<u32> for DiceRuntime {
                         }
                     }
                     Event::Notify(msg) => {
-                        let _ = self.model.dispatch_msg(&self.unit, &mut self.card_cntr, msg);
+                        let _ = self.model.dispatch_msg(&mut self.unit, &mut self.card_cntr, msg);
                     }
                     Event::Timer => {
                         let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -140,7 +140,7 @@ impl MeasureModel<hinawa::SndDice> for Mbox3Model {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -111,7 +111,7 @@ impl NotifyModel<SndDice, u32> for Mbox3Model {
         elem_id_list.extend_from_slice(&self.button_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -33,7 +33,7 @@ pub struct Mbox3Model{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for Mbox3Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -54,7 +54,7 @@ impl CtlModel<SndDice> for Mbox3Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -78,7 +78,7 @@ impl CtlModel<SndDice> for Mbox3Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -23,7 +23,7 @@ pub struct MinimalModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for MinimalModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -32,13 +32,13 @@ impl CtlModel<SndDice> for MinimalModel {
         self.ctl.load(card_cntr, &caps, &src_labels)
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -66,7 +66,7 @@ impl MeasureModel<hinawa::SndDice> for MinimalModel {
         elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)
     }
 

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -50,7 +50,7 @@ impl NotifyModel<SndDice, u32> for MinimalModel {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
     }
 

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -196,7 +196,7 @@ impl DiceModel {
         Ok(())
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &SndDice, card_cntr: &mut CardCntr,
+    pub fn dispatch_elem_event(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr,
                                elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -224,7 +224,7 @@ impl DiceModel {
         }
     }
 
-    pub fn dispatch_msg(&mut self, unit: &SndDice, card_cntr: &mut CardCntr, msg: u32)
+    pub fn dispatch_msg(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr, msg: u32)
         -> Result<(), Error>
     {
         match &mut self.model {

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -109,7 +109,8 @@ impl DiceModel {
 
         Ok(DiceModel{model, notified_elem_list, measured_elem_list})
     }
-    pub fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr)
+
+    pub fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         // Replace model data when protocol extension is available.

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -251,7 +251,7 @@ impl DiceModel {
         }
     }
 
-    pub fn measure_elems(&mut self, unit: &hinawa::SndDice, card_cntr: &mut CardCntr)
+    pub fn measure_elems(&mut self, unit: &mut hinawa::SndDice, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         match &mut self.model {

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -97,7 +97,7 @@ impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -125,7 +125,7 @@ impl<S> MeasureModel<hinawa::SndDice> for PfireModel<S>
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -38,7 +38,7 @@ const TIMEOUT_MS: u32 = 20;
 impl<S> CtlModel<SndDice> for PfireModel<S>
     where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec<'a>,
 {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -56,7 +56,7 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -72,7 +72,7 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -122,7 +122,7 @@ impl MeasureModel<hinawa::SndDice> for FStudioModel {
         elem_id_list.extend_from_slice(&self.meter_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -105,7 +105,7 @@ impl NotifyModel<SndDice, u32> for FStudioModel {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)
     }
 

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -48,7 +48,7 @@ const AVAIL_CLK_SRC_LABELS: [&str;13] = [
 ];
 
 impl CtlModel<SndDice> for FStudioModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -67,7 +67,7 @@ impl CtlModel<SndDice> for FStudioModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -83,7 +83,7 @@ impl CtlModel<SndDice> for FStudioModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
@@ -104,7 +104,7 @@ impl MeasureModel<hinawa::SndDice> for FStudioMobileModel {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
@@ -28,7 +28,7 @@ pub struct FStudioMobileModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for FStudioMobileModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -45,7 +45,7 @@ impl CtlModel<SndDice> for FStudioMobileModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -58,7 +58,7 @@ impl CtlModel<SndDice> for FStudioMobileModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
@@ -78,7 +78,7 @@ impl NotifyModel<SndDice, u32> for FStudioMobileModel {
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/presonus/fstudioproject_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudioproject_model.rs
@@ -28,7 +28,7 @@ pub struct FStudioProjectModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for FStudioProjectModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -45,7 +45,7 @@ impl CtlModel<SndDice> for FStudioProjectModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -58,7 +58,7 @@ impl CtlModel<SndDice> for FStudioProjectModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/presonus/fstudioproject_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudioproject_model.rs
@@ -104,7 +104,7 @@ impl MeasureModel<hinawa::SndDice> for FStudioProjectModel {
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(unit, &self.proto, &self.extension_sections, TIMEOUT_MS)?;
         Ok(())

--- a/libs/dice/runtime/src/presonus/fstudioproject_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudioproject_model.rs
@@ -78,7 +78,7 @@ impl NotifyModel<SndDice, u32> for FStudioProjectModel {
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
         self.tcd22xx_ctl.parse_notification(unit, &self.proto, &self.sections,
                                         &self.extension_sections, TIMEOUT_MS, *msg)?;

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -106,7 +106,7 @@ impl NotifyModel<SndDice, u32> for Desktopk6Model {
         elem_id_list.extend_from_slice(&self.hw_state_ctl.0);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         self.proto.parse_notification(&unit.get_node(), &mut self.segments.panel, TIMEOUT_MS, msg)?;

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -34,7 +34,7 @@ pub struct Desktopk6Model{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for Desktopk6Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -57,7 +57,7 @@ impl CtlModel<SndDice> for Desktopk6Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -77,7 +77,7 @@ impl CtlModel<SndDice> for Desktopk6Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -136,7 +136,7 @@ impl MeasureModel<hinawa::SndDice> for Desktopk6Model {
         elem_id_list.extend_from_slice(&self.meter_ctl.0);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
 
         self.proto.read_segment(&unit.get_node(), &mut self.segments.meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -38,7 +38,7 @@ pub struct ItwinModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for ItwinModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -67,7 +67,7 @@ impl CtlModel<SndDice> for ItwinModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -96,7 +96,7 @@ impl CtlModel<SndDice> for ItwinModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -142,7 +142,7 @@ impl NotifyModel<SndDice, u32> for ItwinModel {
         elem_id_list.extend_from_slice(&self.specific_ctl.0);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         let node = unit.get_node();

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -186,7 +186,7 @@ impl MeasureModel<hinawa::SndDice> for ItwinModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.ch_strip_ctl.measure_states(unit, &self.proto, &self.segments.ch_strip_state,
                                          &mut self.segments.ch_strip_meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -217,7 +217,7 @@ impl MeasureModel<hinawa::SndDice> for K24dModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.ch_strip_ctl.measure_states(unit, &self.proto, &self.segments.ch_strip_state,
                                          &mut self.segments.ch_strip_meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -171,7 +171,7 @@ impl NotifyModel<SndDice, u32> for K24dModel {
         elem_id_list.extend_from_slice(&self.prog_ctl.0);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         let node = unit.get_node();

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -43,7 +43,7 @@ pub struct K24dModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for K24dModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -76,7 +76,7 @@ impl CtlModel<SndDice> for K24dModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -113,7 +113,7 @@ impl CtlModel<SndDice> for K24dModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -162,7 +162,7 @@ impl MeasureModel<hinawa::SndDice> for K8Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
 
         self.proto.read_segment(&unit.get_node(), &mut self.segments.mixer_meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -126,7 +126,7 @@ impl NotifyModel<SndDice, u32> for K8Model {
         elem_id_list.extend_from_slice(&self.specific_ctl.0);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         let node = unit.get_node();

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -35,7 +35,7 @@ pub struct K8Model{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for K8Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -60,7 +60,7 @@ impl CtlModel<SndDice> for K8Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -85,7 +85,7 @@ impl CtlModel<SndDice> for K8Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -233,7 +233,7 @@ impl MeasureModel<hinawa::SndDice> for KliveModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.ch_strip_ctl.measure_states(unit, &self.proto, &self.segments.ch_strip_state,
                                          &mut self.segments.ch_strip_meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -187,7 +187,7 @@ impl NotifyModel<SndDice, u32> for KliveModel {
         elem_id_list.extend_from_slice(&self.prog_ctl.0);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         let node = unit.get_node();

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -46,7 +46,7 @@ pub struct KliveModel{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for KliveModel {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -81,7 +81,7 @@ impl CtlModel<SndDice> for KliveModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -122,7 +122,7 @@ impl CtlModel<SndDice> for KliveModel {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -190,7 +190,7 @@ impl MeasureModel<hinawa::SndDice> for Studiok48Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndDice) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
         self.ctl.measure_states(unit, &self.proto, &self.sections, TIMEOUT_MS)?;
         self.ch_strip_ctl.measure_states(unit, &self.proto, &self.segments.ch_strip_state,
                                          &mut self.segments.ch_strip_meter, TIMEOUT_MS)?;

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -43,7 +43,7 @@ pub struct Studiok48Model{
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<SndDice> for Studiok48Model {
-    fn load(&mut self, unit: &SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
@@ -74,7 +74,7 @@ impl CtlModel<SndDice> for Studiok48Model {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, unit: &mut SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.read(unit, &self.proto, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
@@ -102,7 +102,7 @@ impl CtlModel<SndDice> for Studiok48Model {
         }
     }
 
-    fn write(&mut self, unit: &SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndDice, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.ctl.write(unit, &self.proto, &self.sections, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -145,7 +145,7 @@ impl NotifyModel<SndDice, u32> for Studiok48Model {
         elem_id_list.extend_from_slice(&self.remote_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, unit: &SndDice, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
         self.ctl.parse_notification(unit, &self.proto, &self.sections, *msg, TIMEOUT_MS)?;
 
         let node = unit.get_node();

--- a/libs/efw/src/model.rs
+++ b/libs/efw/src/model.rs
@@ -158,7 +158,7 @@ impl MeasureModel<hinawa::SndEfw> for EfwModel {
         elem_id_list.extend_from_slice(&self.meter_ctl.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndEfw) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndEfw) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit)
     }
 

--- a/libs/efw/src/model.rs
+++ b/libs/efw/src/model.rs
@@ -90,7 +90,7 @@ impl EfwModel {
 }
 
 impl CtlModel<hinawa::SndEfw> for EfwModel {
-    fn load(&mut self, unit: &hinawa::SndEfw, card_cntr: &mut card_cntr::CardCntr)
+    fn load(&mut self, unit: &mut hinawa::SndEfw, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error> {
         let hwinfo = EfwInfo::get_hwinfo(unit)?;
         self.clk_ctl.load(&hwinfo, card_cntr)?;
@@ -104,7 +104,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
         Ok(())
     }
 
-    fn read(&mut self, unit: &hinawa::SndEfw, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut hinawa::SndEfw, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error> {
         if self.clk_ctl.read(unit, elem_id, elem_value)? {
@@ -128,7 +128,7 @@ impl CtlModel<hinawa::SndEfw> for EfwModel {
 
     fn write(
         &mut self,
-        unit: &hinawa::SndEfw,
+        unit: &mut hinawa::SndEfw,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/efw/src/runtime.rs
+++ b/libs/efw/src/runtime.rs
@@ -85,7 +85,7 @@ impl RuntimeOperation<u32> for EfwRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,
                                                    Self::TIMER_NAME, 0);

--- a/libs/efw/src/runtime.rs
+++ b/libs/efw/src/runtime.rs
@@ -115,7 +115,7 @@ impl RuntimeOperation<u32> for EfwRuntime {
                 Event::Elem((elem_id, events)) => {
                     if elem_id.get_name() != Self::TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
-                            &self.unit,
+                            &mut self.unit,
                             &elem_id,
                             &events,
                             &mut self.model,

--- a/libs/efw/src/runtime.rs
+++ b/libs/efw/src/runtime.rs
@@ -109,7 +109,7 @@ impl RuntimeOperation<u32> for EfwRuntime {
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Timer => {
-                    let _ = self.card_cntr.measure_elems(&self.unit, &self.measure_elems,
+                    let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems,
                                                          &mut self.model);
                 }
                 Event::Elem((elem_id, events)) => {

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -31,7 +31,7 @@ pub struct Ff400Model{
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff400Model {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
         self.mixer_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
@@ -41,7 +41,7 @@ impl CtlModel<SndUnit> for Ff400Model {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.out_ctl.read(elem_id, elem_value)? {
@@ -57,7 +57,7 @@ impl CtlModel<SndUnit> for Ff400Model {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.out_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -80,7 +80,7 @@ impl MeasureModel<SndUnit> for Ff400Model {
         elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
     }
 
-    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -28,7 +28,7 @@ pub struct Ff800Model{
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff800Model {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.cfg_ctl.load(unit, &self.proto, &self.status_ctl.status, card_cntr, TIMEOUT_MS)?;
         self.out_ctl.load(unit, &self.proto, card_cntr, TIMEOUT_MS)?;
@@ -38,7 +38,7 @@ impl CtlModel<SndUnit> for Ff800Model {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.read(elem_id, elem_value)? {
@@ -52,7 +52,7 @@ impl CtlModel<SndUnit> for Ff800Model {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, old: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)? {

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -73,7 +73,7 @@ impl MeasureModel<SndUnit> for Ff800Model {
         self.meter_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
         self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -66,7 +66,7 @@ impl MeasureModel<SndUnit> for Ff802Model {
         self.meter_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
         self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -27,7 +27,7 @@ pub struct Ff802Model{
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff802Model {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
@@ -35,7 +35,7 @@ impl CtlModel<SndUnit> for Ff802Model {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.read(elem_id, elem_value)? {
@@ -47,7 +47,7 @@ impl CtlModel<SndUnit> for Ff802Model {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -110,7 +110,7 @@ impl RuntimeOperation<u32> for FfRuntime {
                         }
                     }
                     Event::Timer => {
-                        let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
+                        let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                     }
                 }
             }

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -72,7 +72,7 @@ impl RuntimeOperation<u32> for FfRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measured_elem_list.len() > 0 {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::TIMER_NAME, 0);

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -93,7 +93,7 @@ impl RuntimeOperation<u32> for FfRuntime {
                     }
                     Event::Elem(elem_id, events) => {
                         if elem_id.get_name() != Self::TIMER_NAME {
-                            let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                            let _ = self.model.dispatch_elem_event(&mut self.unit, &mut self.card_cntr,
                                                                    &elem_id, &events);
                         } else {
                             let mut elem_value = alsactl::ElemValue::new();

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -55,7 +55,7 @@ impl FfModel {
         Ok(FfModel{model, measured_elem_list})
     }
 
-    pub fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    pub fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         match &mut self.model {
             Model::Ff800(m) => m.load(unit, card_cntr),
             Model::Ff400(m) => m.load(unit, card_cntr),

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -73,7 +73,7 @@ impl FfModel {
         Ok(())
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr,
+    pub fn dispatch_elem_event(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr,
                                elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -85,7 +85,7 @@ impl FfModel {
         }
     }
 
-    pub fn measure_elems(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr)
+    pub fn measure_elems(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         match &mut self.model {

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -27,7 +27,7 @@ pub struct UcxModel{
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for UcxModel {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
         self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
@@ -35,7 +35,7 @@ impl CtlModel<SndUnit> for UcxModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.read(elem_id, elem_value)? {
@@ -47,7 +47,7 @@ impl CtlModel<SndUnit> for UcxModel {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -66,7 +66,7 @@ impl MeasureModel<SndUnit> for UcxModel {
         self.meter_ctl.get_measured_elem_list(elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
         self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
         Ok(())

--- a/libs/motu/runtime/src/audioexpress.rs
+++ b/libs/motu/runtime/src/audioexpress.rs
@@ -21,7 +21,7 @@ pub struct AudioExpress{
 }
 
 impl CtlModel<SndMotu> for AudioExpress {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -29,7 +29,7 @@ impl CtlModel<SndMotu> for AudioExpress {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -42,7 +42,7 @@ impl CtlModel<SndMotu> for AudioExpress {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -24,7 +24,7 @@ pub struct F828 {
 }
 
 impl CtlModel<SndMotu> for F828 {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         self.specific_ctls.load(&self.proto, card_cntr)?;
@@ -33,7 +33,7 @@ impl CtlModel<SndMotu> for F828 {
 
     fn read(
         &mut self,
-        unit: &SndMotu,
+        unit: &mut SndMotu,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
@@ -59,7 +59,7 @@ impl CtlModel<SndMotu> for F828 {
 
     fn write(
         &mut self,
-        unit: &SndMotu,
+        unit: &mut SndMotu,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,

--- a/libs/motu/runtime/src/f828mk2.rs
+++ b/libs/motu/runtime/src/f828mk2.rs
@@ -79,7 +79,7 @@ impl NotifyModel<SndMotu, u32> for F828mk2 {
         elem_id_list.extend_from_slice(&self.word_clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndMotu, msg: &u32) -> Result<(), Error> {
         self.msg_cache = *msg;
         Ok(())
     }

--- a/libs/motu/runtime/src/f828mk2.rs
+++ b/libs/motu/runtime/src/f828mk2.rs
@@ -28,7 +28,7 @@ impl F828mk2 {
 }
 
 impl CtlModel<SndMotu> for F828mk2 {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -38,7 +38,7 @@ impl CtlModel<SndMotu> for F828mk2 {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -55,7 +55,7 @@ impl CtlModel<SndMotu> for F828mk2 {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/f828mk3.rs
+++ b/libs/motu/runtime/src/f828mk3.rs
@@ -31,7 +31,7 @@ impl F828mk3 {
 }
 
 impl CtlModel<SndMotu> for F828mk3 {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -42,7 +42,7 @@ impl CtlModel<SndMotu> for F828mk3 {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -61,7 +61,7 @@ impl CtlModel<SndMotu> for F828mk3 {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/f828mk3.rs
+++ b/libs/motu/runtime/src/f828mk3.rs
@@ -88,7 +88,7 @@ impl NotifyModel<SndMotu, u32> for F828mk3 {
         elem_id_list.extend_from_slice(&self.word_clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndMotu, msg: &u32) -> Result<(), Error> {
         self.msg_cache = *msg;
         Ok(())
     }

--- a/libs/motu/runtime/src/f896.rs
+++ b/libs/motu/runtime/src/f896.rs
@@ -26,7 +26,7 @@ pub struct F896 {
 }
 
 impl CtlModel<SndMotu> for F896 {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(&self.proto, card_cntr)?;
         self.monitor_input_ctl.load(&self.proto, card_cntr)?;
         self.word_clk_ctl.load(&self.proto, card_cntr)?;
@@ -37,7 +37,7 @@ impl CtlModel<SndMotu> for F896 {
 
     fn read(
         &mut self,
-        unit: &SndMotu,
+        unit: &mut SndMotu,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
@@ -76,7 +76,7 @@ impl CtlModel<SndMotu> for F896 {
 
     fn write(
         &mut self,
-        unit: &SndMotu,
+        unit: &mut SndMotu,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,

--- a/libs/motu/runtime/src/f8pre.rs
+++ b/libs/motu/runtime/src/f8pre.rs
@@ -22,7 +22,7 @@ pub struct F8pre{
 }
 
 impl CtlModel<SndMotu> for F8pre {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -31,7 +31,7 @@ impl CtlModel<SndMotu> for F8pre {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -46,7 +46,7 @@ impl CtlModel<SndMotu> for F8pre {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/h4pre.rs
+++ b/libs/motu/runtime/src/h4pre.rs
@@ -21,7 +21,7 @@ pub struct H4pre {
 }
 
 impl CtlModel<SndMotu> for H4pre {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -29,7 +29,7 @@ impl CtlModel<SndMotu> for H4pre {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -42,7 +42,7 @@ impl CtlModel<SndMotu> for H4pre {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -125,7 +125,7 @@ impl<'a> RuntimeOperation<u32> for MotuRuntime {
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Elem((elem_id, events)) => {
-                    let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                    let _ = self.model.dispatch_elem_event(&mut self.unit, &mut self.card_cntr,
                                                            &elem_id, &events);
                 }
                 Event::Notify(msg) => {

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -129,7 +129,7 @@ impl<'a> RuntimeOperation<u32> for MotuRuntime {
                                                            &elem_id, &events);
                 }
                 Event::Notify(msg) => {
-                    let _ = self.model.dispatch_notification(&self.unit, &msg, &mut self.card_cntr);
+                    let _ = self.model.dispatch_notification(&mut self.unit, &msg, &mut self.card_cntr);
                 }
             }
         }

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -107,7 +107,7 @@ impl<'a> RuntimeOperation<u32> for MotuRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         Ok(())
     }

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -110,7 +110,7 @@ impl MotuModel {
         }
     }
 
-    pub fn dispatch_notification(&mut self, unit: &hinawa::SndMotu, msg: &u32, card_cntr: &mut CardCntr)
+    pub fn dispatch_notification(&mut self, unit: &mut hinawa::SndMotu, msg: &u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         let elem_id_list = &self.notified_elems;

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -64,7 +64,7 @@ impl MotuModel {
         Ok(model)
     }
 
-    pub fn load(&mut self, unit: &hinawa::SndMotu, card_cntr: &mut CardCntr)
+    pub fn load(&mut self, unit: &mut hinawa::SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -92,7 +92,7 @@ impl MotuModel {
         Ok(())
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndMotu, card_cntr: &mut CardCntr,
+    pub fn dispatch_elem_event(&mut self, unit: &mut hinawa::SndMotu, card_cntr: &mut CardCntr,
                                elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {

--- a/libs/motu/runtime/src/traveler.rs
+++ b/libs/motu/runtime/src/traveler.rs
@@ -29,7 +29,7 @@ impl Traveler {
 }
 
 impl CtlModel<SndMotu> for Traveler {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -39,7 +39,7 @@ impl CtlModel<SndMotu> for Traveler {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -56,7 +56,7 @@ impl CtlModel<SndMotu> for Traveler {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/traveler.rs
+++ b/libs/motu/runtime/src/traveler.rs
@@ -79,7 +79,7 @@ impl NotifyModel<SndMotu, u32> for Traveler {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndMotu, msg: &u32) -> Result<(), Error> {
         self.msg_cache = *msg;
         Ok(())
     }

--- a/libs/motu/runtime/src/ultralite.rs
+++ b/libs/motu/runtime/src/ultralite.rs
@@ -27,7 +27,7 @@ impl UltraLite {
 }
 
 impl CtlModel<SndMotu> for UltraLite {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -36,7 +36,7 @@ impl CtlModel<SndMotu> for UltraLite {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -51,7 +51,7 @@ impl CtlModel<SndMotu> for UltraLite {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/motu/runtime/src/ultralite.rs
+++ b/libs/motu/runtime/src/ultralite.rs
@@ -73,7 +73,7 @@ impl NotifyModel<SndMotu, u32> for UltraLite {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndMotu, msg: &u32) -> Result<(), Error> {
         self.msg_cache = *msg;
         Ok(())
     }

--- a/libs/motu/runtime/src/ultralite_mk3.rs
+++ b/libs/motu/runtime/src/ultralite_mk3.rs
@@ -75,7 +75,7 @@ impl NotifyModel<SndMotu, u32> for UltraLiteMk3 {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &SndMotu, msg: &u32) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndMotu, msg: &u32) -> Result<(), Error> {
         self.msg_cache = *msg;
         Ok(())
     }

--- a/libs/motu/runtime/src/ultralite_mk3.rs
+++ b/libs/motu/runtime/src/ultralite_mk3.rs
@@ -29,7 +29,7 @@ impl UltraLiteMk3 {
 }
 
 impl CtlModel<SndMotu> for UltraLiteMk3 {
-    fn load(&mut self, _: &SndMotu, card_cntr: &mut CardCntr)
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
         self.clk_ctls.load(&self.proto, card_cntr)?;
@@ -38,7 +38,7 @@ impl CtlModel<SndMotu> for UltraLiteMk3 {
         Ok(())
     }
 
-    fn read(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId,
+    fn read(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -53,7 +53,7 @@ impl CtlModel<SndMotu> for UltraLiteMk3 {
         }
     }
 
-    fn write(&mut self, unit: &SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut SndMotu, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -98,7 +98,7 @@ impl card_cntr::MeasureModel<hinawa::SndUnit> for ApogeeModel {
         elem_id_list.extend_from_slice(&self.hwstate.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndUnit) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndUnit) -> Result<(), Error> {
         self.hwstate.measure_states(&unit.get_node(), &self.avc, &self.company_id)
     }
 

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -115,7 +115,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for ApogeeModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -29,7 +29,7 @@ impl<'a> ApogeeModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
         let mut op = UnitInfo{
@@ -50,7 +50,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -71,7 +71,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for ApogeeModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue)
         -> Result<bool, Error>
     {

--- a/libs/oxfw/runtime/src/common_model.rs
+++ b/libs/oxfw/runtime/src/common_model.rs
@@ -53,7 +53,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for CommonModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/common_model.rs
+++ b/libs/oxfw/runtime/src/common_model.rs
@@ -19,7 +19,7 @@ impl<'a> CommonModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for CommonModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -27,7 +27,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for CommonModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -37,7 +37,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for CommonModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
              new: &alsactl::ElemValue) -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -155,7 +155,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for GriffinModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -33,7 +33,7 @@ impl<'a> GriffinModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for GriffinModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -79,7 +79,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for GriffinModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -119,7 +119,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for GriffinModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, old: &alsactl::ElemValue,
              new: &alsactl::ElemValue) -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -31,7 +31,7 @@ impl<'a> LacieModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for LacieModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
         self.common_ctl.load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -77,7 +77,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for LacieModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, Self::FCP_TIMEOUT_MS)? {
@@ -117,7 +117,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for LacieModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
              new: &alsactl::ElemValue) -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -153,7 +153,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for LacieModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -139,7 +139,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
                 }
                 Event::Elem((elem_id, events)) => {
                     if elem_id.get_name() != Self::TIMER_NAME {
-                        let _ = self.model.dispatch_elem_event(&self.unit, &mut self.card_cntr,
+                        let _ = self.model.dispatch_elem_event(&mut self.unit, &mut self.card_cntr,
                                                                &elem_id, &events);
                     } else {
                         let mut elem_value = alsactl::ElemValue::new();

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -158,7 +158,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
                     let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                 }
                 Event::StreamLock(locked) => {
-                    let _ = self.model.dispatch_notification(&self.unit, &mut self.card_cntr, locked);
+                    let _ = self.model.dispatch_notification(&mut self.unit, &mut self.card_cntr, locked);
                 }
             }
         }

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measure_elem_list.len() > 0 {
             let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -155,7 +155,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
                     }
                 }
                 Event::Timer => {
-                    let _ = self.model.measure_elems(&self.unit, &mut self.card_cntr);
+                    let _ = self.model.measure_elems(&mut self.unit, &mut self.card_cntr);
                 }
                 Event::StreamLock(locked) => {
                     let _ = self.model.dispatch_notification(&self.unit, &mut self.card_cntr, locked);

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -61,7 +61,7 @@ impl NotifyModel<SndUnit, bool> for LinkFwModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -22,7 +22,7 @@ pub struct LinkFwModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for LinkFwModel {
-    fn load(&mut self, unit: &SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.avc.bind(&unit.get_node())?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
@@ -31,7 +31,7 @@ impl CtlModel<SndUnit> for LinkFwModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
+    fn read(&mut self, _: &mut SndUnit, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.read(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)? {
@@ -43,7 +43,7 @@ impl CtlModel<SndUnit> for LinkFwModel {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
+    fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, FCP_TIMEOUT_MS)? {

--- a/libs/oxfw/runtime/src/model.rs
+++ b/libs/oxfw/runtime/src/model.rs
@@ -100,7 +100,7 @@ impl OxfwModel {
         }
     }
 
-    pub fn dispatch_notification(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr, locked: bool)
+    pub fn dispatch_notification(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr, locked: bool)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/oxfw/runtime/src/model.rs
+++ b/libs/oxfw/runtime/src/model.rs
@@ -77,7 +77,7 @@ impl OxfwModel {
         Ok(())
     }
 
-    pub fn dispatch_elem_event(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
+    pub fn dispatch_elem_event(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr,
                                elem_id: &alsactl::ElemId, events: &alsactl::ElemEventMask)
         -> Result<(), Error>
     {

--- a/libs/oxfw/runtime/src/model.rs
+++ b/libs/oxfw/runtime/src/model.rs
@@ -48,7 +48,7 @@ impl OxfwModel {
         Ok(model)
     }
 
-    pub fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
+    pub fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/oxfw/runtime/src/model.rs
+++ b/libs/oxfw/runtime/src/model.rs
@@ -91,7 +91,7 @@ impl OxfwModel {
         }
     }
 
-    pub fn measure_elems(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
+    pub fn measure_elems(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>
     {
         match &mut self.ctl_model {

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -155,7 +155,7 @@ impl card_cntr::NotifyModel<hinawa::SndUnit, bool> for TascamModel {
         elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_list);
     }
 
-    fn parse_notification(&mut self, _: &hinawa::SndUnit, _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut hinawa::SndUnit, _: &bool) -> Result<(), Error> {
         Ok(())
     }
 

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -43,7 +43,7 @@ impl<'a> TascamModel {
 }
 
 impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
-    fn load(&mut self, unit: &hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
+    fn load(&mut self, unit: &mut hinawa::SndUnit, card_cntr: &mut card_cntr::CardCntr) -> Result<(), Error> {
         self.avc.fcp.bind(&unit.get_node())?;
 
         let mut op = UnitInfo::new();
@@ -68,7 +68,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
         Ok(())
     }
 
-    fn read(&mut self, _: &hinawa::SndUnit, elem_id: &alsactl::ElemId,
+    fn read(&mut self, _: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId,
             elem_value: &mut alsactl::ElemValue)
         -> Result<bool, Error>
     {
@@ -113,7 +113,7 @@ impl card_cntr::CtlModel<hinawa::SndUnit> for TascamModel {
         }
     }
 
-    fn write(&mut self, unit: &hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
+    fn write(&mut self, unit: &mut hinawa::SndUnit, elem_id: &alsactl::ElemId, _: &alsactl::ElemValue,
              new: &alsactl::ElemValue) -> Result<bool, Error>
     {
         if self.common_ctl.write(unit, &self.avc, elem_id, new, Self::FCP_TIMEOUT_MS)? {

--- a/libs/tascam/src/fw1082_model.rs
+++ b/libs/tascam/src/fw1082_model.rs
@@ -72,7 +72,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1082Model<'a> {
 impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1082Model<'a> {
     fn load(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         card_cntr: &mut card_cntr::CardCntr,
     ) -> Result<(), Error> {
         self.common.load(unit, &self.req, card_cntr)?;
@@ -84,7 +84,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1082Model<'a> {
 
     fn read(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         elem_value: &mut alsactl::ElemValue,
     ) -> Result<bool, Error> {
@@ -99,7 +99,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1082Model<'a> {
 
     fn write(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/tascam/src/fw1082_model.rs
+++ b/libs/tascam/src/fw1082_model.rs
@@ -48,7 +48,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1082Model<'a> {
         elem_id_list.extend_from_slice(&self.console.get_monitored_elems());
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndTscm) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndTscm) -> Result<(), Error> {
         let states = unit.get_state()?;
         self.meter.parse_states(states);
         self.console.parse_states(states);

--- a/libs/tascam/src/fw1804_model.rs
+++ b/libs/tascam/src/fw1804_model.rs
@@ -58,7 +58,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1804Model<'a> {
         elem_id_list.extend_from_slice(&self.meter.measure_elems);
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndTscm) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndTscm) -> Result<(), Error> {
         let states = unit.get_state()?;
         self.meter.parse_states(states);
         Ok(())

--- a/libs/tascam/src/fw1804_model.rs
+++ b/libs/tascam/src/fw1804_model.rs
@@ -79,7 +79,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1804Model<'a> {
 impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1804Model<'a> {
     fn load(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         card_cntr: &mut card_cntr::CardCntr,
     ) -> Result<(), Error> {
         self.common.load(unit, &self.req, card_cntr)?;
@@ -91,7 +91,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1804Model<'a> {
 
     fn read(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         elem_value: &mut alsactl::ElemValue,
     ) -> Result<bool, Error> {
@@ -108,7 +108,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1804Model<'a> {
 
     fn write(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/tascam/src/fw1884_model.rs
+++ b/libs/tascam/src/fw1884_model.rs
@@ -61,7 +61,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1884Model<'a> {
         elem_id_list.extend_from_slice(&self.console.get_monitored_elems());
     }
 
-    fn measure_states(&mut self, unit: &hinawa::SndTscm) -> Result<(), Error> {
+    fn measure_states(&mut self, unit: &mut hinawa::SndTscm) -> Result<(), Error> {
         let states = unit.get_state()?;
         self.meter.parse_states(states);
         self.console.parse_states(states);

--- a/libs/tascam/src/fw1884_model.rs
+++ b/libs/tascam/src/fw1884_model.rs
@@ -85,7 +85,7 @@ impl<'a> card_cntr::MeasureModel<hinawa::SndTscm> for Fw1884Model<'a> {
 impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1884Model<'a> {
     fn load(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         card_cntr: &mut card_cntr::CardCntr,
     ) -> Result<(), Error> {
         self.common.load(unit, &self.req, card_cntr)?;
@@ -98,7 +98,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1884Model<'a> {
 
     fn read(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         elem_value: &mut alsactl::ElemValue,
     ) -> Result<bool, Error> {
@@ -115,7 +115,7 @@ impl<'a> card_cntr::CtlModel<hinawa::SndTscm> for Fw1884Model<'a> {
 
     fn write(
         &mut self,
-        unit: &hinawa::SndTscm,
+        unit: &mut hinawa::SndTscm,
         elem_id: &alsactl::ElemId,
         old: &alsactl::ElemValue,
         new: &alsactl::ElemValue,

--- a/libs/tascam/src/isoc_console_runtime.rs
+++ b/libs/tascam/src/isoc_console_runtime.rs
@@ -191,8 +191,8 @@ impl<'a> IsocConsoleRuntime<'a> {
         self.seq_cntr.open_port()?;
 
         match &mut self.model {
-            ConsoleModel::Fw1884(m) => m.load(&self.unit, &mut self.card_cntr)?,
-            ConsoleModel::Fw1082(m) => m.load(&self.unit, &mut self.card_cntr)?,
+            ConsoleModel::Fw1884(m) => m.load(&mut self.unit, &mut self.card_cntr)?,
+            ConsoleModel::Fw1082(m) => m.load(&mut self.unit, &mut self.card_cntr)?,
         }
 
         self.init_surface()?;

--- a/libs/tascam/src/isoc_console_runtime.rs
+++ b/libs/tascam/src/isoc_console_runtime.rs
@@ -271,10 +271,10 @@ impl<'a> IsocConsoleRuntime<'a> {
                 ConsoleUnitEvent::Interval => {
                     match &mut self.model {
                         ConsoleModel::Fw1884(m) =>{
-                            let _ = self.card_cntr.measure_elems(&self.unit, &self.measure_elems, m);
+                            let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems, m);
                         }
                         ConsoleModel::Fw1082(m) => {
-                            let _ = self.card_cntr.measure_elems(&self.unit, &self.measure_elems, m);
+                            let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems, m);
                         }
                     };
                 }

--- a/libs/tascam/src/isoc_console_runtime.rs
+++ b/libs/tascam/src/isoc_console_runtime.rs
@@ -251,9 +251,9 @@ impl<'a> IsocConsoleRuntime<'a> {
                     if elem_id.get_name() != Self::TIMER_NAME {
                         let _ = match &mut self.model {
                             ConsoleModel::Fw1884(m) =>
-                                self.card_cntr.dispatch_elem_event(&self.unit, &elem_id, &events, m),
+                                self.card_cntr.dispatch_elem_event(&mut self.unit, &elem_id, &events, m),
                             ConsoleModel::Fw1082(m) =>
-                                self.card_cntr.dispatch_elem_event(&self.unit, &elem_id, &events, m),
+                                self.card_cntr.dispatch_elem_event(&mut self.unit, &elem_id, &events, m),
                         };
                     } else {
                         let mut elem_value = alsactl::ElemValue::new();

--- a/libs/tascam/src/isoc_rack_runtime.rs
+++ b/libs/tascam/src/isoc_rack_runtime.rs
@@ -200,7 +200,7 @@ impl<'a> IsocRackRuntime<'a> {
                     }
                 }
                 RackUnitEvent::Timer => {
-                    let _ = self.card_cntr.measure_elems(&self.unit, &self.measure_elems,
+                    let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems,
                                                          &mut self.model);
                 }
             }

--- a/libs/tascam/src/isoc_rack_runtime.rs
+++ b/libs/tascam/src/isoc_rack_runtime.rs
@@ -184,7 +184,7 @@ impl<'a> IsocRackRuntime<'a> {
                 }
                 RackUnitEvent::Elem((elem_id, events)) => {
                     if elem_id.get_name() != Self::TIMER_NAME {
-                        let _ = self.card_cntr.dispatch_elem_event(&self.unit, &elem_id, &events,
+                        let _ = self.card_cntr.dispatch_elem_event(&mut self.unit, &elem_id, &events,
                                                                    &mut self.model);
                     } else {
                         let mut elem_value = alsactl::ElemValue::new();

--- a/libs/tascam/src/isoc_rack_runtime.rs
+++ b/libs/tascam/src/isoc_rack_runtime.rs
@@ -133,7 +133,7 @@ impl<'a> IsocRackRuntime<'a> {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
-        self.model.load(&self.unit, &mut self.card_cntr)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
             alsactl::ElemIfaceType::Mixer,


### PR DESCRIPTION
In current implementation of CtlModel, MeasureModel, and NotifyModel traits
in core crate, immutable reference for unit instance is used as argument for
several methods. However, in most of the methods, transactions is initiated to
inquire or change state of target device. The transaction can change the state,
especially so as proxy object.

This patchset changes these traits so that mutable reference is passed instead
of immutable one. It affect whole crates in the repository, but the core change
is small.

```
Takashi Sakamoto (6):
  core: use mutable reference to unit instance to dispatch element event
  core: use mutable reference to unit instance to measure element
  core: use mutable reference to unit instance to dispatch notifications
  core: pass mutable reference to unit instance in methods of CtlModel
    trait
  core: pass mutable reference to unit instance in methods of
    MeasureModel trait
  core: pass mutable reference to unit instance in methods of
    NotifyModel trait

 libs/bebob/src/apogee/apogee_model.rs            | 10 +++++-----
 libs/bebob/src/behringer/firepower_model.rs      |  8 ++++----
 libs/bebob/src/esi.rs                            |  8 ++++----
 libs/bebob/src/maudio/audiophile_model.rs        | 10 +++++-----
 libs/bebob/src/maudio/fw410_model.rs             | 10 +++++-----
 libs/bebob/src/maudio/ozonic_model.rs            | 10 +++++-----
 .../bebob/src/maudio/profirelightbridge_model.rs | 10 +++++-----
 libs/bebob/src/maudio/solo_model.rs              | 10 +++++-----
 libs/bebob/src/maudio/special_model.rs           | 10 +++++-----
 libs/bebob/src/model.rs                          |  8 ++++----
 libs/bebob/src/runtime.rs                        | 10 +++++-----
 libs/bebob/src/stanton.rs                        |  8 ++++----
 libs/core/src/card_cntr.rs                       | 16 ++++++++--------
 libs/dg00x/src/model.rs                          |  8 ++++----
 libs/dg00x/src/runtime.rs                        |  6 +++---
 libs/dice/runtime/src/blackbird_model.rs         | 10 +++++-----
 libs/dice/runtime/src/extension_model.rs         | 10 +++++-----
 .../runtime/src/focusrite/liquids56_model.rs     | 10 +++++-----
 libs/dice/runtime/src/focusrite/spro26_model.rs  | 10 +++++-----
 libs/dice/runtime/src/focusrite/spro40_model.rs  | 10 +++++-----
 libs/dice/runtime/src/io_fw_model.rs             | 10 +++++-----
 libs/dice/runtime/src/ionix_model.rs             | 10 +++++-----
 libs/dice/runtime/src/lib.rs                     |  8 ++++----
 libs/dice/runtime/src/mbox3_model.rs             | 10 +++++-----
 libs/dice/runtime/src/minimal_model.rs           | 10 +++++-----
 libs/dice/runtime/src/model.rs                   |  9 +++++----
 libs/dice/runtime/src/pfire_model.rs             | 10 +++++-----
 libs/dice/runtime/src/presonus/fstudio_model.rs  | 10 +++++-----
 .../runtime/src/presonus/fstudiomobile_model.rs  | 10 +++++-----
 .../runtime/src/presonus/fstudioproject_model.rs | 10 +++++-----
 .../runtime/src/tcelectronic/desktopk6_model.rs  | 10 +++++-----
 .../dice/runtime/src/tcelectronic/itwin_model.rs | 10 +++++-----
 libs/dice/runtime/src/tcelectronic/k24d_model.rs | 10 +++++-----
 libs/dice/runtime/src/tcelectronic/k8_model.rs   | 10 +++++-----
 .../dice/runtime/src/tcelectronic/klive_model.rs | 10 +++++-----
 .../runtime/src/tcelectronic/studiok48_model.rs  | 10 +++++-----
 libs/efw/src/model.rs                            |  8 ++++----
 libs/efw/src/runtime.rs                          |  6 +++---
 libs/ff/runtime/src/ff400_model.rs               |  8 ++++----
 libs/ff/runtime/src/ff800_model.rs               |  8 ++++----
 libs/ff/runtime/src/ff802_model.rs               |  8 ++++----
 libs/ff/runtime/src/lib.rs                       |  6 +++---
 libs/ff/runtime/src/model.rs                     |  6 +++---
 libs/ff/runtime/src/ucx_model.rs                 |  8 ++++----
 libs/motu/runtime/src/audioexpress.rs            |  6 +++---
 libs/motu/runtime/src/f828.rs                    |  6 +++---
 libs/motu/runtime/src/f828mk2.rs                 |  8 ++++----
 libs/motu/runtime/src/f828mk3.rs                 |  8 ++++----
 libs/motu/runtime/src/f896.rs                    |  6 +++---
 libs/motu/runtime/src/f8pre.rs                   |  6 +++---
 libs/motu/runtime/src/h4pre.rs                   |  6 +++---
 libs/motu/runtime/src/lib.rs                     |  6 +++---
 libs/motu/runtime/src/model.rs                   |  6 +++---
 libs/motu/runtime/src/traveler.rs                |  8 ++++----
 libs/motu/runtime/src/ultralite.rs               |  8 ++++----
 libs/motu/runtime/src/ultralite_mk3.rs           |  8 ++++----
 libs/oxfw/runtime/src/apogee_model.rs            | 10 +++++-----
 libs/oxfw/runtime/src/common_model.rs            |  8 ++++----
 libs/oxfw/runtime/src/griffin_model.rs           |  8 ++++----
 libs/oxfw/runtime/src/lacie_model.rs             |  8 ++++----
 libs/oxfw/runtime/src/lib.rs                     |  8 ++++----
 libs/oxfw/runtime/src/loud_model.rs              |  8 ++++----
 libs/oxfw/runtime/src/model.rs                   |  8 ++++----
 libs/oxfw/runtime/src/tascam_model.rs            |  8 ++++----
 libs/tascam/src/fw1082_model.rs                  |  8 ++++----
 libs/tascam/src/fw1804_model.rs                  |  8 ++++----
 libs/tascam/src/fw1884_model.rs                  |  8 ++++----
 libs/tascam/src/isoc_console_runtime.rs          | 12 ++++++------
 libs/tascam/src/isoc_rack_runtime.rs             |  6 +++---
 69 files changed, 299 insertions(+), 298 deletions(-)

-- 
```