### PR TITLE
[PATCH] efw-runtime: use static lifetime for constant data during runtime

### DIFF
--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -28,9 +28,9 @@ pub struct ClkCtl {
     rates: Vec<u32>,
 }
 
-impl<'a> ClkCtl {
-    const SRC_NAME: &'a str = "clock-source";
-    const RATE_NAME: &'a str = "clock-rate";
+impl ClkCtl {
+    const SRC_NAME: &'static str = "clock-source";
+    const RATE_NAME: &'static str = "clock-rate";
 
     pub fn new() -> Self {
         ClkCtl {

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -10,10 +10,10 @@ use efw_protocols::robot_guitar::*;
 
 pub struct GuitarCtl {}
 
-impl<'a> GuitarCtl {
-    const MANUAL_CHARGE_NAME: &'a str = "guitar-manual-chage";
-    const AUTO_CHARGE_NAME: &'a str = "guitar-auto-chage";
-    const SUSPEND_TO_CHARGE: &'a str = "guitar-suspend-to-charge";
+impl GuitarCtl {
+    const MANUAL_CHARGE_NAME: &'static str = "guitar-manual-chage";
+    const AUTO_CHARGE_NAME: &'static str = "guitar-auto-chage";
+    const SUSPEND_TO_CHARGE: &'static str = "guitar-suspend-to-charge";
 
     const MIN_SEC: i32 = 0;
     const MAX_SEC: i32 = 60 * 60;   // = One hour.

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -12,9 +12,9 @@ use efw_protocols::hw_ctl::*;
 pub struct Iec60958Ctl {
 }
 
-impl<'a> Iec60958Ctl {
-    const DEFAULT: &'a str = "IEC958 Playback Default";
-    const MASK: &'a str = "IEC958 Playback Mask";
+impl Iec60958Ctl {
+    const DEFAULT: &'static str = "IEC958 Playback Default";
+    const MASK: &'static str = "IEC958 Playback Mask";
 
     const AES0_PROFESSIONAL: u8 = 0x1;
     const AES0_NONAUDIO: u8 = 0x2;

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -14,11 +14,11 @@ pub struct InputCtl {
     cache: Option<Vec::<NominalSignalLevel>>,
 }
 
-impl<'a> InputCtl {
-    const IN_NOMINAL_NAME: &'a str = "input-nominal";
+impl InputCtl {
+    const IN_NOMINAL_NAME: &'static str = "input-nominal";
 
-    const IN_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "-10dBV"];
-    const IN_NOMINAL_LEVELS: &'a [NominalSignalLevel] = &[
+    const IN_NOMINAL_LABELS: [&'static str;2] = ["+4dBu", "-10dBV"];
+    const IN_NOMINAL_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Professional,
         NominalSignalLevel::Consumer,
     ];
@@ -37,7 +37,7 @@ impl<'a> InputCtl {
             let elem_id = alsactl::ElemId::new_by_name(
                 alsactl::ElemIfaceType::Mixer, 0, 0, Self::IN_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
-                self.phys_inputs, Self::IN_NOMINAL_LABELS, None, true)?;
+                self.phys_inputs, &Self::IN_NOMINAL_LABELS, None, true)?;
         }
 
         // FPGA models return invalid state of nominal level. Here, initialize them and cache the

--- a/libs/efw/runtime/src/lib.rs
+++ b/libs/efw/runtime/src/lib.rs
@@ -155,12 +155,12 @@ impl RuntimeOperation<u32> for EfwRuntime {
     }
 }
 
-impl<'a> EfwRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl EfwRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/libs/efw/runtime/src/meter_ctl.rs
+++ b/libs/efw/runtime/src/meter_ctl.rs
@@ -15,15 +15,15 @@ pub struct MeterCtl {
     midi_outputs: usize,
 }
 
-impl<'a> MeterCtl {
-    const CLK_DETECT: &'a str = "clock-detect";
-    const MIDI_IN_DETECT: &'a str = "midi-in-detect";
-    const MIDI_OUT_DETECT: &'a str = "midi-out-detect";
-    const INPUT_METERS: &'a str = "input-meter";
-    const OUTPUT_METERS: &'a str = "output-meter";
-    const GUITAR_STEREO_CONNECT: &'a str = "guitar-stereo-detect";
-    const GUITAR_HEX_SIGNAL: &'a str = "guitar-hex-signal-detect";
-    const GUITAR_CHARGE_STATE: &'a str = "guitar-charge-state-detect";
+impl MeterCtl {
+    const CLK_DETECT: &'static str = "clock-detect";
+    const MIDI_IN_DETECT: &'static str = "midi-in-detect";
+    const MIDI_OUT_DETECT: &'static str = "midi-out-detect";
+    const INPUT_METERS: &'static str = "input-meter";
+    const OUTPUT_METERS: &'static str = "output-meter";
+    const GUITAR_STEREO_CONNECT: &'static str = "guitar-stereo-detect";
+    const GUITAR_HEX_SIGNAL: &'static str = "guitar-hex-signal-detect";
+    const GUITAR_CHARGE_STATE: &'static str = "guitar-charge-state-detect";
 
     const COEF_MIN: i32 = 0;
     const COEF_MAX: i32 = 0x007fffff;

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -18,17 +18,17 @@ pub struct MixerCtl {
     has_fpga: bool,
 }
 
-impl<'a> MixerCtl {
-    const PLAYBACK_VOL_NAME: &'a str = "playback-volume";
-    const PLAYBACK_MUTE_NAME: &'a str = "playback-mute";
-    const PLAYBACK_SOLO_NAME: &'a str = "playback-solo";
+impl MixerCtl {
+    const PLAYBACK_VOL_NAME: &'static str = "playback-volume";
+    const PLAYBACK_MUTE_NAME: &'static str = "playback-mute";
+    const PLAYBACK_SOLO_NAME: &'static str = "playback-solo";
 
-    const MONITOR_GAIN_NAME: &'a str = "monitor-gain";
-    const MONITOR_MUTE_NAME: &'a str = "monitor-mute";
-    const MONITOR_SOLO_NAME: &'a str = "monitor-solo";
-    const MONITOR_PAN_NAME: &'a str = "monitor-pan";
+    const MONITOR_GAIN_NAME: &'static str = "monitor-gain";
+    const MONITOR_MUTE_NAME: &'static str = "monitor-mute";
+    const MONITOR_SOLO_NAME: &'static str = "monitor-solo";
+    const MONITOR_PAN_NAME: &'static str = "monitor-pan";
 
-    const ENABLE_MIXER: &'a str = "enable-mixer";
+    const ENABLE_MIXER: &'static str = "enable-mixer";
 
     // The fixed point number of 8.24 format.
     const COEF_MIN: i32 = 0x00000000;

--- a/libs/efw/runtime/src/output_ctl.rs
+++ b/libs/efw/runtime/src/output_ctl.rs
@@ -15,10 +15,10 @@ pub struct OutputCtl {
     phys_outputs: usize,
 }
 
-impl<'a> OutputCtl {
-    const OUT_VOL_NAME: &'a str = "output-volume";
-    const OUT_MUTE_NAME: &'a str = "output-mute";
-    const OUT_NOMINAL_NAME: &'a str = "output-nominal";
+impl OutputCtl {
+    const OUT_VOL_NAME: &'static str = "output-volume";
+    const OUT_MUTE_NAME: &'static str = "output-mute";
+    const OUT_NOMINAL_NAME: &'static str = "output-nominal";
 
     // The fixed point number of 8.24 format.
     const COEF_MIN: i32 = 0x00000000;
@@ -26,8 +26,8 @@ impl<'a> OutputCtl {
     const COEF_STEP: i32 = 0x00000001;
     const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 600, linear: false, mute_avail: false};
 
-    const OUT_NOMINAL_LABELS: &'a [&'a str] = &["+4dBu", "-10dBV"];
-    const OUT_NOMINAL_LEVELS: &'a [NominalSignalLevel] = &[
+    const OUT_NOMINAL_LABELS: [&'static str;2] = ["+4dBu", "-10dBV"];
+    const OUT_NOMINAL_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Professional,
         NominalSignalLevel::Consumer,
     ];
@@ -61,7 +61,7 @@ impl<'a> OutputCtl {
             let elem_id = alsactl::ElemId::new_by_name(
                 alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
-                self.phys_outputs, Self::OUT_NOMINAL_LABELS, None, true)?;
+                self.phys_outputs, &Self::OUT_NOMINAL_LABELS, None, true)?;
         }
 
         Ok(())

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -42,14 +42,14 @@ pub struct PortCtl {
     tx_pairs: usize,
 }
 
-impl<'a> PortCtl {
-    const MIRROR_OUTPUT_NAME: &'a str = "mirror-output";
-    const DIG_MODE_NAME: &'a str = "digital-mode";
-    const PHANTOM_NAME: &'a str = "phantom-powering";
-    const RX_MAP_NAME: &'a str = "stream-playback-routing";
-    const TX_MAP_NAME: &'a str = "stream-capture-routing";
+impl PortCtl {
+    const MIRROR_OUTPUT_NAME: &'static str = "mirror-output";
+    const DIG_MODE_NAME: &'static str = "digital-mode";
+    const PHANTOM_NAME: &'static str = "phantom-powering";
+    const RX_MAP_NAME: &'static str = "stream-playback-routing";
+    const TX_MAP_NAME: &'static str = "stream-capture-routing";
 
-    const DIG_MODES: &'a [(HwCap, DigitalMode)] = &[
+    const DIG_MODES: [(HwCap, DigitalMode);4] = [
         (HwCap::SpdifCoax, DigitalMode::SpdifCoax),
         (HwCap::AesebuXlr, DigitalMode::AesebuXlr),
         (HwCap::SpdifOpt, DigitalMode::SpdifOpt),
@@ -69,7 +69,7 @@ impl<'a> PortCtl {
     fn add_mapping_ctl(
         &self,
         card_cntr: &mut card_cntr::CardCntr,
-        name: &'a str,
+        name: &str,
         phys_pairs: usize,
         stream_pairs: usize,
     ) -> Result<(), Error> {


### PR DESCRIPTION
The constant data during runtime can be assigned to static lifetime. In this patch, some arbitrary lifetime for the constant date is replaced with static lifetime.