### PR TITLE
[PATCH 0/8] dice-runtime/dice-protocols: code refactoring to use static lifetime

### DIFF
--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -18,20 +18,20 @@ use super::tcat::tcd22xx_spec::*;
 #[derive(Default, Debug)]
 pub struct Mbox3State(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for  Mbox3State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for  Mbox3State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 6, label: None},
         Input{id: SrcBlkId::Ins1, offset: 0, count: 2, label: Some("Reverb")},
         Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
         Output{id: DstBlkId::Ins1, offset: 0, count: 4, label: Some("Headphone")},
         Output{id: DstBlkId::Ins1, offset: 4, count: 2, label: Some("Reverb")},
         Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
         Output{id: DstBlkId::Reserved(0x08), offset: 0, count: 2, label: Some("ControlRoom")},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
         SrcBlk{id: SrcBlkId::Ins0, ch: 2},

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -28,8 +28,8 @@ impl Default for LiquidS56State {
     }
 }
 
-impl<'a> Tcd22xxSpec<'a> for LiquidS56State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for LiquidS56State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: None},
         Input{id: SrcBlkId::Ins1, offset: 0, count: 6, label: None},
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
@@ -38,7 +38,7 @@ impl<'a> Tcd22xxSpec<'a> for LiquidS56State {
         Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-opt")},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 2, label: None},
         Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
@@ -49,7 +49,7 @@ impl<'a> Tcd22xxSpec<'a> for LiquidS56State {
     ];
     // NOTE: The 8 entries are selected by unique protocol from the first 26 entries in router
     // section are used to display hardware metering.
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins1, ch: 0},
         SrcBlk{id: SrcBlkId::Ins1, ch: 1},
         SrcBlk{id: SrcBlkId::Ins1, ch: 2},

--- a/libs/dice/protocols/src/focusrite/spro26.rs
+++ b/libs/dice/protocols/src/focusrite/spro26.rs
@@ -27,21 +27,21 @@ impl Default for SPro26State {
     }
 }
 
-impl<'a> Tcd22xxSpec<'a> for SPro26State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for SPro26State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 6, label: None},
         Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-coax")},
         // NOTE: share the same optical interface.
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-opt")},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
         Output{id: DstBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-coax")},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
     ];
     // NOTE: The first 6 entries in router section are used to display hardware metering.
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
         SrcBlk{id: SrcBlkId::Ins0, ch: 2},

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -27,15 +27,15 @@ impl Default for SPro40State {
     }
 }
 
-impl<'a> Tcd22xxSpec<'a> for SPro40State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for SPro40State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins1, offset: 0, count: 6, label: None},
         Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
         // NOTE: share the same optical interface.
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 2, label: None},
         Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Aes, offset: 0, count: 2, label: Some("S/PDIF-coax")},
@@ -44,7 +44,7 @@ impl<'a> Tcd22xxSpec<'a> for SPro40State {
         Output{id: DstBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
     ];
     // NOTE: The first 8 entries in router section are used to display hardware metering.
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins1, ch: 0},
         SrcBlk{id: SrcBlkId::Ins1, ch: 1},
         SrcBlk{id: SrcBlkId::Ins1, ch: 2},

--- a/libs/dice/protocols/src/loud.rs
+++ b/libs/dice/protocols/src/loud.rs
@@ -12,16 +12,16 @@ use super::tcat::tcd22xx_spec::*;
 #[derive(Default, Debug)]
 pub struct BlackbirdState(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for BlackbirdState {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for BlackbirdState {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
         SrcBlk{id: SrcBlkId::Ins0, ch: 2},

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -29,20 +29,20 @@ pub trait PfireClkSpec {
 #[derive(Default, Debug)]
 pub struct Pfire2626State(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for Pfire2626State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for Pfire2626State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins1, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 0, count: 2, label: None},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins1, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 8, count: 8, label: None},
         Output{id: DstBlkId::Aes, offset: 0, count: 2, label: None},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins1, ch: 0},
         SrcBlk{id: SrcBlkId::Ins1, ch: 1},
         SrcBlk{id: SrcBlkId::Ins1, ch: 2},
@@ -82,16 +82,16 @@ impl PfireClkSpec for Pfire2626State {
 pub struct Pfire610State(Tcd22xxState);
 
 // NOTE: the second rx stream is firstly available at higher sampling rate.
-impl<'a> Tcd22xxSpec<'a> for Pfire610State {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for Pfire610State {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 4, label: None},
         Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
     ];

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -15,14 +15,14 @@ use super::tcat::tcd22xx_spec::*;
 use super::tcat::extension::{*, appl_section::*};
 
 /// The trait to represent available rate and source of sampling clock.
-pub trait PfireClkSpec<'a> {
-    const AVAIL_CLK_RATES: &'a [ClockRate] = &[
+pub trait PfireClkSpec {
+    const AVAIL_CLK_RATES: [ClockRate; 7] = [
         ClockRate::R32000, ClockRate::R44100, ClockRate::R48000,
         ClockRate::R88200, ClockRate::R96000,
         ClockRate::R176400, ClockRate::R192000,
     ];
 
-    const AVAIL_CLK_SRCS: &'a [ClockSource];
+    const AVAIL_CLK_SRCS: &'static [ClockSource];
 }
 
 /// The structure to represent state of TCD22xx on ProFire 2626.
@@ -66,8 +66,8 @@ impl AsRef<Tcd22xxState> for Pfire2626State {
     }
 }
 
-impl<'a> PfireClkSpec<'a> for Pfire2626State {
-    const AVAIL_CLK_SRCS: &'a [ClockSource] = &[
+impl PfireClkSpec for Pfire2626State {
+    const AVAIL_CLK_SRCS: &'static [ClockSource] = &[
             ClockSource::Aes1,
             ClockSource::Aes4,
             ClockSource::Adat,
@@ -109,8 +109,8 @@ impl AsMut<Tcd22xxState> for Pfire610State {
     }
 }
 
-impl<'a> PfireClkSpec<'a> for Pfire610State {
-    const AVAIL_CLK_SRCS: &'a [ClockSource] = &[
+impl PfireClkSpec for Pfire610State {
+    const AVAIL_CLK_SRCS: &'static [ClockSource] = &[
             ClockSource::Aes1,
             ClockSource::Internal,
     ];

--- a/libs/dice/protocols/src/presonus/fstudiomobile.rs
+++ b/libs/dice/protocols/src/presonus/fstudiomobile.rs
@@ -6,16 +6,16 @@ use crate::tcat::tcd22xx_spec::*;
 #[derive(Default, Debug)]
 pub struct FStudioMobileState(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for  FStudioMobileState {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for  FStudioMobileState {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 4, label: None},
         Output{id: DstBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
     ];

--- a/libs/dice/protocols/src/presonus/fstudioproject.rs
+++ b/libs/dice/protocols/src/presonus/fstudioproject.rs
@@ -6,16 +6,16 @@ use crate::tcat::tcd22xx_spec::*;
 #[derive(Default, Debug)]
 pub struct FStudioProjectState(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for  FStudioProjectState {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for  FStudioProjectState {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Aes,  offset: 2, count: 2, label: Some("S/PDIF")},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
         SrcBlk{id: SrcBlkId::Ins0, ch: 2},

--- a/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
+++ b/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
@@ -19,26 +19,26 @@ pub struct Tcd22xxState {
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct Input<'a> {
+pub struct Input {
     pub id: SrcBlkId,
     pub offset: u8,
     pub count: u8,
-    pub label: Option<&'a str>,
+    pub label: Option<&'static str>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
-pub struct Output<'a> {
+pub struct Output {
     pub id: DstBlkId,
     pub offset: u8,
     pub count: u8,
-    pub label: Option<&'a str>,
+    pub label: Option<&'static str>,
 }
 
-pub trait Tcd22xxSpec<'a> {
+pub trait Tcd22xxSpec {
     // For each model.
-    const INPUTS: &'a [Input<'a>];
-    const OUTPUTS: &'a [Output<'a>];
-    const FIXED: &'a [SrcBlk];
+    const INPUTS: &'static [Input];
+    const OUTPUTS: &'static [Output];
+    const FIXED: &'static [SrcBlk];
 
     // From specification of TCD22xx.
     const MIXER_OUT_PORTS: [u8;3] = [16, 16, 8];
@@ -208,7 +208,7 @@ pub trait Tcd22xxSpec<'a> {
     }
 }
 
-pub trait Tcd22xxRouterOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>
+pub trait Tcd22xxRouterOperation<T, U> : Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>
     where T: AsRef<FwNode>,
           U: CmdSectionProtocol<T> + RouterSectionProtocol<T> + CurrentConfigSectionProtocol<T>,
 {
@@ -268,7 +268,7 @@ pub trait Tcd22xxRouterOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxStat
     }
 }
 
-pub trait Tcd22xxMixerOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>
+pub trait Tcd22xxMixerOperation<T, U> : Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>
     where T: AsRef<FwNode>,
           U: MixerSectionProtocol<T>,
 {
@@ -313,8 +313,8 @@ pub trait Tcd22xxMixerOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState
     }
 }
 
-pub trait Tcd22xxStateOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
-                                            Tcd22xxRouterOperation<'a, T, U> +  Tcd22xxMixerOperation<'a, T, U>
+pub trait Tcd22xxStateOperation<T, U> : Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
+                                            Tcd22xxRouterOperation<T, U> +  Tcd22xxMixerOperation<T, U>
     where T: AsRef<FwNode>,
           U: CmdSectionProtocol<T> + MixerSectionProtocol<T> + RouterSectionProtocol<T> +
              CurrentConfigSectionProtocol<T>,
@@ -330,21 +330,21 @@ pub trait Tcd22xxStateOperation<'a, T, U> : Tcd22xxSpec<'a> + AsRef<Tcd22xxState
     }
 }
 
-impl<'a, O, T, U> Tcd22xxRouterOperation<'a, T, U> for O
-    where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+impl<O, T, U> Tcd22xxRouterOperation<T, U> for O
+    where O: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
           T: AsRef<FwNode>,
           U: CmdSectionProtocol<T> + RouterSectionProtocol<T> + CurrentConfigSectionProtocol<T>,
 {}
 
-impl<'a, O, T, U> Tcd22xxMixerOperation<'a, T, U> for O
-    where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+impl<O, T, U> Tcd22xxMixerOperation<T, U> for O
+    where O: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
           T: AsRef<FwNode>,
           U: MixerSectionProtocol<T>,
 {}
 
-impl<'a, O, T, U> Tcd22xxStateOperation<'a, T, U> for O
-    where O: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
-             Tcd22xxRouterOperation<'a, T, U> +  Tcd22xxMixerOperation<'a, T, U>,
+impl<O, T, U> Tcd22xxStateOperation<T, U> for O
+    where O: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState> +
+             Tcd22xxRouterOperation<T, U> +  Tcd22xxMixerOperation<T, U>,
           T: AsRef<FwNode>,
           U: CmdSectionProtocol<T> + MixerSectionProtocol<T> + RouterSectionProtocol<T> +
              CurrentConfigSectionProtocol<T>,

--- a/libs/dice/protocols/src/tcelectronic/shell.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell.rs
@@ -145,7 +145,7 @@ pub struct ShellMonitorSrcPair{
     pub right: MonitorSrcParam,
 }
 
-impl<'a> ShellMonitorSrcPair {
+impl ShellMonitorSrcPair {
     const SIZE: usize = 28;
 
     pub fn build(&self, raw: &mut [u8]) {
@@ -641,8 +641,8 @@ impl From<u32> for ShellStandaloneClkSrc {
     }
 }
 
-pub trait ShellStandaloneClkSpec<'a> : TcKonnektSegmentData + AsRef<ShellStandaloneClkSrc> + AsMut<ShellStandaloneClkSrc> {
-    const STANDALONE_CLOCK_SOURCES: &'a [ShellStandaloneClkSrc];
+pub trait ShellStandaloneClkSpec : TcKonnektSegmentData + AsRef<ShellStandaloneClkSrc> + AsMut<ShellStandaloneClkSrc> {
+    const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc];
 }
 
 /// The structure to represent source pair of stream to mixer.

--- a/libs/dice/protocols/src/tcelectronic/shell/itwin.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/itwin.rs
@@ -190,8 +190,8 @@ impl AsMut<ShellStandaloneClkSrc> for ItwinConfig {
     }
 }
 
-impl<'a> ShellStandaloneClkSpec<'a> for ItwinConfig {
-    const STANDALONE_CLOCK_SOURCES: &'a [ShellStandaloneClkSrc] = &[
+impl ShellStandaloneClkSpec for ItwinConfig {
+    const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc] = &[
         ShellStandaloneClkSrc::Optical,
         ShellStandaloneClkSrc::Coaxial,
         ShellStandaloneClkSrc::Internal,

--- a/libs/dice/protocols/src/tcelectronic/shell/k24d.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/k24d.rs
@@ -154,8 +154,8 @@ impl AsMut<ShellStandaloneClkSrc> for K24dConfig {
     }
 }
 
-impl<'a> ShellStandaloneClkSpec<'a> for K24dConfig {
-    const STANDALONE_CLOCK_SOURCES: &'a [ShellStandaloneClkSrc] = &[
+impl ShellStandaloneClkSpec for K24dConfig {
+    const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc] = &[
         ShellStandaloneClkSrc::Optical,
         ShellStandaloneClkSrc::Coaxial,
         ShellStandaloneClkSrc::Internal,

--- a/libs/dice/protocols/src/tcelectronic/shell/k8.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/k8.rs
@@ -117,8 +117,8 @@ impl AsMut<ShellStandaloneClkSrc> for K8Config {
     }
 }
 
-impl<'a> ShellStandaloneClkSpec<'a> for K8Config {
-    const STANDALONE_CLOCK_SOURCES: &'a [ShellStandaloneClkSrc] = &[
+impl ShellStandaloneClkSpec for K8Config {
+    const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc] = &[
         ShellStandaloneClkSrc::Coaxial,
         ShellStandaloneClkSrc::Internal,
     ];

--- a/libs/dice/protocols/src/tcelectronic/shell/klive.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/klive.rs
@@ -177,8 +177,8 @@ impl AsMut<ShellStandaloneClkSrc> for KliveConfig {
     }
 }
 
-impl<'a> ShellStandaloneClkSpec<'a> for KliveConfig {
-    const STANDALONE_CLOCK_SOURCES: &'a [ShellStandaloneClkSrc] = &[
+impl ShellStandaloneClkSpec for KliveConfig {
+    const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc] = &[
         ShellStandaloneClkSrc::Optical,
         ShellStandaloneClkSrc::Coaxial,
         ShellStandaloneClkSrc::Internal,

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -126,8 +126,8 @@ impl MeasureModel<hinawa::SndDice> for ExtensionModel {
 #[derive(Default, Debug)]
 struct ExtensionState(Tcd22xxState);
 
-impl<'a> Tcd22xxSpec<'a> for  ExtensionState {
-    const INPUTS: &'a [Input<'a>] = &[
+impl Tcd22xxSpec for  ExtensionState {
+    const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 0, count: 16, label: None},
         Input{id: SrcBlkId::Ins1, offset: 0, count: 16, label: None},
         Input{id: SrcBlkId::Aes,  offset: 0, count: 2, label: None},
@@ -137,7 +137,7 @@ impl<'a> Tcd22xxSpec<'a> for  ExtensionState {
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Adat, offset: 8, count: 8, label: None},
     ];
-    const OUTPUTS: &'a [Output<'a>] = &[
+    const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 16, label: None},
         Output{id: DstBlkId::Ins1, offset: 0, count: 16, label: None},
         Output{id: DstBlkId::Aes,  offset: 0, count: 2, label: None},
@@ -147,7 +147,7 @@ impl<'a> Tcd22xxSpec<'a> for  ExtensionState {
         Output{id: DstBlkId::Adat, offset: 0, count: 8, label: None},
         Output{id: DstBlkId::Adat, offset: 8, count: 8, label: None},
     ];
-    const FIXED: &'a [SrcBlk] = &[
+    const FIXED: &'static [SrcBlk] = &[
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
         SrcBlk{id: SrcBlkId::Ins0, ch: 2},

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -185,16 +185,16 @@ fn mic_amp_emulation_type_to_string(emulation_type: &MicAmpEmulationType) -> Str
 #[derive(Default, Debug)]
 struct SpecificCtl;
 
-impl<'a> SpecificCtl {
-    const ANALOG_OUT_0_1_PAD_NAME: &'a str = "analog-output-1/2-pad";
-    const OPT_OUT_IFACE_MODE_NAME: &'a str = "optical-output-interface-mode";
-    const MIC_AMP_TRANSFORMER_NAME: &'a str = "mic-amp-transformer";
-    const ANALOG_INPUT_LEVEL_NAME: &'a str = "analog-input-levels";
-    const MIC_AMP_EMULATION_TYPE_NAME: &'a str = "mic-amp-emulation-types";
-    const MIC_AMP_HARMONICS_NAME: &'a str = "mic-amp-harmonics";
-    const MIC_AMP_POLARITY_NAME: &'a str = "mic-amp-polarities";
-    const LED_STATE_NAME: &'a str = "LED-states";
-    const METER_DISPLAY_TARGETS_NAME: &'a str = "meter-display-targets";
+impl SpecificCtl {
+    const ANALOG_OUT_0_1_PAD_NAME: &'static str = "analog-output-1/2-pad";
+    const OPT_OUT_IFACE_MODE_NAME: &'static str = "optical-output-interface-mode";
+    const MIC_AMP_TRANSFORMER_NAME: &'static str = "mic-amp-transformer";
+    const ANALOG_INPUT_LEVEL_NAME: &'static str = "analog-input-levels";
+    const MIC_AMP_EMULATION_TYPE_NAME: &'static str = "mic-amp-emulation-types";
+    const MIC_AMP_HARMONICS_NAME: &'static str = "mic-amp-harmonics";
+    const MIC_AMP_POLARITY_NAME: &'static str = "mic-amp-polarities";
+    const LED_STATE_NAME: &'static str = "LED-states";
+    const METER_DISPLAY_TARGETS_NAME: &'static str = "meter-display-targets";
 
     const OPT_OUT_IFACE_MODES: [OptOutIfaceMode;3] = [
         OptOutIfaceMode::Adat,
@@ -226,9 +226,9 @@ impl<'a> SpecificCtl {
     const HARMONICS_MAX: i32 = 21;
     const HARMONICS_STEP: i32 = 1;
 
-    const LED_STATE_LABELS: [&'a str;4] = ["ADAT1", "ADAT2", "S/PDIF", "MIDI-in"];
+    const LED_STATE_LABELS: [&'static str;4] = ["ADAT1", "ADAT2", "S/PDIF", "MIDI-in"];
 
-    const METER_DISPLAY_TARGETS: [&'a str;26] = [
+    const METER_DISPLAY_TARGETS: [&'static str;26] = [
         "Analog-input-1", "Analog-input-2", "Analog-input-3", "Analog-input-4",
         "Analog-input-5", "Analog-input-6", "Analog-input-7", "Analog-input-8",
         "S/PDIF-input-1", "S/PDIF-input-2",

--- a/libs/dice/runtime/src/focusrite/out_grp_ctl.rs
+++ b/libs/dice/runtime/src/focusrite/out_grp_ctl.rs
@@ -16,14 +16,14 @@ use core::elem_value_accessor::*;
 #[derive(Default, Debug)]
 pub struct OutGroupCtl(Vec<ElemId>);
 
-impl<'a> OutGroupCtl {
-    const VOL_NAME: &'a str = "output-group-volume";
-    const VOL_HWCTL_NAME: &'a str = "output-group-volume-hwctl";
-    const VOL_MUTE_NAME: &'a str = "output-group-volume-mute";
-    const MUTE_NAME: &'a str = "output-group-mute";
-    const DIM_NAME: &'a str = "output-group-dim";
-    const DIM_HWCTL_NAME: &'a str= "output-group-dim-hwctl";
-    const MUTE_HWCTL_NAME: &'a str = "output-group-mute-hwctl";
+impl OutGroupCtl {
+    const VOL_NAME: &'static str = "output-group-volume";
+    const VOL_HWCTL_NAME: &'static str = "output-group-volume-hwctl";
+    const VOL_MUTE_NAME: &'static str = "output-group-volume-mute";
+    const MUTE_NAME: &'static str = "output-group-mute";
+    const DIM_NAME: &'static str = "output-group-dim";
+    const DIM_HWCTL_NAME: &'static str= "output-group-dim-hwctl";
+    const MUTE_HWCTL_NAME: &'static str = "output-group-mute-hwctl";
 
     const LEVEL_MIN: i32 = 0x00;
     const LEVEL_MAX: i32 = 0x7f;

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -157,9 +157,9 @@ fn opt_out_iface_mode_to_string(mode: &OptOutIfaceMode) -> String {
 #[derive(Default, Debug)]
 struct SpecificCtl;
 
-impl<'a> SpecificCtl {
-    const ANALOG_OUT_0_1_PAD_NAME: &'a str = "analog-output-1/2-pad";
-    const OPT_OUT_IFACE_MODE_NAME: &'a str = "optical-output-interface-mode";
+impl SpecificCtl {
+    const ANALOG_OUT_0_1_PAD_NAME: &'static str = "analog-output-1/2-pad";
+    const OPT_OUT_IFACE_MODE_NAME: &'static str = "optical-output-interface-mode";
 
     const OPT_OUT_IFACE_MODES: [OptOutIfaceMode;2] = [
         OptOutIfaceMode::Adat,

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -227,11 +227,11 @@ struct IoFwState<M, S>
 #[derive(Default, Debug)]
 struct MeterCtl(Vec<ElemId>);
 
-impl<'a> MeterCtl {
-    const ANALOG_INPUT_METER_NAME: &'a str = "analog-input-meters";
-    const DIGITAL_A_INPUT_METER_NAME: &'a str = "digital-a-input-meters";
-    const DIGITAL_B_INPUT_METER_NAME: &'a str = "digital-b-input-meters";
-    const MIXER_OUT_METER_NAME: &'a str = "mixer-output-meters";
+impl MeterCtl {
+    const ANALOG_INPUT_METER_NAME: &'static str = "analog-input-meters";
+    const DIGITAL_A_INPUT_METER_NAME: &'static str = "digital-a-input-meters";
+    const DIGITAL_B_INPUT_METER_NAME: &'static str = "digital-b-input-meters";
+    const MIXER_OUT_METER_NAME: &'static str = "mixer-output-meters";
 
     const LEVEL_MIN: i32 = 0;
     const LEVEL_MAX: i32 = 0x007fff00;
@@ -307,17 +307,17 @@ impl<'a> MeterCtl {
 #[derive(Default, Debug)]
 struct MixerCtl(Vec<ElemId>);
 
-impl<'a> MixerCtl {
-    const INPUT_GAIN_NAME: &'a str = "monitor-input-gain";
-    const INPUT_MUTE_NAME: &'a str = "monitor-input-mute";
+impl MixerCtl {
+    const INPUT_GAIN_NAME: &'static str = "monitor-input-gain";
+    const INPUT_MUTE_NAME: &'static str = "monitor-input-mute";
 
-    const STREAM_GAIN_NAME: &'a str = "mixer-stream-gain";
+    const STREAM_GAIN_NAME: &'static str = "mixer-stream-gain";
 
-    const OUTPUT_VOL_NAME: &'a str = "monitor-output-volume";
-    const OUTPUT_MUTE_NAME: &'a str = "monitor-output-mute";
+    const OUTPUT_VOL_NAME: &'static str = "monitor-output-volume";
+    const OUTPUT_MUTE_NAME: &'static str = "monitor-output-mute";
 
-    const MIX_BLEND_KNOB_NAME: &'a str = "mix-blend-knob";
-    const MAIN_LEVEL_KNOB_NAME: &'a str = "main-level-knob";
+    const MIX_BLEND_KNOB_NAME: &'static str = "mix-blend-knob";
+    const MAIN_LEVEL_KNOB_NAME: &'static str = "main-level-knob";
 
     const LEVEL_MIN: i32 = 0;
     const LEVEL_MAX: i32 = 0x007fff00;
@@ -567,11 +567,11 @@ fn mixer_out_pair_to_string(pair: &MixerOutPair) -> String {
 #[derive(Default, Debug)]
 struct OutCtl;
 
-impl<'a> OutCtl {
-    const OUT_LEVEL_NAME: &'a str = "output-level";
-    const DIGITAL_B_67_SRC_NAME: &'a str = "monitor-digital-b-7/8-source";
-    const SPDIF_OUT_SRC_NAME: &'a str = "S/PDIF-1/2-output-source";
-    const HP23_SRC_NAME: &'a str = "Headphone-3/4-output-source";
+impl OutCtl {
+    const OUT_LEVEL_NAME: &'static str = "output-level";
+    const DIGITAL_B_67_SRC_NAME: &'static str = "monitor-digital-b-7/8-source";
+    const SPDIF_OUT_SRC_NAME: &'static str = "S/PDIF-1/2-output-source";
+    const HP23_SRC_NAME: &'static str = "Headphone-3/4-output-source";
 
     const OUT_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Consumer,

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -115,12 +115,12 @@ struct MeterCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> MeterCtl {
-    const SPDIF_INPUT_NAME: &'a str = "spdif-input-meter";
-    const STREAM_INPUT_NAME: &'a str = "stream-input-meter";
-    const ANALOG_INPUT_NAME: &'a str = "analog-input-meter";
-    const BUS_OUTPUT_NAME: &'a str = "bus-output-meter";
-    const MAIN_OUTPUT_NAME: &'a str = "main-output-meter";
+impl MeterCtl {
+    const SPDIF_INPUT_NAME: &'static str = "spdif-input-meter";
+    const STREAM_INPUT_NAME: &'static str = "stream-input-meter";
+    const ANALOG_INPUT_NAME: &'static str = "analog-input-meter";
+    const BUS_OUTPUT_NAME: &'static str = "bus-output-meter";
+    const MAIN_OUTPUT_NAME: &'static str = "main-output-meter";
 
     const LEVEL_MIN: i32 = 0;
     const LEVEL_MAX: i32 = 0x00000fff;
@@ -187,10 +187,10 @@ fn mixer_src_to_string(src: &MixerSrc) -> String {
 #[derive(Default, Debug)]
 struct MixerCtl;
 
-impl<'a> MixerCtl {
-    const BUS_SRC_GAIN_NAME: &'a str = "mixer-bus-input-gain";
-    const MAIN_SRC_GAIN_NAME: &'a str = "mixer-main-input-gain";
-    const REVERB_SRC_GAIN_NAME: &'a str = "mixer-reverb-input-gain";
+impl MixerCtl {
+    const BUS_SRC_GAIN_NAME: &'static str = "mixer-bus-input-gain";
+    const MAIN_SRC_GAIN_NAME: &'static str = "mixer-main-input-gain";
+    const REVERB_SRC_GAIN_NAME: &'static str = "mixer-reverb-input-gain";
 
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 0x00007fff;

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -144,12 +144,12 @@ impl Drop for DiceRuntime {
     }
 }
 
-impl<'a> DiceRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl DiceRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -162,10 +162,10 @@ impl MeasureModel<hinawa::SndDice> for Mbox3Model {
 #[derive(Default)]
 struct StandaloneCtl;
 
-impl<'a> StandaloneCtl {
-    const USE_CASE_NAME: &'a str = "standalone-usecase";
+impl StandaloneCtl {
+    const USE_CASE_NAME: &'static str = "standalone-usecase";
 
-    const USE_CASE_LABELS: [&'a str;3] = [
+    const USE_CASE_LABELS: [&'static str;3] = [
         "Mixer",
         "AD/DA",
         "Preamp",
@@ -227,12 +227,12 @@ impl<'a> StandaloneCtl {
 #[derive(Default)]
 struct HwCtl;
 
-impl<'a> HwCtl {
-    const MASTER_KNOB_ASSIGN_NAME: &'a str = "master-knob-assign";
-    const DIM_LED_USAGE_NAME: &'a str = "dim-led";
-    const HOLD_DURATION_NAME: &'a str = "hold-duration";
-    const INPUT_HPF_NAME: &'a str = "input-hp-filter";
-    const OUTPUT_TRIM_NAME: &'a str = "output-trim";
+impl HwCtl {
+    const MASTER_KNOB_ASSIGN_NAME: &'static str = "master-knob-assign";
+    const DIM_LED_USAGE_NAME: &'static str = "dim-led";
+    const HOLD_DURATION_NAME: &'static str = "hold-duration";
+    const INPUT_HPF_NAME: &'static str = "input-hp-filter";
+    const OUTPUT_TRIM_NAME: &'static str = "output-trim";
 
     const HOLD_DURATION_MAX: i32 = 1000;
     const HOLD_DURATION_MIN: i32 = 0;
@@ -352,13 +352,13 @@ impl<'a> HwCtl {
 #[derive(Default)]
 struct ReverbCtl;
 
-impl<'a> ReverbCtl {
-    const TYPE_NAME: &'a str = "reverb-type";
-    const VOL_NAME: &'a str = "reverb-output-volume";
-    const DURATION_NAME: &'a str = "reverb-duration";
-    const FEEDBACK_NAME: &'a str = "reverb-feedback";
+impl ReverbCtl {
+    const TYPE_NAME: &'static str = "reverb-type";
+    const VOL_NAME: &'static str = "reverb-output-volume";
+    const DURATION_NAME: &'static str = "reverb-duration";
+    const FEEDBACK_NAME: &'static str = "reverb-feedback";
 
-    const TYPE_LABELS: &'a [&'a str] = &[
+    const TYPE_LABELS: [&'static str;9] = [
         "Room-1", "Room-2", "Room-3", "Room-4",
         "Hall-1", "Hall-2", "Plate", "Echo",
         "Delay",
@@ -486,23 +486,23 @@ struct ButtonCtl{
     pub notified_elem_list: Vec<ElemId>,
 }
 
-impl<'a> ButtonCtl {
-    const MUTE_BUTTON_NAME: &'a str = "mute-button";
-    const MONO_BUTTON_NAME: &'a str = "mono-button";
-    const SPKR_BUTTON_NAME: &'a str = "spkr-button";
+impl ButtonCtl {
+    const MUTE_BUTTON_NAME: &'static str = "mute-button";
+    const MONO_BUTTON_NAME: &'static str = "mono-button";
+    const SPKR_BUTTON_NAME: &'static str = "spkr-button";
 
-    const MUTE_BUTTON_LABELS: &'a [&'a str] = &[
+    const MUTE_BUTTON_LABELS: [&'static str;3] = [
         "Off",
         "Blink",
         "On",
     ];
 
-    const MONO_BUTTON_LABELS: &'a [&'a str] = &[
+    const MONO_BUTTON_LABELS: [&'static str;2] = [
         "Off",
         "On",
     ];
 
-    const SPKR_BUTTON_LABELS: &'a [&'a str] = &[
+    const SPKR_BUTTON_LABELS: [&'static str;7] = [
         "Off",
         "Green",
         "Green-Blink",

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -20,7 +20,7 @@ use super::tcd22xx_ctl::*;
 
 #[derive(Default)]
 pub struct PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
+    where S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec + PfireClkSpec,
 {
     proto: FwReq,
     sections: GeneralSections,
@@ -36,7 +36,7 @@ pub type Pfire610Model = PfireModel<Pfire610State>;
 const TIMEOUT_MS: u32 = 20;
 
 impl<S> CtlModel<SndDice> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
+    where S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec + PfireClkSpec,
 {
     fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
@@ -90,7 +90,7 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
 }
 
 impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
+    where S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec + PfireClkSpec,
 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
@@ -118,7 +118,7 @@ impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
 }
 
 impl<S> MeasureModel<hinawa::SndDice> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
+    where S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec + PfireClkSpec,
 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -20,7 +20,7 @@ use super::tcd22xx_ctl::*;
 
 #[derive(Default)]
 pub struct PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec<'a>,
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
 {
     proto: FwReq,
     sections: GeneralSections,
@@ -36,13 +36,13 @@ pub type Pfire610Model = PfireModel<Pfire610State>;
 const TIMEOUT_MS: u32 = 20;
 
 impl<S> CtlModel<SndDice> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec<'a>,
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
 {
     fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let node = unit.get_node();
 
         self.sections = self.proto.read_general_sections(&node, TIMEOUT_MS)?;
-        let caps = ClockCaps::new(S::AVAIL_CLK_RATES, S::AVAIL_CLK_SRCS);
+        let caps = ClockCaps::new(&S::AVAIL_CLK_RATES, S::AVAIL_CLK_SRCS);
         let src_labels = self.proto.read_clock_source_labels(&node, &self.sections, TIMEOUT_MS)?;
         self.ctl.load(card_cntr, &caps, &src_labels)?;
 
@@ -90,7 +90,7 @@ impl<S> CtlModel<SndDice> for PfireModel<S>
 }
 
 impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec<'a>,
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
@@ -118,7 +118,7 @@ impl<S> NotifyModel<SndDice, u32> for PfireModel<S>
 }
 
 impl<S> MeasureModel<hinawa::SndDice> for PfireModel<S>
-    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec<'a>,
+    where for<'a> S: AsRef<Tcd22xxState> + AsMut<Tcd22xxState> + Tcd22xxSpec<'a> + PfireClkSpec,
 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -149,20 +149,20 @@ struct SpecificCtl{
     targets: [bool;KNOB_COUNT],
 }
 
-impl<'a> SpecificCtl {
-    const MASTER_KNOB_NAME: &'a str = "master-knob-target";
-    const OPT_IFACE_B_MODE_NAME: &'a str = "optical-iface-b-mode";
-    const STANDALONE_CONVERTER_MODE_NAME: &'a str = "standalone-converter-mode";
+impl SpecificCtl {
+    const MASTER_KNOB_NAME: &'static str = "master-knob-target";
+    const OPT_IFACE_B_MODE_NAME: &'static str = "optical-iface-b-mode";
+    const STANDALONE_CONVERTER_MODE_NAME: &'static str = "standalone-converter-mode";
 
     // MEMO: Both models support 'Output{id: DstBlkId::Ins0, count: 8}'.
-    const MASTER_KNOB_TARGET_LABELS: &'a [&'a str] = &[
+    const MASTER_KNOB_TARGET_LABELS: [&'static str;4] = [
         "analog-out-1/2",
         "analog-out-3/4",
         "analog-out-5/6",
         "analog-out-7/8",
     ];
-    const OPT_IFACE_B_MODE_LABELS: &'a [&'a str] = &["ADAT", "S/PDIF"];
-    const STANDALONE_CONVERTER_MODE_LABELS: &'a [&'a str] = &["A/D-D/A", "A/D-only"];
+    const OPT_IFACE_B_MODE_LABELS: [&'static str;2] = ["ADAT", "S/PDIF"];
+    const STANDALONE_CONVERTER_MODE_LABELS: [&'static str;2] = ["A/D-D/A", "A/D-only"];
 
     fn load(&self, caps: &ClockCaps, src_labels: &ClockSourceLabels, card_cntr: &mut CardCntr)
         -> Result<(), Error>
@@ -173,10 +173,10 @@ impl<'a> SpecificCtl {
         // NOTE: ClockSource::Tdif is used for second optical interface as 'ADAT_AUX'.
         if ClockSource::Tdif.is_supported(caps, src_labels) {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_IFACE_B_MODE_NAME, 0);
-            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::OPT_IFACE_B_MODE_LABELS, None, true)?;
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &Self::OPT_IFACE_B_MODE_LABELS, None, true)?;
 
             let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::STANDALONE_CONVERTER_MODE_NAME, 0);
-            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, Self::STANDALONE_CONVERTER_MODE_LABELS, None, true)?;
+            let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &Self::STANDALONE_CONVERTER_MODE_LABELS, None, true)?;
         }
 
         Ok(())

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -147,10 +147,10 @@ struct MeterCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> MeterCtl {
-    const ANALOG_INPUT_NAME: &'a str = "analog-input-meter";
-    const STREAM_INPUT_NAME: &'a str = "stream-input-meter";
-    const MIXER_OUTPUT_NAME: &'a str = "mixer-output-meter";
+impl MeterCtl {
+    const ANALOG_INPUT_NAME: &'static str = "analog-input-meter";
+    const STREAM_INPUT_NAME: &'static str = "stream-input-meter";
+    const MIXER_OUTPUT_NAME: &'static str = "mixer-output-meter";
 
     const LEVEL_MIN: i32 = 0x00;
     const LEVEL_MAX: i32 = 0xff;
@@ -230,12 +230,12 @@ fn output_src_to_string(src: &OutputSrc) -> String {
     }
 }
 
-impl<'a> OutputCtl {
-    const SRC_NAME: &'a str = "output-source";
-    const VOL_NAME: &'a str = "output-volume";
-    const MUTE_NAME: &'a str = "output-mute";
-    const LINK_NAME: &'a str = "output-link";
-    const TERMINATE_BNC_NAME: &'a str = "terminate-bnc";
+impl OutputCtl {
+    const SRC_NAME: &'static str = "output-source";
+    const VOL_NAME: &'static str = "output-volume";
+    const MUTE_NAME: &'static str = "output-mute";
+    const LINK_NAME: &'static str = "output-link";
+    const TERMINATE_BNC_NAME: &'static str = "terminate-bnc";
 
     const VOL_MIN: i32 = 0;
     const VOL_MAX: i32 = 0xff;
@@ -406,11 +406,11 @@ fn assign_target_to_string(target: &AssignTarget) -> String {
 #[derive(Default, Debug)]
 struct AssignCtl;
 
-impl<'a> AssignCtl {
-    const MAIN_NAME: &'a str = "main-assign";
-    const HP_NAME: &'a str = "headphone-assign";
+impl AssignCtl {
+    const MAIN_NAME: &'static str = "main-assign";
+    const HP_NAME: &'static str = "headphone-assign";
 
-    const HP_LABELS: [&'a str;3] = [
+    const HP_LABELS: [&'static str;3] = [
         "HP-1/2",
         "HP-3/4",
         "HP-5/6",
@@ -517,18 +517,18 @@ struct MixerCtl{
     outs: OutParams,
 }
 
-impl<'a> MixerCtl {
-    const PHYS_SRC_GAIN_NAME: &'a str = "mixer-phys-source-gain";
-    const PHYS_SRC_PAN_NAME: &'a str = "mixer-phys-source-pan";
-    const PHYS_SRC_MUTE_NAME: &'a str = "mixer-phys-source-mute";
-    const PHYS_SRC_LINK_NAME: &'a str = "mixer-phys-source-link";
-    const STREAM_SRC_GAIN_NAME: &'a str = "mixer-stream-source-gain";
-    const STREAM_SRC_PAN_NAME: &'a str = "mixer-stream-source-pan";
-    const STREAM_SRC_MUTE_NAME: &'a str = "mixer-stream-source-mute";
-    const STREAM_SRC_LINK_NAME: &'a str = "mixer-stream-source-link";
-    const OUT_VOL_NAME: &'a str = "mixer-output-volume";
-    const OUT_MUTE_NAME: &'a str = "mixer-output-mute";
-    const EXPANSION_MODE_NAME: &'a str = "mixer-expansion-mode";
+impl MixerCtl {
+    const PHYS_SRC_GAIN_NAME: &'static str = "mixer-phys-source-gain";
+    const PHYS_SRC_PAN_NAME: &'static str = "mixer-phys-source-pan";
+    const PHYS_SRC_MUTE_NAME: &'static str = "mixer-phys-source-mute";
+    const PHYS_SRC_LINK_NAME: &'static str = "mixer-phys-source-link";
+    const STREAM_SRC_GAIN_NAME: &'static str = "mixer-stream-source-gain";
+    const STREAM_SRC_PAN_NAME: &'static str = "mixer-stream-source-pan";
+    const STREAM_SRC_MUTE_NAME: &'static str = "mixer-stream-source-mute";
+    const STREAM_SRC_LINK_NAME: &'static str = "mixer-stream-source-link";
+    const OUT_VOL_NAME: &'static str = "mixer-output-volume";
+    const OUT_MUTE_NAME: &'static str = "mixer-output-mute";
+    const EXPANSION_MODE_NAME: &'static str = "mixer-expansion-mode";
 
     const LEVEL_MIN: i32 = 0x00;
     const LEVEL_MAX: i32 = 0xff;

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -20,7 +20,7 @@ use dice_protocols::tcat::tcd22xx_spec::*;
 
 #[derive(Default, Debug)]
 pub struct Tcd22xxCtl<S>
-    where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+    where S: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
 {
     pub state: S,
     caps: ExtensionCaps,
@@ -31,7 +31,7 @@ pub struct Tcd22xxCtl<S>
 }
 
 impl<S> Tcd22xxCtl<S>
-    where for<'a> S: Tcd22xxSpec<'a> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+    where S: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
 {
     pub fn load(&mut self, unit: &SndDice, proto: &FwReq, sections: &ExtensionSections,
                 caps: &ClockCaps, src_labels: &ClockSourceLabels, timeout_ms: u32, card_cntr: &mut CardCntr)
@@ -166,7 +166,7 @@ impl MeterCtl {
     pub fn load<T>(&mut self, node: &FwNode, proto: &FwReq, sections: &ExtensionSections,
                    caps: &ExtensionCaps, state: &T, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where for<'b> T: Tcd22xxSpec<'b>,
+        where T: Tcd22xxSpec,
     {
         let (_, real_blk_dsts) = state.compute_avail_real_blk_pair(RateMode::Low);
         self.real_blk_dsts = real_blk_dsts;
@@ -274,7 +274,7 @@ impl RouterCtl {
                    caps: &ExtensionCaps, state: &T, clk_caps: &ClockCaps, timeout_ms: u32,
                    card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where for<'b> T: Tcd22xxSpec<'b>,
+        where T: Tcd22xxSpec,
     {
         self.real_blk_pair = state.compute_avail_real_blk_pair(RateMode::Low);
 
@@ -359,7 +359,7 @@ impl RouterCtl {
                     caps: &ExtensionCaps, state: &mut T, elem_id: &ElemId,
                     old: &ElemValue, new: &ElemValue, timeout_ms: u32)
         -> Result<bool, Error>
-        where for<'b> T: Tcd22xxSpec<'b> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+        where T: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
     {
         match elem_id.get_name().as_str() {
             Self::OUT_SRC_NAME => {
@@ -385,7 +385,7 @@ impl RouterCtl {
     fn add_an_elem_for_src<T>(card_cntr: &mut CardCntr, label: &str, dsts: &[DstBlk],
                               srcs: &[&[SrcBlk]], state: &T)
         -> Result<Vec<ElemId>, Error>
-        where for<'b> T: Tcd22xxSpec<'b>,
+        where T: Tcd22xxSpec,
     {
         let targets = dsts.iter().map(|&dst| state.get_dst_blk_label(dst)).collect::<Vec<String>>();
         let mut sources = srcs.iter()
@@ -422,7 +422,7 @@ impl RouterCtl {
                          caps: &ExtensionCaps, state: &mut T, old: &ElemValue, new: &ElemValue,
                          dsts: &[DstBlk], srcs: &[&[SrcBlk]], timeout_ms: u32)
         -> Result<(), Error>
-        where for<'b> T: Tcd22xxSpec<'b> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+        where T: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
     {
         let mut entries = state.as_ref().router_entries.clone();
 
@@ -471,7 +471,7 @@ impl MixerCtl {
 
     pub fn load<T>(&mut self, caps: &ExtensionCaps, state: &T, card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where for<'b> T: Tcd22xxSpec<'b> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+        where T: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
     {
         self.mixer_blk_pair = state.compute_avail_mixer_blk_pair(caps, RateMode::Low);
 
@@ -488,7 +488,7 @@ impl MixerCtl {
 
     pub fn read<T>(&self, state: &T, elem_id: &alsactl::ElemId, elem_value: &alsactl::ElemValue)
         -> Result<bool, Error>
-        where for<'b> T: Tcd22xxSpec<'b> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+        where T: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
     {
         match elem_id.get_name().as_str() {
             Self::SRC_GAIN_NAME => {
@@ -510,7 +510,7 @@ impl MixerCtl {
                    caps: &ExtensionCaps, state: &mut T, elem_id: &ElemId,
                    old: &ElemValue, new: &ElemValue, timeout_ms: u32)
         -> Result<bool, Error>
-        where for<'b> T: Tcd22xxSpec<'b> + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
+        where T: Tcd22xxSpec + AsRef<Tcd22xxState> + AsMut<Tcd22xxState>,
     {
         match elem_id.get_name().as_str() {
             Self::SRC_GAIN_NAME => {

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -153,11 +153,11 @@ pub struct MeterCtl {
     measured_elem_list: Vec<alsactl::ElemId>,
 }
 
-impl<'a> MeterCtl {
-    const OUT_METER_NAME: &'a str = "output-source-meter";
-    const STREAM_TX_METER_NAME: &'a str = "stream-source-meter";
-    const MIXER_INPUT_METER_NAME: &'a str = "mixer-source-meter";
-    const INPUT_SATURATION_NAME: &'a str = "mixer-out-saturation";
+impl MeterCtl {
+    const OUT_METER_NAME: &'static str = "output-source-meter";
+    const STREAM_TX_METER_NAME: &'static str = "stream-source-meter";
+    const MIXER_INPUT_METER_NAME: &'static str = "mixer-source-meter";
+    const INPUT_SATURATION_NAME: &'static str = "mixer-out-saturation";
 
     const COEF_MIN: i32 = 0;
     const COEF_MAX: i32 = 0x00000fffi32; // Upper 12 bits of each sample.
@@ -263,12 +263,12 @@ pub struct RouterCtl {
     pub notified_elem_list: Vec<alsactl::ElemId>,
 }
 
-impl<'a> RouterCtl {
-    const OUT_SRC_NAME: &'a str = "output-source";
-    const CAP_SRC_NAME: &'a str = "stream-source";
-    const MIXER_SRC_NAME: &'a str = "mixer-source";
+impl RouterCtl {
+    const OUT_SRC_NAME: &'static str = "output-source";
+    const CAP_SRC_NAME: &'static str = "stream-source";
+    const MIXER_SRC_NAME: &'static str = "mixer-source";
 
-    const NONE_SRC_LABEL: &'a str = "None";
+    const NONE_SRC_LABEL: &'static str = "None";
 
     pub fn load<T>(&mut self, node: &FwNode, proto: &FwReq, sections: &ExtensionSections,
                    caps: &ExtensionCaps, state: &T, clk_caps: &ClockCaps, timeout_ms: u32,
@@ -382,7 +382,7 @@ impl<'a> RouterCtl {
         }
     }
 
-    fn add_an_elem_for_src<T>(card_cntr: &mut CardCntr, label: &'a str, dsts: &[DstBlk],
+    fn add_an_elem_for_src<T>(card_cntr: &mut CardCntr, label: &str, dsts: &[DstBlk],
                               srcs: &[&[SrcBlk]], state: &T)
         -> Result<Vec<ElemId>, Error>
         where for<'b> T: Tcd22xxSpec<'b>,
@@ -461,8 +461,8 @@ pub struct MixerCtl {
     pub notified_elem_list: Vec<alsactl::ElemId>,
 }
 
-impl<'a> MixerCtl {
-    const SRC_GAIN_NAME: &'a str = "mixer-source-gain";
+impl MixerCtl {
+    const SRC_GAIN_NAME: &'static str = "mixer-source-gain";
 
     const COEF_MIN: i32 = 0;
     const COEF_MAX: i32 = 0x0000ffffi32; // 2:14 Fixed-point.
@@ -540,18 +540,18 @@ pub struct StandaloneCtl {
     srcs: Vec<ClockSource>,
 }
 
-impl<'a> StandaloneCtl {
-    const CLK_SRC_NAME: &'a str = "standalone-clock-source";
-    const SPDIF_HIGH_RATE_NAME: &'a str = "standalone-spdif-high-rate";
-    const ADAT_MODE_NAME: &'a str = "standalone-adat-mode";
-    const WC_MODE_NAME: &'a str = "standalone-word-clock-mode";
-    const WC_RATE_NUMERATOR_NAME: &'a str = "standalone-word-clock-rate-numerator";
-    const WC_RATE_DENOMINATOR_NAME: &'a str = "standalone-word-clock-rate-denominator";
-    const INTERNAL_CLK_RATE_NAME: &'a str = "standalone-internal-clock-rate";
+impl StandaloneCtl {
+    const CLK_SRC_NAME: &'static str = "standalone-clock-source";
+    const SPDIF_HIGH_RATE_NAME: &'static str = "standalone-spdif-high-rate";
+    const ADAT_MODE_NAME: &'static str = "standalone-adat-mode";
+    const WC_MODE_NAME: &'static str = "standalone-word-clock-mode";
+    const WC_RATE_NUMERATOR_NAME: &'static str = "standalone-word-clock-rate-numerator";
+    const WC_RATE_DENOMINATOR_NAME: &'static str = "standalone-word-clock-rate-denominator";
+    const INTERNAL_CLK_RATE_NAME: &'static str = "standalone-internal-clock-rate";
 
-    const ADAT_MODE_LABELS: &'a [&'a str] = &["Normal", "S/MUX2", "S/MUX4", "Auto"];
+    const ADAT_MODE_LABELS: [&'static str;4] = ["Normal", "S/MUX2", "S/MUX4", "Auto"];
 
-    const WC_MODE_LABELS: &'a [&'a str] = &["Normal", "Low", "Middle", "High"];
+    const WC_MODE_LABELS: [&'static str;4] = ["Normal", "Low", "Middle", "High"];
 
     pub fn load(&mut self, caps: &ClockCaps, src_labels: &ClockSourceLabels, card_cntr: &mut CardCntr)
         -> Result<(), Error>

--- a/libs/dice/runtime/src/tcelectronic/ch_strip_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/ch_strip_ctl.rs
@@ -75,32 +75,32 @@ pub struct ChStripCtl {
     pub notified_elem_list: Vec<ElemId>,
 }
 
-impl<'a> ChStripCtl {
-    const SRC_TYPE_NAME: &'a str = "ch-strip-source-type";
-    const DEESSER_BYPASS_NAME: &'a str = "deesser-bypass";
-    const EQ_BYPASS_NAME: &'a str = "equalizer-bypass";
-    const LIMITTER_BYPASS_NAME: &'a str = "limitter-bypass";
-    const BYPASS_NAME: &'a str = "ch-strip-bypass";
+impl ChStripCtl {
+    const SRC_TYPE_NAME: &'static str = "ch-strip-source-type";
+    const DEESSER_BYPASS_NAME: &'static str = "deesser-bypass";
+    const EQ_BYPASS_NAME: &'static str = "equalizer-bypass";
+    const LIMITTER_BYPASS_NAME: &'static str = "limitter-bypass";
+    const BYPASS_NAME: &'static str = "ch-strip-bypass";
 
-    const COMP_INPUT_GAIN_NAME: &'a str = "comp-input-gain";
-    const COMP_MAKE_UP_GAIN: &'a str = "comp-make-up-gain";
-    const COMP_FULL_BAND_ENABLE_NAME: &'a str = "comp-full-band-enable";
-    const COMP_CTL_NAME: &'a str = "comp-control";
-    const COMP_LEVEL_NAME: &'a str = "comp-level";
+    const COMP_INPUT_GAIN_NAME: &'static str = "comp-input-gain";
+    const COMP_MAKE_UP_GAIN: &'static str = "comp-make-up-gain";
+    const COMP_FULL_BAND_ENABLE_NAME: &'static str = "comp-full-band-enable";
+    const COMP_CTL_NAME: &'static str = "comp-control";
+    const COMP_LEVEL_NAME: &'static str = "comp-level";
 
-    const DEESSER_RATIO_NAME: &'a str = "deesser-ratio";
+    const DEESSER_RATIO_NAME: &'static str = "deesser-ratio";
 
-    const EQ_ENABLE_NAME: &'a str = "equalizer-enable";
-    const EQ_BANDWIDTH_NAME: &'a str = "equalizer-bandwidth";
-    const EQ_GAIN_NAME: &'a str = "equalizer-gain";
-    const EQ_FREQ_NAME: &'a str = "equalizer-freq";
+    const EQ_ENABLE_NAME: &'static str = "equalizer-enable";
+    const EQ_BANDWIDTH_NAME: &'static str = "equalizer-bandwidth";
+    const EQ_GAIN_NAME: &'static str = "equalizer-gain";
+    const EQ_FREQ_NAME: &'static str = "equalizer-freq";
 
-    const LIMITTER_THRESHOLD: &'a str = "limitter-threshold";
+    const LIMITTER_THRESHOLD: &'static str = "limitter-threshold";
 
-    const INPUT_METER_NAME: &'a str = "ch-strip-input-meter";
-    const LIMIT_METER_NAME: &'a str = "ch-strip-limit-meter";
-    const OUTPUT_METER_NAME: &'a str = "ch-strip-output-meter";
-    const GAIN_METER_NAME: &'a str = "ch-strip-gain-meter";
+    const INPUT_METER_NAME: &'static str = "ch-strip-input-meter";
+    const LIMIT_METER_NAME: &'static str = "ch-strip-limit-meter";
+    const OUTPUT_METER_NAME: &'static str = "ch-strip-output-meter";
+    const GAIN_METER_NAME: &'static str = "ch-strip-gain-meter";
 
     const COMP_GAIN_MIN: i32 = 0;
     const COMP_GAIN_MAX: i32 = 36;

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -170,10 +170,10 @@ impl AsRef<FwReq> for Desktopk6Proto {
 #[derive(Default, Debug)]
 pub struct MeterCtl(Vec<ElemId>);
 
-impl<'a> MeterCtl {
-    const ANALOG_IN_NAME: &'a str = "analog-input-meters";
-    const MIXER_OUT_NAME: &'a str = "mixer-output-meters";
-    const STREAM_IN_NAME: &'a str = "stream-input-meters";
+impl MeterCtl {
+    const ANALOG_IN_NAME: &'static str = "analog-input-meters";
+    const MIXER_OUT_NAME: &'static str = "mixer-output-meters";
+    const STREAM_IN_NAME: &'static str = "stream-input-meters";
 
     const METER_MIN: i32 = -1000;
     const METER_MAX: i32 = 0;
@@ -235,13 +235,13 @@ struct PanelCtl{
     fw_led_ctl: FwLedCtl,
 }
 
-impl<'a> PanelCtl {
-    const PANEL_BUTTON_COUNT_NAME: &'a str = "panel-button-count";
-    const MIXER_OUT_VOL: &'a str = "mixer-output-volume";
-    const PHONE_KNOB_VALUE_NAME: &'a str = "phone-knob-value";
-    const MIX_KNOB_VALUE_NAME: &'a str = "mix-knob-value";
-    const REVERB_LED_STATE_NAME: &'a str = "reverb-led-state";
-    const REVERB_KNOB_VALUE_NAME: &'a str = "reverb-knob-value";
+impl PanelCtl {
+    const PANEL_BUTTON_COUNT_NAME: &'static str = "panel-button-count";
+    const MIXER_OUT_VOL: &'static str = "mixer-output-volume";
+    const PHONE_KNOB_VALUE_NAME: &'static str = "phone-knob-value";
+    const MIX_KNOB_VALUE_NAME: &'static str = "mix-knob-value";
+    const REVERB_LED_STATE_NAME: &'static str = "reverb-led-state";
+    const REVERB_KNOB_VALUE_NAME: &'static str = "reverb-knob-value";
 
     const KNOB_MIN: i32 = -1000;
     const KNOB_MAX: i32 = 0;
@@ -357,20 +357,20 @@ fn hp_src_to_string(src: DesktopHpSrc) -> String {
 #[derive(Default, Debug)]
 struct MixerCtl;
 
-impl<'a> MixerCtl {
-    const MIXER_MIC_INST_SRC_LEVEL_NAME: &'a str = "mixer-mic-inst-source-level";
-    const MIXER_MIC_INST_SRC_BALANCE_NAME: &'a str = "mixer-mic-inst-source-pan";
-    const MIXER_MIC_INST_SRC_SEND_NAME: &'a str = "mixer-mic-inst-source-send";
+impl MixerCtl {
+    const MIXER_MIC_INST_SRC_LEVEL_NAME: &'static str = "mixer-mic-inst-source-level";
+    const MIXER_MIC_INST_SRC_BALANCE_NAME: &'static str = "mixer-mic-inst-source-pan";
+    const MIXER_MIC_INST_SRC_SEND_NAME: &'static str = "mixer-mic-inst-source-send";
 
-    const MIXER_DUAL_INST_SRC_LEVEL_NAME: &'a str = "mixer-dual-inst-source-level";
-    const MIXER_DUAL_INST_SRC_BALANCE_NAME: &'a str = "mixer-dual-inst-source-pan";
-    const MIXER_DUAL_INST_SRC_SEND_NAME: &'a str = "mixer-dual-inst-source-send";
+    const MIXER_DUAL_INST_SRC_LEVEL_NAME: &'static str = "mixer-dual-inst-source-level";
+    const MIXER_DUAL_INST_SRC_BALANCE_NAME: &'static str = "mixer-dual-inst-source-pan";
+    const MIXER_DUAL_INST_SRC_SEND_NAME: &'static str = "mixer-dual-inst-source-send";
 
-    const MIXER_STEREO_IN_SRC_LEVEL_NAME: &'a str = "mixer-stereo-input-source-level";
-    const MIXER_STEREO_IN_SRC_BALANCE_NAME: &'a str = "mixer-stereo-input-source-pan";
-    const MIXER_STEREO_IN_SRC_SEND_NAME: &'a str = "mixer-stereo-input-source-send";
+    const MIXER_STEREO_IN_SRC_LEVEL_NAME: &'static str = "mixer-stereo-input-source-level";
+    const MIXER_STEREO_IN_SRC_BALANCE_NAME: &'static str = "mixer-stereo-input-source-pan";
+    const MIXER_STEREO_IN_SRC_SEND_NAME: &'static str = "mixer-stereo-input-source-send";
 
-    const HP_SRC_NAME: &'a str = "headphone-source";
+    const HP_SRC_NAME: &'static str = "headphone-source";
 
     const LEVEL_MIN: i32 = -1000;
     const LEVEL_MAX: i32 = 0;
@@ -610,18 +610,18 @@ fn input_scene_to_string(scene: &InputScene) -> String {
 #[derive(Default, Debug)]
 struct HwStateCtl(Vec<ElemId>);
 
-impl<'a> HwStateCtl {
-    const METER_TARGET_NAME: &'a str = "meter-target";
-    const MIXER_OUT_MONAURAL_NAME: &'a str = "mixer-out-monaural";
-    const KNOB_ASSIGN_TO_HP_NAME: &'a str = "knob-assign-to-headphone";
-    const MIXER_OUTPUT_DIM_ENABLE_NAME: &'a str = "mixer-output-dim-enable";
-    const MIXER_OUTPUT_DIM_LEVEL_NAME: &'a str = "mixer-output-dim-level";
-    const SCENE_NAME: &'a str = "scene-select";
-    const REVERB_TO_MAIN_NAME: &'a str = "reverb-to-main";
-    const REVERB_TO_HP_NAME: &'a str = "reverb-to-hp";
-    const KNOB_BACKLIGHT_NAME: &'a str = "knob-backlight";
-    const MIC_0_PHANTOM_NAME: &'a str = "mic-1-phantom";
-    const MIC_0_BOOST_NAME: &'a str = "mic-1-boost";
+impl HwStateCtl {
+    const METER_TARGET_NAME: &'static str = "meter-target";
+    const MIXER_OUT_MONAURAL_NAME: &'static str = "mixer-out-monaural";
+    const KNOB_ASSIGN_TO_HP_NAME: &'static str = "knob-assign-to-headphone";
+    const MIXER_OUTPUT_DIM_ENABLE_NAME: &'static str = "mixer-output-dim-enable";
+    const MIXER_OUTPUT_DIM_LEVEL_NAME: &'static str = "mixer-output-dim-level";
+    const SCENE_NAME: &'static str = "scene-select";
+    const REVERB_TO_MAIN_NAME: &'static str = "reverb-to-main";
+    const REVERB_TO_HP_NAME: &'static str = "reverb-to-hp";
+    const KNOB_BACKLIGHT_NAME: &'static str = "knob-backlight";
+    const MIC_0_PHANTOM_NAME: &'static str = "mic-1-phantom";
+    const MIC_0_BOOST_NAME: &'static str = "mic-1-boost";
 
     const METER_TARGETS: [MeterTarget;3] = [
         MeterTarget::Input,

--- a/libs/dice/runtime/src/tcelectronic/fw_led_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/fw_led_ctl.rs
@@ -25,8 +25,8 @@ pub fn firewire_led_state_to_string(state: &FireWireLedState) -> String {
 #[derive(Default, Debug)]
 pub struct FwLedCtl(pub Vec<ElemId>);
 
-impl<'a> FwLedCtl {
-    const STATE_NAME: &'a str = "FireWire-LED-state";
+impl FwLedCtl {
+    const STATE_NAME: &'static str = "FireWire-LED-state";
 
     const STATES: [FireWireLedState;4] = [
         FireWireLedState::Off,

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -255,11 +255,11 @@ fn listening_mode_to_string(mode: &ListeningMode) -> String {
 #[derive(Default, Debug)]
 struct ItwinSpecificCtl(Vec<ElemId>);
 
-impl<'a> ItwinSpecificCtl {
-    const CLK_RECOVERY_NAME: &'a str = "clock-recovery";
-    const OUT_SRC_NAME: &'a str = "output-source";
-    const MIXER_ENABLE_NAME: &'a str = "mixer-enable";
-    const LISTENING_MODE_NAME: &'a str = "listening-mode";
+impl ItwinSpecificCtl {
+    const CLK_RECOVERY_NAME: &'static str = "clock-recovery";
+    const OUT_SRC_NAME: &'static str = "output-source";
+    const MIXER_ENABLE_NAME: &'static str = "mixer-enable";
+    const LISTENING_MODE_NAME: &'static str = "listening-mode";
 
     const OUT_SRCS: [ItwinOutputPairSrc;16] = [
         ItwinOutputPairSrc::MixerOut01,

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -255,11 +255,11 @@ impl AsRef<FwReq> for K24dProto {
 #[derive(Default, Debug)]
 struct K24dSpecificCtl(Vec<ElemId>);
 
-impl<'a> K24dSpecificCtl {
-    const OUT_23_SRC_NAME: &'a str = "output-3/4-source";
-    const USE_CH_STRIP_AS_PLUGIN_NAME: &'a str = "use-channel-strip-as-plugin";
-    const USE_REVERB_AT_MID_RATE: &'a str = "use-reverb-at-mid-rate";
-    const MIXER_ENABLE_NAME: &'a str = "mixer-enable";
+impl K24dSpecificCtl {
+    const OUT_23_SRC_NAME: &'static str = "output-3/4-source";
+    const USE_CH_STRIP_AS_PLUGIN_NAME: &'static str = "use-channel-strip-as-plugin";
+    const USE_REVERB_AT_MID_RATE: &'static str = "use-reverb-at-mid-rate";
+    const MIXER_ENABLE_NAME: &'static str = "mixer-enable";
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = PHYS_OUT_SRCS.iter()

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -194,9 +194,9 @@ impl AsRef<FwReq> for K8Proto {
 #[derive(Default, Debug)]
 struct K8SpecificCtl(Vec<ElemId>);
 
-impl<'a> K8SpecificCtl {
-    const MIXER_ENABLE_NAME: &'a str = "mixer-enable";
-    const AUX_IN_ENABLED_NAME: &'a str = "aux-input-enable";
+impl K8SpecificCtl {
+    const MIXER_ENABLE_NAME: &'static str = "mixer-enable";
+    const AUX_IN_ENABLED_NAME: &'static str = "aux-input-enable";
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIXER_ENABLE_NAME, 0);

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -301,15 +301,15 @@ fn ch_strip_mode_to_string(mode: &ChStripMode) -> String {
 #[derive(Default, Debug)]
 struct KliveSpecificCtl;
 
-impl<'a> KliveSpecificCtl {
-    const OUTPUT_IMPEDANCE_NAME: &'a str = "output-impedance";
-    const OUT_01_SRC_NAME: &'a str = "output-1/2-source";
-    const OUT_23_SRC_NAME: &'a str = "output-3/4-source";
-    const USE_CH_STRIP_AS_PLUGIN_NAME: &'a str = "use-channel-strip-as-plugin";
-    const CH_STRIP_SRC_NAME: &'a str = "channel-strip-source";
-    const CH_STRIP_MODE_NAME: &'a str = "channel-strip-mode";
-    const USE_REVERB_AT_MID_RATE: &'a str = "use-reverb-at-mid-rate";
-    const MIXER_ENABLE_NAME: &'a str = "mixer-enable";
+impl KliveSpecificCtl {
+    const OUTPUT_IMPEDANCE_NAME: &'static str = "output-impedance";
+    const OUT_01_SRC_NAME: &'static str = "output-1/2-source";
+    const OUT_23_SRC_NAME: &'static str = "output-3/4-source";
+    const USE_CH_STRIP_AS_PLUGIN_NAME: &'static str = "use-channel-strip-as-plugin";
+    const CH_STRIP_SRC_NAME: &'static str = "channel-strip-source";
+    const CH_STRIP_MODE_NAME: &'static str = "channel-strip-mode";
+    const USE_REVERB_AT_MID_RATE: &'static str = "use-reverb-at-mid-rate";
+    const MIXER_ENABLE_NAME: &'static str = "mixer-enable";
 
     const OUTPUT_IMPEDANCES: [OutputImpedance;2] = [
         OutputImpedance::Unbalance,

--- a/libs/dice/runtime/src/tcelectronic/midi_send_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/midi_send_ctl.rs
@@ -14,13 +14,13 @@ use core::elem_value_accessor::*;
 #[derive(Default, Debug)]
 pub struct MidiSendCtl;
 
-impl<'a> MidiSendCtl {
-    const NORMAL_EVENT_CH_NAME: &'a str = "midi-normal-event-channel";
-    const NORMAL_EVENT_CC_NAME: &'a str = "midi-normal-event-cc";
-    const PUSHED_EVENT_CH_NAME: &'a str = "midi-pushed-event-channel";
-    const PUSHED_EVENT_CC_NAME: &'a str = "midi-pushed-event-cc";
-    const EVENT_TO_PORT_NAME: &'a str = "midi-event-to-port";
-    const EVENT_TO_STREAM_NAME: &'a str = "midi-event-to-stream";
+impl MidiSendCtl {
+    const NORMAL_EVENT_CH_NAME: &'static str = "midi-normal-event-channel";
+    const NORMAL_EVENT_CC_NAME: &'static str = "midi-normal-event-cc";
+    const PUSHED_EVENT_CH_NAME: &'static str = "midi-pushed-event-channel";
+    const PUSHED_EVENT_CC_NAME: &'static str = "midi-pushed-event-cc";
+    const EVENT_TO_PORT_NAME: &'static str = "midi-event-to-port";
+    const EVENT_TO_STREAM_NAME: &'static str = "midi-event-to-stream";
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Rawmidi, 0, 0, Self::NORMAL_EVENT_CH_NAME, 0);

--- a/libs/dice/runtime/src/tcelectronic/prog_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/prog_ctl.rs
@@ -15,10 +15,10 @@ use core::elem_value_accessor::*;
 #[derive(Default, Debug)]
 pub struct TcKonnektProgramCtl(pub Vec<ElemId>);
 
-impl<'a> TcKonnektProgramCtl {
-    const LOADED_NAME: &'a str = "loaded-program";
+impl TcKonnektProgramCtl {
+    const LOADED_NAME: &'static str = "loaded-program";
 
-    const PROG_LABELS: [&'a str;3] = ["P1", "P2", "P3"];
+    const PROG_LABELS: [&'static str;3] = ["P1", "P2", "P3"];
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = Self::PROG_LABELS.iter()

--- a/libs/dice/runtime/src/tcelectronic/reverb_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/reverb_ctl.rs
@@ -58,25 +58,25 @@ pub struct ReverbCtl {
     pub measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> ReverbCtl {
-    const REVERB_INPUT_LEVEL_NAME: &'a str = "reverb-input-level";
-    const REVERB_BYPASS_NAME: &'a str = "reverb-bypass";
-    const REVERB_KILL_WET: &'a str = "reverb-kill-wet";
-    const REVERB_KILL_DRY: &'a str = "reverb-kill-dry";
-    const REVERB_OUTPUT_LEVEL_NAME: &'a str = "reverb-output-level";
-    const REVERB_TIME_DECAY_NAME: &'a str = "reverb-time-decay";
-    const REVERB_TIME_PRE_DECAY_NAME: &'a str = "reverb-time-pre-decay";
-    const REVERB_COLOR_LOW_NAME: &'a str = "reverb-color-low";
-    const REVERB_COLOR_HIGH_NAME: &'a str = "reverb-color-high";
-    const REVERB_COLOR_HIGH_FACTOR_NAME: &'a str = "reverb-color-high-factor";
-    const REVERB_MOD_RATE_NAME: &'a str = "reverb-mod-rate";
-    const REVERB_MOD_DEPTH_NAME: &'a str = "reverb-mod-depth";
-    const REVERB_LEVEL_EARLY_NAME: &'a str = "reverb-level-early";
-    const REVERB_LEVEL_REVERB_NAME: &'a str = "reverb-level-reverb";
-    const REVERB_LEVEL_DRY_NAME: &'a str = "reverb-level-dry";
-    const REVERB_ALGORITHM_NAME: &'a str = "reverb-algorithm";
-    const REVERB_OUTPUT_METER_NAME: &'a str = "reverb-output-meter";
-    const REVERB_INPUT_METER_NAME: &'a str = "reverb-input-meter";
+impl ReverbCtl {
+    const REVERB_INPUT_LEVEL_NAME: &'static str = "reverb-input-level";
+    const REVERB_BYPASS_NAME: &'static str = "reverb-bypass";
+    const REVERB_KILL_WET: &'static str = "reverb-kill-wet";
+    const REVERB_KILL_DRY: &'static str = "reverb-kill-dry";
+    const REVERB_OUTPUT_LEVEL_NAME: &'static str = "reverb-output-level";
+    const REVERB_TIME_DECAY_NAME: &'static str = "reverb-time-decay";
+    const REVERB_TIME_PRE_DECAY_NAME: &'static str = "reverb-time-pre-decay";
+    const REVERB_COLOR_LOW_NAME: &'static str = "reverb-color-low";
+    const REVERB_COLOR_HIGH_NAME: &'static str = "reverb-color-high";
+    const REVERB_COLOR_HIGH_FACTOR_NAME: &'static str = "reverb-color-high-factor";
+    const REVERB_MOD_RATE_NAME: &'static str = "reverb-mod-rate";
+    const REVERB_MOD_DEPTH_NAME: &'static str = "reverb-mod-depth";
+    const REVERB_LEVEL_EARLY_NAME: &'static str = "reverb-level-early";
+    const REVERB_LEVEL_REVERB_NAME: &'static str = "reverb-level-reverb";
+    const REVERB_LEVEL_DRY_NAME: &'static str = "reverb-level-dry";
+    const REVERB_ALGORITHM_NAME: &'static str = "reverb-algorithm";
+    const REVERB_OUTPUT_METER_NAME: &'static str = "reverb-output-meter";
+    const REVERB_INPUT_METER_NAME: &'static str = "reverb-input-meter";
 
     const INPUT_LEVEL_MIN: i32 = -240;
     const INPUT_LEVEL_MAX: i32 = 0;

--- a/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
@@ -641,7 +641,7 @@ impl ShellStandaloneCtl {
 
     pub fn load<S>(&mut self, _: &TcKonnektSegment<S>, card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where for<'b> S: TcKonnektSegmentData + ShellStandaloneClkSpec<'b>,
+        where S: TcKonnektSegmentData + ShellStandaloneClkSpec,
     {
         let labels: Vec<String> = S::STANDALONE_CLOCK_SOURCES.iter()
             .map(|r| standalone_src_to_string(r))
@@ -656,8 +656,8 @@ impl ShellStandaloneCtl {
 
     pub fn read<S>(&mut self, segment: &TcKonnektSegment<S>, elem_id: &ElemId, elem_value: &ElemValue)
         -> Result<bool, Error>
-        where for<'b> S: TcKonnektSegmentData + AsRef<ShellStandaloneClkSrc> + ShellStandaloneClkSpec<'b> +
-                         AsRef<TcKonnektStandaloneClkRate>,
+        where S: TcKonnektSegmentData + AsRef<ShellStandaloneClkSrc> + ShellStandaloneClkSpec +
+                 AsRef<TcKonnektStandaloneClkRate>,
     {
         match elem_id.get_name().as_str() {
             Self::SRC_NAME => {
@@ -678,8 +678,8 @@ impl ShellStandaloneCtl {
                        elem_id: &ElemId, elem_value: &ElemValue, timeout_ms: u32)
         -> Result<bool, Error>
         where T: TcKonnektSegmentProtocol<FwNode, S>,
-              for<'b> S: TcKonnektSegmentData + AsMut<ShellStandaloneClkSrc> + ShellStandaloneClkSpec<'b> +
-                         AsMut<TcKonnektStandaloneClkRate>,
+              S: TcKonnektSegmentData + AsMut<ShellStandaloneClkSrc> + ShellStandaloneClkSpec +
+                 AsMut<TcKonnektStandaloneClkRate>,
               TcKonnektSegment<S>: TcKonnektSegmentSpec
     {
         match elem_id.get_name().as_str() {

--- a/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
@@ -36,11 +36,11 @@ pub struct HwStateCtl {
     fw_led_ctl: FwLedCtl,
 }
 
-impl<'a> HwStateCtl {
+impl HwStateCtl {
     // TODO: For Jack detection in ALSA applications.
-    const ANALOG_JACK_STATE_NAME: &'a str = "analog-jack-state";
+    const ANALOG_JACK_STATE_NAME: &'static str = "analog-jack-state";
 
-    const ANALOG_JACK_STATE_LABELS: &'a [ShellAnalogJackState] = &[
+    const ANALOG_JACK_STATE_LABELS: [ShellAnalogJackState;5] = [
         ShellAnalogJackState::FrontSelected,
         ShellAnalogJackState::FrontInserted,
         ShellAnalogJackState::FrontInsertedAttenuated,
@@ -98,27 +98,27 @@ pub struct ShellMixerCtl{
     pub measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> ShellMixerCtl {
-    const MIXER_STREAM_SRC_PAIR_GAIN_NAME: &'a str = "mixer-stream-source-gain";
-    const MIXER_STREAM_SRC_PAIR_PAN_NAME: &'a str = "mixer-stream-source-pan";
-    const MIXER_STREAM_SRC_PAIR_MUTE_NAME: &'a str = "mixer-stream-source-mute";
-    const REVERB_STREAM_SRC_PAIR_GAIN_NAME: &'a str = "send-stream-source-gain";
-    const MIXER_PHYS_SRC_STEREO_LINK_NAME: &'a str = "mixer-phys-source-link";
+impl ShellMixerCtl {
+    const MIXER_STREAM_SRC_PAIR_GAIN_NAME: &'static str = "mixer-stream-source-gain";
+    const MIXER_STREAM_SRC_PAIR_PAN_NAME: &'static str = "mixer-stream-source-pan";
+    const MIXER_STREAM_SRC_PAIR_MUTE_NAME: &'static str = "mixer-stream-source-mute";
+    const REVERB_STREAM_SRC_PAIR_GAIN_NAME: &'static str = "send-stream-source-gain";
+    const MIXER_PHYS_SRC_STEREO_LINK_NAME: &'static str = "mixer-phys-source-link";
 
-    const MIXER_PHYS_SRC_GAIN_NAME: &'a str = "mixer-phys-source-gain";
-    const MIXER_PHYS_SRC_PAN_NAME: &'a str = "mixer-phys-source-pan";
-    const MIXER_PHYS_SRC_MUTE_NAME: &'a str = "mixer-phys-source-mute";
+    const MIXER_PHYS_SRC_GAIN_NAME: &'static str = "mixer-phys-source-gain";
+    const MIXER_PHYS_SRC_PAN_NAME: &'static str = "mixer-phys-source-pan";
+    const MIXER_PHYS_SRC_MUTE_NAME: &'static str = "mixer-phys-source-mute";
 
-    const REVERB_PHYS_SRC_GAIN_NAME: &'a str = "send-phys-source-gain";
+    const REVERB_PHYS_SRC_GAIN_NAME: &'static str = "send-phys-source-gain";
 
-    const MIXER_OUT_DIM_NAME: &'a str = "mixer-out-dim-enable";
-    const MIXER_OUT_VOL_NAME: &'a str = "mixer-out-volume";
-    const MIXER_OUT_DIM_VOL_NAME: &'a str = "mixer-out-dim-volume";
+    const MIXER_OUT_DIM_NAME: &'static str = "mixer-out-dim-enable";
+    const MIXER_OUT_VOL_NAME: &'static str = "mixer-out-volume";
+    const MIXER_OUT_DIM_VOL_NAME: &'static str = "mixer-out-dim-volume";
 
-    const STREAM_IN_METER_NAME: &'a str = "stream-input-meters";
-    const ANALOG_IN_METER_NAME: &'a str = "analog-input-meters";
-    const DIGITAL_IN_METER_NAME: &'a str = "digital-input-meters";
-    const MIXER_OUT_METER_NAME: &'a str = "mixer-output-meters";
+    const STREAM_IN_METER_NAME: &'static str = "stream-input-meters";
+    const ANALOG_IN_METER_NAME: &'static str = "analog-input-meters";
+    const DIGITAL_IN_METER_NAME: &'static str = "digital-input-meters";
+    const MIXER_OUT_METER_NAME: &'static str = "mixer-output-meters";
 
     const LEVEL_MIN: i32 = -1000;
     const LEVEL_MAX: i32 = 0;
@@ -528,10 +528,10 @@ impl<'a> ShellMixerCtl {
 #[derive(Default, Debug)]
 pub struct ShellReverbReturnCtl(pub Vec<ElemId>);
 
-impl<'a> ShellReverbReturnCtl {
-    const USE_AS_PLUGIN_NAME: &'a str = "use-reverb-as-plugin";
-    const GAIN_NAME: &'a str = "reverb-return-gain";
-    const MUTE_NAME: &'a str = "reverb-return-mute";
+impl ShellReverbReturnCtl {
+    const USE_AS_PLUGIN_NAME: &'static str = "use-reverb-as-plugin";
+    const GAIN_NAME: &'static str = "reverb-return-gain";
+    const MUTE_NAME: &'static str = "reverb-return-mute";
 
     const GAIN_MIN: i32 = -1000;
     const GAIN_MAX: i32 = 0;
@@ -636,8 +636,8 @@ fn standalone_src_to_string(src: &ShellStandaloneClkSrc) -> String {
 #[derive(Default, Debug)]
 pub struct ShellStandaloneCtl(TcKonnektStandaloneCtl);
 
-impl<'a> ShellStandaloneCtl {
-    const SRC_NAME: &'a str = "standalone-clock-source";
+impl ShellStandaloneCtl {
+    const SRC_NAME: &'static str = "standalone-clock-source";
 
     pub fn load<S>(&mut self, _: &TcKonnektSegment<S>, card_cntr: &mut CardCntr)
         -> Result<(), Error>
@@ -716,8 +716,8 @@ fn mixer_stream_src_pair_to_string(src: &ShellMixerStreamSrcPair) -> String {
 #[derive(Default, Debug)]
 pub struct MixerStreamSrcPairCtl;
 
-impl<'a> MixerStreamSrcPairCtl {
-    const MIXER_STREAM_SRC_NAME: &'a str = "mixer-stream-soruce";
+impl MixerStreamSrcPairCtl {
+    const MIXER_STREAM_SRC_NAME: &'static str = "mixer-stream-soruce";
     const MIXER_STREAM_SRC_PAIRS: [ShellMixerStreamSrcPair;7] = [
         ShellMixerStreamSrcPair::Stream01,
         ShellMixerStreamSrcPair::Stream23,
@@ -809,8 +809,8 @@ pub const PHYS_OUT_SRCS: [ShellPhysOutSrc;4] = [
 #[derive(Default, Debug)]
 pub struct ShellCoaxIfaceCtl;
 
-impl<'a> ShellCoaxIfaceCtl {
-    const OUT_SRC_NAME: &'a str = "coaxial-output-source";
+impl ShellCoaxIfaceCtl {
+    const OUT_SRC_NAME: &'static str = "coaxial-output-source";
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = PHYS_OUT_SRCS.iter()
@@ -885,10 +885,10 @@ fn opt_out_fmt_to_string(fmt: &ShellOptOutputIfaceFormat) -> String {
 #[derive(Default, Debug)]
 pub struct ShellOptIfaceCtl;
 
-impl<'a> ShellOptIfaceCtl {
-    const IN_FMT_NAME: &'a str = "optical-input-format";
-    const OUT_FMT_NAME: &'a str = "optical-output-format";
-    const OUT_SRC_NAME: &'a str = "optical-output-source";
+impl ShellOptIfaceCtl {
+    const IN_FMT_NAME: &'static str = "optical-input-format";
+    const OUT_FMT_NAME: &'static str = "optical-output-format";
+    const OUT_SRC_NAME: &'static str = "optical-output-source";
 
     const IN_FMTS: [ShellOptInputIfaceFormat;3] = [
         ShellOptInputIfaceFormat::Adat0to7,
@@ -1028,22 +1028,22 @@ pub struct ShellKnobCtl{
     pub notified_elem_list: Vec<ElemId>,
 }
 
-impl<'a> ShellKnobCtl {
-    const TARGET_NAME: &'a str = "knob-target";
+impl ShellKnobCtl {
+    const TARGET_NAME: &'static str = "knob-target";
 
-    const K8_TARGETS: &'a [&'a str] = &[
+    const K8_TARGETS: [&'static str;4] = [
         "Analog-1",
         "Analog-2",
         "S/PDIF-1/2",
         "Configurable",
     ];
-    const K24D_KLIVE_TARGETS: &'a [&'a str] = &[
+    const K24D_KLIVE_TARGETS: [&'static str;4] = [
         "Analog-1",
         "Analog-2",
         "Analog-3/4",
         "Configurable",
     ];
-    const ITWIN_TARGETS: &'a [&'a str] = &[
+    const ITWIN_TARGETS: [&'static str;4] = [
         "Channel-strip-1",
         "Channel-strip-2",
         "Reverb-1/2",
@@ -1116,14 +1116,14 @@ impl<'a> ShellKnobCtl {
 #[derive(Default, Debug)]
 pub struct ShellKnob2Ctl;
 
-impl<'a> ShellKnob2Ctl {
-    const KNOB2_NAME: &'a str = "configurable-knob-target";
+impl ShellKnob2Ctl {
+    const KNOB2_NAME: &'static str = "configurable-knob-target";
 
-    const K8_LABELS: &'a [&'a str] = &[
+    const K8_LABELS: [&'static str;2] = [
         "Stream-input-1/2",
         "Mixer-1/2",
     ];
-    const K24D_LABELS: &'a [&'a str] = &[
+    const K24D_LABELS: [&'static str;8] = [
         "Digital-1/2",
         "Digital-3/4",
         "Digital-5/6",
@@ -1133,7 +1133,7 @@ impl<'a> ShellKnob2Ctl {
         "Mixer-1/2",
         "Tune-pitch-tone",
     ];
-    const KLIVE_LABELS: &'a [&'a str] = &[
+    const KLIVE_LABELS: [&'static str;9] = [
         "Digital-1/2",
         "Digital-3/4",
         "Digital-5/6",
@@ -1150,11 +1150,11 @@ impl<'a> ShellKnob2Ctl {
         where S: TcKonnektSegmentData + ShellKnob2TargetSpec,
     {
         let labels = if S::KNOB2_TARGET_COUNT == 9 {
-            Self::KLIVE_LABELS
+            &Self::KLIVE_LABELS[..]
         } else if S::KNOB2_TARGET_COUNT == 8 {
-            Self::K24D_LABELS
+            &Self::K24D_LABELS[..]
         } else if S::KNOB2_TARGET_COUNT == 2 {
-            Self::K8_LABELS
+            &Self::K8_LABELS[..]
         } else {
             unreachable!();
         };

--- a/libs/dice/runtime/src/tcelectronic/standalone_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/standalone_ctl.rs
@@ -24,8 +24,8 @@ fn standalone_rate_to_string(rate: &TcKonnektStandaloneClkRate) -> String {
 #[derive(Default, Debug)]
 pub struct TcKonnektStandaloneCtl;
 
-impl<'a> TcKonnektStandaloneCtl {
-    const RATE_NAME: &'a str = "standalone-clock-rate";
+impl TcKonnektStandaloneCtl {
+    const RATE_NAME: &'static str = "standalone-clock-rate";
 
     const RATES: [TcKonnektStandaloneClkRate;4] = [
         TcKonnektStandaloneClkRate::R44100,

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -244,13 +244,13 @@ struct HwStateCtl {
     fw_led_ctl: FwLedCtl,
 }
 
-impl<'a> HwStateCtl {
+impl HwStateCtl {
     // TODO: For Jack detection in ALSA applications.
-    const ANALOG_JACK_STATE_NAME: &'a str = "analog-jack-state";
-    const HP_JACK_STATE_NAME: &'a str = "headphone-jack-state";
-    const VALID_MASTER_LEVEL_NAME: &'a str = "valid-master-level";
+    const ANALOG_JACK_STATE_NAME: &'static str = "analog-jack-state";
+    const HP_JACK_STATE_NAME: &'static str = "headphone-jack-state";
+    const VALID_MASTER_LEVEL_NAME: &'static str = "valid-master-level";
 
-    const ANALOG_JACK_STATES: &'a [StudioAnalogJackState] = &[
+    const ANALOG_JACK_STATES: [StudioAnalogJackState;4] = [
         StudioAnalogJackState::FrontSelected,
         StudioAnalogJackState::FrontInserted,
         StudioAnalogJackState::RearSelected,
@@ -379,28 +379,28 @@ fn low_pass_freq_to_string(freq: &LowPassFreq) -> String {
 #[derive(Default, Debug)]
 struct PhysOutCtl(pub Vec<ElemId>);
 
-impl<'a> PhysOutCtl {
-    const MASTER_OUT_DIM_NAME: &'a str = "master-out-dim";
-    const MASTER_OUT_VOL_NAME: &'a str = "master-out-volume";
-    const MASTER_OUT_DIM_VOL_NAME: &'a str = "master-out-dim-volume";
+impl PhysOutCtl {
+    const MASTER_OUT_DIM_NAME: &'static str = "master-out-dim";
+    const MASTER_OUT_VOL_NAME: &'static str = "master-out-volume";
+    const MASTER_OUT_DIM_VOL_NAME: &'static str = "master-out-dim-volume";
 
-    const OUT_STEREO_LINK_NAME: &'a str = "output-stereo-link";
-    const OUT_MUTE_NAME: &'a str = "output-mute";
-    const OUT_SRC_NAME: &'a str = "output-source";
+    const OUT_STEREO_LINK_NAME: &'static str = "output-stereo-link";
+    const OUT_MUTE_NAME: &'static str = "output-mute";
+    const OUT_SRC_NAME: &'static str = "output-source";
 
-    const OUT_GRP_SELECT_NAME: &'a str = "output-group:select";
-    const OUT_GRP_SRC_ENABLE_NAME: &'a str = "output-group:source-enable";
-    const OUT_GRP_SRC_TRIM_NAME: &'a str = "output-group:source-trim";
-    const OUT_GRP_SRC_DELAY_NAME: &'a str = "output-group:source-delay";
-    const OUT_GRP_SRC_ASSIGN_NAME: &'a str = "output-group:source-assign";
-    const OUT_GRP_BASS_MANAGEMENT_NAME: &'a str = "output-group:bass-management";
-    const OUT_GRP_MAIN_CROSS_OVER_FREQ_NAME: &'a str = "output-group:main-cross-over-frequency";
-    const OUT_GRP_MAIN_LEVEL_TO_SUB_NAME: &'a str = "output-group:main-level-to-sub";
-    const OUT_GRP_SUB_LEVEL_TO_SUB_NAME: &'a str = "output-group:sub-level-to-sub";
-    const OUT_GRP_MAIN_FILTER_FOR_MAIN_NAME: &'a str = "output-group:main-filter-for-main";
-    const OUT_GRP_MAIN_FILTER_FOR_SUB_NAME: &'a str = "output-group:main-filter-for-sub";
+    const OUT_GRP_SELECT_NAME: &'static str = "output-group:select";
+    const OUT_GRP_SRC_ENABLE_NAME: &'static str = "output-group:source-enable";
+    const OUT_GRP_SRC_TRIM_NAME: &'static str = "output-group:source-trim";
+    const OUT_GRP_SRC_DELAY_NAME: &'static str = "output-group:source-delay";
+    const OUT_GRP_SRC_ASSIGN_NAME: &'static str = "output-group:source-assign";
+    const OUT_GRP_BASS_MANAGEMENT_NAME: &'static str = "output-group:bass-management";
+    const OUT_GRP_MAIN_CROSS_OVER_FREQ_NAME: &'static str = "output-group:main-cross-over-frequency";
+    const OUT_GRP_MAIN_LEVEL_TO_SUB_NAME: &'static str = "output-group:main-level-to-sub";
+    const OUT_GRP_SUB_LEVEL_TO_SUB_NAME: &'static str = "output-group:sub-level-to-sub";
+    const OUT_GRP_MAIN_FILTER_FOR_MAIN_NAME: &'static str = "output-group:main-filter-for-main";
+    const OUT_GRP_MAIN_FILTER_FOR_SUB_NAME: &'static str = "output-group:main-filter-for-sub";
 
-    const PHYS_OUT_SRCS: &'a [SrcEntry] = &[
+    const PHYS_OUT_SRCS: [SrcEntry;59] = [
         SrcEntry::Unused,
         SrcEntry::Analog(0), SrcEntry::Analog(1), SrcEntry::Analog(2), SrcEntry::Analog(3),
         SrcEntry::Analog(4), SrcEntry::Analog(5), SrcEntry::Analog(6), SrcEntry::Analog(7),
@@ -425,7 +425,7 @@ impl<'a> PhysOutCtl {
     const VOL_STEP: i32 = 1;
     const VOL_TLV: DbInterval = DbInterval{min: -7200, max: 0, linear: false, mute_avail: false};
 
-    const OUT_GRPS: [&'a str;3] = ["Group-A", "Group-B", "Group-C"];
+    const OUT_GRPS: [&'static str;3] = ["Group-A", "Group-B", "Group-C"];
 
     const CROSS_OVER_FREQS: [CrossOverFreq;6] = [
         CrossOverFreq::F50,
@@ -879,34 +879,34 @@ pub struct MixerCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> MixerCtl {
-    const SRC_PAIR_MODE_NAME: &'a str = "mixer-input-mode";
-    const SRC_ENTRY_NAME: &'a str = "mixer-input-source";
-    const SRC_STEREO_LINK_NAME: &'a str = "mixer-input-stereo-link";
-    const SRC_GAIN_NAME: &'a str = "mixer-input-gain";
-    const SRC_PAN_NAME: &'a str = "mixer-input-pan";
-    const REVERB_SRC_GAIN_NAME: &'a str = "reverb-input-gain";
-    const AUX01_SRC_GAIN_NAME: &'a str = "aux-1/2-input-gain";
-    const AUX23_SRC_GAIN_NAME: &'a str = "aux-3/4-input-gain";
-    const SRC_MUTE_NAME: &'a str = "mixer-input-mute";
+impl MixerCtl {
+    const SRC_PAIR_MODE_NAME: &'static str = "mixer-input-mode";
+    const SRC_ENTRY_NAME: &'static str = "mixer-input-source";
+    const SRC_STEREO_LINK_NAME: &'static str = "mixer-input-stereo-link";
+    const SRC_GAIN_NAME: &'static str = "mixer-input-gain";
+    const SRC_PAN_NAME: &'static str = "mixer-input-pan";
+    const REVERB_SRC_GAIN_NAME: &'static str = "reverb-input-gain";
+    const AUX01_SRC_GAIN_NAME: &'static str = "aux-1/2-input-gain";
+    const AUX23_SRC_GAIN_NAME: &'static str = "aux-3/4-input-gain";
+    const SRC_MUTE_NAME: &'static str = "mixer-input-mute";
 
-    const OUT_DIM_NAME: &'a str = "mixer-output-dim";
-    const OUT_VOL_NAME: &'a str = "mixer-output-volume";
-    const OUT_DIM_VOL_NAME: &'a str = "mixer-output-dim-volume";
-    const REVERB_RETURN_MUTE_NAME: &'a str = "reverb-return-mute";
-    const REVERB_RETURN_GAIN_NAME: &'a str = "reverb-return-gain";
+    const OUT_DIM_NAME: &'static str = "mixer-output-dim";
+    const OUT_VOL_NAME: &'static str = "mixer-output-volume";
+    const OUT_DIM_VOL_NAME: &'static str = "mixer-output-dim-volume";
+    const REVERB_RETURN_MUTE_NAME: &'static str = "reverb-return-mute";
+    const REVERB_RETURN_GAIN_NAME: &'static str = "reverb-return-gain";
 
-    const POST_FADER_NAME: &'a str = "mixer-post-fader";
+    const POST_FADER_NAME: &'static str = "mixer-post-fader";
 
-    const CH_STRIP_AS_PLUGIN_NAME: &'a str = "channel-strip-as-plugin";
-    const CH_STRIP_SRC_NAME: &'a str = "channel-strip-source";
-    const CH_STRIP_23_AT_MID_RATE: &'a str = "channel-strip-3/4-at-mid-rate";
+    const CH_STRIP_AS_PLUGIN_NAME: &'static str = "channel-strip-as-plugin";
+    const CH_STRIP_SRC_NAME: &'static str = "channel-strip-source";
+    const CH_STRIP_23_AT_MID_RATE: &'static str = "channel-strip-3/4-at-mid-rate";
 
-    const MIXER_ENABLE_NAME: &'a str = "mixer-direct-monitoring";
+    const MIXER_ENABLE_NAME: &'static str = "mixer-direct-monitoring";
 
-    const MIXER_INPUT_METER_NAME: &'a str = "mixer-input-meter";
-    const MIXER_OUTPUT_METER_NAME: &'a str = "mixer-output-meter";
-    const AUX_OUTPUT_METER_NAME: &'a str = "aux-output-meter";
+    const MIXER_INPUT_METER_NAME: &'static str = "mixer-input-meter";
+    const MIXER_OUTPUT_METER_NAME: &'static str = "mixer-output-meter";
+    const AUX_OUTPUT_METER_NAME: &'static str = "aux-output-meter";
 
     const SRC_PAIR_MODES: [MonitorSrcPairMode;3] = [
         MonitorSrcPairMode::Inactive,
@@ -914,7 +914,7 @@ impl<'a> MixerCtl {
         MonitorSrcPairMode::Fixed,
     ];
 
-    const SRC_PAIR_ENTRIES: &'a [SrcEntry] = &[
+    const SRC_PAIR_ENTRIES: [SrcEntry;51] = [
         SrcEntry::Unused,
         SrcEntry::Analog(0), SrcEntry::Analog(1), SrcEntry::Analog(2), SrcEntry::Analog(3),
         SrcEntry::Analog(4), SrcEntry::Analog(5), SrcEntry::Analog(6), SrcEntry::Analog(7),
@@ -931,8 +931,8 @@ impl<'a> MixerCtl {
         SrcEntry::StreamB(8), SrcEntry::StreamB(9), SrcEntry::StreamB(10), SrcEntry::StreamB(11),
     ];
 
-    const OUT_LABELS: [&'a str;3] = ["Main-1/2", "Aux-1/2", "Aux-3/4"];
-    const SEND_TARGET_LABELS: [&'a str;3] = ["Reverb-1/2", "Aux-1/2", "Aux-3/4"];
+    const OUT_LABELS: [&'static str;3] = ["Main-1/2", "Aux-1/2", "Aux-3/4"];
+    const SEND_TARGET_LABELS: [&'static str;3] = ["Reverb-1/2", "Aux-1/2", "Aux-3/4"];
 
     const LEVEL_MIN: i32 = -1000;
     const LEVEL_MAX: i32 = 0;
@@ -1430,10 +1430,10 @@ pub struct ConfigCtl{
     midi_send: MidiSendCtl,
 }
 
-impl<'a> ConfigCtl {
-    const OPT_IFACE_MODE_NAME: &'a str = "opt-iface-mode";
-    const STANDALONE_CLK_SRC_NAME: &'a str = "standalone-clock-source";
-    const CLOCK_RECOVERY_NAME: &'a str = "clock-recovery";
+impl ConfigCtl {
+    const OPT_IFACE_MODE_NAME: &'static str = "opt-iface-mode";
+    const STANDALONE_CLK_SRC_NAME: &'static str = "standalone-clock-source";
+    const CLOCK_RECOVERY_NAME: &'static str = "clock-recovery";
 
     const OPT_IFACE_MODES: [OptIfaceMode;2] = [OptIfaceMode::Adat, OptIfaceMode::Spdif];
 
@@ -1583,12 +1583,12 @@ pub struct RemoteCtl{
     prog_ctl: TcKonnektProgramCtl,
 }
 
-impl<'a> RemoteCtl {
-    const USER_ASSIGN_NAME: &'a str = "remote-user-assign";
-    const EFFECT_BUTTON_MODE_NAME: &'a str = "remote-effect-button-mode";
-    const FALLBACK_TO_MASTER_ENABLE_NAME: &'a str = "remote-fallback-to-master-enable";
-    const FALLBACK_TO_MASTER_DURATION_NAME: &'a str = "remote-fallback-to-master-duration";
-    const KNOB_PUSH_MODE_NAME: &'a str = "remote-knob-push-mode";
+impl RemoteCtl {
+    const USER_ASSIGN_NAME: &'static str = "remote-user-assign";
+    const EFFECT_BUTTON_MODE_NAME: &'static str = "remote-effect-button-mode";
+    const FALLBACK_TO_MASTER_ENABLE_NAME: &'static str = "remote-fallback-to-master-enable";
+    const FALLBACK_TO_MASTER_DURATION_NAME: &'static str = "remote-fallback-to-master-duration";
+    const KNOB_PUSH_MODE_NAME: &'static str = "remote-knob-push-mode";
 
     const EFFECT_BUTTON_MODES: [RemoteEffectButtonMode;2] = [
         RemoteEffectButtonMode::Reverb,
@@ -1772,11 +1772,11 @@ fn nominal_signal_level_to_string(level: &NominalSignalLevel) -> String {
 #[derive(Default, Debug)]
 pub struct LineoutCtl;
 
-impl<'a> LineoutCtl {
-    const LINE_OUT_45_LEVEL_NAME: &'a str = "line-out-5/6-level";
-    const LINE_OUT_67_LEVEL_NAME: &'a str = "line-out-7/8-level";
-    const LINE_OUT_89_LEVEL_NAME: &'a str = "line-out-9/10-level";
-    const LINE_OUT_1011_LEVEL_NAME: &'a str = "line-out-11/12-level";
+impl LineoutCtl {
+    const LINE_OUT_45_LEVEL_NAME: &'static str = "line-out-5/6-level";
+    const LINE_OUT_67_LEVEL_NAME: &'static str = "line-out-7/8-level";
+    const LINE_OUT_89_LEVEL_NAME: &'static str = "line-out-9/10-level";
+    const LINE_OUT_1011_LEVEL_NAME: &'static str = "line-out-11/12-level";
 
     const NOMINAL_SIGNAL_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Professional,


### PR DESCRIPTION
The constant data during runtime can be assigned to static lifetime. In this patchset, some arbitrary lifetime for the constant date is replaced with static lifetime.

```
Takashi Sakamoto (8):
  dice-runtime: tcelectronic: code refactoring to use static lifetime
  dice-runtime: focusrite: code refactoring to use static lifetime
  dice-runtime: presonus: code refactoring to use static lifetime
  dice-runtime: code refactoring to use static lifetime for misc models
  dice-runtime: code refactoring to use static lifetime for runtime implementation
  dice-protocols: tcelectronic: code refactoring to use static lifetime
  dice-protocols: maudio: code refactoring to use static lifetime
  dice-protocols: tcat: code refactoring to use static lifetime for Tcd22xxSpec

 libs/dice/protocols/src/avid.rs               |   8 +-
 .../dice/protocols/src/focusrite/liquids56.rs |   8 +-
 libs/dice/protocols/src/focusrite/spro26.rs   |   8 +-
 libs/dice/protocols/src/focusrite/spro40.rs   |   8 +-
 libs/dice/protocols/src/loud.rs               |   8 +-
 libs/dice/protocols/src/maudio.rs             |  30 ++--
 .../protocols/src/presonus/fstudiomobile.rs   |   8 +-
 .../protocols/src/presonus/fstudioproject.rs  |   8 +-
 libs/dice/protocols/src/tcat/tcd22xx_spec.rs  |  38 ++---
 libs/dice/protocols/src/tcelectronic/shell.rs |   6 +-
 .../protocols/src/tcelectronic/shell/itwin.rs |   4 +-
 .../protocols/src/tcelectronic/shell/k24d.rs  |   4 +-
 .../protocols/src/tcelectronic/shell/k8.rs    |   4 +-
 .../protocols/src/tcelectronic/shell/klive.rs |   4 +-
 libs/dice/runtime/src/extension_model.rs      |   8 +-
 .../runtime/src/focusrite/liquids56_model.rs  |  24 +--
 .../dice/runtime/src/focusrite/out_grp_ctl.rs |  16 +-
 .../runtime/src/focusrite/spro40_model.rs     |   6 +-
 libs/dice/runtime/src/io_fw_model.rs          |  36 ++---
 libs/dice/runtime/src/ionix_model.rs          |  20 +--
 libs/dice/runtime/src/lib.rs                  |  10 +-
 libs/dice/runtime/src/mbox3_model.rs          |  44 +++---
 libs/dice/runtime/src/pfire_model.rs          |  28 ++--
 .../runtime/src/presonus/fstudio_model.rs     |  52 +++----
 libs/dice/runtime/src/tcd22xx_ctl.rs          |  66 ++++-----
 .../runtime/src/tcelectronic/ch_strip_ctl.rs  |  52 +++----
 .../src/tcelectronic/desktopk6_model.rs       |  68 ++++-----
 .../runtime/src/tcelectronic/fw_led_ctl.rs    |   4 +-
 .../runtime/src/tcelectronic/itwin_model.rs   |  10 +-
 .../runtime/src/tcelectronic/k24d_model.rs    |  10 +-
 .../dice/runtime/src/tcelectronic/k8_model.rs |   6 +-
 .../runtime/src/tcelectronic/klive_model.rs   |  18 +--
 .../runtime/src/tcelectronic/midi_send_ctl.rs |  14 +-
 .../dice/runtime/src/tcelectronic/prog_ctl.rs |   6 +-
 .../runtime/src/tcelectronic/reverb_ctl.rs    |  38 ++---
 .../runtime/src/tcelectronic/shell_ctl.rs     | 104 ++++++-------
 .../src/tcelectronic/standalone_ctl.rs        |   4 +-
 .../src/tcelectronic/studiok48_model.rs       | 138 +++++++++---------
 38 files changed, 464 insertions(+), 464 deletions(-)
```