### PR TITLE
[PATCH 0/2] motu-protocols/motu-runtime: add support for MOTU 896HD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2020/12/08
+2021/08/23
 Takashi Sakamoto
 
 Introduction
@@ -106,6 +106,7 @@ your device, please contact to developer.
   * MOTU 896
   * MOTU Traveler
   * MOTU 828mkII
+  * MOTU 896HD
   * MOTU UltraLite
   * MOTU 8pre
   * MOTU 828mk3

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -271,14 +271,15 @@ pub enum AesebuRateConvertMode {
     OutputDoubleSystem,
 }
 
-const AESEBU_RATE_CONVERT_MASK: u32 = 0x00000060;
-const AESEBU_RATE_CONVERT_SHIFT: usize = 5;
-const AESEBU_RATE_CONVERT_VALS: [u8; 4] = [0x00, 0x01, 0x02, 0x03];
-
 const AESEBU_RATE_CONVERT_LABEL: &str = "aesebu-rate-convert";
 
 /// The trait for protocol of rate convert specific to AES/EBU input/output signals.
 pub trait AesebuRateConvertProtocol<'a>: CommonProtocol<'a> {
+    const AESEBU_RATE_CONVERT_MASK: u32;
+    const AESEBU_RATE_CONVERT_SHIFT: usize;
+
+    const AESEBU_RATE_CONVERT_VALS: [u8; 4] = [0x00, 0x01, 0x02, 0x03];
+
     const AESEBU_RATE_CONVERT_MODES: [AesebuRateConvertMode; 4] = [
         AesebuRateConvertMode::None,
         AesebuRateConvertMode::InputToSystem,
@@ -293,11 +294,11 @@ pub trait AesebuRateConvertProtocol<'a>: CommonProtocol<'a> {
     ) -> Result<usize, Error> {
         self.get_idx_from_val(
             Self::OFFSET_CLK,
-            AESEBU_RATE_CONVERT_MASK,
-            AESEBU_RATE_CONVERT_SHIFT,
+            Self::AESEBU_RATE_CONVERT_MASK,
+            Self::AESEBU_RATE_CONVERT_SHIFT,
             AESEBU_RATE_CONVERT_LABEL,
             unit,
-            &AESEBU_RATE_CONVERT_VALS,
+            &Self::AESEBU_RATE_CONVERT_VALS,
             timeout_ms,
         )
     }
@@ -310,11 +311,11 @@ pub trait AesebuRateConvertProtocol<'a>: CommonProtocol<'a> {
     ) -> Result<(), Error> {
         self.set_idx_to_val(
             Self::OFFSET_CLK,
-            AESEBU_RATE_CONVERT_MASK,
-            AESEBU_RATE_CONVERT_SHIFT,
+            Self::AESEBU_RATE_CONVERT_MASK,
+            Self::AESEBU_RATE_CONVERT_SHIFT,
             AESEBU_RATE_CONVERT_LABEL,
             unit,
-            &AESEBU_RATE_CONVERT_VALS,
+            &Self::AESEBU_RATE_CONVERT_VALS,
             idx,
             timeout_ms,
         )

--- a/libs/motu/protocols/src/version_1.rs
+++ b/libs/motu/protocols/src/version_1.rs
@@ -727,6 +727,9 @@ impl<'a> V1MonitorInputProtocol<'a> for F896Protocol {
     }
 }
 
-impl<'a> AesebuRateConvertProtocol<'a> for F896Protocol {}
+impl<'a> AesebuRateConvertProtocol<'a> for F896Protocol {
+    const AESEBU_RATE_CONVERT_MASK: u32 = 0x00000060;
+    const AESEBU_RATE_CONVERT_SHIFT: usize = 5;
+}
 
 impl<'a> LevelMetersProtocol<'a> for F896Protocol {}

--- a/libs/motu/protocols/src/version_2.rs
+++ b/libs/motu/protocols/src/version_2.rs
@@ -421,3 +421,66 @@ impl<'a> V2MainAssignProtocol<'a> for UltraliteProtocol {
         ("S/PDIF-1/2", 0x03),
     ];
 }
+
+/// The protocol implementation for 896HD.
+#[derive(Default)]
+pub struct F896hdProtocol(FwReq);
+
+impl AsRef<FwReq> for F896hdProtocol {
+    fn as_ref(&self) -> &FwReq {
+        &self.0
+    }
+}
+
+impl<'a> CommonProtocol<'a> for F896hdProtocol {}
+
+impl<'a> AssignProtocol<'a> for F896hdProtocol {
+    const ASSIGN_PORTS: &'a [(&'a str, u8)] = &[
+        ("Phone-1/2", 0x01),
+        ("Analog-1/2", 0x02),   // Stream-1/2
+        ("Analog-3/4", 0x03),   // Stream-3/4
+        ("Analog-5/6", 0x04),   // Stream-5/6
+        ("Analog-7/8", 0x05),   // Stream-7/8
+        ("Main-out-1/2", 0x06), // Stream-9/10
+        ("AES/EBU-1/2", 0x07),  // Stream-11/12
+        ("ADAT-1/2", 0x08),     // Stream-13/14
+        ("ADAT-3/4", 0x09),     // Stream-15/16
+        ("ADAT-5/6", 0x0a),     // Stream-17/18
+        ("ADAT-7/8", 0x0b),     // Stream-19/20
+    ];
+}
+
+impl<'a> WordClkProtocol<'a> for F896hdProtocol {}
+
+impl<'a> AesebuRateConvertProtocol<'a> for F896hdProtocol {
+    const AESEBU_RATE_CONVERT_MASK: u32 = 0x00000300;
+    const AESEBU_RATE_CONVERT_SHIFT: usize = 8;
+}
+
+impl<'a> LevelMetersProtocol<'a> for F896hdProtocol {}
+
+impl<'a> V2ClkProtocol<'a> for F896hdProtocol {
+    const CLK_RATES: &'a [(ClkRate, u8)] = &[
+        (ClkRate::R44100, 0x00),
+        (ClkRate::R48000, 0x01),
+        (ClkRate::R88200, 0x02),
+        (ClkRate::R96000, 0x03),
+        (ClkRate::R176400, 0x04),
+        (ClkRate::R192000, 0x05),
+    ];
+
+    const CLK_SRCS: &'a [(V2ClkSrc, u8)] = &[
+        (V2ClkSrc::Internal, 0x00),
+        (V2ClkSrc::AdatOpt, 0x01),
+        (V2ClkSrc::AesebuXlr, 0x02),
+        (V2ClkSrc::WordClk, 0x04),
+        (V2ClkSrc::AdatDsub, 0x05),
+    ];
+
+    const HAS_LCD: bool = false;
+}
+
+impl<'a> V2OptIfaceProtocol<'a> for F896hdProtocol {
+    const OPT_IFACE_MODES: &'a [(V2OptIfaceMode, u8)] =
+        &[(V2OptIfaceMode::None, 0x00), (V2OptIfaceMode::Adat, 0x01)];
+}

--- a/libs/motu/runtime/src/f896hd.rs
+++ b/libs/motu/runtime/src/f896hd.rs
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+use glib::Error;
+
+use hinawa::SndMotu;
+
+use alsactl::{ElemId, ElemValue};
+
+use core::card_cntr::{CardCntr, CtlModel};
+
+use motu_protocols::version_2::*;
+
+use super::common_ctls::*;
+use super::v2_ctls::*;
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default)]
+pub struct F896hd {
+    proto: F896hdProtocol,
+    clk_ctls: V2ClkCtl,
+    opt_iface_ctl: V2OptIfaceCtl,
+    word_clk_ctl: CommonWordClkCtl,
+    aesebu_rate_convert_ctl: CommonAesebuRateConvertCtl,
+    level_meters_ctl: CommonLevelMetersCtl,
+}
+
+impl CtlModel<SndMotu> for F896hd {
+    fn load(&mut self, _: &mut SndMotu, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.clk_ctls.load(&self.proto, card_cntr)?;
+        self.opt_iface_ctl.load(&self.proto, card_cntr)?;
+        self.word_clk_ctl.load(&self.proto, card_cntr)?;
+        self.aesebu_rate_convert_ctl.load(&self.proto, card_cntr)?;
+        self.level_meters_ctl.load(&self.proto, card_cntr)?;
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        unit: &mut SndMotu,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .opt_iface_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.aesebu_rate_convert_ctl.read(
+            unit,
+            &self.proto,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self
+            .level_meters_ctl
+            .read(unit, &self.proto, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut SndMotu,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .opt_iface_ctl
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.aesebu_rate_convert_ctl.write(
+            unit,
+            &self.proto,
+            elem_id,
+            old,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self
+            .level_meters_ctl
+            .write(unit, &self.proto, elem_id, old, new, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -9,6 +9,7 @@ mod ultralite;
 mod traveler;
 mod f8pre;
 mod f828mk2;
+mod f896hd;
 mod f828;
 mod f896;
 

--- a/libs/motu/runtime/src/model.rs
+++ b/libs/motu/runtime/src/model.rs
@@ -9,6 +9,7 @@ use motu_protocols::ClkRate;
 use super::f828::F828;
 use super::f896::F896;
 use super::f828mk2::F828mk2;
+use super::f896hd::F896hd;
 use super::traveler::Traveler;
 use super::ultralite::UltraLite;
 use super::f8pre::F8pre;
@@ -28,6 +29,7 @@ enum MotuCtlModel {
     F828(F828),
     F896(F896),
     F828mk2(F828mk2),
+    F896hd(F896hd),
     Traveler(Traveler),
     UltraLite(UltraLite),
     F8pre(F8pre),
@@ -43,6 +45,7 @@ impl MotuModel {
             0x000001 => MotuCtlModel::F828(Default::default()),
             0x000002 => MotuCtlModel::F896(Default::default()),
             0x000003 => MotuCtlModel::F828mk2(Default::default()),
+            0x000005 => MotuCtlModel::F896hd(Default::default()),
             0x000009 => MotuCtlModel::Traveler(Default::default()),
             0x00000d => MotuCtlModel::UltraLite(Default::default()),
             0x00000f => MotuCtlModel::F8pre(Default::default()),
@@ -71,6 +74,7 @@ impl MotuModel {
             MotuCtlModel::F828(m) => m.load(unit, card_cntr),
             MotuCtlModel::F896(m) => m.load(unit, card_cntr),
             MotuCtlModel::F828mk2(m) => m.load(unit, card_cntr),
+            MotuCtlModel::F896hd(m) => m.load(unit, card_cntr),
             MotuCtlModel::Traveler(m) => m.load(unit, card_cntr),
             MotuCtlModel::UltraLite(m) => m.load(unit, card_cntr),
             MotuCtlModel::F8pre(m) => m.load(unit, card_cntr),
@@ -100,6 +104,7 @@ impl MotuModel {
             MotuCtlModel::F828(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F896(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F828mk2(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
+            MotuCtlModel::F896hd(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::Traveler(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::UltraLite(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),
             MotuCtlModel::F8pre(m) => card_cntr.dispatch_elem_event(unit, elem_id, events, m),


### PR DESCRIPTION
Mark of the Unicorn (MOTU) shipped 896HD 2003 as one of models in second
generation of its FireWire series, and already discontinued it. The model
consists of below ICs:

 * Texas Instruments TSB41AB2
 * Phillips Semiconductors PDI1394L40
 * Altera cyclone EP1C3
 * Texas Instruments TMS320VC5402

It supports sampling transmission frequency up to 192.0 kHz. The packet
format differs depending on both of sampling transfer frequency and enabling
ADAT channels. The model doesn't support MIDI message transmission.

Like 896, the model supports below functions:

 * Display meter
 * AES/EBU sampling frequency converter

This patchset adds support for the model to operate the above functions.    

```
Takashi Sakamoto (2):
  motu-protocols: add protocol implementation for 896HD
  motu-runtime: add support for 896HD

 libs/motu/protocols/src/lib.rs       |  21 ++---
 libs/motu/protocols/src/version_1.rs |   5 +-
 libs/motu/protocols/src/version_2.rs |  63 +++++++++++++++
 libs/motu/runtime/src/f896hd.rs      | 117 +++++++++++++++++++++++++++
 libs/motu/runtime/src/lib.rs         |   1 +
 libs/motu/runtime/src/model.rs       |   5 ++
 6 files changed, 201 insertions(+), 11 deletions(-)
 create mode 100644 libs/motu/runtime/src/f896hd.rs
```