### PR TITLE
[PATCH 00/26] ff-protocols/ff-runtime: code refactoring to obsolete AsRef for FwReq and FwNode

### DIFF
--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -115,19 +115,30 @@ pub trait RmeFfFormerMeterOperation<U> : AsRef<FwReq>
 ///
 /// The value for volume is between 0x00000000 and 0x00010000 through 0x00000001 and 0x00080000 to
 /// represent the range from negative infinite to 6.00 dB through -90.30 dB and 0.00 dB.
-pub trait RmeFormerOutputProtocol<T, U> : AsRef<FwReq>
-    where T: AsRef<FwNode>,
-          U: AsRef<[i32]> + AsMut<[i32]>,
+pub trait RmeFormerOutputOperation<U> : AsRef<FwReq>
+    where U: AsRef<[i32]> + AsMut<[i32]>,
 {
-    fn write_output_vol(&self, node: &T, ch: usize, vol: i32, timeout_ms: u32) -> Result<(), Error>;
+    fn write_output_vol(
+        &self,
+        node: &mut FwNode,
+        ch: usize,
+        vol: i32,
+        timeout_ms: u32
+    ) -> Result<(), Error>;
 
-    fn init_output_vols(&self, node: &T, state: &U, timeout_ms: u32) -> Result<(), Error> {
+    fn init_output_vols(&self, node: &mut FwNode, state: &U, timeout_ms: u32) -> Result<(), Error> {
         state.as_ref().iter()
             .enumerate()
             .try_for_each(|(i, vol)| self.write_output_vol(node, i, *vol, timeout_ms))
     }
 
-    fn write_output_vols(&self, node: &T, state: &mut U, vols: &[i32], timeout_ms: u32) -> Result<(), Error> {
+    fn write_output_vols(
+        &self,
+        node: &mut FwNode,
+        state: &mut U,
+        vols: &[i32],
+        timeout_ms: u32
+    ) -> Result<(), Error> {
         state.as_mut().iter_mut()
             .zip(vols.iter())
             .enumerate()

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -173,14 +173,16 @@ pub trait RmeFormerMixerSpec : AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>
     const SPDIF_OUTPUT_COUNT: usize;
     const ADAT_OUTPUT_COUNT: usize;
 
+    const DST_COUNT: usize =
+        Self::ANALOG_OUTPUT_COUNT + Self::SPDIF_OUTPUT_COUNT + Self::ADAT_OUTPUT_COUNT;
+
     fn create_mixer_state() -> Vec<FormerMixerSrc> {
-        let dst_count = Self::ANALOG_OUTPUT_COUNT + Self::SPDIF_OUTPUT_COUNT + Self::ADAT_OUTPUT_COUNT;
         vec![FormerMixerSrc{
-            analog_gains: vec![0;Self::ANALOG_INPUT_COUNT],
-            spdif_gains: vec![0;Self::SPDIF_INPUT_COUNT],
-            adat_gains: vec![0;Self::ADAT_INPUT_COUNT],
-            stream_gains: vec![0;Self::STREAM_INPUT_COUNT],
-        };dst_count]
+            analog_gains: vec![0; Self::ANALOG_INPUT_COUNT],
+            spdif_gains: vec![0; Self::SPDIF_INPUT_COUNT],
+            adat_gains: vec![0; Self::ADAT_INPUT_COUNT],
+            stream_gains: vec![0; Self::STREAM_INPUT_COUNT],
+        }; Self::DST_COUNT]
     }
 }
 

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -37,23 +37,9 @@ const AMP_MIC_IN_CH_OFFSET: u8 = 0;
 const AMP_LINE_IN_CH_OFFSET: u8 = 2;
 const AMP_OUT_CH_OFFSET: u8 = 4;
 
-/// The structure to represent state of hardware meter for Fireface 400.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff400MeterState(FormerMeterState);
+impl RmeFfFormerMeterOperation for Ff400Protocol {
+    const METER_OFFSET: usize = METER_OFFSET;
 
-impl AsRef<FormerMeterState> for Ff400MeterState {
-    fn as_ref(&self) -> &FormerMeterState {
-        &self.0
-    }
-}
-
-impl AsMut<FormerMeterState> for Ff400MeterState {
-    fn as_mut(&mut self) -> &mut FormerMeterState {
-        &mut self.0
-    }
-}
-
-impl FormerMeterSpec for Ff400MeterState {
     const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
     const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
@@ -62,16 +48,6 @@ impl FormerMeterSpec for Ff400MeterState {
     const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
-
-impl Default for Ff400MeterState {
-    fn default() -> Self {
-        Self(Self::create_meter_state())
-    }
-}
-
-impl RmeFfFormerMeterOperation<Ff400MeterState> for Ff400Protocol {
-    const METER_OFFSET: usize = METER_OFFSET;
 }
 
 impl Ff400Protocol {

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -929,22 +929,30 @@ impl Ff400Config {
     }
 }
 
-/// The trait to represent configuration protocol specific to RME Fireface 800.
-pub trait RmeFf400ConfigProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
-    fn write_cfg(&self, node: &T, cfg: &Ff400Config, timeout_ms: u32) -> Result<(), Error> {
-        let mut quads = [0u32;3];
+impl Ff400Protocol {
+    pub fn write_cfg(
+        &self,
+        node: &mut FwNode,
+        cfg: &Ff400Config,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut quads = [0u32; 3];
         cfg.build(&mut quads);
 
-        let mut raw = [0;12];
+        let mut raw = [0; 12];
         quads.iter()
             .enumerate()
             .for_each(|(i, quad)| {
                 let pos = i * 4;
                 raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
             });
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest, CFG_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::WriteBlockRequest,
+            CFG_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
     }
 }
-
-impl<T: AsRef<FwNode>> RmeFf400ConfigProtocol<T> for Ff400Protocol {}

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -244,10 +244,7 @@ impl Default for Ff400MixerState {
     }
 }
 
-impl<T, U> RmeFormerMixerProtocol<T, U> for Ff400Protocol
-    where T: AsRef<FwNode>,
-          U: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
-{
+impl RmeFormerMixerOperation<Ff400MixerState> for Ff400Protocol {
     const MIXER_OFFSET: usize = MIXER_OFFSET as usize;
     const AVAIL_COUNT: usize = 18;
 }

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -490,15 +490,25 @@ impl Ff400Status {
     }
 }
 
-/// The trait to represent status protocol specific to RME Fireface 800.
-pub trait RmeFf400StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
-    fn read_status(&self, node: &T, status: &mut Ff400Status, timeout_ms: u32) -> Result<(), Error> {
-        let mut raw = [0;8];
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, STATUS_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+impl Ff400Protocol {
+    pub fn read_status(
+        &self,
+        node: &mut FwNode,
+        status: &mut Ff400Status,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 8];
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::ReadBlockRequest,
+            STATUS_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
             .map(|_| {
-                let mut quadlet = [0;4];
-                let mut quads = [0u32;2];
+                let mut quadlet = [0; 4];
+                let mut quads = [0u32; 2];
                 quads.iter_mut()
                     .enumerate()
                     .for_each(|(i, quad)| {
@@ -510,8 +520,6 @@ pub trait RmeFf400StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
             })
     }
 }
-
-impl<T: AsRef<FwNode>> RmeFf400StatusProtocol<T> for Ff400Protocol {}
 
 // NOTE: for first quadlet of configuration quadlets.
 const Q0_HP_OUT_LEVEL_MASK: u32                 = 0x00060000;

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -189,23 +189,7 @@ impl RmeFormerOutputOperation for Ff400Protocol {
 }
 
 
-/// The structure to represent state of mixer for RME Fireface 400.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff400MixerState(pub Vec<FormerMixerSrc>);
-
-impl AsRef<[FormerMixerSrc]> for Ff400MixerState {
-    fn as_ref(&self) -> &[FormerMixerSrc] {
-        &self.0
-    }
-}
-
-impl AsMut<[FormerMixerSrc]> for Ff400MixerState {
-    fn as_mut(&mut self) -> &mut [FormerMixerSrc] {
-        &mut self.0
-    }
-}
-
-impl RmeFormerMixerSpec for Ff400MixerState {
+impl RmeFormerMixerOperation for Ff400Protocol {
     const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
     const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
@@ -214,15 +198,7 @@ impl RmeFormerMixerSpec for Ff400MixerState {
     const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
 
-impl Default for Ff400MixerState {
-    fn default() -> Self {
-        Self(Self::create_mixer_state())
-    }
-}
-
-impl RmeFormerMixerOperation<Ff400MixerState> for Ff400Protocol {
     const MIXER_OFFSET: usize = MIXER_OFFSET as usize;
     const AVAIL_COUNT: usize = 18;
 }

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -182,13 +182,24 @@ impl AsRef<[i32]> for Ff400OutputVolumeState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFormerOutputProtocol<T, Ff400OutputVolumeState> for Ff400Protocol {
-    fn write_output_vol(&self, node: &T, ch: usize, vol: i32, timeout_ms: u32) -> Result<(), Error> {
-        let mut raw = [0;4];
+impl RmeFormerOutputOperation<Ff400OutputVolumeState> for Ff400Protocol {
+    fn write_output_vol(
+        &self,
+        node: &mut FwNode,
+        ch: usize,
+        vol: i32,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 4];
         raw.copy_from_slice(&vol.to_le_bytes());
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest,
-                                       (OUTPUT_OFFSET + ch * 4) as u64, raw.len(), &mut raw,
-                                       timeout_ms)
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::WriteBlockRequest,
+            (OUTPUT_OFFSET + ch * 4) as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
             .and_then(|_| {
                 // The value for level is between 0x3f to 0x00 by step 1 to represent -57 dB
                 // (=mute) to +6 dB.

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -156,26 +156,11 @@ impl Ff400Protocol {
     }
 }
 
-/// The structure to represent volume of outputs for Fireface 400.
-///
-/// The value is between 0x00000000, 0x00010000 through 0x00000001 and 0x00008000 by step 1 to
-/// represent the range from negative infinite to + 6dB through -90.30 dB and 0 dB.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub struct Ff400OutputVolumeState([i32;ANALOG_OUTPUT_COUNT + SPDIF_OUTPUT_COUNT + ADAT_OUTPUT_COUNT]);
+impl RmeFormerOutputOperation for Ff400Protocol {
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 
-impl AsMut<[i32]> for Ff400OutputVolumeState {
-    fn as_mut(&mut self) -> &mut [i32] {
-        &mut self.0
-    }
-}
-
-impl AsRef<[i32]> for Ff400OutputVolumeState {
-    fn as_ref(&self) -> &[i32] {
-        &self.0
-    }
-}
-
-impl RmeFormerOutputOperation<Ff400OutputVolumeState> for Ff400Protocol {
     fn write_output_vol(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -76,10 +76,7 @@ impl Default for Ff400MeterState {
     }
 }
 
-impl<T, O> RmeFfFormerMeterProtocol<T, Ff400MeterState> for O
-    where T: AsRef<FwNode>,
-          O: AsRef<FwReq>,
-{
+impl RmeFfFormerMeterOperation<Ff400MeterState> for Ff400Protocol {
     const METER_OFFSET: usize = METER_OFFSET;
 }
 

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -73,10 +73,7 @@ impl Default for Ff800MeterState {
     }
 }
 
-impl<T, O> RmeFfFormerMeterProtocol<T, Ff800MeterState> for O
-    where T: AsRef<FwNode>,
-          O: AsRef<FwReq>,
-{
+impl RmeFfFormerMeterOperation<Ff800MeterState> for Ff800Protocol {
     const METER_OFFSET: usize = METER_OFFSET;
 }
 

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -150,10 +150,7 @@ impl Default for Ff800MixerState {
     }
 }
 
-impl<T, U> RmeFormerMixerProtocol<T, U> for Ff800Protocol
-    where T: AsRef<FwNode>,
-          U: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
-{
+impl RmeFormerMixerOperation<Ff800MixerState> for Ff800Protocol {
     const MIXER_OFFSET: usize = MIXER_OFFSET;
     const AVAIL_COUNT: usize = 32;
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -34,23 +34,9 @@ const ANALOG_OUTPUT_COUNT: usize = 10;
 const SPDIF_OUTPUT_COUNT: usize = 2;
 const ADAT_OUTPUT_COUNT: usize = 16;
 
-/// The structure to represent state of hardware meter for Fireface 400.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff800MeterState(FormerMeterState);
+impl RmeFfFormerMeterOperation for Ff800Protocol {
+    const METER_OFFSET: usize = METER_OFFSET;
 
-impl AsRef<FormerMeterState> for Ff800MeterState {
-    fn as_ref(&self) -> &FormerMeterState {
-        &self.0
-    }
-}
-
-impl AsMut<FormerMeterState> for Ff800MeterState {
-    fn as_mut(&mut self) -> &mut FormerMeterState {
-        &mut self.0
-    }
-}
-
-impl FormerMeterSpec for Ff800MeterState {
     const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
     const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
@@ -59,16 +45,6 @@ impl FormerMeterSpec for Ff800MeterState {
     const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
-
-impl Default for Ff800MeterState {
-    fn default() -> Self {
-        Self(Self::create_meter_state())
-    }
-}
-
-impl RmeFfFormerMeterOperation<Ff800MeterState> for Ff800Protocol {
-    const METER_OFFSET: usize = METER_OFFSET;
 }
 
 /// The structure to represent volume of outputs for Fireface 800.

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -47,26 +47,11 @@ impl RmeFfFormerMeterOperation for Ff800Protocol {
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 }
 
-/// The structure to represent volume of outputs for Fireface 800.
-///
-/// The value for volume is between 0x00000000 and 0x00010000 through 0x00000001 and 0x00080000 to
-/// represent the range from negative infinite to 6.00 dB through -90.30 dB and 0.00 dB.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
-pub struct Ff800OutputVolumeState([i32;ANALOG_OUTPUT_COUNT + SPDIF_OUTPUT_COUNT + ADAT_OUTPUT_COUNT]);
+impl RmeFormerOutputOperation for Ff800Protocol {
+    const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
+    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
+    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 
-impl AsRef<[i32]> for Ff800OutputVolumeState {
-    fn as_ref(&self) -> &[i32] {
-        &self.0
-    }
-}
-
-impl AsMut<[i32]> for Ff800OutputVolumeState {
-    fn as_mut(&mut self) -> &mut [i32] {
-        &mut self.0
-    }
-}
-
-impl RmeFormerOutputOperation<Ff800OutputVolumeState> for Ff800Protocol {
     fn write_output_vol(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -9,13 +9,7 @@ use crate::*;
 
 /// The structure to represent unique protocol for Fireface 800.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub struct Ff800Protocol(FwReq);
-
-impl AsRef<FwReq> for Ff800Protocol {
-    fn as_ref(&self) -> &FwReq {
-        &self.0
-    }
-}
+pub struct Ff800Protocol;
 
 const MIXER_OFFSET: usize       = 0x000080080000;
 const OUTPUT_OFFSET: usize      = 0x000080081f80;
@@ -98,7 +92,7 @@ impl AsMut<[i32]> for Ff800OutputVolumeState {
 
 impl RmeFormerOutputOperation<Ff800OutputVolumeState> for Ff800Protocol {
     fn write_output_vol(
-        &self,
+        req: &mut FwReq,
         node: &mut FwNode,
         ch: usize,
         vol: i32,
@@ -106,7 +100,7 @@ impl RmeFormerOutputOperation<Ff800OutputVolumeState> for Ff800Protocol {
     ) -> Result<(), Error> {
         let mut raw = [0; 4];
         raw.copy_from_slice(&vol.to_le_bytes());
-        self.as_ref().transaction_sync(
+        req.transaction_sync(
             node,
             FwTcode::WriteBlockRequest,
             (OUTPUT_OFFSET + ch * 4) as u64,
@@ -392,13 +386,13 @@ impl Ff800Status {
 
 impl Ff800Protocol {
     pub fn read_status(
-        &self,
+        req: &mut FwReq,
         node: &mut FwNode,
         status: &mut Ff800Status,
         timeout_ms: u32
     ) -> Result<(), Error> {
         let mut raw = [0; 8];
-        self.as_ref().transaction_sync(
+        req.transaction_sync(
             node,
             FwTcode::ReadBlockRequest,
             STATUS_OFFSET as u64,
@@ -825,7 +819,7 @@ impl Ff800Config {
 
 impl Ff800Protocol {
     pub fn write_cfg(
-        &self,
+        req: &mut FwReq,
         node: &mut FwNode,
         cfg: &Ff800Config,
         timeout_ms: u32
@@ -840,7 +834,7 @@ impl Ff800Protocol {
                 let pos = i * 4;
                 raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
             });
-        self.as_ref().transaction_sync(
+        req.transaction_sync(
             node,
             FwTcode::WriteBlockRequest,
             CFG_OFFSET as u64,

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -823,25 +823,33 @@ impl Ff800Config {
     }
 }
 
-/// The trait to represent configuration protocol specific to RME Fireface 800.
-pub trait RmeFf800ConfigProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
-    fn write_cfg(&self, node: &T, cfg: &Ff800Config, timeout_ms: u32) -> Result<(), Error> {
+impl Ff800Protocol {
+    pub fn write_cfg(
+        &self,
+        node: &mut FwNode,
+        cfg: &Ff800Config,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
         let mut quads = [0u32;3];
         cfg.build(&mut quads);
 
-        let mut raw = [0;12];
+        let mut raw = [0; 12];
         quads.iter()
             .enumerate()
             .for_each(|(i, quad)| {
                 let pos = i * 4;
                 raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
             });
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest, CFG_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::WriteBlockRequest,
+            CFG_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
     }
 }
-
-impl<T: AsRef<FwNode>> RmeFf800ConfigProtocol<T> for Ff800Protocol {}
 
 #[cfg(test)]
 mod test {

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -72,23 +72,7 @@ impl RmeFormerOutputOperation for Ff800Protocol {
     }
 }
 
-/// The structure to represent state of mixer for RME Fireface 800.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff800MixerState(pub Vec<FormerMixerSrc>);
-
-impl AsRef<[FormerMixerSrc]> for Ff800MixerState {
-    fn as_ref(&self) -> &[FormerMixerSrc] {
-        &self.0
-    }
-}
-
-impl AsMut<[FormerMixerSrc]> for Ff800MixerState {
-    fn as_mut(&mut self) -> &mut [FormerMixerSrc] {
-        &mut self.0
-    }
-}
-
-impl RmeFormerMixerSpec for Ff800MixerState {
+impl RmeFormerMixerOperation for Ff800Protocol {
     const ANALOG_INPUT_COUNT: usize = ANALOG_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
     const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
@@ -97,15 +81,7 @@ impl RmeFormerMixerSpec for Ff800MixerState {
     const ANALOG_OUTPUT_COUNT: usize = ANALOG_OUTPUT_COUNT;
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
 
-impl Default for Ff800MixerState {
-    fn default() -> Self {
-        Self(Self::create_mixer_state())
-    }
-}
-
-impl RmeFormerMixerOperation<Ff800MixerState> for Ff800Protocol {
     const MIXER_OFFSET: usize = MIXER_OFFSET;
     const AVAIL_COUNT: usize = 32;
 }

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -96,13 +96,24 @@ impl AsMut<[i32]> for Ff800OutputVolumeState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFormerOutputProtocol<T, Ff800OutputVolumeState> for Ff800Protocol {
-    fn write_output_vol(&self, node: &T, ch: usize, vol: i32, timeout_ms: u32) -> Result<(), Error> {
-        let mut raw = [0;4];
+impl RmeFormerOutputOperation<Ff800OutputVolumeState> for Ff800Protocol {
+    fn write_output_vol(
+        &self,
+        node: &mut FwNode,
+        ch: usize,
+        vol: i32,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 4];
         raw.copy_from_slice(&vol.to_le_bytes());
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteBlockRequest,
-                                       (OUTPUT_OFFSET + ch * 4) as u64, raw.len(), &mut raw,
-                                       timeout_ms)
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::WriteBlockRequest,
+            (OUTPUT_OFFSET + ch * 4) as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
     }
 }
 

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -390,15 +390,25 @@ impl Ff800Status {
     }
 }
 
-/// The trait to represent status protocol specific to RME Fireface 800.
-pub trait RmeFf800StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
-    fn read_status(&self, node: &T, status: &mut Ff800Status, timeout_ms: u32) -> Result<(), Error> {
-        let mut raw = [0;8];
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, STATUS_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+impl Ff800Protocol {
+    pub fn read_status(
+        &self,
+        node: &mut FwNode,
+        status: &mut Ff800Status,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 8];
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::ReadBlockRequest,
+            STATUS_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
             .map(|_| {
-                let mut quadlet = [0;4];
-                let mut quads = [0u32;2];
+                let mut quadlet = [0; 4];
+                let mut quads = [0u32; 2];
                 quads.iter_mut()
                     .enumerate()
                     .for_each(|(i, quad)| {
@@ -410,8 +420,6 @@ pub trait RmeFf800StatusProtocol<T: AsRef<FwNode>> : AsRef<FwReq> {
             })
     }
 }
-
-impl<T: AsRef<FwNode>> RmeFf800StatusProtocol<T> for Ff800Protocol {}
 
 // NOTE: for first quadlet of configuration quadlets.
 const Q0_LINE_OUT_LEVEL_MASK: u32 =             0x00001c00;

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -150,14 +150,24 @@ fn optional_val_to_clk_rate(clk_rate: &mut Option<ClkNominalRate>, quad: &u32, s
 }
 
 /// The trait to represent status protocol.
-pub trait RmeFfLatterStatusProtocol<T, U> : AsRef<FwReq>
-    where T: AsRef<FwNode>,
-          U: RmeFfLatterRegisterValueOperation,
+pub trait RmeFfLatterStatusOperation<U> : AsRef<FwReq>
+    where U: RmeFfLatterRegisterValueOperation,
 {
-    fn read_status(&self, node: &T, status: &mut U, timeout_ms: u32) -> Result<(), Error> {
-        let mut raw = [0;4];
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadQuadletRequest, DSP_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+    fn read_status(
+        &self,
+        node: &mut FwNode,
+        status: &mut U,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 4];
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::ReadQuadletRequest,
+            DSP_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
             .map(|_| {
                 let quad = u32::from_le_bytes(raw);
                 status.parse(&quad)

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -291,15 +291,25 @@ pub trait RmeFfLatterMeterSpec {
 }
 
 /// The trait to represent meter protocol.
-pub trait RmeFfLatterMeterProtocol<T, U> : AsRef<FwReq>
-    where T: AsRef<FwNode>,
-          U: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
+pub trait RmeFfLatterMeterOperation<U> : AsRef<FwReq>
+    where U: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
 {
-    fn read_meter(&self, node: &T, state: &mut U, timeout_ms: u32) -> Result<(), Error> {
+    fn read_meter(
+        &self,
+        node: &mut FwNode,
+        state: &mut U,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
         (0..5).try_for_each(|_| {
             let mut raw = vec![0;392];
-            self.as_ref().transaction_sync(node.as_ref(), FwTcode::ReadBlockRequest, METER_OFFSET as u64,
-                                           raw.len(), &mut raw, timeout_ms)
+            self.as_ref().transaction_sync(
+                node,
+                FwTcode::ReadBlockRequest,
+                METER_OFFSET as u64,
+                raw.len(),
+                &mut raw,
+                timeout_ms
+            )
                 .map(|_| parse_meter::<U>(state.as_mut(), &raw))
         })
     }

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -69,18 +69,23 @@ pub trait RmeFfLatterRegisterValueOperation {
 }
 
 /// The trait to represent configuration protocol.
-pub trait RmeFfLatterConfigProtocol<T, U> : AsRef<FwReq>
-    where T: AsRef<FwNode>,
-          U: RmeFfLatterRegisterValueOperation,
+pub trait RmeFfLatterConfigOperation<U> : AsRef<FwReq>
+    where U: RmeFfLatterRegisterValueOperation,
 {
-    fn write_cfg(&self, node: &T, cfg: &U, timeout_ms: u32) -> Result<(), Error> {
+    fn write_cfg(&self, node: &mut FwNode, cfg: &U, timeout_ms: u32) -> Result<(), Error> {
         let mut quad = 0u32;
         cfg.build(&mut quad);
 
-        let mut raw = [0;4];
+        let mut raw = [0; 4];
         raw.copy_from_slice(&quad.to_le_bytes());
-        self.as_ref().transaction_sync(node.as_ref(), FwTcode::WriteQuadletRequest, CFG_OFFSET as u64,
-                                       raw.len(), &mut raw, timeout_ms)
+        self.as_ref().transaction_sync(
+            node,
+            FwTcode::WriteQuadletRequest,
+            CFG_OFFSET as u64,
+            raw.len(),
+            &mut raw,
+            timeout_ms
+        )
     }
 }
 

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -385,23 +385,7 @@ impl Default for Ff802MeterState {
 
 impl RmeFfLatterMeterOperation<Ff802MeterState> for Ff802Protocol {}
 
-/// The structure to represent state of DSP.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff802DspState(FfLatterDspState);
-
-impl AsRef<FfLatterDspState> for Ff802DspState {
-    fn as_ref(&self) -> &FfLatterDspState {
-        &self.0
-    }
-}
-
-impl AsMut<FfLatterDspState> for Ff802DspState {
-    fn as_mut(&mut self) -> &mut FfLatterDspState {
-        &mut self.0
-    }
-}
-
-impl RmeFfLatterDspSpec for Ff802DspState {
+impl RmeFfLatterDspOperation for Ff802Protocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
     const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
@@ -413,11 +397,3 @@ impl RmeFfLatterDspSpec for Ff802DspState {
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 }
-
-impl Default for Ff802DspState {
-    fn default() -> Self {
-        Self(Self::create_dsp_state())
-    }
-}
-
-impl RmeFfLatterDspOperation<Ff802DspState> for Ff802Protocol {}

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -348,23 +348,7 @@ const HP_OUTPUT_COUNT: usize = 4;
 const SPDIF_OUTPUT_COUNT: usize = 2;
 const ADAT_OUTPUT_COUNT: usize = 16;
 
-/// The structure to represent state of meter.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct Ff802MeterState(FfLatterMeterState);
-
-impl AsRef<FfLatterMeterState> for Ff802MeterState {
-    fn as_ref(&self) -> &FfLatterMeterState {
-        &self.0
-    }
-}
-
-impl AsMut<FfLatterMeterState> for Ff802MeterState {
-    fn as_mut(&mut self) -> &mut FfLatterMeterState {
-        &mut self.0
-    }
-}
-
-impl RmeFfLatterMeterSpec for Ff802MeterState {
+impl RmeFfLatterMeterOperation for Ff802Protocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
     const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
@@ -376,14 +360,6 @@ impl RmeFfLatterMeterSpec for Ff802MeterState {
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 }
-
-impl Default for Ff802MeterState {
-    fn default() -> Self {
-        Self(Self::create_meter_state())
-    }
-}
-
-impl RmeFfLatterMeterOperation<Ff802MeterState> for Ff802Protocol {}
 
 impl RmeFfLatterDspOperation for Ff802Protocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -154,7 +154,7 @@ impl RmeFfLatterRegisterValueOperation for Ff802Config{
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterConfigProtocol<T, Ff802Config> for Ff802Protocol {}
+impl RmeFfLatterConfigOperation<Ff802Config> for Ff802Protocol {}
 
 // For status register (0x'ffff'0000'001c).
 #[allow(dead_code)]

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -383,7 +383,7 @@ impl Default for Ff802MeterState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, Ff802MeterState> for Ff802Protocol {}
+impl RmeFfLatterMeterOperation<Ff802MeterState> for Ff802Protocol {}
 
 /// The structure to represent state of DSP.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -335,7 +335,7 @@ impl RmeFfLatterRegisterValueOperation for Ff802Status {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterStatusProtocol<T, Ff802Status> for Ff802Protocol {}
+impl RmeFfLatterStatusOperation<Ff802Status> for Ff802Protocol {}
 
 const LINE_INPUT_COUNT: usize = 8;
 const MIC_INPUT_COUNT: usize = 4;

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -3,20 +3,12 @@
 
 //! Protocol defined by RME GmbH for Fireface 802.
 
-use hinawa::FwReq;
-
 use super::*;
 use crate::*;
 
 /// The structure to represent unique protocol for Fireface 802.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub struct Ff802Protocol(FwReq);
-
-impl AsRef<FwReq> for Ff802Protocol {
-    fn as_ref(&self) -> &FwReq {
-        &self.0
-    }
-}
+pub struct Ff802Protocol;
 
 // For configuration register (0x'ffff'0000'0014).
 const CFG_CLK_SRC_MASK: u32                     = 0x00001c00;

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -420,4 +420,4 @@ impl Default for Ff802DspState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterDspProtocol<T, Ff802DspState> for Ff802Protocol {}
+impl RmeFfLatterDspOperation<Ff802DspState> for Ff802Protocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -386,4 +386,4 @@ impl Default for FfUcxDspState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterDspProtocol<T, FfUcxDspState> for FfUcxProtocol {}
+impl RmeFfLatterDspOperation<FfUcxDspState> for FfUcxProtocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -351,23 +351,7 @@ impl Default for FfUcxMeterState {
 
 impl RmeFfLatterMeterOperation<FfUcxMeterState> for FfUcxProtocol {}
 
-/// The structure to represent state of DSP.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FfUcxDspState(FfLatterDspState);
-
-impl AsRef<FfLatterDspState> for FfUcxDspState {
-    fn as_ref(&self) -> &FfLatterDspState {
-        &self.0
-    }
-}
-
-impl AsMut<FfLatterDspState> for FfUcxDspState {
-    fn as_mut(&mut self) -> &mut FfLatterDspState {
-        &mut self.0
-    }
-}
-
-impl RmeFfLatterDspSpec for FfUcxDspState {
+impl RmeFfLatterDspOperation for FfUcxProtocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
     const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
@@ -379,11 +363,3 @@ impl RmeFfLatterDspSpec for FfUcxDspState {
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 }
-
-impl Default for FfUcxDspState {
-    fn default() -> Self {
-        Self(Self::create_dsp_state())
-    }
-}
-
-impl RmeFfLatterDspOperation<FfUcxDspState> for FfUcxProtocol {}

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -3,20 +3,12 @@
 
 //! Protocol defined by RME GmbH for Fireface UCX.
 
-use hinawa::FwReq;
-
 use super::*;
 use crate::*;
 
 /// The structure to represent unique protocol for Fireface UCX.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
-pub struct FfUcxProtocol(FwReq);
-
-impl AsRef<FwReq> for FfUcxProtocol {
-    fn as_ref(&self) -> &FwReq {
-        &self.0
-    }
-}
+pub struct FfUcxProtocol;
 
 // For configuration register (0x'ffff'0000'0014).
 const CFG_CLK_SRC_MASK: u32                         = 0x00000c00;

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -132,7 +132,7 @@ impl RmeFfLatterRegisterValueOperation for FfUcxConfig{
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterConfigProtocol<T, FfUcxConfig> for FfUcxProtocol {}
+impl RmeFfLatterConfigOperation<FfUcxConfig> for FfUcxProtocol {}
 
 // For status register (0x'ffff'0000'001c).
 #[allow(dead_code)]

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -314,23 +314,7 @@ const HP_OUTPUT_COUNT: usize = 2;
 const SPDIF_OUTPUT_COUNT: usize = 2;
 const ADAT_OUTPUT_COUNT: usize = 8;
 
-/// The structure to represent state of meter.
-#[derive(Debug, Clone, Eq, PartialEq)]
-pub struct FfUcxMeterState(FfLatterMeterState);
-
-impl AsRef<FfLatterMeterState> for FfUcxMeterState {
-    fn as_ref(&self) -> &FfLatterMeterState {
-        &self.0
-    }
-}
-
-impl AsMut<FfLatterMeterState> for FfUcxMeterState {
-    fn as_mut(&mut self) -> &mut FfLatterMeterState {
-        &mut self.0
-    }
-}
-
-impl RmeFfLatterMeterSpec for FfUcxMeterState {
+impl RmeFfLatterMeterOperation for FfUcxProtocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
     const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
     const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
@@ -342,14 +326,6 @@ impl RmeFfLatterMeterSpec for FfUcxMeterState {
     const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
     const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
 }
-
-impl Default for FfUcxMeterState {
-    fn default() -> Self {
-        Self(Self::create_meter_state())
-    }
-}
-
-impl RmeFfLatterMeterOperation<FfUcxMeterState> for FfUcxProtocol {}
 
 impl RmeFfLatterDspOperation for FfUcxProtocol {
     const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -349,7 +349,7 @@ impl Default for FfUcxMeterState {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterMeterProtocol<T, FfUcxMeterState> for FfUcxProtocol {}
+impl RmeFfLatterMeterOperation<FfUcxMeterState> for FfUcxProtocol {}
 
 /// The structure to represent state of DSP.
 #[derive(Debug, Clone, Eq, PartialEq)]

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -301,7 +301,7 @@ impl RmeFfLatterRegisterValueOperation for FfUcxStatus {
     }
 }
 
-impl<T: AsRef<FwNode>> RmeFfLatterStatusProtocol<T, FfUcxStatus> for FfUcxProtocol {}
+impl RmeFfLatterStatusOperation<FfUcxStatus> for FfUcxProtocol {}
 
 const LINE_INPUT_COUNT: usize = 6;
 const MIC_INPUT_COUNT: usize = 2;

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -2,9 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
-
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use alsa_ctl_tlv_codec::items::DbInterval;
 
@@ -19,7 +20,7 @@ use super::model::*;
 
 #[derive(Default, Debug)]
 pub struct Ff400Model{
-    req: Ff400Protocol,
+    req: FwReq,
     meter_ctl: MeterCtl,
     out_ctl: OutputCtl,
     input_gain_ctl: InputGainCtl,
@@ -162,7 +163,7 @@ impl InputGainCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
     ) -> Result<(), Error> {
@@ -202,7 +203,7 @@ impl InputGainCtl {
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -255,7 +256,7 @@ fn clk_src_to_string(src: &Ff400ClkSrc) -> String {
 
 fn update_cfg<F>(
     unit: &mut SndUnit,
-    req: &mut Ff400Protocol,
+    req: &mut FwReq,
     cfg: &mut Ff400Config,
     timeout_ms: u32,
     cb: F
@@ -303,7 +304,7 @@ impl StatusCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
     ) -> Result<(), Error> {
@@ -339,7 +340,7 @@ impl StatusCtl {
     fn measure_states(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         Ff400Protocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)
@@ -448,7 +449,7 @@ impl CfgCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         status: &Ff400Status,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
@@ -645,7 +646,7 @@ impl CfgCtl {
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff400Protocol,
+        req: &mut FwReq,
         elem_id: &ElemId,
         _: &ElemValue,
         new: &ElemValue,

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -210,8 +210,7 @@ fn update_cfg<F>(unit: &SndUnit, proto: &Ff400Protocol, cfg: &mut Ff400Config, t
 {
     let mut cache = cfg.clone();
     cb(&mut cache)?;
-    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
-        .map(|_| *cfg = cache)
+    Ff400Protocol::write_cfg(proto, &mut unit.get_node(), &cache, timeout_ms).map(|_| *cfg = cache)
 }
 
 #[derive(Default, Debug)]
@@ -390,7 +389,7 @@ impl<'a> CfgCtl {
         -> Result<(), Error>
     {
         self.0.init(&status);
-        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+        Ff400Protocol::write_cfg(proto, &mut unit.get_node(), &self.0, timeout_ms)?;
 
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -21,7 +21,7 @@ use super::model::*;
 pub struct Ff400Model{
     req: Ff400Protocol,
     meter_ctl: MeterCtl,
-    out_ctl: FormerOutCtl<Ff400OutputVolumeState>,
+    out_ctl: OutputCtl,
     input_gain_ctl: InputGainCtl,
     mixer_ctl: FormerMixerCtl<Ff400MixerState>,
     status_ctl: StatusCtl,
@@ -112,6 +112,19 @@ impl FormerMeterCtlOperation<Ff400Protocol, Ff400MeterState> for MeterCtl {
         &mut self.0
     }
 
+}
+
+#[derive(Default, Debug)]
+struct OutputCtl(Ff400OutputVolumeState);
+
+impl FormerOutputCtlOperation<Ff400Protocol, Ff400OutputVolumeState> for OutputCtl {
+    fn state(&self) -> &Ff400OutputVolumeState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut Ff400OutputVolumeState {
+        &mut self.0
+    }
 }
 
 #[derive(Default, Debug)]

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -250,7 +250,7 @@ impl<'a> StatusCtl {
     fn load(&mut self, unit: &SndUnit, proto: &Ff400Protocol, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)?;
+        Ff400Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
@@ -282,7 +282,7 @@ impl<'a> StatusCtl {
     fn measure_states(&mut self, unit: &SndUnit, proto: &Ff400Protocol, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)
+        Ff400Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)
     }
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -116,14 +116,14 @@ impl FormerMeterCtlOperation<Ff400Protocol> for MeterCtl {
 }
 
 #[derive(Default, Debug)]
-struct OutputCtl(Ff400OutputVolumeState);
+struct OutputCtl(FormerOutputVolumeState);
 
-impl FormerOutputCtlOperation<Ff400Protocol, Ff400OutputVolumeState> for OutputCtl {
-    fn state(&self) -> &Ff400OutputVolumeState {
+impl FormerOutputCtlOperation<Ff400Protocol> for OutputCtl {
+    fn state(&self) -> &FormerOutputVolumeState {
         &self.0
     }
 
-    fn state_mut(&mut self) -> &mut Ff400OutputVolumeState {
+    fn state_mut(&mut self) -> &mut FormerOutputVolumeState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -121,7 +121,7 @@ impl<'a> InputGainCtl {
     fn load(&mut self, unit: &SndUnit, proto: &Ff400Protocol, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.init_input_gains(&unit.get_node(), &mut self.status, timeout_ms)?;
+        Ff400Protocol::init_input_gains(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_GAIN_NAME, 0);
         card_cntr.add_int_elems(&elem_id, 1, Self::MIC_GAIN_MIN, Self::MIC_GAIN_MAX, Self::MIC_GAIN_STEP,
@@ -165,7 +165,13 @@ impl<'a> InputGainCtl {
                 let gains: Vec<i8> = vals.iter()
                     .map(|&val| val as i8)
                     .collect();
-                proto.write_input_mic_gains(&unit.get_node(), &mut self.status, &gains, timeout_ms)
+                Ff400Protocol::write_input_mic_gains(
+                    proto,
+                    &mut unit.get_node(),
+                    &mut self.status,
+                    &gains,
+                    timeout_ms
+                )
                     .map(|_| true)
             }
             Self::LINE_GAIN_NAME => {
@@ -174,7 +180,13 @@ impl<'a> InputGainCtl {
                 let gains: Vec<i8> = vals.iter()
                     .map(|&val| val as i8)
                     .collect();
-                proto.write_input_line_gains(&unit.get_node(), &mut self.status, &gains, timeout_ms)
+                Ff400Protocol::write_input_line_gains(
+                    proto,
+                    &mut unit.get_node(),
+                    &mut self.status,
+                    &gains,
+                    timeout_ms
+                )
                     .map(|_| true)
             }
             _ => Ok(false),

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -102,14 +102,14 @@ impl MeasureModel<SndUnit> for Ff400Model {
 }
 
 #[derive(Default, Debug)]
-struct MeterCtl(Ff400MeterState, Vec<ElemId>);
+struct MeterCtl(FormerMeterState, Vec<ElemId>);
 
-impl FormerMeterCtlOperation<Ff400Protocol, Ff400MeterState> for MeterCtl {
-    fn meter(&self) -> &Ff400MeterState {
+impl FormerMeterCtlOperation<Ff400Protocol> for MeterCtl {
+    fn meter(&self) -> &FormerMeterState {
         &self.0
     }
 
-    fn meter_mut(&mut self) -> &mut Ff400MeterState {
+    fn meter_mut(&mut self) -> &mut FormerMeterState {
         &mut self.0
     }
 

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -129,14 +129,14 @@ impl FormerOutputCtlOperation<Ff400Protocol> for OutputCtl {
 }
 
 #[derive(Default, Debug)]
-struct MixerCtl(Ff400MixerState);
+struct MixerCtl(FormerMixerState);
 
-impl FormerMixerCtlOperation<Ff400Protocol, Ff400MixerState> for MixerCtl {
-    fn state(&self) -> &Ff400MixerState {
+impl FormerMixerCtlOperation<Ff400Protocol> for MixerCtl {
+    fn state(&self) -> &FormerMixerState {
         &self.0
     }
 
-    fn state_mut(&mut self) -> &mut Ff400MixerState {
+    fn state_mut(&mut self) -> &mut FormerMixerState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -104,10 +104,10 @@ struct InputGainCtl{
     status: Ff400InputGainStatus,
 }
 
-impl<'a> InputGainCtl {
-    const MIC_GAIN_NAME: &'a str = "mic-input-gain";
-    const LINE_GAIN_NAME: &'a str = "line-input-gain";
+const MIC_GAIN_NAME: &str = "mic-input-gain";
+const LINE_GAIN_NAME: &str = "line-input-gain";
 
+impl InputGainCtl {
     const MIC_GAIN_MIN: i32 = 0;
     const MIC_GAIN_MAX: i32 = 65;
     const MIC_GAIN_STEP: i32 = 1;
@@ -123,11 +123,11 @@ impl<'a> InputGainCtl {
     {
         Ff400Protocol::init_input_gains(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MIC_GAIN_NAME, 0);
         card_cntr.add_int_elems(&elem_id, 1, Self::MIC_GAIN_MIN, Self::MIC_GAIN_MAX, Self::MIC_GAIN_STEP,
                                 2, Some(&Vec::<u32>::from(&Self::MIC_GAIN_TLV)), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_GAIN_NAME, 0);
         card_cntr.add_int_elems(&elem_id, 1, Self::LINE_GAIN_MIN, Self::LINE_GAIN_MAX, Self::LINE_GAIN_STEP,
                                 2, Some(&Vec::<u32>::from(&Self::LINE_GAIN_TLV)), true)?;
 
@@ -136,14 +136,14 @@ impl<'a> InputGainCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::MIC_GAIN_NAME => {
+            MIC_GAIN_NAME => {
                 let vals: Vec<i32> = self.status.mic.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::LINE_GAIN_NAME => {
+            LINE_GAIN_NAME => {
                 let vals: Vec<i32> = self.status.line.iter()
                     .map(|&gain| gain as i32)
                     .collect();
@@ -159,7 +159,7 @@ impl<'a> InputGainCtl {
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::MIC_GAIN_NAME => {
+            MIC_GAIN_NAME => {
                 let mut vals = [0;2];
                 elem_value.get_int(&mut vals);
                 let gains: Vec<i8> = vals.iter()
@@ -174,7 +174,7 @@ impl<'a> InputGainCtl {
                 )
                     .map(|_| true)
             }
-            Self::LINE_GAIN_NAME => {
+            LINE_GAIN_NAME => {
                 let mut vals = [0;2];
                 elem_value.get_int(&mut vals);
                 let gains: Vec<i8> = vals.iter()
@@ -219,13 +219,13 @@ struct StatusCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> StatusCtl {
-    const EXT_SRC_LOCK_NAME: &'a str = "external-source-lock";
-    const EXT_SRC_SYNC_NAME: &'a str = "external-source-sync";
-    const SPDIF_SRC_RATE_NAME: &'a str = "spdif-source-rate";
-    const EXT_SRC_RATE_NAME: &'a str = "external-source-rate";
-    const ACTIVE_CLK_SRC_NAME: &'a str = "active-clock-source";
+const EXT_SRC_LOCK_NAME: &'static str = "external-source-lock";
+const EXT_SRC_SYNC_NAME: &'static str = "external-source-sync";
+const SPDIF_SRC_RATE_NAME: &'static str = "spdif-source-rate";
+const EXT_SRC_RATE_NAME: &'static str = "external-source-rate";
+const ACTIVE_CLK_SRC_NAME: &'static str = "active-clock-source";
 
+impl StatusCtl {
     const EXT_SRCS: [Ff400ClkSrc;4] = [
         Ff400ClkSrc::Spdif,
         Ff400ClkSrc::Adat,
@@ -254,10 +254,10 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)?;
 
-        [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
+        [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr.add_bool_elems(&elem_id, 1, Self::EXT_SRCS.len(), false)
@@ -267,11 +267,11 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = Self::EXT_SRC_RATES.iter()
             .map(|r| optional_clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::EXT_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
@@ -286,7 +286,7 @@ impl<'a> StatusCtl {
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::EXT_SRC_LOCK_NAME => {
+            EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.lock.spdif,
                     self.status.lock.adat,
@@ -295,7 +295,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_SYNC_NAME => {
+            EXT_SRC_SYNC_NAME => {
                 let vals = [
                     self.status.sync.spdif,
                     self.status.sync.adat,
@@ -304,21 +304,21 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::SPDIF_SRC_RATE_NAME => {
+            SPDIF_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES.iter()
                     .position(|r| r.eq(&self.status.spdif_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::EXT_SRC_RATE_NAME => {
+            EXT_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES.iter()
                     .position(|r| r.eq(&self.status.external_clk_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_SRC_NAME => {
+            ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS.iter()
                     .position(|s| s.eq(&self.status.active_clk_src))
                     .unwrap();
@@ -333,22 +333,22 @@ impl<'a> StatusCtl {
 #[derive(Default, Debug)]
 struct CfgCtl(Ff400Config);
 
-impl<'a> CfgCtl {
-    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
-    const LINE_INPUT_LEVEL_NAME: &'a str = "line-input-level";
-    const MIC_POWER_NAME: &'a str = "mic-1/2-powering";
-    const LINE_INST_NAME: &'a str = "line-3/4-inst";
-    const LINE_PAD_NAME: &'a str = "line-3/4-pad";
-    const LINE_OUTPUT_LEVEL_NAME: &'a str = "line-output-level";
-    const HP_OUTPUT_LEVEL_NAME: &'a str = "headphone-output-level";
-    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
-    const SPDIF_INPUT_USE_PREEMBLE_NAME: &'a str = "spdif-input-use-preemble";
-    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
-    const SPDIF_OUTPUT_EMPHASIS_NAME: &'a str = "spdif-output-emphasis";
-    const SPDIF_OUTPUT_NON_AUDIO_NAME: &'a str = "spdif-output-non-audio";
-    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
-    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+const PRIMARY_CLK_SRC_NAME: &str = "primary-clock-source";
+const LINE_INPUT_LEVEL_NAME: &str = "line-input-level";
+const MIC_POWER_NAME: &str = "mic-1/2-powering";
+const LINE_INST_NAME: &str = "line-3/4-inst";
+const LINE_PAD_NAME: &str = "line-3/4-pad";
+const LINE_OUTPUT_LEVEL_NAME: &str = "line-output-level";
+const HP_OUTPUT_LEVEL_NAME: &str = "headphone-output-level";
+const SPDIF_INPUT_IFACE_NAME: &str = "spdif-input-interface";
+const SPDIF_INPUT_USE_PREEMBLE_NAME: &str = "spdif-input-use-preemble";
+const SPDIF_OUTPUT_FMT_NAME: &str = "spdif-output-format";
+const SPDIF_OUTPUT_EMPHASIS_NAME: &str = "spdif-output-emphasis";
+const SPDIF_OUTPUT_NON_AUDIO_NAME: &str = "spdif-output-non-audio";
+const OPT_OUTPUT_SIGNAL_NAME: &str = "optical-output-signal";
+const WORD_CLOCK_SINGLE_SPPED_NAME: &str = "word-clock-single-speed";
 
+impl CfgCtl {
     const CLK_SRCS: [Ff400ClkSrc;5] = [
         Ff400ClkSrc::Internal,
         Ff400ClkSrc::WordClock,
@@ -394,91 +394,91 @@ impl<'a> CfgCtl {
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, PRIMARY_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::LINE_INPUT_LEVELS.iter()
             .map(|l| former_line_in_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_INPUT_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_INPUT_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MIC_POWER_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MIC_POWER_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_INST_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_INST_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_PAD_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_PAD_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
 
         let labels: Vec<String> = Self::LINE_OUTPUT_LEVELS.iter()
             .map(|l| line_out_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_OUTPUT_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_OUTPUT_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::HP_OUTPUT_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, HP_OUTPUT_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::SPDIF_IFACES.iter()
             .map(|i| spdif_iface_to_string(i))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_IFACE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_FMTS.iter()
             .map(|f| spdif_format_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_FMT_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_EMPHASIS_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
             .map(|f| optical_output_signal_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_OUTPUT_SIGNAL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_SINGLE_SPPED_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_IFACES.iter()
             .map(|i| spdif_iface_to_string(i))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_IFACE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_FMTS.iter()
             .map(|f| spdif_format_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_FMT_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_EMPHASIS_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
             .map(|f| optical_output_signal_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_OUTPUT_SIGNAL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_SINGLE_SPPED_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         Ok(())
@@ -486,33 +486,33 @@ impl<'a> CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 let pos = Self::CLK_SRCS.iter()
                     .position(|s| s.eq(&self.0.clk.primary_src))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::LINE_INPUT_LEVEL_NAME => {
+            LINE_INPUT_LEVEL_NAME => {
                 let pos = Self::LINE_INPUT_LEVELS.iter()
                     .position(|l| l.eq(&self.0.analog_in.line_level))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::MIC_POWER_NAME => {
+            MIC_POWER_NAME => {
                 elem_value.set_bool(&self.0.analog_in.phantom_powering);
                 Ok(true)
             }
-            Self::LINE_INST_NAME => {
+            LINE_INST_NAME => {
                 elem_value.set_bool(&self.0.analog_in.insts);
                 Ok(true)
             }
-            Self::LINE_PAD_NAME => {
+            LINE_PAD_NAME => {
                 elem_value.set_bool(&self.0.analog_in.pad);
                 Ok(true)
             }
-            Self::LINE_OUTPUT_LEVEL_NAME => {
+            LINE_OUTPUT_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::LINE_OUTPUT_LEVELS.iter()
                         .position(|l| l.eq(&self.0.line_out_level))
@@ -521,7 +521,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::HP_OUTPUT_LEVEL_NAME => {
+            HP_OUTPUT_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::LINE_OUTPUT_LEVELS.iter()
                         .position(|l| l.eq(&self.0.line_out_level))
@@ -530,7 +530,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_IFACES.iter()
                         .position(|i| i.eq(&self.0.spdif_in.iface))
@@ -539,11 +539,11 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+            SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 elem_value.set_bool(&[self.0.spdif_in.use_preemble]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_FMTS.iter()
                         .position(|f| f.eq(&self.0.spdif_out.format))
@@ -552,15 +552,15 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+            SPDIF_OUTPUT_EMPHASIS_NAME => {
                 elem_value.set_bool(&[self.0.spdif_out.emphasis]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+            SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 elem_value.set_bool(&[self.0.spdif_out.non_audio]);
                 Ok(true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OPT_OUT_SIGNALS.iter()
                         .position(|f| f.eq(&self.0.opt_out_signal))
@@ -569,7 +569,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
             }
@@ -582,7 +582,7 @@ impl<'a> CfgCtl {
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     Self::CLK_SRCS.iter()
                         .nth(val as usize)
@@ -596,7 +596,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::LINE_INPUT_LEVEL_NAME => {
+            LINE_INPUT_LEVEL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::LINE_INPUT_LEVELS.iter()
@@ -610,25 +610,25 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::MIC_POWER_NAME => {
+            MIC_POWER_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     Ok(new.get_bool(&mut cfg.analog_in.phantom_powering))
                 })
                 .map(|_| true)
             }
-            Self::LINE_INST_NAME => {
+            LINE_INST_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     Ok(new.get_bool(&mut cfg.analog_in.insts))
                 })
                 .map(|_| true)
             }
-            Self::LINE_PAD_NAME => {
+            LINE_PAD_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     Ok(new.get_bool(&mut cfg.analog_in.pad))
                 })
                 .map(|_| true)
             }
-            Self::LINE_OUTPUT_LEVEL_NAME => {
+            LINE_OUTPUT_LEVEL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::LINE_OUTPUT_LEVELS.iter()
@@ -642,7 +642,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::HP_OUTPUT_LEVEL_NAME => {
+            HP_OUTPUT_LEVEL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::LINE_OUTPUT_LEVELS.iter()
@@ -656,7 +656,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::SPDIF_IFACES.iter()
@@ -670,7 +670,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+            SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_in.use_preemble = val;
@@ -679,7 +679,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::SPDIF_FMTS.iter()
@@ -693,7 +693,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+            SPDIF_OUTPUT_EMPHASIS_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_out.emphasis = val;
@@ -702,7 +702,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+            SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_out.non_audio = val;
@@ -711,7 +711,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::OPT_OUT_SIGNALS.iter()
@@ -725,7 +725,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.word_out_single = val;

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -23,7 +23,7 @@ pub struct Ff400Model{
     meter_ctl: MeterCtl,
     out_ctl: OutputCtl,
     input_gain_ctl: InputGainCtl,
-    mixer_ctl: FormerMixerCtl<Ff400MixerState>,
+    mixer_ctl: MixerCtl,
     status_ctl: StatusCtl,
     cfg_ctl: CfgCtl,
 }
@@ -123,6 +123,19 @@ impl FormerOutputCtlOperation<Ff400Protocol, Ff400OutputVolumeState> for OutputC
     }
 
     fn state_mut(&mut self) -> &mut Ff400OutputVolumeState {
+        &mut self.0
+    }
+}
+
+#[derive(Default, Debug)]
+struct MixerCtl(Ff400MixerState);
+
+impl FormerMixerCtlOperation<Ff400Protocol, Ff400MixerState> for MixerCtl {
+    fn state(&self) -> &Ff400MixerState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut Ff400MixerState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -95,14 +95,14 @@ impl MeasureModel<SndUnit> for Ff800Model {
 }
 
 #[derive(Default, Debug)]
-struct MeterCtl(Ff800MeterState, Vec<ElemId>);
+struct MeterCtl(FormerMeterState, Vec<ElemId>);
 
-impl FormerMeterCtlOperation<Ff800Protocol, Ff800MeterState> for MeterCtl {
-    fn meter(&self) -> &Ff800MeterState {
+impl FormerMeterCtlOperation<Ff800Protocol> for MeterCtl {
+    fn meter(&self) -> &FormerMeterState{
         &self.0
     }
 
-    fn meter_mut(&mut self) -> &mut Ff800MeterState {
+    fn meter_mut(&mut self) -> &mut FormerMeterState {
         &mut self.0
     }
 

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -20,7 +20,7 @@ pub struct Ff800Model{
     req: Ff800Protocol,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
-    out_ctl: FormerOutCtl<Ff800OutputVolumeState>,
+    out_ctl: OutputCtl,
     mixer_ctl: FormerMixerCtl<Ff800MixerState>,
     meter_ctl: MeterCtl,
 }
@@ -106,6 +106,20 @@ impl FormerMeterCtlOperation<Ff800Protocol, Ff800MeterState> for MeterCtl {
     }
 
 }
+
+#[derive(Default, Debug)]
+struct OutputCtl(Ff800OutputVolumeState);
+
+impl FormerOutputCtlOperation<Ff800Protocol, Ff800OutputVolumeState> for OutputCtl {
+    fn state(&self) -> &Ff800OutputVolumeState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut Ff800OutputVolumeState {
+        &mut self.0
+    }
+}
+
 fn update_cfg<F>(
     unit: &mut SndUnit,
     req: &mut Ff800Protocol,

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -109,14 +109,14 @@ impl FormerMeterCtlOperation<Ff800Protocol> for MeterCtl {
 }
 
 #[derive(Default, Debug)]
-struct OutputCtl(Ff800OutputVolumeState);
+struct OutputCtl(FormerOutputVolumeState);
 
-impl FormerOutputCtlOperation<Ff800Protocol, Ff800OutputVolumeState> for OutputCtl {
-    fn state(&self) -> &Ff800OutputVolumeState {
+impl FormerOutputCtlOperation<Ff800Protocol> for OutputCtl {
+    fn state(&self) -> &FormerOutputVolumeState {
         &self.0
     }
 
-    fn state_mut(&mut self) -> &mut Ff800OutputVolumeState {
+    fn state_mut(&mut self) -> &mut FormerOutputVolumeState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -158,7 +158,7 @@ impl<'a> StatusCtl {
     fn load(&mut self, unit: &SndUnit, proto: &Ff800Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)?;
+        Ff800Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
@@ -190,7 +190,7 @@ impl<'a> StatusCtl {
     fn measure_states(&mut self, unit: &SndUnit, proto: &Ff800Protocol, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)
+        Ff800Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)
     }
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -122,14 +122,14 @@ impl FormerOutputCtlOperation<Ff800Protocol> for OutputCtl {
 }
 
 #[derive(Default, Debug)]
-struct MixerCtl(Ff800MixerState);
+struct MixerCtl(FormerMixerState);
 
-impl FormerMixerCtlOperation<Ff800Protocol, Ff800MixerState> for MixerCtl {
-    fn state(&self) -> &Ff800MixerState {
+impl FormerMixerCtlOperation<Ff800Protocol> for MixerCtl {
+    fn state(&self) -> &FormerMixerState {
         &self.0
     }
 
-    fn state_mut(&mut self) -> &mut Ff800MixerState {
+    fn state_mut(&mut self) -> &mut FormerMixerState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -2,9 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
-
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use core::card_cntr::*;
 use core::elem_value_accessor::*;
@@ -17,7 +18,7 @@ use super::former_ctls::*;
 
 #[derive(Default, Debug)]
 pub struct Ff800Model{
-    req: Ff800Protocol,
+    req: FwReq,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     out_ctl: OutputCtl,
@@ -135,7 +136,7 @@ impl FormerMixerCtlOperation<Ff800Protocol, Ff800MixerState> for MixerCtl {
 
 fn update_cfg<F>(
     unit: &mut SndUnit,
-    req: &mut Ff800Protocol,
+    req: &mut FwReq,
     cfg: &mut Ff800Config,
     timeout_ms: u32,
     cb: F
@@ -204,7 +205,7 @@ impl StatusCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff800Protocol,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -240,7 +241,7 @@ impl StatusCtl {
     fn measure_states(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff800Protocol,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         Ff800Protocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)
@@ -374,7 +375,7 @@ impl CfgCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff800Protocol,
+        req: &mut FwReq,
         status: &Ff800Status,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
@@ -558,7 +559,7 @@ impl CfgCtl {
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff800Protocol,
+        req: &mut FwReq,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -21,7 +21,7 @@ pub struct Ff800Model{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     out_ctl: OutputCtl,
-    mixer_ctl: FormerMixerCtl<Ff800MixerState>,
+    mixer_ctl: MixerCtl,
     meter_ctl: MeterCtl,
 }
 
@@ -116,6 +116,19 @@ impl FormerOutputCtlOperation<Ff800Protocol, Ff800OutputVolumeState> for OutputC
     }
 
     fn state_mut(&mut self) -> &mut Ff800OutputVolumeState {
+        &mut self.0
+    }
+}
+
+#[derive(Default, Debug)]
+struct MixerCtl(Ff800MixerState);
+
+impl FormerMixerCtlOperation<Ff800Protocol, Ff800MixerState> for MixerCtl {
+    fn state(&self) -> &Ff800MixerState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut Ff800MixerState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -127,13 +127,13 @@ struct StatusCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> StatusCtl {
-    const EXT_SRC_LOCK_NAME: &'a str = "external-source-lock";
-    const EXT_SRC_SYNC_NAME: &'a str = "external-source-sync";
-    const SPDIF_SRC_RATE_NAME: &'a str = "spdif-source-rate";
-    const EXT_SRC_RATE_NAME: &'a str = "external-source-rate";
-    const ACTIVE_CLK_SRC_NAME: &'a str = "active-clock-source";
+const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
+const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
+const SPDIF_SRC_RATE_NAME: &str = "spdif-source-rate";
+const EXT_SRC_RATE_NAME: &str = "external-source-rate";
+const ACTIVE_CLK_SRC_NAME: &str = "active-clock-source";
 
+impl StatusCtl {
     const EXT_SRCS: [Ff800ClkSrc;5] = [
         Ff800ClkSrc::Spdif,
         Ff800ClkSrc::AdatA,
@@ -163,10 +163,10 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)?;
 
-        [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
+        [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr.add_bool_elems(&elem_id, 1, Self::EXT_SRCS.len(), false)
@@ -176,11 +176,11 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = Self::EXT_SRC_RATES.iter()
             .map(|r| optional_clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::EXT_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
@@ -195,7 +195,7 @@ impl<'a> StatusCtl {
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::EXT_SRC_LOCK_NAME => {
+            EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.lock.spdif,
                     self.status.lock.adat_a,
@@ -206,7 +206,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_SYNC_NAME => {
+            EXT_SRC_SYNC_NAME => {
                 let vals = [
                     self.status.sync.spdif,
                     self.status.sync.adat_a,
@@ -217,21 +217,21 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::SPDIF_SRC_RATE_NAME => {
+            SPDIF_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES.iter()
                     .position(|r| r.eq(&self.status.spdif_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::EXT_SRC_RATE_NAME => {
+            EXT_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES.iter()
                     .position(|r| r.eq(&self.status.external_clk_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_SRC_NAME => {
+            ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS.iter()
                     .position(|s| s.eq(&self.status.active_clk_src))
                     .unwrap();
@@ -246,23 +246,23 @@ impl<'a> StatusCtl {
 #[derive(Default, Debug)]
 struct CfgCtl(Ff800Config);
 
-impl<'a> CfgCtl {
-    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
-    const INPUT_JACK_NAME: &'a str = "input-1/7/8-jack";
-    const INPUT_LINE_LEVEL_NAME: &'a str = "input-line-level";
-    const INPUT_POWER_NAME: &'a str = "input-7/8/9/10-powering";
-    const INPUT_INST_DRIVE_NAME: &'a str = "input-1-inst-drive";
-    const INPUT_INST_LIMITTER_NAME: &'a str = "input-1-inst-limitter";
-    const INPUT_INST_SPKR_EMU_NAME: &'a str = "input-1-inst-speaker-emu";
-    const OUTPUT_LINE_LEVEL_NAME: &'a str = "output-line-level";
-    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
-    const SPDIF_INPUT_USE_PREEMBLE_NAME: &'a str = "spdif-input-use-preemble";
-    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
-    const SPDIF_OUTPUT_EMPHASIS_NAME: &'a str = "spdif-output-emphasis";
-    const SPDIF_OUTPUT_NON_AUDIO_NAME: &'a str = "spdif-output-non-audio";
-    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
-    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+const PRIMARY_CLK_SRC_NAME: &str = "primary-clock-source";
+const INPUT_JACK_NAME: &str = "input-1/7/8-jack";
+const INPUT_LINE_LEVEL_NAME: &str = "input-line-level";
+const INPUT_POWER_NAME: &str = "input-7/8/9/10-powering";
+const INPUT_INST_DRIVE_NAME: &str = "input-1-inst-drive";
+const INPUT_INST_LIMITTER_NAME: &str = "input-1-inst-limitter";
+const INPUT_INST_SPKR_EMU_NAME: &str = "input-1-inst-speaker-emu";
+const OUTPUT_LINE_LEVEL_NAME: &str = "output-line-level";
+const SPDIF_INPUT_IFACE_NAME: &str = "spdif-input-interface";
+const SPDIF_INPUT_USE_PREEMBLE_NAME: &str = "spdif-input-use-preemble";
+const SPDIF_OUTPUT_FMT_NAME: &str = "spdif-output-format";
+const SPDIF_OUTPUT_EMPHASIS_NAME: &str = "spdif-output-emphasis";
+const SPDIF_OUTPUT_NON_AUDIO_NAME: &str = "spdif-output-non-audio";
+const OPT_OUTPUT_SIGNAL_NAME: &str = "optical-output-signal";
+const WORD_CLOCK_SINGLE_SPPED_NAME: &str = "word-clock-single-speed";
 
+impl CfgCtl {
     const CLK_SRCS: [Ff800ClkSrc;6] = [
         Ff800ClkSrc::Internal,
         Ff800ClkSrc::WordClock,
@@ -272,13 +272,13 @@ impl<'a> CfgCtl {
         Ff800ClkSrc::Tco,
     ];
 
-    const INPUT_INPUT_JACK_TARGETS: [&'a str;3] = [
+    const INPUT_INPUT_JACK_TARGETS: [&'static str; 3] = [
         "analog-1",
         "analog-7",
         "analog-8",
     ];
 
-    const INPUT_POWER_TARGETS: [&'a str;4] = [
+    const INPUT_POWER_TARGETS: [&'static str; 4] = [
         "analog-7",
         "analog-8",
         "analog-9",
@@ -328,68 +328,68 @@ impl<'a> CfgCtl {
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, PRIMARY_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::INPUT_JACKS.iter()
             .map(|l| line_in_jack_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_JACK_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_JACK_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, Self::INPUT_INPUT_JACK_TARGETS.len(), &labels,
                                          None, true)?;
 
         let labels: Vec<String> = Self::INPUT_LINE_LEVELS.iter()
             .map(|l| former_line_in_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_LINE_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_LINE_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_POWER_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_POWER_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::INPUT_POWER_TARGETS.len(), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_DRIVE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_INST_DRIVE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_LIMITTER_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_INST_LIMITTER_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_INST_SPKR_EMU_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_INST_SPKR_EMU_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::OUTPUT_LINE_LEVELS.iter()
             .map(|l| line_out_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OUTPUT_LINE_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OUTPUT_LINE_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::SPDIF_IFACES.iter()
             .map(|i| spdif_iface_to_string(i))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_IFACE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_USE_PREEMBLE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_FMTS.iter()
             .map(|f| spdif_format_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_FMT_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_EMPHASIS_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_EMPHASIS_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_NON_AUDIO_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
             .map(|f| optical_output_signal_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_OUTPUT_SIGNAL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_SINGLE_SPPED_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         Ok(())
@@ -397,7 +397,7 @@ impl<'a> CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::CLK_SRCS.iter()
                         .position(|s| s.eq(&self.0.clk.primary_src))
@@ -406,7 +406,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_JACK_NAME => {
+            INPUT_JACK_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, 3, |idx| {
                     let pos = Self::INPUT_JACKS.iter()
                         .position(|j| j.eq(&self.0.analog_in.jacks[idx]))
@@ -415,30 +415,30 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_LINE_LEVEL_NAME => {
+            INPUT_LINE_LEVEL_NAME => {
                 let pos = Self::INPUT_LINE_LEVELS.iter()
                     .position(|l| l.eq(&self.0.analog_in.line_level))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::INPUT_POWER_NAME => {
+            INPUT_POWER_NAME => {
                 elem_value.set_bool(&self.0.analog_in.phantom_powering);
                 Ok(true)
             }
-            Self::INPUT_INST_DRIVE_NAME => {
+            INPUT_INST_DRIVE_NAME => {
                 elem_value.set_bool(&[self.0.analog_in.inst.drive]);
                 Ok(true)
             }
-            Self::INPUT_INST_LIMITTER_NAME => {
+            INPUT_INST_LIMITTER_NAME => {
                 elem_value.set_bool(&[self.0.analog_in.inst.limitter]);
                 Ok(true)
             }
-            Self::INPUT_INST_SPKR_EMU_NAME => {
+            INPUT_INST_SPKR_EMU_NAME => {
                 elem_value.set_bool(&[self.0.analog_in.inst.speaker_emulation]);
                 Ok(true)
             }
-            Self::OUTPUT_LINE_LEVEL_NAME => {
+            OUTPUT_LINE_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OUTPUT_LINE_LEVELS.iter()
                         .position(|l| l.eq(&self.0.line_out_level))
@@ -447,7 +447,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_IFACES.iter()
                         .position(|i| i.eq(&self.0.spdif_in.iface))
@@ -456,11 +456,11 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+            SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 elem_value.set_bool(&[self.0.spdif_in.use_preemble]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_FMTS.iter()
                         .position(|f| f.eq(&self.0.spdif_out.format))
@@ -469,15 +469,15 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+            SPDIF_OUTPUT_EMPHASIS_NAME => {
                 elem_value.set_bool(&[self.0.spdif_out.emphasis]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+            SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 elem_value.set_bool(&[self.0.spdif_out.non_audio]);
                 Ok(true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OPT_OUT_SIGNALS.iter()
                         .position(|f| f.eq(&self.0.opt_out_signal))
@@ -486,7 +486,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
             }
@@ -499,7 +499,7 @@ impl<'a> CfgCtl {
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         let src = Self::CLK_SRCS.iter()
@@ -514,7 +514,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_JACK_NAME => {
+            INPUT_JACK_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_vals(new, old, 3, |idx, val| {
                         let jack = Self::INPUT_JACKS.iter()
@@ -529,7 +529,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_LINE_LEVEL_NAME => {
+            INPUT_LINE_LEVEL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::INPUT_LINE_LEVELS.iter()
@@ -543,14 +543,14 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_POWER_NAME => {
+            INPUT_POWER_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     new.get_bool(&mut cfg.analog_in.phantom_powering);
                     Ok(())
                 })
                 .map(|_| true)
             }
-            Self::INPUT_INST_DRIVE_NAME => {
+            INPUT_INST_DRIVE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.analog_in.inst.drive = val;
@@ -559,7 +559,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_INST_LIMITTER_NAME => {
+            INPUT_INST_LIMITTER_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.analog_in.inst.limitter = val;
@@ -568,7 +568,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::INPUT_INST_SPKR_EMU_NAME => {
+            INPUT_INST_SPKR_EMU_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.analog_in.inst.speaker_emulation = val;
@@ -577,7 +577,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OUTPUT_LINE_LEVEL_NAME => {
+            OUTPUT_LINE_LEVEL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::OUTPUT_LINE_LEVELS.iter()
@@ -591,7 +591,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::SPDIF_IFACES.iter()
@@ -605,7 +605,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_USE_PREEMBLE_NAME => {
+            SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_in.use_preemble = val;
@@ -614,7 +614,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::SPDIF_FMTS.iter()
@@ -628,7 +628,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_EMPHASIS_NAME => {
+            SPDIF_OUTPUT_EMPHASIS_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_out.emphasis = val;
@@ -637,7 +637,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_NON_AUDIO_NAME => {
+            SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.spdif_out.non_audio = val;
@@ -646,7 +646,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::OPT_OUT_SIGNALS.iter()
@@ -660,7 +660,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         cfg.word_out_single = val;

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -98,7 +98,7 @@ fn update_cfg<F>(unit: &SndUnit, proto: &Ff800Protocol, cfg: &mut Ff800Config, t
 {
     let mut cache = cfg.clone();
     cb(&mut cache)?;
-    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+    Ff800Protocol::write_cfg(proto, &mut unit.get_node(), &cache, timeout_ms)
         .map(|_| *cfg = cache)
 }
 
@@ -323,7 +323,7 @@ impl<'a> CfgCtl {
         -> Result<(), Error>
     {
         self.0.init(&status);
-        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+        Ff800Protocol::write_cfg(proto, &mut unit.get_node(), &self.0, timeout_ms)?;
 
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -20,7 +20,7 @@ pub struct Ff802Model{
     req: Ff802Protocol,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
-    meter_ctl: FfLatterMeterCtl<Ff802MeterState>,
+    meter_ctl: MeterCtl,
     dsp_ctl: FfLatterDspCtl<Ff802DspState>,
 }
 
@@ -30,7 +30,8 @@ impl CtlModel<SndUnit> for Ff802Model {
     fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.cfg_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         self.status_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.meter_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.meter_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)
+            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
         self.dsp_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
@@ -63,7 +64,7 @@ impl CtlModel<SndUnit> for Ff802Model {
 impl MeasureModel<SndUnit> for Ff802Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
-        self.meter_ctl.get_measured_elem_list(elem_id_list);
+        elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 
     fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
@@ -82,6 +83,19 @@ impl MeasureModel<SndUnit> for Ff802Model {
         } else {
             Ok(false)
         }
+    }
+}
+
+#[derive(Default, Debug)]
+struct MeterCtl(Ff802MeterState, Vec<ElemId>);
+
+impl FfLatterMeterCtlOperation<Ff802Protocol, Ff802MeterState> for MeterCtl {
+    fn meter(&self) -> &Ff802MeterState {
+        &self.0
+    }
+
+    fn meter_mut(&mut self) -> &mut Ff802MeterState {
+        &mut self.0
     }
 }
 

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -21,7 +21,7 @@ pub struct Ff802Model{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: MeterCtl,
-    dsp_ctl: FfLatterDspCtl<Ff802DspState>,
+    dsp_ctl: DspCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -95,6 +95,19 @@ impl FfLatterMeterCtlOperation<Ff802Protocol, Ff802MeterState> for MeterCtl {
     }
 
     fn meter_mut(&mut self) -> &mut Ff802MeterState {
+        &mut self.0
+    }
+}
+
+#[derive(Default, Debug)]
+struct DspCtl(FfLatterDspState);
+
+impl FfLatterDspCtlOperation<Ff802Protocol> for DspCtl {
+    fn state(&self) -> &FfLatterDspState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut FfLatterDspState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -17,7 +17,7 @@ use super::latter_ctls::*;
 
 #[derive(Default, Debug)]
 pub struct Ff802Model{
-    proto: Ff802Protocol,
+    req: Ff802Protocol,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: FfLatterMeterCtl<Ff802MeterState>,
@@ -28,10 +28,10 @@ const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<SndUnit> for Ff802Model {
     fn load(&mut self, unit: &mut SndUnit, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.cfg_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
-        self.status_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
-        self.meter_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
-        self.dsp_ctl.load(unit, &self.proto, TIMEOUT_MS, card_cntr)?;
+        self.cfg_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.status_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.meter_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.dsp_ctl.load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
 
@@ -50,9 +50,9 @@ impl CtlModel<SndUnit> for Ff802Model {
     fn write(&mut self, unit: &mut SndUnit, elem_id: &ElemId, _: &ElemValue, new: &ElemValue)
         -> Result<bool, Error>
     {
-        if self.cfg_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+        if self.cfg_ctl.write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.dsp_ctl.write(unit, &self.proto, elem_id, new, TIMEOUT_MS)? {
+        } else if self.dsp_ctl.write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)
@@ -67,8 +67,8 @@ impl MeasureModel<SndUnit> for Ff802Model {
     }
 
     fn measure_states(&mut self, unit: &mut SndUnit) -> Result<(), Error> {
-        self.status_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
-        self.meter_ctl.measure_states(unit, &self.proto, TIMEOUT_MS)?;
+        self.status_ctl.measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+        self.meter_ctl.measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -102,13 +102,18 @@ fn ff802_spdif_iface_to_string(iface: &Ff802SpdifIface) -> String {
     }.to_string()
 }
 
-fn update_cfg<F>(unit: &SndUnit, proto: &Ff802Protocol, cfg: &mut Ff802Config, timeout_ms: u32, cb: F)
-    -> Result<(), Error>
+fn update_cfg<F>(
+    unit: &mut SndUnit,
+    req: &mut Ff802Protocol,
+    cfg: &mut Ff802Config,
+    timeout_ms: u32,
+    cb: F
+) -> Result<(), Error>
     where F: Fn(&mut Ff802Config) -> Result<(), Error>,
 {
     let mut cache = cfg.clone();
     cb(&mut cache)?;
-    Ff802Protocol::write_cfg(proto, &mut unit.get_node(), &cache, timeout_ms)
+    Ff802Protocol::write_cfg(req, &mut unit.get_node(), &cache, timeout_ms)
         .map(|_| *cfg = cache)
 }
 
@@ -158,10 +163,14 @@ impl CfgCtl {
         SpdifFormat::Professional,
     ];
 
-    fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
-        -> Result<(), Error>
-    {
-        Ff802Protocol::write_cfg(proto, &mut unit.get_node(), &self.0, timeout_ms)?;
+    fn load(
+        &mut self,
+        unit: &mut SndUnit,
+        req: &mut Ff802Protocol,
+        timeout_ms: u32,
+        card_cntr: &mut CardCntr
+    ) -> Result<(), Error> {
+        Ff802Protocol::write_cfg(req, &mut unit.get_node(), &self.0, timeout_ms)?;
 
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
@@ -196,7 +205,11 @@ impl CfgCtl {
         Ok(())
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read(
+        &mut self,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             PRIMARY_CLK_SRC_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
@@ -246,13 +259,17 @@ impl CfgCtl {
         }
     }
 
-    fn write(&mut self, unit: &SndUnit, proto: &Ff802Protocol, elem_id: &ElemId,
-             elem_value: &alsactl::ElemValue, timeout_ms: u32)
-        -> Result<bool, Error>
-    {
+    fn write(
+        &mut self,
+        unit: &mut SndUnit,
+        req: &mut Ff802Protocol,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32
+    ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             PRIMARY_CLK_SRC_NAME => {
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         let src = Self::CLK_SRCS.iter()
                             .nth(val as usize)
@@ -267,7 +284,7 @@ impl CfgCtl {
                 .map(|_| true)
             }
             SPDIF_INPUT_IFACE_NAME => {
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::SPDIF_IFACES.iter()
                             .nth(val as usize)
@@ -281,7 +298,7 @@ impl CfgCtl {
                 .map(|_| true)
             }
             OPT_OUTPUT_SIGNAL_NAME => {
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::OPT_OUT_SIGNALS.iter()
                             .nth(val as usize)
@@ -297,14 +314,14 @@ impl CfgCtl {
             EFFECT_ON_INPUT_NAME => {
                 let mut vals = [false];
                 elem_value.get_bool(&mut vals);
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     cfg.effect_on_inputs = vals[0];
                     Ok(())
                 })
                 .map(|_| true)
             }
             SPDIF_OUTPUT_FMT_NAME => {
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::SPDIF_FMTS.iter()
                             .nth(val as usize)
@@ -318,7 +335,7 @@ impl CfgCtl {
                 .map(|_| true)
             }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
-                update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
+                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                         cfg.word_out_single = val;
                         Ok(())
@@ -364,10 +381,14 @@ impl StatusCtl {
         Some(ClkNominalRate::R192000),
     ];
 
-    fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
-        -> Result<(), Error>
-    {
-        Ff802Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
+    fn load(
+        &mut self,
+        unit: &mut SndUnit,
+        req: &mut Ff802Protocol,
+        timeout_ms: u32,
+        card_cntr: &mut CardCntr
+    ) -> Result<(), Error> {
+        Ff802Protocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
@@ -400,10 +421,13 @@ impl StatusCtl {
         Ok(())
     }
 
-    fn measure_states(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32)
-        -> Result<(), Error>
-    {
-        Ff802Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)
+    fn measure_states(
+        &mut self,
+        unit: &mut SndUnit,
+        req: &mut Ff802Protocol,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Ff802Protocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -2,9 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
-
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use core::card_cntr::*;
 use core::elem_value_accessor::*;
@@ -17,7 +18,7 @@ use super::latter_ctls::*;
 
 #[derive(Default, Debug)]
 pub struct Ff802Model{
-    req: Ff802Protocol,
+    req: FwReq,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: MeterCtl,
@@ -131,7 +132,7 @@ fn ff802_spdif_iface_to_string(iface: &Ff802SpdifIface) -> String {
 
 fn update_cfg<F>(
     unit: &mut SndUnit,
-    req: &mut Ff802Protocol,
+    req: &mut FwReq,
     cfg: &mut Ff802Config,
     timeout_ms: u32,
     cb: F
@@ -193,7 +194,7 @@ impl CfgCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff802Protocol,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -289,7 +290,7 @@ impl CfgCtl {
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff802Protocol,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -411,7 +412,7 @@ impl StatusCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff802Protocol,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -451,7 +452,7 @@ impl StatusCtl {
     fn measure_states(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut Ff802Protocol,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         Ff802Protocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -108,7 +108,7 @@ fn update_cfg<F>(unit: &SndUnit, proto: &Ff802Protocol, cfg: &mut Ff802Config, t
 {
     let mut cache = cfg.clone();
     cb(&mut cache)?;
-    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+    Ff802Protocol::write_cfg(proto, &mut unit.get_node(), &cache, timeout_ms)
         .map(|_| *cfg = cache)
 }
 
@@ -161,7 +161,7 @@ impl<'a> CfgCtl {
     fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+        Ff802Protocol::write_cfg(proto, &mut unit.get_node(), &self.0, timeout_ms)?;
 
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -367,7 +367,7 @@ impl<'a> StatusCtl {
     fn load(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)?;
+        Ff802Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
@@ -403,7 +403,7 @@ impl<'a> StatusCtl {
     fn measure_states(&mut self, unit: &SndUnit, proto: &Ff802Protocol, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)
+        Ff802Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -115,14 +115,14 @@ fn update_cfg<F>(unit: &SndUnit, proto: &Ff802Protocol, cfg: &mut Ff802Config, t
 #[derive(Default, Debug)]
 struct CfgCtl(Ff802Config);
 
-impl<'a> CfgCtl {
-    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
-    const SPDIF_INPUT_IFACE_NAME: &'a str = "spdif-input-interface";
-    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
-    const EFFECT_ON_INPUT_NAME: &'a str = "effect-on-input";
-    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
-    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
+const PRIMARY_CLK_SRC_NAME: &str = "primary-clock-source";
+const SPDIF_INPUT_IFACE_NAME: &str = "spdif-input-interface";
+const OPT_OUTPUT_SIGNAL_NAME: &str = "optical-output-signal";
+const EFFECT_ON_INPUT_NAME: &str = "effect-on-input";
+const SPDIF_OUTPUT_FMT_NAME: &str = "spdif-output-format";
+const WORD_CLOCK_SINGLE_SPPED_NAME: &str = "word-clock-single-speed";
 
+impl CfgCtl {
     const SPDIF_IFACES: [Ff802SpdifIface;2] = [
         Ff802SpdifIface::Xlr,
         Ff802SpdifIface::Optical,
@@ -166,31 +166,31 @@ impl<'a> CfgCtl {
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, PRIMARY_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::SPDIF_IFACES.iter()
             .map(|i| ff802_spdif_iface_to_string(i))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_INPUT_IFACE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_INPUT_IFACE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
             .map(|f| optical_output_signal_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_OUTPUT_SIGNAL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::EFFECT_ON_INPUT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EFFECT_ON_INPUT_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_FMTS.iter()
             .map(|f| spdif_format_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_FMT_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_SINGLE_SPPED_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         Ok(())
@@ -198,7 +198,7 @@ impl<'a> CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::CLK_SRCS.iter()
                         .position(|s| s.eq(&self.0.clk_src))
@@ -207,7 +207,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_IFACES.iter()
                         .position(|i| i.eq(&self.0.spdif_in_iface))
@@ -216,7 +216,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OPT_OUT_SIGNALS.iter()
                         .position(|f| f.eq(&self.0.opt_out_signal))
@@ -225,11 +225,11 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::EFFECT_ON_INPUT_NAME => {
+            EFFECT_ON_INPUT_NAME => {
                 elem_value.set_bool(&[self.0.effect_on_inputs]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_FMTS.iter()
                         .position(|f| f.eq(&self.0.spdif_out_format))
@@ -238,7 +238,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
             }
@@ -251,7 +251,7 @@ impl<'a> CfgCtl {
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         let src = Self::CLK_SRCS.iter()
@@ -266,7 +266,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_INPUT_IFACE_NAME => {
+            SPDIF_INPUT_IFACE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::SPDIF_IFACES.iter()
@@ -280,7 +280,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::OPT_OUT_SIGNALS.iter()
@@ -294,7 +294,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::EFFECT_ON_INPUT_NAME => {
+            EFFECT_ON_INPUT_NAME => {
                 let mut vals = [false];
                 elem_value.get_bool(&mut vals);
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
@@ -303,7 +303,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::SPDIF_FMTS.iter()
@@ -317,7 +317,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                         cfg.word_out_single = val;
@@ -337,13 +337,13 @@ struct StatusCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> StatusCtl {
-    const EXT_SRC_LOCK_NAME: &'a str = "external-source-lock";
-    const EXT_SRC_SYNC_NAME: &'a str = "external-source-sync";
-    const EXT_SRC_RATE_NAME: &'a str = "external-source-rate";
-    const ACTIVE_CLK_RATE_NAME: &'a str = "active-clock-rate";
-    const ACTIVE_CLK_SRC_NAME: &'a str = "active-clock-source";
+const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
+const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
+const EXT_SRC_RATE_NAME: &str = "external-source-rate";
+const ACTIVE_CLK_RATE_NAME: &str = "active-clock-rate";
+const ACTIVE_CLK_SRC_NAME: &str = "active-clock-source";
 
+impl StatusCtl {
     const EXT_CLK_SRCS: [Ff802ClkSrc;4] = [
         Ff802ClkSrc::AdatA,
         Ff802ClkSrc::AdatB,
@@ -369,7 +369,7 @@ impl<'a> StatusCtl {
     {
         Ff802Protocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
-        [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
+        [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr.add_bool_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), false)
@@ -379,21 +379,21 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = Self::EXT_CLK_RATES.iter()
             .map(|r| optional_clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::EXT_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|r| clk_src_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_RATES.iter()
             .map(|r| clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
@@ -408,7 +408,7 @@ impl<'a> StatusCtl {
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::EXT_SRC_LOCK_NAME => {
+            EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.ext_lock.adat_a,
                     self.status.ext_lock.adat_b,
@@ -418,7 +418,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_SYNC_NAME => {
+            EXT_SRC_SYNC_NAME => {
                 let vals = [
                     self.status.ext_sync.adat_a,
                     self.status.ext_sync.adat_b,
@@ -428,7 +428,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_RATE_NAME => {
+            EXT_SRC_RATE_NAME => {
                 let vals: Vec<u32> = [
                     self.status.ext_rate.adat_a,
                     self.status.ext_rate.adat_b,
@@ -445,7 +445,7 @@ impl<'a> StatusCtl {
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_SRC_NAME => {
+            ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS.iter()
                     .position(|r| r.eq(&self.status.active_clk_src))
                     .map(|p| p as u32)
@@ -453,7 +453,7 @@ impl<'a> StatusCtl {
                 elem_value.set_enum(&[pos]);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_RATE_NAME => {
+            ACTIVE_CLK_RATE_NAME => {
                 let pos = CfgCtl::CLK_RATES.iter()
                     .position(|r| r.eq(&self.status.active_clk_rate))
                     .map(|p| p as u32)

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -87,14 +87,14 @@ impl MeasureModel<SndUnit> for Ff802Model {
 }
 
 #[derive(Default, Debug)]
-struct MeterCtl(Ff802MeterState, Vec<ElemId>);
+struct MeterCtl(FfLatterMeterState, Vec<ElemId>);
 
-impl FfLatterMeterCtlOperation<Ff802Protocol, Ff802MeterState> for MeterCtl {
-    fn meter(&self) -> &Ff802MeterState {
+impl FfLatterMeterCtlOperation<Ff802Protocol> for MeterCtl {
+    fn meter(&self) -> &FfLatterMeterState{
         &self.0
     }
 
-    fn meter_mut(&mut self) -> &mut Ff802MeterState {
+    fn meter_mut(&mut self) -> &mut FfLatterMeterState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -232,10 +232,10 @@ impl<'a, V> FormerMeterCtl<V>
 
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
-        where U: RmeFfFormerMeterProtocol<FwNode, V>,
+        where U: RmeFfFormerMeterOperation<V>,
               V: FormerMeterSpec + AsRef<FormerMeterState> + AsMut<FormerMeterState>,
     {
-        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)?;
+        U::read_meter(proto, &mut unit.get_node(), &mut self.state, timeout_ms)?;
 
         let s = self.state.as_ref();
         [
@@ -261,10 +261,10 @@ impl<'a, V> FormerMeterCtl<V>
 
     pub fn measure_states<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32)
         -> Result<(), Error>
-        where U: RmeFfFormerMeterProtocol<FwNode, V>,
+        where U: RmeFfFormerMeterOperation<V>,
               V: FormerMeterSpec + AsRef<FormerMeterState> + AsMut<FormerMeterState>,
     {
-        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)
+        U::read_meter(proto, &mut unit.get_node(), &mut self.state, timeout_ms)
     }
 
     pub fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue)

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -24,11 +24,11 @@ pub struct FormerOutCtl<V>
     state: V,
 }
 
-impl<'a, V> FormerOutCtl<V>
+const VOL_NAME: &str = "output-volume";
+
+impl< V> FormerOutCtl<V>
     where V: AsRef<[i32]> + AsMut<[i32]>,
 {
-    const VOL_NAME: &'a str = "output-volume";
-
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
         where U: RmeFormerOutputOperation<V>,
@@ -38,7 +38,7 @@ impl<'a, V> FormerOutCtl<V>
             .for_each(|vol| *vol = VOL_ZERO);
         U::init_output_vols(proto, &mut unit.get_node(), &self.state, timeout_ms)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::VOL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, VOL_MIN, VOL_MAX, VOL_STEP,
                                         self.state.as_ref().len(), Some(&Vec::<u32>::from(&VOL_TLV)), true)?;
 
@@ -47,7 +47,7 @@ impl<'a, V> FormerOutCtl<V>
 
     pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::VOL_NAME => {
+            VOL_NAME => {
                 elem_value.set_int(&mut self.state.as_ref());
                 Ok(true)
             },
@@ -62,7 +62,7 @@ impl<'a, V> FormerOutCtl<V>
               V: AsRef<[i32]> + AsMut<[i32]>,
     {
         match elem_id.get_name().as_str() {
-            Self::VOL_NAME => {
+            VOL_NAME => {
                 let mut vals = self.state.as_ref().to_vec();
                 new.get_int(&mut vals);
                 U::write_output_vols(proto, &mut unit.get_node(), &mut self.state, &vals, timeout_ms)
@@ -86,14 +86,14 @@ pub struct FormerMixerCtl<V>
     state: V,
 }
 
-impl<'a, V> FormerMixerCtl<V>
+const ANALOG_SRC_GAIN_NAME: &str = "mixer:analog-source-gain";
+const SPDIF_SRC_GAIN_NAME: &str = "mixer:spdif-source-gain";
+const ADAT_SRC_GAIN_NAME: &str = "mixer:adat-source-gain";
+const STREAM_SRC_GAIN_NAME: &str = "mixer:stream-source-gain";
+
+impl< V> FormerMixerCtl<V>
     where V: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
 {
-    const ANALOG_SRC_GAIN_NAME: &'a str = "mixer:analog-source-gain";
-    const SPDIF_SRC_GAIN_NAME: &'a str = "mixer:spdif-source-gain";
-    const ADAT_SRC_GAIN_NAME: &'a str = "mixer:adat-source-gain";
-    const STREAM_SRC_GAIN_NAME: &'a str = "mixer:stream-source-gain";
-
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
         where U: RmeFormerMixerOperation<V>,
@@ -120,19 +120,19 @@ impl<'a, V> FormerMixerCtl<V>
 
         let mixers = self.state.as_ref();
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ANALOG_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ANALOG_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, mixers.len(), GAIN_MIN, GAIN_MAX, GAIN_STEP,
                                         mixers[0].analog_gains.len(), Some(&Vec::<u32>::from(&GAIN_TLV)), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::SPDIF_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, SPDIF_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, mixers.len(), GAIN_MIN, GAIN_MAX, GAIN_STEP,
                                         mixers[0].spdif_gains.len(), Some(&Vec::<u32>::from(&GAIN_TLV)), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ADAT_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ADAT_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, mixers.len(), GAIN_MIN, GAIN_MAX, GAIN_STEP,
                                         mixers[0].adat_gains.len(), Some(&Vec::<u32>::from(&GAIN_TLV)), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STREAM_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, STREAM_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, mixers.len(), GAIN_MIN, GAIN_MAX, GAIN_STEP,
                                         mixers[0].stream_gains.len(), Some(&Vec::<u32>::from(&GAIN_TLV)), true)?;
 
@@ -141,22 +141,22 @@ impl<'a, V> FormerMixerCtl<V>
 
     pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::ANALOG_SRC_GAIN_NAME => {
+            ANALOG_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 elem_value.set_int(&self.state.as_ref()[index].analog_gains);
                 Ok(true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 elem_value.set_int(&self.state.as_ref()[index].spdif_gains);
                 Ok(true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 elem_value.set_int(&self.state.as_ref()[index].adat_gains);
                 Ok(true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 elem_value.set_int(&self.state.as_ref()[index].stream_gains);
                 Ok(true)
@@ -172,7 +172,7 @@ impl<'a, V> FormerMixerCtl<V>
               V: RmeFormerMixerSpec + AsRef<[FormerMixerSrc]> + AsMut<[FormerMixerSrc]>,
     {
         match elem_id.get_name().as_str() {
-            Self::ANALOG_SRC_GAIN_NAME => {
+            ANALOG_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut gains = self.state.as_mut()[index].analog_gains.clone();
                 new.get_int(&mut gains);
@@ -186,7 +186,7 @@ impl<'a, V> FormerMixerCtl<V>
                 )
                     .map(|_| true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut gains = self.state.as_mut()[index].spdif_gains.clone();
                 new.get_int(&mut gains);
@@ -200,7 +200,7 @@ impl<'a, V> FormerMixerCtl<V>
                 )
                     .map(|_| true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut gains = self.state.as_mut()[index].adat_gains.clone();
                 new.get_int(&mut gains);
@@ -214,7 +214,7 @@ impl<'a, V> FormerMixerCtl<V>
                 )
                     .map(|_| true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut gains = self.state.as_mut()[index].stream_gains.clone();
                 new.get_int(&mut gains);
@@ -246,18 +246,18 @@ const LEVEL_MAX: i32 = 0x7fffff00;
 const LEVEL_STEP: i32 = 0x100;
 const LEVEL_TLV: DbInterval = DbInterval{min: -9003, max: 600, linear: false, mute_avail: false};
 
-impl<'a, V> FormerMeterCtl<V>
+const ANALOG_INPUT_NAME: &str = "meter:analog-input";
+const SPDIF_INPUT_NAME: &str = "meter:spdif-input";
+const ADAT_INPUT_NAME: &str = "meter:adat-input";
+const STREAM_INPUT_NAME: &str = "meter:stream-input";
+
+const ANALOG_OUTPUT_NAME: &str = "meter:analog-output";
+const SPDIF_OUTPUT_NAME: &str = "meter:spdif-output";
+const ADAT_OUTPUT_NAME: &str = "meter:adat-output";
+
+impl<V> FormerMeterCtl<V>
     where V: FormerMeterSpec + AsRef<FormerMeterState> + AsMut<FormerMeterState>,
 {
-    const ANALOG_INPUT_NAME: &'a str = "meter:analog-input";
-    const SPDIF_INPUT_NAME: &'a str = "meter:spdif-input";
-    const ADAT_INPUT_NAME: &'a str = "meter:adat-input";
-    const STREAM_INPUT_NAME: &'a str = "meter:stream-input";
-
-    const ANALOG_OUTPUT_NAME: &'a str = "meter:analog-output";
-    const SPDIF_OUTPUT_NAME: &'a str = "meter:spdif-output";
-    const ADAT_OUTPUT_NAME: &'a str = "meter:adat-output";
-
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, card_cntr: &mut CardCntr, timeout_ms: u32)
         -> Result<(), Error>
         where U: RmeFfFormerMeterOperation<V>,
@@ -267,13 +267,13 @@ impl<'a, V> FormerMeterCtl<V>
 
         let s = self.state.as_ref();
         [
-            (Self::ANALOG_INPUT_NAME, s.analog_inputs.len()),
-            (Self::SPDIF_INPUT_NAME, s.spdif_inputs.len()),
-            (Self::ADAT_INPUT_NAME, s.adat_inputs.len()),
-            (Self::STREAM_INPUT_NAME, s.stream_inputs.len()),
-            (Self::ANALOG_OUTPUT_NAME, s.analog_outputs.len()),
-            (Self::SPDIF_OUTPUT_NAME, s.spdif_outputs.len()),
-            (Self::ADAT_OUTPUT_NAME, s.adat_outputs.len()),
+            (ANALOG_INPUT_NAME, s.analog_inputs.len()),
+            (SPDIF_INPUT_NAME, s.spdif_inputs.len()),
+            (ADAT_INPUT_NAME, s.adat_inputs.len()),
+            (STREAM_INPUT_NAME, s.stream_inputs.len()),
+            (ANALOG_OUTPUT_NAME, s.analog_outputs.len()),
+            (SPDIF_OUTPUT_NAME, s.spdif_outputs.len()),
+            (ADAT_OUTPUT_NAME, s.adat_outputs.len()),
         ].iter()
             .try_for_each(|&(name, count)| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
@@ -299,31 +299,31 @@ impl<'a, V> FormerMeterCtl<V>
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::ANALOG_INPUT_NAME => {
+            ANALOG_INPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().analog_inputs);
                 Ok(true)
             }
-            Self::SPDIF_INPUT_NAME => {
+            SPDIF_INPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().spdif_inputs);
                 Ok(true)
             }
-            Self::ADAT_INPUT_NAME => {
+            ADAT_INPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().adat_inputs);
                 Ok(true)
             }
-            Self::STREAM_INPUT_NAME => {
+            STREAM_INPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().stream_inputs);
                 Ok(true)
             }
-            Self::ANALOG_OUTPUT_NAME => {
+            ANALOG_OUTPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().analog_outputs);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_NAME => {
+            SPDIF_OUTPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().spdif_outputs);
                 Ok(true)
             }
-            Self::ADAT_OUTPUT_NAME => {
+            ADAT_OUTPUT_NAME => {
                 elem_value.set_int(&self.state.as_ref().adat_outputs);
                 Ok(true)
             }

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -2,8 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::Error;
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use alsa_ctl_tlv_codec::items::DbInterval;
 
@@ -30,7 +32,7 @@ pub trait FormerOutputCtlOperation<U, V>
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut U,
+        req: &mut FwReq,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
     ) -> Result<(), Error> {
@@ -66,7 +68,7 @@ pub trait FormerOutputCtlOperation<U, V>
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut U,
+        req: &mut FwReq,
         elem_id: &ElemId,
         new: &ElemValue,
         timeout_ms: u32
@@ -105,7 +107,7 @@ where
     fn load(
         &mut self,
         unit: &SndUnit,
-        req: &mut U,
+        req: &mut FwReq,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
     ) -> Result<(), Error> {
@@ -208,7 +210,7 @@ where
     fn write(
         &mut self,
         unit: &SndUnit,
-        req: &mut U,
+        req: &mut FwReq,
         elem_id: &ElemId,
         new: &ElemValue,
         timeout_ms: u32
@@ -300,7 +302,7 @@ pub trait FormerMeterCtlOperation<S, T>
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut S,
+        req: &mut FwReq,
         card_cntr: &mut CardCntr,
         timeout_ms: u32
     ) -> Result<Vec<ElemId>, Error> {
@@ -337,7 +339,7 @@ pub trait FormerMeterCtlOperation<S, T>
     fn measure_states(
         &mut self,
         unit: &SndUnit,
-        req: &mut S,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         S::read_meter(req, &mut unit.get_node(), self.meter_mut(), timeout_ms)

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -21,19 +21,19 @@ pub struct FfLatterMeterCtl<V>
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a, V> FfLatterMeterCtl<V>
+const LINE_INPUT_METER: &str = "meter:line-input";
+const MIC_INPUT_METER: &str = "meter:mic-input";
+const SPDIF_INPUT_METER: &str = "meter:spdif-input";
+const ADAT_INPUT_METER: &str = "meter:adat-input";
+const STREAM_INPUT_METER: &str = "meter:stream-input";
+const LINE_OUTPUT_METER: &str = "meter:line-output";
+const HP_OUTPUT_METER: &str = "meter:hp-output";
+const SPDIF_OUTPUT_METER: &str = "meter:spdif-output";
+const ADAT_OUTPUT_METER: &str = "meter:adat-output";
+
+impl<V> FfLatterMeterCtl<V>
     where V: RmeFfLatterMeterSpec + AsRef<FfLatterMeterState> + AsMut<FfLatterMeterState>,
 {
-    const LINE_INPUT_METER: &'a str = "meter:line-input";
-    const MIC_INPUT_METER: &'a str = "meter:mic-input";
-    const SPDIF_INPUT_METER: &'a str = "meter:spdif-input";
-    const ADAT_INPUT_METER: &'a str = "meter:adat-input";
-    const STREAM_INPUT_METER: &'a str = "meter:stream-input";
-    const LINE_OUTPUT_METER: &'a str = "meter:line-output";
-    const HP_OUTPUT_METER: &'a str = "meter:hp-output";
-    const SPDIF_OUTPUT_METER: &'a str = "meter:spdif-output";
-    const ADAT_OUTPUT_METER: &'a str = "meter:adat-output";
-
     const LEVEL_MIN: i32 = 0x0;
     const LEVEL_MAX: i32 = 0x07fffff0;
     const LEVEL_STEP: i32 = 0x10;
@@ -46,15 +46,15 @@ impl<'a, V> FfLatterMeterCtl<V>
         U::read_meter(proto, &mut unit.get_node(), &mut self.state, timeout_ms)?;
 
         [
-            (Self::LINE_INPUT_METER, V::LINE_INPUT_COUNT),
-            (Self::MIC_INPUT_METER, V::MIC_INPUT_COUNT),
-            (Self::SPDIF_INPUT_METER, V::SPDIF_INPUT_COUNT),
-            (Self::ADAT_INPUT_METER, V::ADAT_INPUT_COUNT),
-            (Self::STREAM_INPUT_METER, V::STREAM_INPUT_COUNT),
-            (Self::LINE_OUTPUT_METER, V::LINE_OUTPUT_COUNT),
-            (Self::HP_OUTPUT_METER, V::HP_OUTPUT_COUNT),
-            (Self::SPDIF_OUTPUT_METER, V::SPDIF_OUTPUT_COUNT),
-            (Self::ADAT_OUTPUT_METER, V::ADAT_OUTPUT_COUNT),
+            (LINE_INPUT_METER, V::LINE_INPUT_COUNT),
+            (MIC_INPUT_METER, V::MIC_INPUT_COUNT),
+            (SPDIF_INPUT_METER, V::SPDIF_INPUT_COUNT),
+            (ADAT_INPUT_METER, V::ADAT_INPUT_COUNT),
+            (STREAM_INPUT_METER, V::STREAM_INPUT_COUNT),
+            (LINE_OUTPUT_METER, V::LINE_OUTPUT_COUNT),
+            (HP_OUTPUT_METER, V::HP_OUTPUT_COUNT),
+            (SPDIF_OUTPUT_METER, V::SPDIF_OUTPUT_COUNT),
+            (ADAT_OUTPUT_METER, V::ADAT_OUTPUT_COUNT),
         ].iter()
             .try_for_each(|(name, count)| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
@@ -81,39 +81,39 @@ impl<'a, V> FfLatterMeterCtl<V>
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::LINE_INPUT_METER => {
+            LINE_INPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().line_inputs);
                 Ok(true)
             }
-            Self::MIC_INPUT_METER => {
+            MIC_INPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().mic_inputs);
                 Ok(true)
             }
-            Self::SPDIF_INPUT_METER => {
+            SPDIF_INPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().spdif_inputs);
                 Ok(true)
             }
-            Self::ADAT_INPUT_METER => {
+            ADAT_INPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().adat_inputs);
                 Ok(true)
             }
-            Self::STREAM_INPUT_METER => {
+            STREAM_INPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().stream_inputs);
                 Ok(true)
             }
-            Self::LINE_OUTPUT_METER => {
+            LINE_OUTPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().line_outputs);
                 Ok(true)
             }
-            Self::HP_OUTPUT_METER => {
+            HP_OUTPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().hp_outputs);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_METER => {
+            SPDIF_OUTPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().spdif_outputs);
                 Ok(true)
             }
-            Self::ADAT_OUTPUT_METER => {
+            ADAT_OUTPUT_METER => {
                 elem_value.set_int(&self.state.as_ref().adat_outputs);
                 Ok(true)
             }
@@ -135,7 +135,7 @@ pub struct FfLatterDspCtl<V>
     fx_ctl: FfLatterFxCtl,
 }
 
-impl<'a, V> FfLatterDspCtl<V>
+impl<V> FfLatterDspCtl<V>
     where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
 {
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32, card_cntr: &mut CardCntr)
@@ -205,14 +205,14 @@ impl<'a, V> FfLatterDspCtl<V>
 #[derive(Default, Debug)]
 struct FfLatterInputCtl;
 
-impl<'a> FfLatterInputCtl {
-    const STEREO_LINK_NAME: &'a str = "input:stereo-link";
-    const LINE_GAIN_NAME: &'a str = "input:line-gain";
-    const LINE_LEVEL_NAME: &'a str = "input:line-level";
-    const MIC_POWER_NAME: &'a str = "input:mic-power";
-    const MIC_INST_NAME: &'a str = "input:mic-instrument";
-    const INVERT_PHASE_NAME: &'a str = "input:invert-phase";
+const INPUT_STEREO_LINK_NAME: &str = "input:stereo-link";
+const INPUT_LINE_GAIN_NAME: &str = "input:line-gain";
+const INPUT_LINE_LEVEL_NAME: &str = "input:line-level";
+const INPUT_MIC_POWER_NAME: &str = "input:mic-power";
+const INPUT_MIC_INST_NAME: &str = "input:mic-instrument";
+const INPUT_INVERT_PHASE_NAME: &str = "input:invert-phase";
 
+impl FfLatterInputCtl {
     const GAIN_MIN: i32 = 0;
     const GAIN_MAX: i32 = 120;
     const GAIN_STEP: i32 = 1;
@@ -233,10 +233,10 @@ impl<'a> FfLatterInputCtl {
 
         let s = &state.as_ref().input;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STEREO_LINK_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_STEREO_LINK_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.stereo_links.len(), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::LINE_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_LINE_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s.line_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
@@ -244,16 +244,16 @@ impl<'a> FfLatterInputCtl {
         let labels: Vec<String> = Self::LINE_LEVELS.iter()
             .map(|l| latter_line_in_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::LINE_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_LINE_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, s.line_levels.len(), &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIC_POWER_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_MIC_POWER_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.mic_powers.len(), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIC_INST_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_MIC_INST_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.mic_insts.len(), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::INVERT_PHASE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_INVERT_PHASE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.invert_phases.len(), true)?;
 
         Ok(())
@@ -264,18 +264,18 @@ impl<'a> FfLatterInputCtl {
         where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::STEREO_LINK_NAME => {
+            INPUT_STEREO_LINK_NAME => {
                 elem_value.set_bool(&state.as_ref().input.stereo_links);
                 Ok(true)
             }
-            Self::LINE_GAIN_NAME => {
+            INPUT_LINE_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().input.line_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::LINE_LEVEL_NAME => {
+            INPUT_LINE_LEVEL_NAME => {
                 let vals: Vec<u32> = state.as_ref().input.line_levels.iter()
                     .map(|level| {
                         let pos = Self::LINE_LEVELS.iter()
@@ -287,15 +287,15 @@ impl<'a> FfLatterInputCtl {
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
-            Self::MIC_POWER_NAME => {
+            INPUT_MIC_POWER_NAME => {
                 elem_value.set_bool(&state.as_ref().input.mic_powers);
                 Ok(true)
             }
-            Self::MIC_INST_NAME => {
+            INPUT_MIC_INST_NAME => {
                 elem_value.set_bool(&state.as_ref().input.mic_insts);
                 Ok(true)
             }
-            Self::INVERT_PHASE_NAME => {
+            INPUT_INVERT_PHASE_NAME => {
                 elem_value.set_bool(&state.as_ref().input.invert_phases);
                 Ok(true)
             }
@@ -310,13 +310,13 @@ impl<'a> FfLatterInputCtl {
               V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::STEREO_LINK_NAME => {
+            INPUT_STEREO_LINK_NAME => {
                 let mut s = state.as_ref().input.clone();
                 elem_value.get_bool(&mut s.stereo_links);
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::LINE_GAIN_NAME => {
+            INPUT_LINE_GAIN_NAME => {
                 let mut s = state.as_ref().input.clone();
                 let mut vals = vec![0;s.line_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -326,7 +326,7 @@ impl<'a> FfLatterInputCtl {
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::LINE_LEVEL_NAME => {
+            INPUT_LINE_LEVEL_NAME => {
                 let mut s = state.as_mut().input.clone();
                 let mut vals = vec![0;s.line_levels.len()];
                 elem_value.get_enum(&mut vals);
@@ -344,19 +344,19 @@ impl<'a> FfLatterInputCtl {
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::MIC_POWER_NAME => {
+            INPUT_MIC_POWER_NAME => {
                 let mut s = state.as_ref().input.clone();
                 elem_value.get_bool(&mut s.mic_powers);
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::MIC_INST_NAME => {
+            INPUT_MIC_INST_NAME => {
                 let mut s = state.as_ref().input.clone();
                 elem_value.get_bool(&mut s.mic_insts);
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::INVERT_PHASE_NAME => {
+            INPUT_INVERT_PHASE_NAME => {
                 let mut s = state.as_ref().input.clone();
                 elem_value.get_bool(&mut s.invert_phases);
                 U::write_input(proto, &mut unit.get_node(), state, s, timeout_ms)
@@ -370,13 +370,13 @@ impl<'a> FfLatterInputCtl {
 #[derive(Default, Debug)]
 struct FfLatterOutputCtl;
 
-impl<'a> FfLatterOutputCtl {
-    const VOL_NAME: &'a str = "output:volume";
-    const STEREO_BALANCE_NAME: &'a str = "output:stereo-balance";
-    const STEREO_LINK_NAME: &'a str = "output:stereo-link";
-    const INVERT_PHASE_NAME: &'a str = "output:invert-phase";
-    const LINE_LEVEL_NAME: &'a str = "output:line-level";
+const VOL_NAME: &str = "output:volume";
+const STEREO_BALANCE_NAME: &str = "output:stereo-balance";
+const STEREO_LINK_NAME: &str = "output:stereo-link";
+const INVERT_PHASE_NAME: &str = "output:invert-phase";
+const LINE_LEVEL_NAME: &str = "output:line-level";
 
+impl FfLatterOutputCtl {
     const VOL_MIN: i32 = -650;
     const VOL_MAX: i32 = 60;
     const VOL_STEP: i32 = 1;
@@ -404,25 +404,25 @@ impl<'a> FfLatterOutputCtl {
 
         let s = &state.as_ref().output;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::VOL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, Self::VOL_MIN, Self::VOL_MAX, Self::VOL_STEP,
                                         s.vols.len(), Some(&Vec::<u32>::from(&Self::VOL_TLV)),
                                         true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STEREO_BALANCE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, STEREO_BALANCE_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, Self::BALANCE_MIN, Self::BALANCE_MAX, Self::BALANCE_STEP,
                                         s.stereo_balance.len(), None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STEREO_LINK_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, STEREO_LINK_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.stereo_links.len(), true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::INVERT_PHASE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INVERT_PHASE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, s.invert_phases.len(), true)?;
 
         let labels: Vec<String> = Self::LINE_LEVELS.iter()
             .map(|l| line_out_nominal_level_to_string(l))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::LINE_LEVEL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, LINE_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, s.line_levels.len(), &labels, None, true)?;
 
         Ok(())
@@ -433,29 +433,29 @@ impl<'a> FfLatterOutputCtl {
         where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::VOL_NAME => {
+            VOL_NAME => {
                 let vals: Vec<i32> = state.as_ref().output.vols.iter()
                     .map(|&vol| vol as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::STEREO_BALANCE_NAME => {
+            STEREO_BALANCE_NAME => {
                 let vals: Vec<i32> = state.as_ref().output.stereo_balance.iter()
                     .map(|&balance| balance as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::STEREO_LINK_NAME => {
+            STEREO_LINK_NAME => {
                 elem_value.set_bool(&state.as_ref().output.stereo_links);
                 Ok(true)
             }
-            Self::INVERT_PHASE_NAME => {
+            INVERT_PHASE_NAME => {
                 elem_value.set_bool(&state.as_ref().output.invert_phases);
                 Ok(true)
             }
-            Self::LINE_LEVEL_NAME => {
+            LINE_LEVEL_NAME => {
                 let vals: Vec<u32> = state.as_ref().output.line_levels.iter()
                     .map(|level| {
                         let pos = Self::LINE_LEVELS.iter()
@@ -478,7 +478,7 @@ impl<'a> FfLatterOutputCtl {
               V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::VOL_NAME => {
+            VOL_NAME => {
                 let mut s = state.as_ref().output.clone();
                 let mut vals = vec![0;s.vols.len()];
                 elem_value.get_int(&mut vals);
@@ -488,7 +488,7 @@ impl<'a> FfLatterOutputCtl {
                 U::write_output(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::STEREO_BALANCE_NAME  => {
+            STEREO_BALANCE_NAME  => {
                 let mut s = state.as_ref().output.clone();
                 let mut vals = vec![0;s.stereo_balance.len()];
                 elem_value.get_int(&mut vals);
@@ -498,19 +498,19 @@ impl<'a> FfLatterOutputCtl {
                 U::write_output(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::STEREO_LINK_NAME => {
+            STEREO_LINK_NAME => {
                 let mut s = state.as_ref().output.clone();
                 elem_value.get_bool(&mut s.stereo_links);
                 U::write_output(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::INVERT_PHASE_NAME => {
+            INVERT_PHASE_NAME => {
                 let mut s = state.as_ref().output.clone();
                 elem_value.get_bool(&mut s.invert_phases);
                 U::write_output(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::LINE_LEVEL_NAME => {
+            LINE_LEVEL_NAME => {
                 let mut s = state.as_ref().output.clone();
                 let mut vals = vec![0;s.line_levels.len()];
                 elem_value.get_enum(&mut vals);
@@ -536,13 +536,13 @@ impl<'a> FfLatterOutputCtl {
 #[derive(Default, Debug)]
 struct FfLatterMixerCtl;
 
-impl<'a> FfLatterMixerCtl {
-    const LINE_SRC_GAIN_NAME: &'a str = "mixer:line-source-gain";
-    const MIC_SRC_GAIN_NAME: &'a str = "mixer:mic-source-gain";
-    const SPDIF_SRC_GAIN_NAME: &'a str = "mixer:spdif-source-gain";
-    const ADAT_SRC_GAIN_NAME: &'a str = "mixer:adat-source-gain";
-    const STREAM_SRC_GAIN_NAME: &'a str = "mixer:stream-source-gain";
+const MIXER_LINE_SRC_GAIN_NAME: &str = "mixer:line-source-gain";
+const MIXER_MIC_SRC_GAIN_NAME: &str = "mixer:mic-source-gain";
+const MIXER_SPDIF_SRC_GAIN_NAME: &str = "mixer:spdif-source-gain";
+const MIXER_ADAT_SRC_GAIN_NAME: &str = "mixer:adat-source-gain";
+const MIXER_STREAM_SRC_GAIN_NAME: &str = "mixer:stream-source-gain";
 
+impl FfLatterMixerCtl {
     const GAIN_MIN: i32 = 0x0000 as i32;
     const GAIN_ZERO: i32 = 0x9000 as i32;
     const GAIN_MAX: i32 = 0xa000 as i32;
@@ -567,27 +567,27 @@ impl<'a> FfLatterMixerCtl {
 
         let s = &state.as_ref().mixer;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::LINE_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_LINE_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, s.len(), Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s[0].line_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::MIC_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_MIC_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, s.len(), Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s[0].mic_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::SPDIF_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SPDIF_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, s.len(), Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s[0].spdif_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ADAT_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_ADAT_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, s.len(), Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s[0].adat_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STREAM_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_STREAM_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, s.len(), Self::GAIN_MIN, Self::GAIN_MAX, Self::GAIN_STEP,
                                         s[0].stream_gains.len(), Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                                         true)?;
@@ -600,7 +600,7 @@ impl<'a> FfLatterMixerCtl {
         where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::LINE_SRC_GAIN_NAME => {
+            MIXER_LINE_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let vals: Vec<i32> = state.as_ref().mixer[index].line_gains.iter()
                     .map(|&gain| gain as i32)
@@ -608,7 +608,7 @@ impl<'a> FfLatterMixerCtl {
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::MIC_SRC_GAIN_NAME => {
+            MIXER_MIC_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let vals: Vec<i32> = state.as_ref().mixer[index].mic_gains.iter()
                     .map(|&gain| gain as i32)
@@ -616,7 +616,7 @@ impl<'a> FfLatterMixerCtl {
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            MIXER_SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let vals: Vec<i32> = state.as_ref().mixer[index].spdif_gains.iter()
                     .map(|&gain| gain as i32)
@@ -624,7 +624,7 @@ impl<'a> FfLatterMixerCtl {
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            MIXER_ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let vals: Vec<i32> = state.as_ref().mixer[index].adat_gains.iter()
                     .map(|&gain| gain as i32)
@@ -632,7 +632,7 @@ impl<'a> FfLatterMixerCtl {
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            MIXER_STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let vals: Vec<i32> = state.as_ref().mixer[index].stream_gains.iter()
                     .map(|&gain| gain as i32)
@@ -651,7 +651,7 @@ impl<'a> FfLatterMixerCtl {
               V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::LINE_SRC_GAIN_NAME => {
+            MIXER_LINE_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut s = state.as_ref().mixer[index].clone();
                 let mut vals = vec![0;s.line_gains.len()];
@@ -662,7 +662,7 @@ impl<'a> FfLatterMixerCtl {
                 U::write_mixer(proto, &mut unit.get_node(), state, index, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::MIC_SRC_GAIN_NAME => {
+            MIXER_MIC_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut s = state.as_ref().mixer[index].clone();
                 let mut vals = vec![0;s.mic_gains.len()];
@@ -673,7 +673,7 @@ impl<'a> FfLatterMixerCtl {
                 U::write_mixer(proto, &mut unit.get_node(), state, index, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            MIXER_SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut s = state.as_ref().mixer[index].clone();
                 let mut vals = vec![0;s.spdif_gains.len()];
@@ -684,7 +684,7 @@ impl<'a> FfLatterMixerCtl {
                 U::write_mixer(proto, &mut unit.get_node(), state, index, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            MIXER_ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut s = state.as_ref().mixer[index].clone();
                 let mut vals = vec![0;s.adat_gains.len()];
@@ -695,7 +695,7 @@ impl<'a> FfLatterMixerCtl {
                 U::write_mixer(proto, &mut unit.get_node(), state, index, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            MIXER_STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.get_index() as usize;
                 let mut s = state.as_ref().mixer[index].clone();
                 let mut vals = vec![0;s.stream_gains.len()];
@@ -728,39 +728,39 @@ fn eq_type_to_string(eq_type: &FfLatterChStripEqType) -> String {
     }.to_string()
 }
 
-trait RmeFfLatterChStripCtl<'a, T>
+trait RmeFfLatterChStripCtl<T>
     where T: AsMut<FfLatterChStripState> + AsRef<FfLatterChStripState>,
 {
-    const HPF_ACTIVATE_NAME: &'a str;
-    const HPF_CUT_OFF_NAME: &'a str;
-    const HPF_ROLL_OFF_NAME: &'a str;
+    const HPF_ACTIVATE_NAME: &'static str;
+    const HPF_CUT_OFF_NAME: &'static str;
+    const HPF_ROLL_OFF_NAME: &'static str;
 
-    const EQ_ACTIVATE_NAME: &'a str;
-    const EQ_LOW_TYPE_NAME: &'a str;
-    const EQ_LOW_GAIN_NAME: &'a str;
-    const EQ_LOW_FREQ_NAME: &'a str;
-    const EQ_LOW_QUALITY_NAME: &'a str;
-    const EQ_MIDDLE_GAIN_NAME: &'a str;
-    const EQ_MIDDLE_FREQ_NAME: &'a str;
-    const EQ_MIDDLE_QUALITY_NAME: &'a str;
-    const EQ_HIGH_TYPE_NAME: &'a str;
-    const EQ_HIGH_GAIN_NAME: &'a str;
-    const EQ_HIGH_FREQ_NAME: &'a str;
-    const EQ_HIGH_QUALITY_NAME: &'a str;
+    const EQ_ACTIVATE_NAME: &'static str;
+    const EQ_LOW_TYPE_NAME: &'static str;
+    const EQ_LOW_GAIN_NAME: &'static str;
+    const EQ_LOW_FREQ_NAME: &'static str;
+    const EQ_LOW_QUALITY_NAME: &'static str;
+    const EQ_MIDDLE_GAIN_NAME: &'static str;
+    const EQ_MIDDLE_FREQ_NAME: &'static str;
+    const EQ_MIDDLE_QUALITY_NAME: &'static str;
+    const EQ_HIGH_TYPE_NAME: &'static str;
+    const EQ_HIGH_GAIN_NAME: &'static str;
+    const EQ_HIGH_FREQ_NAME: &'static str;
+    const EQ_HIGH_QUALITY_NAME: &'static str;
 
-    const DYN_ACTIVATE_NAME: &'a str;
-    const DYN_GAIN_NAME: &'a str;
-    const DYN_ATTACK_NAME: &'a str;
-    const DYN_RELEASE_NAME: &'a str;
-    const DYN_COMP_THRESHOLD_NAME: &'a str;
-    const DYN_COMP_RATIO_NAME: &'a str;
-    const DYN_EX_THRESHOLD_NAME: &'a str;
-    const DYN_EX_RATIO_NAME: &'a str;
+    const DYN_ACTIVATE_NAME: &'static str;
+    const DYN_GAIN_NAME: &'static str;
+    const DYN_ATTACK_NAME: &'static str;
+    const DYN_RELEASE_NAME: &'static str;
+    const DYN_COMP_THRESHOLD_NAME: &'static str;
+    const DYN_COMP_RATIO_NAME: &'static str;
+    const DYN_EX_THRESHOLD_NAME: &'static str;
+    const DYN_EX_RATIO_NAME: &'static str;
 
-    const AUTOLEVEL_ACTIVATE_NAME: &'a str;
-    const AUTOLEVEL_MAX_GAIN_NAME: &'a str;
-    const AUTOLEVEL_HEAD_ROOM_NAME: &'a str;
-    const AUTOLEVEL_RISE_TIME_NAME: &'a str;
+    const AUTOLEVEL_ACTIVATE_NAME: &'static str;
+    const AUTOLEVEL_MAX_GAIN_NAME: &'static str;
+    const AUTOLEVEL_HEAD_ROOM_NAME: &'static str;
+    const AUTOLEVEL_RISE_TIME_NAME: &'static str;
 
     const HPF_ROLL_OFF_LEVELS: [FfLatterHpfRollOffLevel;4] = [
         FfLatterHpfRollOffLevel::L6,
@@ -1358,73 +1358,73 @@ trait RmeFfLatterChStripCtl<'a, T>
 #[derive(Default, Debug)]
 struct FfLatterInputChStripCtl;
 
-impl<'a> RmeFfLatterChStripCtl<'a, FfLatterInputChStripState> for FfLatterInputChStripCtl {
-    const HPF_ACTIVATE_NAME: &'a str = "input:hpf-activate";
-    const HPF_CUT_OFF_NAME: &'a str = "input:hpf-cut-off";
-    const HPF_ROLL_OFF_NAME: &'a str = "input:hpf-roll-off";
+impl RmeFfLatterChStripCtl<FfLatterInputChStripState> for FfLatterInputChStripCtl {
+    const HPF_ACTIVATE_NAME: &'static str = "input:hpf-activate";
+    const HPF_CUT_OFF_NAME: &'static str = "input:hpf-cut-off";
+    const HPF_ROLL_OFF_NAME: &'static str = "input:hpf-roll-off";
 
-    const EQ_ACTIVATE_NAME: &'a str = "input:eq-activate";
-    const EQ_LOW_TYPE_NAME: &'a str = "input:eq-low-type";
-    const EQ_LOW_GAIN_NAME: &'a str = "input:eq-low-gain";
-    const EQ_LOW_FREQ_NAME: &'a str = "input:eq-low-freq";
-    const EQ_LOW_QUALITY_NAME: &'a str = "input:eq-low-quality";
-    const EQ_MIDDLE_GAIN_NAME: &'a str = "input:eq-middle-gain";
-    const EQ_MIDDLE_FREQ_NAME: &'a str = "input:eq-middle-freq";
-    const EQ_MIDDLE_QUALITY_NAME: &'a str = "input:eq-middle-quality";
-    const EQ_HIGH_TYPE_NAME: &'a str = "input:eq-high-type";
-    const EQ_HIGH_GAIN_NAME: &'a str = "input:eq-high-gain";
-    const EQ_HIGH_FREQ_NAME: &'a str = "input:eq-high-freq";
-    const EQ_HIGH_QUALITY_NAME: &'a str = "input:eq-high-quality";
+    const EQ_ACTIVATE_NAME: &'static str = "input:eq-activate";
+    const EQ_LOW_TYPE_NAME: &'static str = "input:eq-low-type";
+    const EQ_LOW_GAIN_NAME: &'static str = "input:eq-low-gain";
+    const EQ_LOW_FREQ_NAME: &'static str = "input:eq-low-freq";
+    const EQ_LOW_QUALITY_NAME: &'static str = "input:eq-low-quality";
+    const EQ_MIDDLE_GAIN_NAME: &'static str = "input:eq-middle-gain";
+    const EQ_MIDDLE_FREQ_NAME: &'static str = "input:eq-middle-freq";
+    const EQ_MIDDLE_QUALITY_NAME: &'static str = "input:eq-middle-quality";
+    const EQ_HIGH_TYPE_NAME: &'static str = "input:eq-high-type";
+    const EQ_HIGH_GAIN_NAME: &'static str = "input:eq-high-gain";
+    const EQ_HIGH_FREQ_NAME: &'static str = "input:eq-high-freq";
+    const EQ_HIGH_QUALITY_NAME: &'static str = "input:eq-high-quality";
 
-    const DYN_ACTIVATE_NAME: &'a str = "input:dyn-activate";
-    const DYN_GAIN_NAME: &'a str = "input:dyn-gain";
-    const DYN_ATTACK_NAME: &'a str = "input:dyn-attack";
-    const DYN_RELEASE_NAME: &'a str = "input:dyn-release";
-    const DYN_COMP_THRESHOLD_NAME: &'a str = "input:dyn-compressor-threshold";
-    const DYN_COMP_RATIO_NAME: &'a str = "input:dyn-compressor-ratio";
-    const DYN_EX_THRESHOLD_NAME: &'a str = "input:dyn-expander-threshold";
-    const DYN_EX_RATIO_NAME: &'a str =  "input:dyn-expander-ratio";
+    const DYN_ACTIVATE_NAME: &'static str = "input:dyn-activate";
+    const DYN_GAIN_NAME: &'static str = "input:dyn-gain";
+    const DYN_ATTACK_NAME: &'static str = "input:dyn-attack";
+    const DYN_RELEASE_NAME: &'static str = "input:dyn-release";
+    const DYN_COMP_THRESHOLD_NAME: &'static str = "input:dyn-compressor-threshold";
+    const DYN_COMP_RATIO_NAME: &'static str = "input:dyn-compressor-ratio";
+    const DYN_EX_THRESHOLD_NAME: &'static str = "input:dyn-expander-threshold";
+    const DYN_EX_RATIO_NAME: &'static str =  "input:dyn-expander-ratio";
 
-    const AUTOLEVEL_ACTIVATE_NAME: &'a str = "input:autolevel-activate";
-    const AUTOLEVEL_MAX_GAIN_NAME: &'a str = "input:autolevel-max-gain";
-    const AUTOLEVEL_HEAD_ROOM_NAME: &'a str = "input:autolevel-head-room";
-    const AUTOLEVEL_RISE_TIME_NAME: &'a str = "input:autolevel-rise-time";
+    const AUTOLEVEL_ACTIVATE_NAME: &'static str = "input:autolevel-activate";
+    const AUTOLEVEL_MAX_GAIN_NAME: &'static str = "input:autolevel-max-gain";
+    const AUTOLEVEL_HEAD_ROOM_NAME: &'static str = "input:autolevel-head-room";
+    const AUTOLEVEL_RISE_TIME_NAME: &'static str = "input:autolevel-rise-time";
 }
 
 #[derive(Default, Debug)]
 struct FfLatterOutputChStripCtl;
 
-impl<'a> RmeFfLatterChStripCtl<'a, FfLatterOutputChStripState> for FfLatterOutputChStripCtl {
-    const HPF_ACTIVATE_NAME: &'a str = "output:hpf-activate";
-    const HPF_CUT_OFF_NAME: &'a str = "output:hpf-cut-off";
-    const HPF_ROLL_OFF_NAME: &'a str = "output:hpf-roll-off";
+impl RmeFfLatterChStripCtl<FfLatterOutputChStripState> for FfLatterOutputChStripCtl {
+    const HPF_ACTIVATE_NAME: &'static str = "output:hpf-activate";
+    const HPF_CUT_OFF_NAME: &'static str = "output:hpf-cut-off";
+    const HPF_ROLL_OFF_NAME: &'static str = "output:hpf-roll-off";
 
-    const EQ_ACTIVATE_NAME: &'a str = "output:eq-activate";
-    const EQ_LOW_TYPE_NAME: &'a str = "output:eq-low-type";
-    const EQ_LOW_GAIN_NAME: &'a str = "output:eq-low-gain";
-    const EQ_LOW_FREQ_NAME: &'a str = "output:eq-low-freq";
-    const EQ_LOW_QUALITY_NAME: &'a str = "output:eq-low-quality";
-    const EQ_MIDDLE_GAIN_NAME: &'a str = "output:eq-middle-gain";
-    const EQ_MIDDLE_FREQ_NAME: &'a str = "output:eq-middle-freq";
-    const EQ_MIDDLE_QUALITY_NAME: &'a str = "output:eq-middle-quality";
-    const EQ_HIGH_TYPE_NAME: &'a str = "output:eq-high-type";
-    const EQ_HIGH_GAIN_NAME: &'a str = "output:eq-high-gain";
-    const EQ_HIGH_FREQ_NAME: &'a str = "output:eq-high-freq";
-    const EQ_HIGH_QUALITY_NAME: &'a str = "output:eq-high-quality";
+    const EQ_ACTIVATE_NAME: &'static str = "output:eq-activate";
+    const EQ_LOW_TYPE_NAME: &'static str = "output:eq-low-type";
+    const EQ_LOW_GAIN_NAME: &'static str = "output:eq-low-gain";
+    const EQ_LOW_FREQ_NAME: &'static str = "output:eq-low-freq";
+    const EQ_LOW_QUALITY_NAME: &'static str = "output:eq-low-quality";
+    const EQ_MIDDLE_GAIN_NAME: &'static str = "output:eq-middle-gain";
+    const EQ_MIDDLE_FREQ_NAME: &'static str = "output:eq-middle-freq";
+    const EQ_MIDDLE_QUALITY_NAME: &'static str = "output:eq-middle-quality";
+    const EQ_HIGH_TYPE_NAME: &'static str = "output:eq-high-type";
+    const EQ_HIGH_GAIN_NAME: &'static str = "output:eq-high-gain";
+    const EQ_HIGH_FREQ_NAME: &'static str = "output:eq-high-freq";
+    const EQ_HIGH_QUALITY_NAME: &'static str = "output:eq-high-quality";
 
-    const DYN_ACTIVATE_NAME: &'a str = "output:dyn-activate";
-    const DYN_GAIN_NAME: &'a str = "output:dyn-gain";
-    const DYN_ATTACK_NAME: &'a str = "output:dyn-attack";
-    const DYN_RELEASE_NAME: &'a str = "output:dyn-release";
-    const DYN_COMP_THRESHOLD_NAME: &'a str = "output:dyn-compressor-threshold";
-    const DYN_COMP_RATIO_NAME: &'a str = "output:dyn-compressor-ratio";
-    const DYN_EX_THRESHOLD_NAME: &'a str = "output:dyn-expander-threshold";
-    const DYN_EX_RATIO_NAME: &'a str =  "output:dyn-expander-ratio";
+    const DYN_ACTIVATE_NAME: &'static str = "output:dyn-activate";
+    const DYN_GAIN_NAME: &'static str = "output:dyn-gain";
+    const DYN_ATTACK_NAME: &'static str = "output:dyn-attack";
+    const DYN_RELEASE_NAME: &'static str = "output:dyn-release";
+    const DYN_COMP_THRESHOLD_NAME: &'static str = "output:dyn-compressor-threshold";
+    const DYN_COMP_RATIO_NAME: &'static str = "output:dyn-compressor-ratio";
+    const DYN_EX_THRESHOLD_NAME: &'static str = "output:dyn-expander-threshold";
+    const DYN_EX_RATIO_NAME: &'static str =  "output:dyn-expander-ratio";
 
-    const AUTOLEVEL_ACTIVATE_NAME: &'a str = "output:autolevel-activate";
-    const AUTOLEVEL_MAX_GAIN_NAME: &'a str = "output:autolevel-max-gain";
-    const AUTOLEVEL_HEAD_ROOM_NAME: &'a str = "output:autolevel-head-room";
-    const AUTOLEVEL_RISE_TIME_NAME: &'a str = "output:autolevel-rise-time";
+    const AUTOLEVEL_ACTIVATE_NAME: &'static str = "output:autolevel-activate";
+    const AUTOLEVEL_MAX_GAIN_NAME: &'static str = "output:autolevel-max-gain";
+    const AUTOLEVEL_HEAD_ROOM_NAME: &'static str = "output:autolevel-head-room";
+    const AUTOLEVEL_RISE_TIME_NAME: &'static str = "output:autolevel-rise-time";
 }
 
 fn fx_reverb_type_to_string(reverb_type: &FfLatterFxReverbType) -> String {
@@ -1469,41 +1469,41 @@ fn fx_echo_lpf_freq_to_string(lpf_freq: &FfLatterFxEchoLpfFreq) -> String {
 #[derive(Default, Debug)]
 struct FfLatterFxCtl;
 
-impl<'a> FfLatterFxCtl {
-    const LINE_SRC_GAIN_NAME: &'a str = "fx:line-source-gain";
-    const MIC_SRC_GAIN_NAME: &'a str = "fx:mic-source-gain";
-    const SPDIF_SRC_GAIN_NAME: &'a str = "fx:spdif-source-gain";
-    const ADAT_SRC_GAIN_NAME: &'a str = "fx:adat-source-gain";
-    const STREAM_SRC_GAIN_NAME: &'a str = "fx:stream-source-gain";
+const LINE_SRC_GAIN_NAME: &str = "fx:line-source-gain";
+const MIC_SRC_GAIN_NAME: &str = "fx:mic-source-gain";
+const SPDIF_SRC_GAIN_NAME: &str = "fx:spdif-source-gain";
+const ADAT_SRC_GAIN_NAME: &str = "fx:adat-source-gain";
+const STREAM_SRC_GAIN_NAME: &str = "fx:stream-source-gain";
 
-    const LINE_OUT_VOL_NAME: &'a str = "fx:line-output-volume";
-    const HP_OUT_VOL_NAME: &'a str = "fx:hp-output-volume";
-    const SPDIF_OUT_VOL_NAME: &'a str = "fx:spdif-output-volume";
-    const ADAT_OUT_VOL_NAME: &'a str = "fx:adat-output-volume";
+const LINE_OUT_VOL_NAME: &str = "fx:line-output-volume";
+const HP_OUT_VOL_NAME: &str = "fx:hp-output-volume";
+const SPDIF_OUT_VOL_NAME: &str = "fx:spdif-output-volume";
+const ADAT_OUT_VOL_NAME: &str = "fx:adat-output-volume";
 
-    const REVERB_ACTIVATE_NAME: &'a str = "fx:reverb-activate";
-    const REVERB_TYPE_NAME: &'a str = "fx:reverb-type";
-    const REVERB_PRE_DELAY_NAME: &'a str = "fx:reverb-pre-delay";
-    const REVERB_PRE_HPF_FREQ_NAME: &'a str = "fx:reverb-pre-hpf-freq";
-    const REVERB_ROOM_SCALE_NAME: &'a str = "fx:reverb-room-scale";
-    const REVERB_ATTACK_NAME: &'a str = "fx:reverb-attack";
-    const REVERB_HOLD_NAME: &'a str = "fx:reverb-hold";
-    const REVERB_RELEASE_NAME: &'a str = "fx:reverb-release";
-    const REVERB_POST_LPF_FREQ_NAME: &'a str = "fx:reverb-post-lpf-freq";
-    const REVERB_TIME_NAME: &'a str = "fx:reverb-time";
-    const REVERB_DAMPING_NAME: &'a str = "fx:reverb-damping";
-    const REVERB_SMOOTH_NAME: &'a str = "fx:reverb-smooth";
-    const REVERB_VOL_NAME: &'a str = "fx:reverb-volume";
-    const REVERB_STEREO_WIDTH_NAME: &'a str = "fx:reverb-stereo-width";
+const REVERB_ACTIVATE_NAME: &str = "fx:reverb-activate";
+const REVERB_TYPE_NAME: &str = "fx:reverb-type";
+const REVERB_PRE_DELAY_NAME: &str = "fx:reverb-pre-delay";
+const REVERB_PRE_HPF_FREQ_NAME: &str = "fx:reverb-pre-hpf-freq";
+const REVERB_ROOM_SCALE_NAME: &str = "fx:reverb-room-scale";
+const REVERB_ATTACK_NAME: &str = "fx:reverb-attack";
+const REVERB_HOLD_NAME: &str = "fx:reverb-hold";
+const REVERB_RELEASE_NAME: &str = "fx:reverb-release";
+const REVERB_POST_LPF_FREQ_NAME: &str = "fx:reverb-post-lpf-freq";
+const REVERB_TIME_NAME: &str = "fx:reverb-time";
+const REVERB_DAMPING_NAME: &str = "fx:reverb-damping";
+const REVERB_SMOOTH_NAME: &str = "fx:reverb-smooth";
+const REVERB_VOL_NAME: &str = "fx:reverb-volume";
+const REVERB_STEREO_WIDTH_NAME: &str = "fx:reverb-stereo-width";
 
-    const ECHO_ACTIVATE_NAME: &'a str = "fx:echo-activate";
-    const ECHO_TYPE_NAME: &'a str = "fx:echo-type";
-    const ECHO_DELAY_NAME: &'a str = "fx:echo-delay";
-    const ECHO_FEEDBACK_NAME: &'a str = "fx:echo-feedback";
-    const ECHO_LPF_FREQ_NAME: &'a str = "fx:echo-lpf-freq";
-    const ECHO_VOL_NAME: &'a str = "fx:echo-volume";
-    const ECHO_STEREO_WIDTH_NAME: &'a str = "fx:echo-stereo-width";
+const ECHO_ACTIVATE_NAME: &str = "fx:echo-activate";
+const ECHO_TYPE_NAME: &str = "fx:echo-type";
+const ECHO_DELAY_NAME: &str = "fx:echo-delay";
+const ECHO_FEEDBACK_NAME: &str = "fx:echo-feedback";
+const ECHO_LPF_FREQ_NAME: &str = "fx:echo-lpf-freq";
+const ECHO_VOL_NAME: &str = "fx:echo-volume";
+const ECHO_STEREO_WIDTH_NAME: &str = "fx:echo-stereo-width";
 
+impl FfLatterFxCtl {
     const PHYS_LEVEL_MIN: i32 = -650;
     const PHYS_LEVEL_MAX: i32 = 0;
     const PHYS_LEVEL_STEP: i32 = 1;
@@ -1558,10 +1558,10 @@ impl<'a> FfLatterFxCtl {
         let s = state.as_ref();
 
         [
-            (Self::LINE_SRC_GAIN_NAME, &s.fx.line_input_gains),
-            (Self::MIC_SRC_GAIN_NAME, &s.fx.mic_input_gains),
-            (Self::SPDIF_SRC_GAIN_NAME, &s.fx.spdif_input_gains),
-            (Self::ADAT_SRC_GAIN_NAME, &s.fx.adat_input_gains),
+            (LINE_SRC_GAIN_NAME, &s.fx.line_input_gains),
+            (MIC_SRC_GAIN_NAME, &s.fx.mic_input_gains),
+            (SPDIF_SRC_GAIN_NAME, &s.fx.spdif_input_gains),
+            (ADAT_SRC_GAIN_NAME, &s.fx.adat_input_gains),
         ].iter()
             .try_for_each(|(name, gains)| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
@@ -1571,17 +1571,17 @@ impl<'a> FfLatterFxCtl {
                     .map(|_| ())
             })?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::STREAM_SRC_GAIN_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, STREAM_SRC_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1,
                                         Self::VIRT_LEVEL_MIN, Self::VIRT_LEVEL_MAX, Self::VIRT_LEVEL_STEP,
                                         s.fx.stream_input_gains.len(),
                                         Some(&Vec::<u32>::from(&Self::VIRT_LEVEL_TLV)), true)?;
 
         [
-            (Self::LINE_OUT_VOL_NAME, &s.fx.line_output_vols),
-            (Self::HP_OUT_VOL_NAME, &s.fx.hp_output_vols),
-            (Self::SPDIF_OUT_VOL_NAME, &s.fx.spdif_output_vols),
-            (Self::ADAT_OUT_VOL_NAME, &s.fx.adat_output_vols),
+            (LINE_OUT_VOL_NAME, &s.fx.line_output_vols),
+            (HP_OUT_VOL_NAME, &s.fx.hp_output_vols),
+            (SPDIF_OUT_VOL_NAME, &s.fx.spdif_output_vols),
+            (ADAT_OUT_VOL_NAME, &s.fx.adat_output_vols),
         ].iter()
             .try_for_each(|(name, vols)| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
@@ -1591,76 +1591,76 @@ impl<'a> FfLatterFxCtl {
                     .map(|_| ())
             })?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_ACTIVATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_ACTIVATE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::REVERB_TYPES.iter()
             .map(|t| fx_reverb_type_to_string(t))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_TYPE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_TYPE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_PRE_DELAY_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_PRE_DELAY_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 999, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_PRE_HPF_FREQ_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_PRE_HPF_FREQ_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 20, 500, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_ROOM_SCALE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_ROOM_SCALE_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 50, 300, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_ATTACK_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_ATTACK_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 5, 400, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_HOLD_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_HOLD_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 5, 400, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_RELEASE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_RELEASE_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 5, 500, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_POST_LPF_FREQ_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_POST_LPF_FREQ_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 200, 20000, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_TIME_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_TIME_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 1, 49, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_DAMPING_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_DAMPING_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 2000, 20000, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_SMOOTH_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_SMOOTH_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 100, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_VOL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, -650, 60, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_STEREO_WIDTH_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_STEREO_WIDTH_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 100, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_ACTIVATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_ACTIVATE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::ECHO_TYPES.iter()
             .map(|t| fx_echo_type_to_string(t))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_TYPE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_TYPE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_DELAY_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_DELAY_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 100, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_FEEDBACK_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_FEEDBACK_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 100, 1, 1, None, true)?;
 
         let labels: Vec<String> = Self::ECHO_LPF_FREQS.iter()
             .map(|t| fx_echo_lpf_freq_to_string(t))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_LPF_FREQ_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_LPF_FREQ_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_VOL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, -650, 0, 1, 1, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::ECHO_STEREO_WIDTH_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_STEREO_WIDTH_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1, 0, 100, 1, 1, None, true)?;
 
         Ok(())
@@ -1671,159 +1671,159 @@ impl<'a> FfLatterFxCtl {
         where V: RmeFfLatterDspSpec + AsRef<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::LINE_SRC_GAIN_NAME => {
+            LINE_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.line_input_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::MIC_SRC_GAIN_NAME => {
+            MIC_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.mic_input_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            SPDIF_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.spdif_input_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            ADAT_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.adat_input_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            STREAM_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.stream_input_gains.iter()
                     .map(|&gain| gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::LINE_OUT_VOL_NAME => {
+            LINE_OUT_VOL_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.line_output_vols.iter()
                     .map(|&vol| vol as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::HP_OUT_VOL_NAME => {
+            HP_OUT_VOL_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.hp_output_vols.iter()
                     .map(|&vol| vol as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::SPDIF_OUT_VOL_NAME => {
+            SPDIF_OUT_VOL_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.spdif_output_vols.iter()
                     .map(|&vol| vol as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::ADAT_OUT_VOL_NAME => {
+            ADAT_OUT_VOL_NAME => {
                 let vals: Vec<i32> = state.as_ref().fx.adat_output_vols.iter()
                     .map(|&vol| vol as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
-            Self::REVERB_ACTIVATE_NAME => {
+            REVERB_ACTIVATE_NAME => {
                 elem_value.set_bool(&[state.as_ref().fx.reverb.activate]);
                 Ok(true)
             }
-            Self::REVERB_TYPE_NAME => {
+            REVERB_TYPE_NAME => {
                 let val = Self::REVERB_TYPES.iter()
                     .position(|t| t.eq(&state.as_ref().fx.reverb.reverb_type))
                     .unwrap();
                 elem_value.set_enum(&[val as u32]);
                 Ok(true)
             }
-            Self::REVERB_PRE_DELAY_NAME => {
+            REVERB_PRE_DELAY_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.pre_delay as i32]);
                 Ok(true)
             }
-            Self::REVERB_PRE_HPF_FREQ_NAME => {
+            REVERB_PRE_HPF_FREQ_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.pre_hpf as i32]);
                 Ok(true)
             }
-            Self::REVERB_ROOM_SCALE_NAME => {
+            REVERB_ROOM_SCALE_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.room_scale as i32]);
                 Ok(true)
             }
-            Self::REVERB_ATTACK_NAME => {
+            REVERB_ATTACK_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.attack as i32]);
                 Ok(true)
             }
-            Self::REVERB_HOLD_NAME => {
+            REVERB_HOLD_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.hold as i32]);
                 Ok(true)
             }
-            Self::REVERB_RELEASE_NAME => {
+            REVERB_RELEASE_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.release as i32]);
                 Ok(true)
             }
-            Self::REVERB_POST_LPF_FREQ_NAME => {
+            REVERB_POST_LPF_FREQ_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.post_lpf as i32]);
                 Ok(true)
             }
-            Self::REVERB_TIME_NAME => {
+            REVERB_TIME_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.time as i32]);
                 Ok(true)
             }
-            Self::REVERB_DAMPING_NAME => {
+            REVERB_DAMPING_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.damping as i32]);
                 Ok(true)
             }
-            Self::REVERB_SMOOTH_NAME => {
+            REVERB_SMOOTH_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.smooth as i32]);
                 Ok(true)
             }
-            Self::REVERB_VOL_NAME => {
+            REVERB_VOL_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.volume as i32]);
                 Ok(true)
             }
-            Self::REVERB_STEREO_WIDTH_NAME => {
+            REVERB_STEREO_WIDTH_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.reverb.stereo_width as i32]);
                 Ok(true)
             }
-            Self::ECHO_ACTIVATE_NAME => {
+            ECHO_ACTIVATE_NAME => {
                 elem_value.set_bool(&[state.as_ref().fx.echo.activate]);
                 Ok(true)
             }
-            Self::ECHO_TYPE_NAME => {
+            ECHO_TYPE_NAME => {
                 let pos = Self::ECHO_TYPES.iter()
                     .position(|t| t.eq(&state.as_ref().fx.echo.echo_type))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::ECHO_DELAY_NAME => {
+            ECHO_DELAY_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.echo.delay as i32]);
                 Ok(true)
             }
-            Self::ECHO_FEEDBACK_NAME => {
+            ECHO_FEEDBACK_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.echo.feedback as i32]);
                 Ok(true)
             }
-            Self::ECHO_LPF_FREQ_NAME => {
+            ECHO_LPF_FREQ_NAME => {
                 let pos = Self::ECHO_LPF_FREQS.iter()
                     .position(|f| f.eq(&state.as_ref().fx.echo.lpf))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            Self::ECHO_VOL_NAME => {
+            ECHO_VOL_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.echo.volume as i32]);
                 Ok(true)
             }
-            Self::ECHO_STEREO_WIDTH_NAME => {
+            ECHO_STEREO_WIDTH_NAME => {
                 elem_value.set_int(&[state.as_ref().fx.echo.stereo_width as i32]);
                 Ok(true)
             }
@@ -1838,7 +1838,7 @@ impl<'a> FfLatterFxCtl {
               V: RmeFfLatterDspSpec + AsRef<FfLatterDspState> + AsMut<FfLatterDspState>,
     {
         match elem_id.get_name().as_str() {
-            Self::LINE_SRC_GAIN_NAME => {
+            LINE_SRC_GAIN_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.line_input_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -1848,7 +1848,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_input_gains(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::MIC_SRC_GAIN_NAME => {
+            MIC_SRC_GAIN_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.mic_input_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -1858,7 +1858,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_input_gains(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::SPDIF_SRC_GAIN_NAME => {
+            SPDIF_SRC_GAIN_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.spdif_input_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -1868,7 +1868,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_input_gains(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::ADAT_SRC_GAIN_NAME => {
+            ADAT_SRC_GAIN_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.adat_input_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -1878,7 +1878,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_input_gains(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::STREAM_SRC_GAIN_NAME => {
+            STREAM_SRC_GAIN_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.stream_input_gains.len()];
                 elem_value.get_int(&mut vals);
@@ -1888,7 +1888,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_input_gains(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::LINE_OUT_VOL_NAME => {
+            LINE_OUT_VOL_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.line_output_vols.len()];
                 elem_value.get_int(&mut vals);
@@ -1898,7 +1898,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_output_volumes(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::HP_OUT_VOL_NAME => {
+            HP_OUT_VOL_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.hp_output_vols.len()];
                 elem_value.get_int(&mut vals);
@@ -1908,7 +1908,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_output_volumes(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::SPDIF_OUT_VOL_NAME => {
+            SPDIF_OUT_VOL_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.spdif_output_vols.len()];
                 elem_value.get_int(&mut vals);
@@ -1918,7 +1918,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_output_volumes(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::ADAT_OUT_VOL_NAME => {
+            ADAT_OUT_VOL_NAME => {
                 let mut s = state.as_ref().fx.clone();
                 let mut vals = vec![0;s.adat_output_vols.len()];
                 elem_value.get_int(&mut vals);
@@ -1928,7 +1928,7 @@ impl<'a> FfLatterFxCtl {
                 U::write_fx_output_volumes(proto, &mut unit.get_node(), state, s, timeout_ms)
                     .map(|_| true)
             }
-            Self::REVERB_ACTIVATE_NAME => {
+            REVERB_ACTIVATE_NAME => {
                 let mut vals = [false];
                 elem_value.get_bool(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1937,7 +1937,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_TYPE_NAME => {
+            REVERB_TYPE_NAME => {
                 let mut vals = [0];
                 elem_value.get_enum(&mut vals);
                 let reverb_type = Self::REVERB_TYPES.iter()
@@ -1953,7 +1953,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_PRE_DELAY_NAME => {
+            REVERB_PRE_DELAY_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1962,7 +1962,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_PRE_HPF_FREQ_NAME => {
+            REVERB_PRE_HPF_FREQ_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1971,7 +1971,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_ROOM_SCALE_NAME => {
+            REVERB_ROOM_SCALE_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1980,7 +1980,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_ATTACK_NAME => {
+            REVERB_ATTACK_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1989,7 +1989,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_HOLD_NAME => {
+            REVERB_HOLD_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -1998,7 +1998,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_RELEASE_NAME => {
+            REVERB_RELEASE_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2007,7 +2007,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_POST_LPF_FREQ_NAME => {
+            REVERB_POST_LPF_FREQ_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2016,7 +2016,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_TIME_NAME => {
+            REVERB_TIME_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2025,7 +2025,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_DAMPING_NAME => {
+            REVERB_DAMPING_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2034,7 +2034,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_SMOOTH_NAME => {
+            REVERB_SMOOTH_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2043,7 +2043,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_VOL_NAME => {
+            REVERB_VOL_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2052,7 +2052,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::REVERB_STEREO_WIDTH_NAME => {
+            REVERB_STEREO_WIDTH_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_reverb(unit, proto, state, timeout_ms, |s| {
@@ -2061,7 +2061,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_ACTIVATE_NAME => {
+            ECHO_ACTIVATE_NAME => {
                 let mut vals = [false];
                 elem_value.get_bool(&mut vals);
                 Self::update_echo(unit, proto, state, timeout_ms, |s| {
@@ -2070,7 +2070,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_TYPE_NAME => {
+            ECHO_TYPE_NAME => {
                 let mut vals = [0];
                 elem_value.get_enum(&mut vals);
                 let echo_type = Self::ECHO_TYPES.iter()
@@ -2086,7 +2086,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_DELAY_NAME => {
+            ECHO_DELAY_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_echo(unit, proto, state, timeout_ms, |s| {
@@ -2095,7 +2095,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_FEEDBACK_NAME => {
+            ECHO_FEEDBACK_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_echo(unit, proto, state, timeout_ms, |s| {
@@ -2104,7 +2104,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_LPF_FREQ_NAME => {
+            ECHO_LPF_FREQ_NAME => {
                 let mut vals = [0];
                 elem_value.get_enum(&mut vals);
                 let lpf = Self::ECHO_LPF_FREQS.iter()
@@ -2120,7 +2120,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_VOL_NAME => {
+            ECHO_VOL_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_echo(unit, proto, state, timeout_ms, |s| {
@@ -2129,7 +2129,7 @@ impl<'a> FfLatterFxCtl {
                 })
                 .map(|_| true)
             }
-            Self::ECHO_STEREO_WIDTH_NAME => {
+            ECHO_STEREO_WIDTH_NAME => {
                 let mut vals = [0];
                 elem_value.get_int(&mut vals);
                 Self::update_echo(unit, proto, state, timeout_ms, |s| {

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -2,8 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use alsa_ctl_tlv_codec::items::DbInterval;
 
@@ -33,7 +35,7 @@ pub trait FfLatterMeterCtlOperation<T: RmeFfLatterMeterOperation> {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<Vec<ElemId>, Error> {
@@ -74,7 +76,7 @@ pub trait FfLatterMeterCtlOperation<T: RmeFfLatterMeterOperation> {
     fn measure_states(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         T::read_meter(req, &mut unit.get_node(), self.meter_mut(), timeout_ms)
@@ -157,7 +159,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>: FfLatterDspCt
     fn load_input(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -244,7 +246,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>: FfLatterDspCt
     fn write_input(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -331,7 +333,7 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>: FfLatterDsp
     fn load_output(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -425,7 +427,7 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>: FfLatterDsp
     fn write_output(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -504,7 +506,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>: FfLatterDspCt
     fn load_mixer(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -634,7 +636,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>: FfLatterDspCt
     fn write_mixer(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         new: &ElemValue,
         timeout_ms: u32
@@ -774,7 +776,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn load_ch_strip(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -1252,7 +1254,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn write_ch_strip(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -1549,7 +1551,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn update_hpf<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -1563,7 +1565,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn update_eq<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -1577,7 +1579,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn update_dynamics<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -1591,7 +1593,7 @@ pub trait FfLatterChStripCtlOperation<T, U>: FfLatterDspCtlOperation<T>
     fn update_autolevel<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -1790,7 +1792,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
     fn load_fx(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -2238,7 +2240,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
     fn write_fx(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -2551,7 +2553,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
     fn update_reverb<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -2565,7 +2567,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
     fn update_echo<F>(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         cb: F
     ) -> Result<(), Error>
@@ -2601,7 +2603,7 @@ where
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -2637,7 +2639,7 @@ where
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut T,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -41,9 +41,9 @@ impl<'a, V> FfLatterMeterCtl<V>
 
     pub fn load<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
-        where U: RmeFfLatterMeterProtocol<FwNode, V>,
+        where U: RmeFfLatterMeterOperation<V>,
     {
-        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)?;
+        U::read_meter(proto, &mut unit.get_node(), &mut self.state, timeout_ms)?;
 
         [
             (Self::LINE_INPUT_METER, V::LINE_INPUT_COUNT),
@@ -72,9 +72,9 @@ impl<'a, V> FfLatterMeterCtl<V>
 
     pub fn measure_states<U>(&mut self, unit: &SndUnit, proto: &U, timeout_ms: u32)
         -> Result<(), Error>
-        where U: RmeFfLatterMeterProtocol<FwNode, V>,
+        where U: RmeFfLatterMeterOperation<V>,
     {
-        proto.read_meter(&unit.get_node(), &mut self.state, timeout_ms)
+        U::read_meter(proto, &mut unit.get_node(), &mut self.state, timeout_ms)
     }
 
     pub fn read_measured_elem(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue)

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -339,7 +339,7 @@ impl<'a> StatusCtl {
     fn load(&mut self, unit: &SndUnit, proto: &FfUcxProtocol, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)?;
+        FfUcxProtocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
         [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
@@ -375,7 +375,7 @@ impl<'a> StatusCtl {
     fn measure_states(&mut self, unit: &SndUnit, proto: &FfUcxProtocol, timeout_ms: u32)
         -> Result<(), Error>
     {
-        proto.read_status(&unit.get_node(), &mut self.status, timeout_ms)
+        FfUcxProtocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -21,7 +21,7 @@ pub struct UcxModel{
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: MeterCtl,
-    dsp_ctl: FfLatterDspCtl<FfUcxDspState>,
+    dsp_ctl: DspCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -95,6 +95,19 @@ impl FfLatterMeterCtlOperation<FfUcxProtocol, FfUcxMeterState> for MeterCtl {
     }
 
     fn meter_mut(&mut self) -> &mut FfUcxMeterState {
+        &mut self.0
+    }
+}
+
+#[derive(Default, Debug)]
+struct DspCtl(FfLatterDspState);
+
+impl FfLatterDspCtlOperation<FfUcxProtocol> for DspCtl {
+    fn state(&self) -> &FfLatterDspState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut FfLatterDspState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -107,14 +107,14 @@ fn update_cfg<F>(unit: &SndUnit, proto: &FfUcxProtocol, cfg: &mut FfUcxConfig, t
 #[derive(Default, Debug)]
 struct CfgCtl(FfUcxConfig);
 
-impl<'a> CfgCtl {
-    const PRIMARY_CLK_SRC_NAME: &'a str = "primary-clock-source";
-    const OPT_OUTPUT_SIGNAL_NAME: &'a str = "optical-output-signal";
-    const EFFECT_ON_INPUT_NAME: &'a str = "effect-on-input";
-    const SPDIF_OUTPUT_FMT_NAME: &'a str = "spdif-output-format";
-    const WORD_CLOCK_SINGLE_SPPED_NAME: &'a str = "word-clock-single-speed";
-    const WORD_CLOCK_IN_TERMINATE_NAME: &'a str = "word-clock-input-terminate";
+const PRIMARY_CLK_SRC_NAME: &str = "primary-clock-source";
+const OPT_OUTPUT_SIGNAL_NAME: &str = "optical-output-signal";
+const EFFECT_ON_INPUT_NAME: &str = "effect-on-input";
+const SPDIF_OUTPUT_FMT_NAME: &str = "spdif-output-format";
+const WORD_CLOCK_SINGLE_SPPED_NAME: &str = "word-clock-single-speed";
+const WORD_CLOCK_IN_TERMINATE_NAME: &str = "word-clock-input-terminate";
 
+impl CfgCtl {
     const CLK_SRCS: [FfUcxClkSrc;4] = [
         FfUcxClkSrc::Internal,
         FfUcxClkSrc::Coax,
@@ -152,28 +152,28 @@ impl<'a> CfgCtl {
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PRIMARY_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, PRIMARY_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels: Vec<String> = Self::OPT_OUT_SIGNALS.iter()
             .map(|f| optical_output_signal_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OPT_OUTPUT_SIGNAL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_OUTPUT_SIGNAL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::EFFECT_ON_INPUT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EFFECT_ON_INPUT_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         let labels: Vec<String> = Self::SPDIF_FMTS.iter()
             .map(|f| spdif_format_to_string(f))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPDIF_OUTPUT_FMT_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_OUTPUT_FMT_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_SINGLE_SPPED_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_SINGLE_SPPED_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::WORD_CLOCK_IN_TERMINATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, WORD_CLOCK_IN_TERMINATE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         Ok(())
@@ -181,7 +181,7 @@ impl<'a> CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::CLK_SRCS.iter()
                         .position(|s| s.eq(&self.0.clk_src))
@@ -190,7 +190,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OPT_OUT_SIGNALS.iter()
                         .position(|f| f.eq(&self.0.opt_out_signal))
@@ -199,11 +199,11 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::EFFECT_ON_INPUT_NAME => {
+            EFFECT_ON_INPUT_NAME => {
                 elem_value.set_bool(&[self.0.effect_on_inputs]);
                 Ok(true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::SPDIF_FMTS.iter()
                         .position(|f| f.eq(&self.0.spdif_out_format))
@@ -212,11 +212,11 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
             }
-            Self::WORD_CLOCK_IN_TERMINATE_NAME => {
+            WORD_CLOCK_IN_TERMINATE_NAME => {
                 elem_value.set_bool(&[self.0.word_in_terminate]);
                 Ok(true)
             }
@@ -229,7 +229,7 @@ impl<'a> CfgCtl {
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {
-            Self::PRIMARY_CLK_SRC_NAME => {
+            PRIMARY_CLK_SRC_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         let src = Self::CLK_SRCS.iter()
@@ -244,7 +244,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::OPT_OUTPUT_SIGNAL_NAME => {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::OPT_OUT_SIGNALS.iter()
@@ -258,7 +258,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::EFFECT_ON_INPUT_NAME => {
+            EFFECT_ON_INPUT_NAME => {
                 let mut vals = [false];
                 elem_value.get_bool(&mut vals);
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
@@ -267,7 +267,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::SPDIF_OUTPUT_FMT_NAME => {
+            SPDIF_OUTPUT_FMT_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::SPDIF_FMTS.iter()
@@ -281,7 +281,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_SINGLE_SPPED_NAME => {
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                         cfg.word_out_single = val;
@@ -290,7 +290,7 @@ impl<'a> CfgCtl {
                 })
                 .map(|_| true)
             }
-            Self::WORD_CLOCK_IN_TERMINATE_NAME => {
+            WORD_CLOCK_IN_TERMINATE_NAME => {
                 update_cfg(unit, proto, &mut self.0, timeout_ms, |cfg| {
                     ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                         cfg.word_in_terminate = val;
@@ -310,13 +310,13 @@ struct StatusCtl{
     measured_elem_list: Vec<ElemId>,
 }
 
-impl<'a> StatusCtl {
-    const EXT_SRC_LOCK_NAME: &'a str = "external-source-lock";
-    const EXT_SRC_SYNC_NAME: &'a str = "external-source-sync";
-    const EXT_SRC_RATE_NAME: &'a str = "external-source-rate";
-    const ACTIVE_CLK_RATE_NAME: &'a str = "active-clock-rate";
-    const ACTIVE_CLK_SRC_NAME: &'a str = "active-clock-source";
+const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
+const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
+const EXT_SRC_RATE_NAME: &str = "external-source-rate";
+const ACTIVE_CLK_RATE_NAME: &str = "active-clock-rate";
+const ACTIVE_CLK_SRC_NAME: &str = "active-clock-source";
 
+impl StatusCtl {
     const EXT_CLK_SRCS: [FfUcxClkSrc;3] = [
         FfUcxClkSrc::Coax,
         FfUcxClkSrc::Opt,
@@ -341,7 +341,7 @@ impl<'a> StatusCtl {
     {
         FfUcxProtocol::read_status(proto, &mut unit.get_node(), &mut self.status, timeout_ms)?;
 
-        [Self::EXT_SRC_LOCK_NAME, Self::EXT_SRC_SYNC_NAME].iter()
+        [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME].iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr.add_bool_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), false)
@@ -351,21 +351,21 @@ impl<'a> StatusCtl {
         let labels: Vec<String> = Self::EXT_CLK_RATES.iter()
             .map(|r| optional_clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::EXT_SRC_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS.iter()
             .map(|r| clk_src_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_SRC_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_RATES.iter()
             .map(|r| clk_nominal_rate_to_string(r))
             .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::ACTIVE_CLK_RATE_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_RATE_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, false)
             .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
 
@@ -380,7 +380,7 @@ impl<'a> StatusCtl {
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::EXT_SRC_LOCK_NAME => {
+            EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.ext_lock.coax_iface,
                     self.status.ext_lock.opt_iface,
@@ -389,7 +389,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_SYNC_NAME => {
+            EXT_SRC_SYNC_NAME => {
                 let vals = [
                     self.status.ext_sync.coax_iface,
                     self.status.ext_sync.opt_iface,
@@ -398,7 +398,7 @@ impl<'a> StatusCtl {
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
-            Self::EXT_SRC_RATE_NAME => {
+            EXT_SRC_RATE_NAME => {
                 let vals: Vec<u32> = [
                     self.status.ext_rate.coax_iface,
                     self.status.ext_rate.opt_iface,
@@ -414,7 +414,7 @@ impl<'a> StatusCtl {
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_SRC_NAME => {
+            ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS.iter()
                     .position(|r| r.eq(&self.status.active_clk_src))
                     .map(|p| p as u32)
@@ -422,7 +422,7 @@ impl<'a> StatusCtl {
                 elem_value.set_enum(&[pos]);
                 Ok(true)
             }
-            Self::ACTIVE_CLK_RATE_NAME => {
+            ACTIVE_CLK_RATE_NAME => {
                 let pos = CfgCtl::CLK_RATES.iter()
                     .position(|r| r.eq(&self.status.active_clk_rate))
                     .map(|p| p as u32)

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -87,14 +87,14 @@ impl MeasureModel<SndUnit> for UcxModel {
 }
 
 #[derive(Default, Debug)]
-struct MeterCtl(FfUcxMeterState, Vec<ElemId>);
+struct MeterCtl(FfLatterMeterState, Vec<ElemId>);
 
-impl FfLatterMeterCtlOperation<FfUcxProtocol, FfUcxMeterState> for MeterCtl {
-    fn meter(&self) -> &FfUcxMeterState {
+impl FfLatterMeterCtlOperation<FfUcxProtocol> for MeterCtl {
+    fn meter(&self) -> &FfLatterMeterState{
         &self.0
     }
 
-    fn meter_mut(&mut self) -> &mut FfUcxMeterState {
+    fn meter_mut(&mut self) -> &mut FfLatterMeterState {
         &mut self.0
     }
 }

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -2,9 +2,10 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::{Error, FileError};
 
-use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
-
+use hinawa::FwReq;
 use hinawa::{SndUnit, SndUnitExt};
+
+use alsactl::{ElemId, ElemIfaceType, ElemValue, ElemValueExt, ElemValueExtManual};
 
 use core::card_cntr::*;
 use core::elem_value_accessor::*;
@@ -17,7 +18,7 @@ use super::latter_ctls::*;
 
 #[derive(Default, Debug)]
 pub struct UcxModel{
-    req: FfUcxProtocol,
+    req: FwReq,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     meter_ctl: MeterCtl,
@@ -123,7 +124,7 @@ fn clk_src_to_string(src: &FfUcxClkSrc) -> String {
 
 fn update_cfg<F>(
     unit: &mut SndUnit,
-    req: &mut FfUcxProtocol,
+    req: &mut FwReq,
     cfg: &mut FfUcxConfig,
     timeout_ms: u32,
     cb: F
@@ -179,7 +180,7 @@ impl CfgCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut FfUcxProtocol,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -267,7 +268,7 @@ impl CfgCtl {
     fn write(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut FfUcxProtocol,
+        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32
@@ -383,7 +384,7 @@ impl StatusCtl {
     fn load(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut FfUcxProtocol,
+        req: &mut FwReq,
         timeout_ms: u32,
         card_cntr: &mut CardCntr
     ) -> Result<(), Error> {
@@ -423,7 +424,7 @@ impl StatusCtl {
     fn measure_states(
         &mut self,
         unit: &mut SndUnit,
-        req: &mut FfUcxProtocol,
+        req: &mut FwReq,
         timeout_ms: u32
     ) -> Result<(), Error> {
         FfUcxProtocol::read_status(req, &mut unit.get_node(), &mut self.status, timeout_ms)

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -100,7 +100,7 @@ fn update_cfg<F>(unit: &SndUnit, proto: &FfUcxProtocol, cfg: &mut FfUcxConfig, t
 {
     let mut cache = cfg.clone();
     cb(&mut cache)?;
-    proto.write_cfg(&unit.get_node(), &cache, timeout_ms)
+    FfUcxProtocol::write_cfg(proto, &mut unit.get_node(), &cache, timeout_ms)
         .map(|_| *cfg = cache)
 }
 
@@ -147,7 +147,7 @@ impl<'a> CfgCtl {
     fn load(&mut self, unit: &SndUnit, proto: &FfUcxProtocol, timeout_ms: u32, card_cntr: &mut CardCntr)
         -> Result<(), Error>
     {
-        proto.write_cfg(&unit.get_node(), &self.0, timeout_ms)?;
+        FfUcxProtocol::write_cfg(proto, &mut unit.get_node(), &self.0, timeout_ms)?;
 
         let labels: Vec<String> = Self::CLK_SRCS.iter()
             .map(|s| clk_src_to_string(s))


### PR DESCRIPTION
This patchset is to obsolete usage of AsRef trait for FwReq and FwNode.

```
Takashi Sakamoto (26):
  ff-protocols: former: obsolete AsRef<FwNode> from trait of meter protocol
  ff-protocols: former: obsolete AsRef<FwNode> from trait of output protocol
  ff-protocols: former: obsolete AsRef<FwNode> from trait of mixer protocol
  ff-protocols: former: ff400: integrate input amplifier protocol
  ff-protocols: former: ff400: integrate status protocol
  ff-protocols: former: ff400: integrate configuration protocol
  ff-protocols: former: ff800: integrate status protocol
  ff-protocols: former: ff800: integrate configuration protocol
  ff-protocols: latter: obsolete AsRef<FwNode> from trait of configuration protocol
  ff-protocols: latter: obsolete AsRef<FwNode> from trait of status protocol
  ff-protocols: latter: obsolete AsRef<FwNode> from trait of meter protocol
  ff-protocols: latter: obsolete AsRef<FwNode> from trait of DSP protocol
  ff-runtime: code refactoring for useless lifetime of str
  ff-runtime: code refactoring for mutable reference of FwReq
  ff-runtime: former_ctls: code refactoring to use trait implementation for meter control
  ff-runtime: former_ctls: code refactoring to use trait implementation for output control
  ff-runtime: former_ctls: code refactoring to use trait implementation for mixer control
  ff-runtime: latter_ctls: code refactoring to use trait implementation for meter control
  ff-runtime: latter_ctls: use trait implementation for dsp controls
  ff-protocols: former: obsolete inclusive structure for protocol
  ff-protocols: former: integrate specification trait for meter state
  ff-protocols: former: integrate specification trait for output volume state
  ff-protocols: former: integrate specification trait for mixer state
  ff-protocols: latter: integrate specification trait for meter state
  ff-protocols: latter: obsolete inclusive protocol structure
  ff-protocols: latter: localize helper function for DSP command

 libs/ff/protocols/src/former.rs       |  322 ++--
 libs/ff/protocols/src/former/ff400.rs |  271 ++-
 libs/ff/protocols/src/former/ff800.rs |  164 +-
 libs/ff/protocols/src/latter.rs       | 1415 ++++++++------
 libs/ff/protocols/src/latter/ff802.rs |   66 +-
 libs/ff/protocols/src/latter/ucx.rs   |   66 +-
 libs/ff/runtime/src/ff400_model.rs    |  388 ++--
 libs/ff/runtime/src/ff800_model.rs    |  331 ++--
 libs/ff/runtime/src/ff802_model.rs    |  212 +-
 libs/ff/runtime/src/former_ctls.rs    |  437 +++--
 libs/ff/runtime/src/latter_ctls.rs    | 2565 +++++++++++++++----------
 libs/ff/runtime/src/ucx_model.rs      |  212 +-
 12 files changed, 3689 insertions(+), 2760 deletions(-)
```