### PR TITLE
[PATCH 0/8] bebob-protocols: focusrite: saffire: add protocol implementation for audio effects

### DIFF
--- a/libs/bebob/protocols/src/focusrite.rs
+++ b/libs/bebob/protocols/src/focusrite.rs
@@ -86,10 +86,13 @@ pub trait SaffireOutputOperation {
         }
     }
 
+    /// It takes a bit time to read changed flag of hwctl after finishing write transaction to
+    /// change it. Use parse_hwctl argument to suppress parsing the flag.
     fn read_output_parameters(
         req: &FwReq,
         node: &FwNode,
         params: &mut SaffireOutputParameters,
+        parse_hwctl: bool,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let mut buf = vec![0; Self::OFFSETS.len() * 4];
@@ -115,11 +118,13 @@ pub trait SaffireOutputOperation {
             .zip(vals.iter())
             .for_each(|(vol, &val)| *vol = 0xff - (val & VOL_MASK) as u8);
 
-        params
-            .hwctls
-            .iter_mut()
-            .zip(vals.iter())
-            .for_each(|(hwctl, &val)| *hwctl = val & HWCTL_FLAG > 0);
+        if parse_hwctl {
+            params
+                .hwctls
+                .iter_mut()
+                .zip(vals.iter())
+                .for_each(|(hwctl, &val)| *hwctl = val & HWCTL_FLAG > 0);
+        }
 
         params
             .dims

--- a/libs/bebob/protocols/src/focusrite/saffire.rs
+++ b/libs/bebob/protocols/src/focusrite/saffire.rs
@@ -1822,3 +1822,208 @@ impl SaffireCompressorProtocol {
             })
     }
 }
+
+/// The structure for equalizer effect in Saffire.
+#[derive(Default, Debug)]
+pub struct SaffireEqualizerParameters {
+    pub enables: [bool; 2],
+    pub input_gains: [i32; 2],
+    pub output_volumes: [i32; 2],
+}
+
+/// The structure for protocol implementation to operate equalizer parameters.
+///
+/// parameters    | ch0    | ch1    | minimum    | maximum    | min val | max val
+/// ------------- | ------ | ------ | ---------- | ---------- | ------- | -------
+/// enable        | 0x0800 | 0x0804 | 0x00000000 | 0x7fffffff | disable | enable
+/// input gain    | 0x0808 | 0x0810 | 0x0203a7e7 | 0x7f17afff | -18     | +18
+/// output volume | 0x080c | 0x0814 | 0x0203a7e7 | 0x7f17afff | -18     | +18
+/// ------------- | ------ | ------ | ---------- | ---------- | ------- | -------
+/// band 0        | 0x0828 | 0x0878 |      -     |      -     |    -    |    -
+/// band 0        | 0x082c | 0x087c |      -     |      -     |    -    |    -
+/// band 0        | 0x0830 | 0x0880 |      -     |      -     |    -    |    -
+/// band 0        | 0x0834 | 0x0884 |      -     |      -     |    -    |    -
+/// band 0        | 0x0840 | 0x0890 |      -     |      -     |    -    |    -
+/// band 0        | 0x0844 | 0x0894 |      -     |      -     |    -    |    -
+/// band 0        | 0x0850 | 0x08a0 |      -     |      -     |    -    |    -
+/// ------------- | ------ |------- | ---------- | ---------- | ------- | -------
+/// band 1        | 0x08c8 | 0x0918 |      -     |      -     |    -    |    -
+/// band 1        | 0x08cc | 0x091c |      -     |      -     |    -    |    -
+/// band 1        | 0x08d0 | 0x0920 |      -     |      -     |    -    |    -
+/// band 1        | 0x08d4 | 0x0924 |      -     |      -     |    -    |    -
+/// band 1        | 0x08e0 | 0x0930 |      -     |      -     |    -    |    -
+/// band 1        | 0x08e4 | 0x0934 |      -     |      -     |    -    |    -
+/// band 1        | 0x08f0 | 0x0940 |      -     |      -     |    -    |    -
+/// ------------- | ------ |------- | ---------- | ---------- | ------- | -------
+/// band 2        | 0x0968 | 0x09b8 |      -     |      -     |    -    |    -
+/// band 2        | 0x096c | 0x09bc |      -     |      -     |    -    |    -
+/// band 2        | 0x0970 | 0x09c0 |      -     |      -     |    -    |    -
+/// band 2        | 0x0974 | 0x09c4 |      -     |      -     |    -    |    -
+/// band 2        | 0x0980 | 0x09d0 |      -     |      -     |    -    |    -
+/// band 2        | 0x0984 | 0x09d4 |      -     |      -     |    -    |    -
+/// band 2        | 0x0990 | 0x09e0 |      -     |      -     |    -    |    -
+/// ------------- | ------ |------- | ---------- | ---------- | ------- | -------
+/// band 3        | 0x0a08 | 0x0a58 |      -     |      -     |    -    |    -
+/// band 3        | 0x0a0c | 0x0a5c |      -     |      -     |    -    |    -
+/// band 3        | 0x0a10 | 0x0a60 |      -     |      -     |    -    |    -
+/// band 3        | 0x0a14 | 0x0a64 |      -     |      -     |    -    |    -
+/// band 3        | 0x0a20 | 0x0a70 |      -     |      -     |    -    |    -
+/// band 3        | 0x0a24 | 0x0a74 |      -     |      -     |    -    |    -
+/// band 3        | 0x0a30 | 0x0a80 |      -     |      -     |    -    |    -
+#[derive(Default)]
+pub struct SaffireEqualizerProtocol;
+
+impl SaffireEqualizerProtocol {
+    const OFFSETS: [usize; 62] = [
+        0x0800,
+        0x0804,
+        0x0808,
+        0x080c,
+        0x0810,
+        0x0814,
+        // ch 0 band 0.
+        0x0828,
+        0x082c,
+        0x0830,
+        0x0834,
+        0x0840,
+        0x0844,
+        0x0850,
+        // ch 0 band 1.
+        0x08c8,
+        0x08cc,
+        0x08d0,
+        0x08d4,
+        0x08e0,
+        0x08e4,
+        0x08f0,
+        // ch 0 band 2.
+        0x0968,
+        0x096c,
+        0x0970,
+        0x0974,
+        0x0980,
+        0x0984,
+        0x0990,
+        // ch 0 band 3.
+        0x0a08,
+        0x0a0c,
+        0x0a10,
+        0x0a14,
+        0x0a20,
+        0x0a24,
+        0x0a30,
+        // ch 1 band 0.
+        0x0878,
+        0x087c,
+        0x0880,
+        0x0884,
+        0x0890,
+        0x0894,
+        0x08a0,
+        // ch 1 band 1.
+        0x0918,
+        0x091c,
+        0x0920,
+        0x0924,
+        0x0930,
+        0x0934,
+        0x0940,
+        // ch 1 band 2.
+        0x09b8,
+        0x09bc,
+        0x09c0,
+        0x09c4,
+        0x09d0,
+        0x09d4,
+        0x09e0,
+        // ch 1 band 3.
+        0x0a58,
+        0x0a5c,
+        0x0a60,
+        0x0a64,
+        0x0a70,
+        0x0a74,
+        0x0a80,
+    ];
+
+    pub fn read_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut SaffireEqualizerParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut buf = vec![0; Self::OFFSETS.len() * 4];
+        saffire_read_quadlets(req, node, &Self::OFFSETS, &mut buf, timeout_ms).map(|_| {
+            let mut quadlet = [0; 4];
+            let vals: Vec<i32> = (0..Self::OFFSETS.len()).fold(Vec::new(), |mut vals, i| {
+                let pos = i * 4;
+                quadlet.copy_from_slice(&buf[pos..(pos + 4)]);
+                vals.push(i32::from_be_bytes(quadlet));
+                vals
+            });
+
+            params.enables[0] = vals[5] > 0;
+            params.enables[1] = vals[13] > 0;
+            params.input_gains[0] = vals[6];
+            params.input_gains[1] = vals[14];
+            params.output_volumes[0] = vals[7];
+            params.output_volumes[1] = vals[15];
+        })
+    }
+
+    pub fn write_enables(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        enables: &[bool],
+        params: &mut SaffireEqualizerParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        enables
+            .iter()
+            .zip(params.enables.iter_mut())
+            .enumerate()
+            .try_for_each(|(i, (&new, old))| {
+                let offset = Self::OFFSETS[i];
+                let val = if new { 0x7fffffffu32 } else { 0x00000000 };
+                let buf = val.to_be_bytes();
+                saffire_write_quadlet(req, node, offset, &buf, timeout_ms).map(|_| *old = new)
+            })
+    }
+
+    pub fn write_input_gains(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        input_gains: &[i32],
+        params: &mut SaffireEqualizerParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        input_gains
+            .iter()
+            .zip(params.input_gains.iter_mut())
+            .enumerate()
+            .try_for_each(|(i, (&new, old))| {
+                let offset = Self::OFFSETS[2 + i * 2];
+                let buf = new.to_be_bytes();
+                saffire_write_quadlet(req, node, offset, &buf, timeout_ms).map(|_| *old = new)
+            })
+    }
+
+    pub fn write_output_volumes(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        output_volumes: &[i32],
+        params: &mut SaffireEqualizerParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        output_volumes
+            .iter()
+            .zip(params.output_volumes.iter_mut())
+            .enumerate()
+            .try_for_each(|(i, (&new, old))| {
+                let offset = Self::OFFSETS[2 + i * 2 + 1];
+                let buf = new.to_be_bytes();
+                saffire_write_quadlet(req, node, offset, &buf, timeout_ms).map(|_| *old = new)
+            })
+    }
+}

--- a/libs/bebob/runtime/src/focusrite.rs
+++ b/libs/bebob/runtime/src/focusrite.rs
@@ -292,13 +292,13 @@ AsRef<SaffireOutputParameters> + AsMut<SaffireOutputParameters>
                 .map(|mut elem_id_list| measure_elem_id_list.append(&mut elem_id_list))?;
         }
 
-        self.measure_params(unit, req, timeout_ms)?;
+        T::read_output_parameters(req, &unit.get_node(), self.as_mut(), true, timeout_ms)?;
 
         Ok(measure_elem_id_list)
     }
 
     fn measure_params(&mut self, unit: &SndUnit, req: &FwReq, timeout_ms: u32) -> Result<(), Error> {
-        T::read_output_parameters(req, &unit.get_node(), self.as_mut(), timeout_ms)
+        T::read_output_parameters(req, &unit.get_node(), self.as_mut(), false, timeout_ms)
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {


### PR DESCRIPTION
Focusrite Saffire supports on-board audio effect and allows software to configure it. This
patchset adds support for the effect partly. The parameters of reverb and compressor are
clear but the ones of equalizer and amplifier are still unknown.

```
Takashi Sakamoto (8):
  bebob-protocols: focusrite: saffire: read current value of monitor knob in meter protocol
  bebob-protocols: focusrite: add argument to suppress parsing hwctl flag
  bebob-protocols: focusrite: saffire: add protocol implementation to operate reverb effect parameters
  bebob-runtime: focusrite: saffire_model: use protocol implementation of operation for reverb effect
  bebob-protocols: focusrite: saffire: add protocol implementation to operate compressor effect
  bebob-protocols: focusrite: saffire: add protocol implementation to operate equalizer effect
  bebob-protocols: focusrite: saffire: add protocol implementation to operate amplifier effect
  bebob-protocols: focusrite: saffire: add protocol implementation to operate channel strip effects

 libs/bebob/protocols/src/focusrite.rs         |  15 +-
 libs/bebob/protocols/src/focusrite/saffire.rs | 706 +++++++++++++++++-
 libs/bebob/runtime/src/focusrite.rs           |   4 +-
 .../runtime/src/focusrite/saffire_model.rs    | 158 ++++
 4 files changed, 875 insertions(+), 8 deletions(-)
```