### PR TITLE
[PATCH 00/13] dg00x/efw/tascam: code refactoring for runtime crate

### DIFF
--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -11,7 +11,7 @@ use efw_protocols::ClkSrc;
 use efw_protocols::hw_info::*;
 use efw_protocols::hw_ctl::*;
 
-fn clk_src_to_string(src: &ClkSrc) -> String {
+fn clk_src_to_str(src: &ClkSrc) -> &'static str {
     match src {
         ClkSrc::Internal => "Internal",
         ClkSrc::WordClock => "WordClock",
@@ -20,7 +20,7 @@ fn clk_src_to_string(src: &ClkSrc) -> String {
         ClkSrc::Adat2 => "ADAT2",
         ClkSrc::Continuous => "Continuous",
         ClkSrc::Reserved(_) => "Reserved",
-    }.to_string()
+    }
 }
 
 #[derive(Default)]
@@ -41,17 +41,13 @@ impl ClkCtl {
         self.srcs.extend_from_slice(&hwinfo.clk_srcs);
         self.rates.extend_from_slice(&hwinfo.clk_rates);
 
-        let labels = self.srcs.iter()
-            .map(|src| clk_src_to_string(src))
-            .collect::<Vec<String>>();
+        let labels: Vec<&str> = self.srcs.iter().map(|src| clk_src_to_str(src)).collect();
 
         let elem_id =
             alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let labels = hwinfo.clk_rates.iter()
-            .map(|rate| rate.to_string())
-            .collect::<Vec<String>>();
+        let labels: Vec<String> = hwinfo.clk_rates.iter().map(|rate| rate.to_string()).collect();
 
         let elem_id =
             alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, RATE_NAME, 0);

--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -28,10 +28,10 @@ pub struct ClkCtl {
     rates: Vec<u32>,
 }
 
-impl ClkCtl {
-    const SRC_NAME: &'static str = "clock-source";
-    const RATE_NAME: &'static str = "clock-rate";
+const SRC_NAME: &str = "clock-source";
+const RATE_NAME: &str = "clock-rate";
 
+impl ClkCtl {
     pub fn new() -> Self {
         ClkCtl {
             srcs: Vec::new(),
@@ -52,7 +52,7 @@ impl ClkCtl {
             .collect::<Vec<String>>();
 
         let elem_id =
-            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::SRC_NAME, 0);
+            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         let labels = hwinfo.clk_rates.iter()
@@ -60,7 +60,7 @@ impl ClkCtl {
             .collect::<Vec<String>>();
 
         let elem_id =
-            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, Self::RATE_NAME, 0);
+            alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         Ok(())
@@ -74,7 +74,7 @@ impl ClkCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::SRC_NAME => {
+            SRC_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let (src, _) = unit.get_clock(timeout_ms)?;
                     if let Some(pos) = self.srcs.iter().position(|s| *s == src) {
@@ -86,7 +86,7 @@ impl ClkCtl {
                 })?;
                 Ok(true)
             }
-            Self::RATE_NAME => {
+            RATE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let (_, rate) = unit.get_clock(timeout_ms)?;
                     if let Some(pos) = self.rates.iter().position(|r| *r == rate) {
@@ -111,7 +111,7 @@ impl ClkCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::SRC_NAME => {
+            SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     if let Some(&src) = self.srcs.iter().nth(val as usize) {
                         unit.lock()?;
@@ -125,7 +125,7 @@ impl ClkCtl {
                 })?;
                 Ok(true)
             }
-            Self::RATE_NAME => {
+            RATE_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     if let Some(&rate) = self.rates.iter().nth(val as usize) {
                         unit.lock()?;

--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -23,6 +23,7 @@ fn clk_src_to_string(src: &ClkSrc) -> String {
     }.to_string()
 }
 
+#[derive(Default)]
 pub struct ClkCtl {
     srcs: Vec<ClkSrc>,
     rates: Vec<u32>,
@@ -32,13 +33,6 @@ const SRC_NAME: &str = "clock-source";
 const RATE_NAME: &str = "clock-rate";
 
 impl ClkCtl {
-    pub fn new() -> Self {
-        ClkCtl {
-            srcs: Vec::new(),
-            rates: Vec::new(),
-        }
-    }
-
     pub fn load(
         &mut self,
         hwinfo: &HwInfo,

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -10,11 +10,11 @@ use efw_protocols::robot_guitar::*;
 
 pub struct GuitarCtl {}
 
-impl GuitarCtl {
-    const MANUAL_CHARGE_NAME: &'static str = "guitar-manual-chage";
-    const AUTO_CHARGE_NAME: &'static str = "guitar-auto-chage";
-    const SUSPEND_TO_CHARGE: &'static str = "guitar-suspend-to-charge";
+const MANUAL_CHARGE_NAME: &str = "guitar-manual-chage";
+const AUTO_CHARGE_NAME: &str = "guitar-auto-chage";
+const SUSPEND_TO_CHARGE: &str = "guitar-suspend-to-charge";
 
+impl GuitarCtl {
     const MIN_SEC: i32 = 0;
     const MAX_SEC: i32 = 60 * 60;   // = One hour.
     const STEP_SEC: i32 = 1;
@@ -30,15 +30,15 @@ impl GuitarCtl {
 
         if has_guitar_charge {
             let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, Self::MANUAL_CHARGE_NAME, 0);
+                alsactl::ElemIfaceType::Card, 0, 0, MANUAL_CHARGE_NAME, 0);
             let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
             let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, Self::AUTO_CHARGE_NAME, 0);
+                alsactl::ElemIfaceType::Card, 0, 0, AUTO_CHARGE_NAME, 0);
             let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
             let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, Self::SUSPEND_TO_CHARGE, 0);
+                alsactl::ElemIfaceType::Card, 0, 0, SUSPEND_TO_CHARGE, 0);
             let _ = card_cntr.add_int_elems(&elem_id, 1,
                 Self::MIN_SEC, Self::MAX_SEC, Self::STEP_SEC, 1, None, true)?;
         }
@@ -54,21 +54,21 @@ impl GuitarCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::MANUAL_CHARGE_NAME => {
+            MANUAL_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::set_val(elem_value, || {
                     unit.get_charge_state(timeout_ms)
                         .map(|s| s.manual_charge)
                 })?;
                 Ok(true)
             }
-            Self::AUTO_CHARGE_NAME => {
+            AUTO_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::set_val(elem_value, || {
                     unit.get_charge_state(timeout_ms)
                         .map(|s| s.auto_charge)
                 })?;
                 Ok(true)
             }
-            Self::SUSPEND_TO_CHARGE => {
+            SUSPEND_TO_CHARGE => {
                 ElemValueAccessor::<i32>::set_val(elem_value, || {
                     unit.get_charge_state(timeout_ms)
                         .map(|s| s.suspend_to_charge as i32)
@@ -88,7 +88,7 @@ impl GuitarCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::MANUAL_CHARGE_NAME => {
+            MANUAL_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::get_val(new, |val| {
                     let mut state = unit.get_charge_state(timeout_ms)?;
                     state.manual_charge = val;
@@ -96,7 +96,7 @@ impl GuitarCtl {
                 })?;
                 Ok(true)
             }
-            Self::AUTO_CHARGE_NAME => {
+            AUTO_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::get_val(new, |val| {
                     let mut state = unit.get_charge_state(timeout_ms)?;
                     state.auto_charge = val;
@@ -104,7 +104,7 @@ impl GuitarCtl {
                 })?;
                 Ok(true)
             }
-            Self::SUSPEND_TO_CHARGE => {
+            SUSPEND_TO_CHARGE => {
                 ElemValueAccessor::<i32>::get_val(new, |val| {
                     let mut state = unit.get_charge_state(timeout_ms)?;
                     state.suspend_to_charge = val as u32;

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -8,7 +8,8 @@ use core::elem_value_accessor::ElemValueAccessor;
 use efw_protocols::hw_info::*;
 use efw_protocols::robot_guitar::*;
 
-pub struct GuitarCtl {}
+#[derive(Default)]
+pub struct GuitarCtl;
 
 const MANUAL_CHARGE_NAME: &str = "guitar-manual-chage";
 const AUTO_CHARGE_NAME: &str = "guitar-auto-chage";
@@ -18,10 +19,6 @@ impl GuitarCtl {
     const MIN_SEC: i32 = 0;
     const MAX_SEC: i32 = 60 * 60;   // = One hour.
     const STEP_SEC: i32 = 1;
-
-    pub fn new() -> Self {
-        GuitarCtl{}
-    }
 
     pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -12,10 +12,10 @@ use efw_protocols::hw_ctl::*;
 pub struct Iec60958Ctl {
 }
 
-impl Iec60958Ctl {
-    const DEFAULT: &'static str = "IEC958 Playback Default";
-    const MASK: &'static str = "IEC958 Playback Mask";
+const DEFAULT_NAME: &str = "IEC958 Playback Default";
+const MASK_NAME: &str = "IEC958 Playback Mask";
 
+impl Iec60958Ctl {
     const AES0_PROFESSIONAL: u8 = 0x1;
     const AES0_NONAUDIO: u8 = 0x2;
 
@@ -27,10 +27,10 @@ impl Iec60958Ctl {
         -> Result<(), Error>
     {
         if hwinfo.caps.iter().find(|&cap| *cap == HwCap::SpdifCoax).is_some() {
-            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, Self::DEFAULT, 0);
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, DEFAULT_NAME, 0);
             let _ = card_cntr.add_iec60958_elem(&elem_id, 1, true)?;
 
-            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, Self::MASK, 0);
+            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, MASK_NAME, 0);
             let _ = card_cntr.add_iec60958_elem(&elem_id, 1, false)?;
         }
 
@@ -45,7 +45,7 @@ impl Iec60958Ctl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::DEFAULT => {
+            DEFAULT_NAME => {
                 let mut val = [0;24];
                 let flags = unit.get_flags(timeout_ms)?;
                 if flags.iter().find(|&flag| *flag == HwCtlFlag::SpdifPro).is_some() {
@@ -57,7 +57,7 @@ impl Iec60958Ctl {
                 elem_value.set_iec60958_channel_status(&val);
                 Ok(true)
             }
-            Self::MASK => {
+            MASK_NAME => {
                 let mut val = [0;24];
                 val[0] = Self::AES0_PROFESSIONAL | Self::AES0_NONAUDIO;
                 elem_value.set_iec60958_channel_status(&val);
@@ -76,7 +76,7 @@ impl Iec60958Ctl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::DEFAULT => {
+            DEFAULT_NAME => {
                 let mut vals = [0;24];
                 new.get_iec60958_channel_status(&mut vals);
 

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -9,8 +9,8 @@ use alsactl::{ElemValueExt, ElemValueExtManual};
 use efw_protocols::hw_info::*;
 use efw_protocols::hw_ctl::*;
 
-pub struct Iec60958Ctl {
-}
+#[derive(Default)]
+pub struct Iec60958Ctl;
 
 const DEFAULT_NAME: &str = "IEC958 Playback Default";
 const MASK_NAME: &str = "IEC958 Playback Mask";
@@ -18,10 +18,6 @@ const MASK_NAME: &str = "IEC958 Playback Mask";
 impl Iec60958Ctl {
     const AES0_PROFESSIONAL: u8 = 0x1;
     const AES0_NONAUDIO: u8 = 0x2;
-
-    pub fn new() -> Self {
-        Iec60958Ctl{}
-    }
 
     pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -14,9 +14,9 @@ pub struct InputCtl {
     cache: Option<Vec::<NominalSignalLevel>>,
 }
 
-impl InputCtl {
-    const IN_NOMINAL_NAME: &'static str = "input-nominal";
+const IN_NOMINAL_NAME: &str = "input-nominal";
 
+impl InputCtl {
     const IN_NOMINAL_LABELS: [&'static str;2] = ["+4dBu", "-10dBV"];
     const IN_NOMINAL_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Professional,
@@ -35,7 +35,7 @@ impl InputCtl {
 
         if hwinfo.caps.iter().find(|&cap| *cap == HwCap::NominalInput).is_some() {
             let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Mixer, 0, 0, Self::IN_NOMINAL_NAME, 0);
+                alsactl::ElemIfaceType::Mixer, 0, 0, IN_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
                 self.phys_inputs, &Self::IN_NOMINAL_LABELS, None, true)?;
         }
@@ -63,7 +63,7 @@ impl InputCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::IN_NOMINAL_NAME => {
+            IN_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, self.phys_inputs, |idx| {
                     if let Some(cache) = &self.cache {
                         // For models with FPGA.
@@ -93,7 +93,7 @@ impl InputCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::IN_NOMINAL_NAME => {
+            IN_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::get_vals(new, old, self.phys_inputs, |idx, val| {
                     if let Some(&level) = Self::IN_NOMINAL_LEVELS.iter().nth(val as usize) {
                         unit.set_nominal(idx, level, timeout_ms)?;

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -9,6 +9,7 @@ use efw_protocols::NominalSignalLevel;
 use efw_protocols::hw_info::*;
 use efw_protocols::phys_input::*;
 
+#[derive(Default)]
 pub struct InputCtl {
     phys_inputs: usize,
     cache: Option<Vec::<NominalSignalLevel>>,
@@ -22,10 +23,6 @@ impl InputCtl {
         NominalSignalLevel::Professional,
         NominalSignalLevel::Consumer,
     ];
-
-    pub fn new() -> Self {
-        InputCtl { phys_inputs: 0, cache: None}
-    }
 
     pub fn load(&mut self, unit: &mut hinawa::SndEfw, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr,
                 timeout_ms: u32)

--- a/libs/efw/runtime/src/meter_ctl.rs
+++ b/libs/efw/runtime/src/meter_ctl.rs
@@ -8,6 +8,7 @@ use alsactl::{ElemId, ElemIfaceType, ElemValueExt, ElemValueExtManual};
 
 use efw_protocols::hw_info::*;
 
+#[derive(Default)]
 pub struct MeterCtl {
     pub measure_elems: Vec<alsactl::ElemId>,
     meters: Option<HwMeter>,
@@ -28,15 +29,6 @@ impl MeterCtl {
     const COEF_MIN: i32 = 0;
     const COEF_MAX: i32 = 0x007fffff;
     const COEF_STEP: i32 = 1;
-
-    pub fn new() -> Self {
-        MeterCtl {
-            measure_elems: Vec::new(),
-            meters: None,
-            midi_inputs: 0,
-            midi_outputs: 0,
-        }
-    }
 
     pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -18,18 +18,18 @@ pub struct MixerCtl {
     has_fpga: bool,
 }
 
+const PLAYBACK_VOL_NAME: &str = "playback-volume";
+const PLAYBACK_MUTE_NAME: &str = "playback-mute";
+const PLAYBACK_SOLO_NAME: &str = "playback-solo";
+
+const MONITOR_GAIN_NAME: &str = "monitor-gain";
+const MONITOR_MUTE_NAME: &str = "monitor-mute";
+const MONITOR_SOLO_NAME: &str = "monitor-solo";
+const MONITOR_PAN_NAME: &str = "monitor-pan";
+
+const ENABLE_MIXER: &str = "enable-mixer";
+
 impl MixerCtl {
-    const PLAYBACK_VOL_NAME: &'static str = "playback-volume";
-    const PLAYBACK_MUTE_NAME: &'static str = "playback-mute";
-    const PLAYBACK_SOLO_NAME: &'static str = "playback-solo";
-
-    const MONITOR_GAIN_NAME: &'static str = "monitor-gain";
-    const MONITOR_MUTE_NAME: &'static str = "monitor-mute";
-    const MONITOR_SOLO_NAME: &'static str = "monitor-solo";
-    const MONITOR_PAN_NAME: &'static str = "monitor-pan";
-
-    const ENABLE_MIXER: &'static str = "enable-mixer";
-
     // The fixed point number of 8.24 format.
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
@@ -57,41 +57,41 @@ impl MixerCtl {
         self.captures = hwinfo.mixer_captures;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_VOL_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, PLAYBACK_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
             self.playbacks, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_MUTE_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, PLAYBACK_MUTE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::PLAYBACK_SOLO_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, PLAYBACK_SOLO_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_GAIN_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, MONITOR_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
             self.captures, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_MUTE_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, MONITOR_MUTE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, self.playbacks, self.captures, true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_SOLO_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, MONITOR_SOLO_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, self.playbacks, self.captures, true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::MONITOR_PAN_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, MONITOR_PAN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,
             Self::PAN_MIN, Self::PAN_MAX, Self::PAN_STEP,
             self.captures, None, true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0,
-                                                   Self::ENABLE_MIXER, 0);
+                                                   ENABLE_MIXER, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
         self.has_fpga = hwinfo.caps.iter().find(|&cap| *cap == HwCap::Fpga).is_some();
 
@@ -106,25 +106,25 @@ impl MixerCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PLAYBACK_VOL_NAME => {
+            PLAYBACK_VOL_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.playbacks, |idx| {
                     unit.get_playback_vol(idx, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::PLAYBACK_MUTE_NAME => {
+            PLAYBACK_MUTE_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.playbacks, |idx| {
                     unit.get_playback_mute(idx, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::PLAYBACK_SOLO_NAME => {
+            PLAYBACK_SOLO_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.playbacks, |idx| {
                     unit.get_playback_solo(idx, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_GAIN_NAME => {
+            MONITOR_GAIN_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_vol(dst, src, timeout_ms)?;
@@ -132,7 +132,7 @@ impl MixerCtl {
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_MUTE_NAME => {
+            MONITOR_MUTE_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_mute(dst, src, timeout_ms)?;
@@ -140,7 +140,7 @@ impl MixerCtl {
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_SOLO_NAME => {
+            MONITOR_SOLO_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_solo(dst, src, timeout_ms)?;
@@ -148,7 +148,7 @@ impl MixerCtl {
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_PAN_NAME => {
+            MONITOR_PAN_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_pan(dst, src, timeout_ms)? as i32;
@@ -156,7 +156,7 @@ impl MixerCtl {
                 })?;
                 Ok(true)
             }
-            Self::ENABLE_MIXER=> {
+            ENABLE_MIXER=> {
                 ElemValueAccessor::<bool>::set_val(elem_value, || {
                     let flags = unit.get_flags(timeout_ms)?;
                     Ok(flags.iter().find(|&flag| *flag == HwCtlFlag::MixerEnabled).is_some())
@@ -176,53 +176,53 @@ impl MixerCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::PLAYBACK_VOL_NAME => {
+            PLAYBACK_VOL_NAME => {
                 ElemValueAccessor::<i32>::get_vals(new, old, self.playbacks, |idx, val| {
                     unit.set_playback_vol(idx, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::PLAYBACK_MUTE_NAME => {
+            PLAYBACK_MUTE_NAME => {
                 ElemValueAccessor::<bool>::get_vals(new, old, self.playbacks, |idx, val| {
                     unit.set_playback_mute(idx, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::PLAYBACK_SOLO_NAME => {
+            PLAYBACK_SOLO_NAME => {
                 ElemValueAccessor::<bool>::get_vals(new, old, self.playbacks, |idx, val| {
                     unit.set_playback_solo(idx, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_GAIN_NAME => {
+            MONITOR_GAIN_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_vol(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_MUTE_NAME => {
+            MONITOR_MUTE_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<bool>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_mute(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_SOLO_NAME => {
+            MONITOR_SOLO_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<bool>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_solo(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::MONITOR_PAN_NAME => {
+            MONITOR_PAN_NAME => {
                 let dst = elem_id.get_index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_pan(dst, src, val as u8, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::ENABLE_MIXER=> {
+            ENABLE_MIXER=> {
                 ElemValueAccessor::<bool>::get_val(new, |val| {
                     if val {
                         let flags = [HwCtlFlag::MixerEnabled];

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -12,6 +12,7 @@ use efw_protocols::hw_ctl::*;
 use efw_protocols::playback::*;
 use efw_protocols::monitor::*;
 
+#[derive(Default)]
 pub struct MixerCtl {
     playbacks: usize,
     captures: usize,
@@ -39,14 +40,6 @@ impl MixerCtl {
     const PAN_MIN: i32 = 0;
     const PAN_MAX: i32 = 255;
     const PAN_STEP: i32 = 1;
-
-    pub fn new() -> Self {
-        MixerCtl {
-            playbacks: 0,
-            captures: 0,
-            has_fpga: false,
-        }
-    }
 
     pub fn load(
         &mut self,

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -22,6 +22,7 @@ use std::convert::TryFrom;
 
 const TIMEOUT_MS: u32 = 100;
 
+#[derive(Default)]
 pub struct EfwModel {
     clk_ctl: clk_ctl::ClkCtl,
     mixer_ctl: mixer_ctl::MixerCtl,
@@ -71,17 +72,7 @@ impl EfwModel {
             (0x00075b, 0x00afb2) |
             // Gibson, Robot Interface Pack (RIP) for Dark Fire series.
             (0x00075b, 0x00afb9) => {
-                let model = EfwModel {
-                    clk_ctl: clk_ctl::ClkCtl::new(),
-                    mixer_ctl: mixer_ctl::MixerCtl::new(),
-                    output_ctl: output_ctl::OutputCtl::new(),
-                    input_ctl: input_ctl::InputCtl::new(),
-                    port_ctl: port_ctl::PortCtl::new(),
-                    meter_ctl: meter_ctl::MeterCtl::new(),
-                    guitar_ctl: guitar_ctl::GuitarCtl::new(),
-                    iec60958_ctl: iec60958_ctl::Iec60958Ctl::new(),
-                };
-                Ok(model)
+                Ok(Default::default())
             },
             _ => {
                 let label = "Not supported.";

--- a/libs/efw/runtime/src/output_ctl.rs
+++ b/libs/efw/runtime/src/output_ctl.rs
@@ -11,6 +11,7 @@ use efw_protocols::NominalSignalLevel;
 use efw_protocols::hw_info::*;
 use efw_protocols::phys_output::*;
 
+#[derive(Default)]
 pub struct OutputCtl {
     phys_outputs: usize,
 }
@@ -31,10 +32,6 @@ impl OutputCtl {
         NominalSignalLevel::Professional,
         NominalSignalLevel::Consumer,
     ];
-
-    pub fn new() -> Self {
-        OutputCtl { phys_outputs: 0 }
-    }
 
     pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
         -> Result<(), Error>

--- a/libs/efw/runtime/src/output_ctl.rs
+++ b/libs/efw/runtime/src/output_ctl.rs
@@ -15,18 +15,18 @@ pub struct OutputCtl {
     phys_outputs: usize,
 }
 
-impl OutputCtl {
-    const OUT_VOL_NAME: &'static str = "output-volume";
-    const OUT_MUTE_NAME: &'static str = "output-mute";
-    const OUT_NOMINAL_NAME: &'static str = "output-nominal";
+const OUT_VOL_NAME: &str = "output-volume";
+const OUT_MUTE_NAME: &str = "output-mute";
+const OUT_NOMINAL_NAME: &str = "output-nominal";
 
+impl OutputCtl {
     // The fixed point number of 8.24 format.
     const COEF_MIN: i32 = 0x00000000;
     const COEF_MAX: i32 = 0x02000000;
     const COEF_STEP: i32 = 0x00000001;
     const COEF_TLV: DbInterval = DbInterval{min: -14400, max: 600, linear: false, mute_avail: false};
 
-    const OUT_NOMINAL_LABELS: [&'static str;2] = ["+4dBu", "-10dBV"];
+    const OUT_NOMINAL_LABELS: [&'static str; 2] = ["+4dBu", "-10dBV"];
     const OUT_NOMINAL_LEVELS: [NominalSignalLevel;2] = [
         NominalSignalLevel::Professional,
         NominalSignalLevel::Consumer,
@@ -48,18 +48,18 @@ impl OutputCtl {
         });
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_VOL_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, OUT_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, 1,
             Self::COEF_MIN, Self::COEF_MAX, Self::COEF_STEP,
             self.phys_outputs, Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)), true)?;
 
         let elem_id = alsactl::ElemId::new_by_name(
-            alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_MUTE_NAME, 0);
+            alsactl::ElemIfaceType::Mixer, 0, 0, OUT_MUTE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, self.phys_outputs, true)?;
 
         if hwinfo.caps.iter().find(|&cap| *cap == HwCap::NominalOutput).is_some() {
             let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Mixer, 0, 0, Self::OUT_NOMINAL_NAME, 0);
+                alsactl::ElemIfaceType::Mixer, 0, 0, OUT_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
                 self.phys_outputs, &Self::OUT_NOMINAL_LABELS, None, true)?;
         }
@@ -75,19 +75,19 @@ impl OutputCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::OUT_VOL_NAME => {
+            OUT_VOL_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.phys_outputs, |idx| {
                     unit.get_vol(idx, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::OUT_MUTE_NAME => {
+            OUT_MUTE_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.phys_outputs, |idx| {
                     unit.get_mute(idx, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::OUT_NOMINAL_NAME => {
+            OUT_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, self.phys_outputs, |idx| {
                     let level = unit.get_nominal(idx, timeout_ms)?;
                     if let Some(pos) = Self::OUT_NOMINAL_LEVELS.iter().position(|&l| l == level) {
@@ -111,19 +111,19 @@ impl OutputCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            Self::OUT_VOL_NAME => {
+            OUT_VOL_NAME => {
                 ElemValueAccessor::<i32>::get_vals(new, old, self.phys_outputs, |idx, val| {
                     unit.set_vol(idx, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::OUT_MUTE_NAME => {
+            OUT_MUTE_NAME => {
                 ElemValueAccessor::<bool>::get_vals(new, old, self.phys_outputs, |idx, val| {
                     unit.set_mute(idx, val, timeout_ms)
                 })?;
                 Ok(true)
             }
-            Self::OUT_NOMINAL_NAME => {
+            OUT_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::get_vals(new, old, self.phys_outputs, |idx, val| {
                     if let Some(&level) = Self::OUT_NOMINAL_LEVELS.iter().nth(val as usize) {
                         unit.set_nominal(idx, level, timeout_ms)

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -34,6 +34,7 @@ fn digital_mode_to_string(mode: &DigitalMode) -> String {
     }.to_string()
 }
 
+#[derive(Default)]
 pub struct PortCtl {
     dig_modes: Vec<DigitalMode>,
     phys_in_pairs: usize,
@@ -55,16 +56,6 @@ impl PortCtl {
         (HwCap::SpdifOpt, DigitalMode::SpdifOpt),
         (HwCap::AdatOpt, DigitalMode::AdatOpt),
     ];
-
-    pub fn new() -> Self {
-        PortCtl {
-            dig_modes: Vec::new(),
-            phys_in_pairs: 0,
-            phys_out_pairs: 0,
-            tx_pairs: 0,
-            rx_pairs: 0,
-        }
-    }
 
     fn add_mapping_ctl(
         &self,

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -8,7 +8,7 @@ use core::elem_value_accessor::ElemValueAccessor;
 use efw_protocols::hw_info::*;
 use efw_protocols::port_conf::*;
 
-fn phys_group_type_to_string(phys_group_type: &PhysGroupType) -> String {
+fn phys_group_type_to_str(phys_group_type: &PhysGroupType) -> &'static str {
     match phys_group_type {
         PhysGroupType::Analog       => "Analog",
         PhysGroupType::Spdif        => "S/PDIF",
@@ -21,17 +21,17 @@ fn phys_group_type_to_string(phys_group_type: &PhysGroupType) -> String {
         PhysGroupType::PiezoGuitar  => "PiezoGuitar",
         PhysGroupType::GuitarString => "GuitarString",
         PhysGroupType::Unknown(_)   => "Unknown",
-    }.to_string()
+    }
 }
 
-fn digital_mode_to_string(mode: &DigitalMode) -> String {
+fn digital_mode_to_str(mode: &DigitalMode) -> &'static str {
     match mode {
         DigitalMode::SpdifCoax  => "S/PDIF-Coaxial",
         DigitalMode::AesebuXlr  => "AES/EBU-XLR",
         DigitalMode::SpdifOpt   => "S/PDIF-Optical",
         DigitalMode::AdatOpt    => "ADAT-Optical",
         DigitalMode::Unknown(_) => "Unknown",
-    }.to_string()
+    }
 }
 
 #[derive(Default)]
@@ -64,9 +64,9 @@ impl PortCtl {
         phys_pairs: usize,
         stream_pairs: usize,
     ) -> Result<(), Error> {
-        let labels = (0..stream_pairs)
+        let labels: Vec<String> = (0..stream_pairs)
             .map(|pair| format!("Stream-{}/{}", pair * 2 + 1, pair * 2 + 2))
-            .collect::<Vec<String>>();
+            .collect();
 
         let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, name, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, phys_pairs, &labels, None, true)?;
@@ -84,7 +84,7 @@ impl PortCtl {
                     (0..(entry.group_count / 2))
                         .map(move |i| {
                             format!("{}-{}/{}",
-                                    phys_group_type_to_string(&entry.group_type), i * 2 + 1, i * 2 + 2)
+                                    phys_group_type_to_str(&entry.group_type), i * 2 + 1, i * 2 + 2)
                         })
                 })
                 .flatten()
@@ -101,9 +101,9 @@ impl PortCtl {
             }
         });
         if self.dig_modes.len() > 1 {
-            let labels = self.dig_modes.iter()
-                .map(|mode| digital_mode_to_string(mode))
-                .collect::<Vec<String>>();
+            let labels: Vec<&str> = self.dig_modes.iter()
+                .map(|mode| digital_mode_to_str(mode))
+                .collect();
 
             let elem_id = alsactl::ElemId::new_by_name(
                 alsactl::ElemIfaceType::Mixer, 0, 0, DIG_MODE_NAME, 0);

--- a/libs/tascam/runtime/src/fe8_model.rs
+++ b/libs/tascam/runtime/src/fe8_model.rs
@@ -15,19 +15,15 @@ pub struct Fe8Model{
 
 const TIMEOUT_MS: u32 = 50;
 
-impl AsRef<SequencerState<Fe8SurfaceState>> for Fe8Model {
-    fn as_ref(&self) -> &SequencerState<Fe8SurfaceState> {
+impl SequencerCtlOperation<FwNode, Fe8Protocol, Fe8SurfaceState> for Fe8Model {
+    fn state(&self) -> &SequencerState<Fe8SurfaceState> {
         &self.seq_state
     }
-}
 
-impl AsMut<SequencerState<Fe8SurfaceState>> for Fe8Model {
-    fn as_mut(&mut self) -> &mut SequencerState<Fe8SurfaceState> {
+    fn state_mut(&mut self) -> &mut SequencerState<Fe8SurfaceState> {
         &mut self.seq_state
     }
-}
 
-impl SequencerCtlOperation<FwNode, Fe8Protocol, Fe8SurfaceState> for Fe8Model {
     fn initialize_surface(
         &mut self,
         node: &mut FwNode,

--- a/libs/tascam/runtime/src/fe8_model.rs
+++ b/libs/tascam/runtime/src/fe8_model.rs
@@ -60,8 +60,8 @@ impl SequencerCtlOperation<FwNode, Fe8Protocol, Fe8SurfaceState> for Fe8Model {
     }
 }
 
-impl Fe8Model {
-    pub fn register_notification_address(
+impl AsynchCtlOperation for Fe8Model {
+    fn register_notification_address(
         &mut self,
         node: &mut FwNode,
         addr: u64,

--- a/libs/tascam/runtime/src/fe8_model.rs
+++ b/libs/tascam/runtime/src/fe8_model.rs
@@ -29,7 +29,6 @@ impl SequencerCtlOperation<FwNode, Fe8Protocol, Fe8SurfaceState> for Fe8Model {
         node: &mut FwNode,
         _: &[(MachineItem, ItemValue)],
     ) -> Result<(), Error> {
-        Fe8Protocol::enable_notification(&mut self.req, node, true, TIMEOUT_MS)?;
         Fe8Protocol::operate_firewire_led(&mut self.req, node, true, TIMEOUT_MS)?;
         Ok(())
     }
@@ -67,5 +66,9 @@ impl AsynchCtlOperation for Fe8Model {
         addr: u64,
     ) -> Result<(), Error> {
         Fe8Protocol::register_notification_address(&mut self.req, node, addr, TIMEOUT_MS)
+    }
+
+    fn enable_notification(&mut self, node: &mut FwNode, enable: bool) -> Result<(), Error> {
+        Fe8Protocol::enable_notification(&mut self.req, node, enable, TIMEOUT_MS)
     }
 }

--- a/libs/tascam/runtime/src/fw1082_model.rs
+++ b/libs/tascam/runtime/src/fw1082_model.rs
@@ -27,19 +27,15 @@ const TIMEOUT_MS: u32 = 50;
 #[derive(Default)]
 struct MeterCtl(IsochMeterState, Vec<ElemId>);
 
-impl AsRef<IsochMeterState> for MeterCtl {
-    fn as_ref(&self) -> &IsochMeterState {
+impl IsochMeterCtlOperation<Fw1082Protocol> for MeterCtl {
+    fn meter(&self) -> &IsochMeterState {
         &self.0
     }
-}
 
-impl AsMut<IsochMeterState> for MeterCtl {
-    fn as_mut(&mut self) -> &mut IsochMeterState {
+    fn meter_mut(&mut self) -> &mut IsochMeterState {
         &mut self.0
     }
-}
 
-impl IsochMeterCtl<Fw1082Protocol> for MeterCtl {
     const INPUT_LABELS: &'static [&'static str] = &[
         "analog-input-1", "analog-input-2", "analog-input-3", "analog-input-4",
         "analog-input-5", "analog-input-6", "analog-input-7", "analog-input-8",

--- a/libs/tascam/runtime/src/fw1082_model.rs
+++ b/libs/tascam/runtime/src/fw1082_model.rs
@@ -54,19 +54,15 @@ impl IsochCommonCtlOperation<Fw1082Protocol> for CommonCtl {}
 #[derive(Default)]
 struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);
 
-impl AsRef<IsochConsoleState> for ConsoleCtl {
-    fn as_ref(&self) -> &IsochConsoleState {
+impl IsochConsoleCtlOperation<Fw1082Protocol> for ConsoleCtl {
+    fn state(&self) -> &IsochConsoleState {
         &self.0
     }
-}
 
-impl AsMut<IsochConsoleState> for ConsoleCtl {
-    fn as_mut(&mut self) -> &mut IsochConsoleState {
+    fn state_mut(&mut self) -> &mut IsochConsoleState {
         &mut self.0
     }
 }
-
-impl IsochConsoleCtl<Fw1082Protocol> for ConsoleCtl {}
 
 impl AsRef<SequencerState<Fw1082SurfaceState>> for Fw1082Model {
     fn as_ref(&self) -> &SequencerState<Fw1082SurfaceState> {

--- a/libs/tascam/runtime/src/fw1082_model.rs
+++ b/libs/tascam/runtime/src/fw1082_model.rs
@@ -49,7 +49,7 @@ impl IsochMeterCtlOperation<Fw1082Protocol> for MeterCtl {
 #[derive(Default)]
 struct CommonCtl;
 
-impl IsochCommonCtl<Fw1082Protocol> for CommonCtl {}
+impl IsochCommonCtlOperation<Fw1082Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);

--- a/libs/tascam/runtime/src/fw1082_model.rs
+++ b/libs/tascam/runtime/src/fw1082_model.rs
@@ -64,19 +64,15 @@ impl IsochConsoleCtlOperation<Fw1082Protocol> for ConsoleCtl {
     }
 }
 
-impl AsRef<SequencerState<Fw1082SurfaceState>> for Fw1082Model {
-    fn as_ref(&self) -> &SequencerState<Fw1082SurfaceState> {
+impl SequencerCtlOperation<SndTscm, Fw1082Protocol, Fw1082SurfaceState> for Fw1082Model {
+    fn state(&self) -> &SequencerState<Fw1082SurfaceState> {
         &self.seq_state
     }
-}
 
-impl AsMut<SequencerState<Fw1082SurfaceState>> for Fw1082Model {
-    fn as_mut(&mut self) -> &mut SequencerState<Fw1082SurfaceState> {
+    fn state_mut(&mut self) -> &mut SequencerState<Fw1082SurfaceState> {
         &mut self.seq_state
     }
-}
 
-impl SequencerCtlOperation<SndTscm, Fw1082Protocol, Fw1082SurfaceState> for Fw1082Model {
     fn initialize_surface(
         &mut self,
         unit: &mut SndTscm,

--- a/libs/tascam/runtime/src/fw1804_model.rs
+++ b/libs/tascam/runtime/src/fw1804_model.rs
@@ -60,7 +60,7 @@ impl IsochCommonCtlOperation<Fw1804Protocol> for CommonCtl {}
 #[derive(Default)]
 struct OpticalCtl;
 
-impl IsochOpticalCtl<Fw1804Protocol> for OpticalCtl {
+impl IsochOpticalCtlOperation<Fw1804Protocol> for OpticalCtl {
     const OPTICAL_OUTPUT_SOURCES: &'static [OpticalOutputSource] = &[
         OpticalOutputSource::StreamInputPairs,
         OpticalOutputSource::CoaxialOutputPair0,

--- a/libs/tascam/runtime/src/fw1804_model.rs
+++ b/libs/tascam/runtime/src/fw1804_model.rs
@@ -71,19 +71,15 @@ impl IsochOpticalCtlOperation<Fw1804Protocol> for OpticalCtl {
 #[derive(Default)]
 struct RackCtl(IsochRackState);
 
-impl AsRef<IsochRackState> for RackCtl {
-    fn as_ref(&self) -> &IsochRackState {
+impl IsochRackCtlOperation<Fw1804Protocol> for RackCtl {
+    fn state(&self) -> &IsochRackState {
         &self.0
     }
-}
 
-impl AsMut<IsochRackState> for RackCtl {
-    fn as_mut(&mut self) -> &mut IsochRackState {
+    fn state_mut(&mut self) -> &mut IsochRackState {
         &mut self.0
     }
 }
-
-impl IsochRackCtl<Fw1804Protocol> for RackCtl {}
 
 impl MeasureModel<SndTscm> for Fw1804Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {

--- a/libs/tascam/runtime/src/fw1804_model.rs
+++ b/libs/tascam/runtime/src/fw1804_model.rs
@@ -27,19 +27,15 @@ const TIMEOUT_MS: u32 = 50;
 #[derive(Default)]
 struct MeterCtl(IsochMeterState, Vec<ElemId>);
 
-impl AsRef<IsochMeterState> for MeterCtl {
-    fn as_ref(&self) -> &IsochMeterState {
+impl IsochMeterCtlOperation<Fw1804Protocol> for MeterCtl {
+    fn meter(&self) -> &IsochMeterState {
         &self.0
     }
-}
 
-impl AsMut<IsochMeterState> for MeterCtl {
-    fn as_mut(&mut self) -> &mut IsochMeterState {
+    fn meter_mut(&mut self) -> &mut IsochMeterState {
         &mut self.0
     }
-}
 
-impl IsochMeterCtl<Fw1804Protocol> for MeterCtl {
     const INPUT_LABELS: &'static [&'static str] = &[
         "analog-input-1", "analog-input-2", "analog-input-3", "analog-input-4",
         "analog-input-5", "analog-input-6", "analog-input-7", "analog-input-8",

--- a/libs/tascam/runtime/src/fw1804_model.rs
+++ b/libs/tascam/runtime/src/fw1804_model.rs
@@ -55,7 +55,7 @@ impl IsochMeterCtlOperation<Fw1804Protocol> for MeterCtl {
 #[derive(Default)]
 struct CommonCtl;
 
-impl IsochCommonCtl<Fw1804Protocol> for CommonCtl {}
+impl IsochCommonCtlOperation<Fw1804Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct OpticalCtl;

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -29,19 +29,15 @@ const TIMEOUT_MS: u32 = 50;
 #[derive(Default)]
 struct MeterCtl(IsochMeterState, Vec<ElemId>);
 
-impl AsRef<IsochMeterState> for MeterCtl {
-    fn as_ref(&self) -> &IsochMeterState {
+impl IsochMeterCtlOperation<Fw1884Protocol> for MeterCtl {
+    fn meter(&self) -> &IsochMeterState {
         &self.0
     }
-}
 
-impl AsMut<IsochMeterState> for MeterCtl {
-    fn as_mut(&mut self) -> &mut IsochMeterState {
+    fn meter_mut(&mut self) -> &mut IsochMeterState {
         &mut self.0
     }
-}
 
-impl IsochMeterCtl<Fw1884Protocol> for MeterCtl {
     const INPUT_LABELS: &'static [&'static str] = &[
         "analog-input-1", "analog-input-2", "analog-input-3", "analog-input-4",
         "analog-input-5", "analog-input-6", "analog-input-7", "analog-input-8",

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -74,19 +74,15 @@ impl IsochOpticalCtlOperation<Fw1884Protocol> for OpticalCtl {
 #[derive(Default)]
 struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);
 
-impl AsRef<IsochConsoleState> for ConsoleCtl {
-    fn as_ref(&self) -> &IsochConsoleState {
+impl IsochConsoleCtlOperation<Fw1884Protocol> for ConsoleCtl {
+    fn state(&self) -> &IsochConsoleState {
         &self.0
     }
-}
 
-impl AsMut<IsochConsoleState> for ConsoleCtl {
-    fn as_mut(&mut self) -> &mut IsochConsoleState {
+    fn state_mut(&mut self) -> &mut IsochConsoleState {
         &mut self.0
     }
 }
-
-impl IsochConsoleCtl<Fw1884Protocol> for ConsoleCtl {}
 
 #[derive(Default)]
 struct SpecificCtl;

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -62,7 +62,7 @@ impl IsochCommonCtlOperation<Fw1884Protocol> for CommonCtl {}
 #[derive(Default)]
 struct OpticalCtl;
 
-impl IsochOpticalCtl<Fw1884Protocol> for OpticalCtl {
+impl IsochOpticalCtlOperation<Fw1884Protocol> for OpticalCtl {
     const OPTICAL_OUTPUT_SOURCES: &'static [OpticalOutputSource] = &[
         OpticalOutputSource::StreamInputPairs,
         OpticalOutputSource::AnalogOutputPairs,

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -57,7 +57,7 @@ impl IsochMeterCtlOperation<Fw1884Protocol> for MeterCtl {
 #[derive(Default)]
 struct CommonCtl;
 
-impl IsochCommonCtl<Fw1884Protocol> for CommonCtl {}
+impl IsochCommonCtlOperation<Fw1884Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct OpticalCtl;

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -87,19 +87,15 @@ impl IsochConsoleCtlOperation<Fw1884Protocol> for ConsoleCtl {
 #[derive(Default)]
 struct SpecificCtl;
 
-impl AsRef<SequencerState<Fw1884SurfaceState>> for Fw1884Model {
-    fn as_ref(&self) -> &SequencerState<Fw1884SurfaceState> {
+impl SequencerCtlOperation<SndTscm, Fw1884Protocol, Fw1884SurfaceState> for Fw1884Model {
+    fn state(&self) -> &SequencerState<Fw1884SurfaceState> {
         &self.seq_state
     }
-}
 
-impl AsMut<SequencerState<Fw1884SurfaceState>> for Fw1884Model {
-    fn as_mut(&mut self) -> &mut SequencerState<Fw1884SurfaceState> {
+    fn state_mut(&mut self) -> &mut SequencerState<Fw1884SurfaceState> {
         &mut self.seq_state
     }
-}
 
-impl SequencerCtlOperation<SndTscm, Fw1884Protocol, Fw1884SurfaceState> for Fw1884Model {
     fn initialize_surface(
         &mut self,
         unit: &mut SndTscm,

--- a/libs/tascam/runtime/src/isoch_console_runtime.rs
+++ b/libs/tascam/runtime/src/isoch_console_runtime.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-// Copyright (c) 2020 Takashi Sakamoto
+// Copyright (c) 2021 Takashi Sakamoto
 use std::sync::mpsc;
 use std::time::Duration;
+use std::marker::PhantomData;
 
 use nix::sys::signal;
 
-use glib::{Error, FileError};
+use glib::Error;
 use glib::source;
 
 use hinawa::FwNodeExt;
@@ -18,7 +19,41 @@ use alsaseq::{EventCntrExt, EventCntrExtManual, EventDataCtl, EventType, UserCli
 use core::dispatcher::*;
 use core::card_cntr::*;
 
+use tascam_protocols::{isoch::{fw1082::*, fw1884::*}};
+
 use crate::{fw1082_model::*, fw1884_model::*, seq_cntr::*, *};
+
+pub type Fw1884Runtime = IsochConsoleRuntime<Fw1884Model, Fw1884Protocol, Fw1884SurfaceState>;
+pub type Fw1082Runtime = IsochConsoleRuntime<Fw1082Model, Fw1082Protocol, Fw1082SurfaceState>;
+
+pub struct IsochConsoleRuntime<S, T, U>
+where
+    S:  CtlModel<SndTscm> + MeasureModel<SndTscm> + SequencerCtlOperation<SndTscm, T, U> + Default,
+    T: MachineStateOperation + SurfaceImageOperation<U>,
+{
+    unit: SndTscm,
+    model: S,
+    card_cntr: CardCntr,
+    seq_cntr: SeqCntr,
+    rx: mpsc::Receiver<ConsoleUnitEvent>,
+    tx: mpsc::SyncSender<ConsoleUnitEvent>,
+    dispatchers: Vec<Dispatcher>,
+    timer: Option<Dispatcher>,
+    measure_elems: Vec<ElemId>,
+    _phantom0: PhantomData<T>,
+    _phantom1: PhantomData<U>,
+}
+
+impl<S, T, U> Drop for IsochConsoleRuntime<S, T, U>
+where
+    S:  CtlModel<SndTscm> + MeasureModel<SndTscm> + SequencerCtlOperation<SndTscm, T, U> + Default,
+    T: MachineStateOperation + SurfaceImageOperation<U>,
+{
+    fn drop(&mut self) {
+        let _ = self.model.finalize_sequencer(&mut self.unit);
+        self.dispatchers.clear();
+    }
+}
 
 enum ConsoleUnitEvent {
     Shutdown,
@@ -30,52 +65,19 @@ enum ConsoleUnitEvent {
     Surface((u32, u32, u32)),
 }
 
-enum ConsoleModel {
-    Fw1884(Fw1884Model),
-    Fw1082(Fw1082Model),
-}
+const NODE_DISPATCHER_NAME: &str = "node event dispatcher";
+const SYSTEM_DISPATCHER_NAME: &str = "system event dispatcher";
+const TIMER_DISPATCHER_NAME: &str = "interval timer dispatcher";
 
-pub struct IsochConsoleRuntime {
-    unit: SndTscm,
-    model: ConsoleModel,
-    card_cntr: CardCntr,
-    seq_cntr: SeqCntr,
-    rx: mpsc::Receiver<ConsoleUnitEvent>,
-    tx: mpsc::SyncSender<ConsoleUnitEvent>,
-    dispatchers: Vec<Dispatcher>,
-    timer: Option<Dispatcher>,
-    measure_elems: Vec<ElemId>,
-}
+const TIMER_NAME: &str = "metering";
+const TIMER_INTERVAL: Duration = Duration::from_millis(50);
 
-impl Drop for IsochConsoleRuntime {
-    fn drop(&mut self) {
-        let _ = match &mut self.model {
-            ConsoleModel::Fw1884(m) => m.finalize_sequencer(&mut self.unit),
-            ConsoleModel::Fw1082(m) => m.finalize_sequencer(&mut self.unit),
-        };
-
-        self.dispatchers.clear();
-    }
-}
-
-impl IsochConsoleRuntime {
-    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
-
-    const TIMER_NAME: &'static str = "metering";
-    const TIMER_INTERVAL: Duration = Duration::from_millis(50);
-
+impl<S, T, U> IsochConsoleRuntime<S, T, U>
+where
+    S:  CtlModel<SndTscm> + MeasureModel<SndTscm> + SequencerCtlOperation<SndTscm, T, U> + Default,
+    T: MachineStateOperation + SurfaceImageOperation<U>,
+{
     pub fn new(unit: SndTscm, name: &str, sysnum: u32) -> Result<Self, Error> {
-        let model = match name {
-            "FW-1884" => ConsoleModel::Fw1884(Default::default()),
-            "FW-1082" => ConsoleModel::Fw1082(Default::default()),
-            _ => {
-                let label = format!("Unsupported model name: {}", name);
-                return Err(Error::new(FileError::Nxio, &label));
-            }
-        };
-
         let card_cntr = CardCntr::new();
         card_cntr.card.open(sysnum, 0)?;
 
@@ -84,23 +86,103 @@ impl IsochConsoleRuntime {
         // Use uni-directional channel for communication to child threads.
         let (tx, rx) = mpsc::sync_channel(32);
 
-        let dispatchers = Vec::new();
-
-        Ok(IsochConsoleRuntime {
+        Ok(Self{
             unit,
-            model,
+            model: Default::default(),
             card_cntr,
             seq_cntr,
             tx,
             rx,
-            dispatchers,
-            timer: None,
-            measure_elems: Vec::new(),
+            dispatchers: Default::default(),
+            timer: Default::default(),
+            measure_elems: Default::default(),
+            _phantom0: Default::default(),
+            _phantom1: Default::default(),
         })
     }
 
+    pub fn listen(&mut self) -> Result<(), Error> {
+        self.launch_node_event_dispatcher()?;
+        self.launch_system_event_dispatcher()?;
+
+        self.seq_cntr.open_port()?;
+        self.model.initialize_sequencer(&mut self.unit)?;
+        self.model.load(&mut self.unit, &mut self.card_cntr)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, TIMER_NAME, 0);
+        let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+        self.model.get_measure_elem_list(&mut self.measure_elems);
+
+        Ok(())
+    }
+
+    pub fn run(&mut self) -> Result<(), Error> {
+        loop {
+            let ev = match self.rx.recv() {
+                Ok(ev) => ev,
+                Err(_) => continue,
+            };
+
+            match ev {
+                ConsoleUnitEvent::Shutdown => break,
+                ConsoleUnitEvent::Disconnected => break,
+                ConsoleUnitEvent::BusReset(generation) => {
+                    println!("IEEE 1394 bus is updated: {}", generation);
+                }
+                ConsoleUnitEvent::Elem((elem_id, events)) => {
+                    if elem_id.get_name() != TIMER_NAME {
+                        let _ = self.card_cntr.dispatch_elem_event(
+                            &mut self.unit,
+                            &elem_id,
+                            &events,
+                            &mut self.model
+                        );
+                    } else {
+                        let mut elem_value = ElemValue::new();
+                        if self.card_cntr.card.read_elem_value(&elem_id, &mut elem_value).is_ok() {
+                            let mut vals = [false];
+                            elem_value.get_bool(&mut vals);
+                            if vals[0] {
+                                let _ = self.start_interval_timer();
+                            } else {
+                                self.stop_interval_timer();
+                            }
+                        }
+                    }
+                }
+                ConsoleUnitEvent::Interval => {
+                    let _ = self.card_cntr.measure_elems(
+                        &mut self.unit,
+                        &self.measure_elems,
+                        &mut self.model
+                    );
+                }
+                ConsoleUnitEvent::SeqAppl(data) => {
+                    let _ = self.model.dispatch_appl_event(
+                        &mut self.unit,
+                        &mut self.seq_cntr,
+                        &data,
+                    );
+                }
+                ConsoleUnitEvent::Surface((index, before, after)) => {
+                    let image = self.unit.get_state().map(|s| s.to_vec())?;
+                    let _ = self.model.dispatch_surface_event(
+                        &mut self.unit,
+                        &mut self.seq_cntr,
+                        &image,
+                        index,
+                        before,
+                        after,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {
-        let name = Self::NODE_DISPATCHER_NAME.to_string();
+        let name = NODE_DISPATCHER_NAME.to_string();
         let mut dispatcher = Dispatcher::run(name)?;
 
         let tx = self.tx.clone();
@@ -130,7 +212,7 @@ impl IsochConsoleRuntime {
     }
 
     fn launch_system_event_dispatcher(&mut self) -> Result<(), Error> {
-        let name = Self::SYSTEM_DISPATCHER_NAME.to_string();
+        let name = SYSTEM_DISPATCHER_NAME.to_string();
         let mut dispatcher = Dispatcher::run(name)?;
 
         let tx = self.tx.clone();
@@ -169,36 +251,10 @@ impl IsochConsoleRuntime {
         Ok(())
     }
 
-    pub fn listen(&mut self) -> Result<(), Error> {
-        self.launch_node_event_dispatcher()?;
-        self.launch_system_event_dispatcher()?;
-
-        self.seq_cntr.open_port()?;
-        match &mut self.model {
-            ConsoleModel::Fw1884(m) => m.initialize_sequencer(&mut self.unit),
-            ConsoleModel::Fw1082(m) => m.initialize_sequencer(&mut self.unit),
-        }?;
-
-        match &mut self.model {
-            ConsoleModel::Fw1884(m) => m.load(&mut self.unit, &mut self.card_cntr)?,
-            ConsoleModel::Fw1082(m) => m.load(&mut self.unit, &mut self.card_cntr)?,
-        }
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::TIMER_NAME, 0);
-        let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
-
-        match &mut self.model {
-            ConsoleModel::Fw1884(m) => m.get_measure_elem_list(&mut self.measure_elems),
-            ConsoleModel::Fw1082(m) => m.get_measure_elem_list(&mut self.measure_elems),
-        }
-
-        Ok(())
-    }
-
     fn start_interval_timer(&mut self) -> Result<(), Error> {
-        let mut dispatcher = Dispatcher::run(Self::TIMER_DISPATCHER_NAME.to_string())?;
+        let mut dispatcher = Dispatcher::run(TIMER_DISPATCHER_NAME.to_string())?;
         let tx = self.tx.clone();
-        dispatcher.attach_interval_handler(Self::TIMER_INTERVAL, move || {
+        dispatcher.attach_interval_handler(TIMER_INTERVAL, move || {
             let _ = tx.send(ConsoleUnitEvent::Interval);
             source::Continue(true)
         });
@@ -213,91 +269,5 @@ impl IsochConsoleRuntime {
             drop(dispatcher);
             self.timer = None;
         }
-    }
-
-    pub fn run(&mut self) -> Result<(), Error> {
-        loop {
-            let ev = match self.rx.recv() {
-                Ok(ev) => ev,
-                Err(_) => continue,
-            };
-
-            match ev {
-                ConsoleUnitEvent::Shutdown => break,
-                ConsoleUnitEvent::Disconnected => break,
-                ConsoleUnitEvent::BusReset(generation) => {
-                    println!("IEEE 1394 bus is updated: {}", generation);
-                }
-                ConsoleUnitEvent::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != Self::TIMER_NAME {
-                        let _ = match &mut self.model {
-                            ConsoleModel::Fw1884(m) =>
-                                self.card_cntr.dispatch_elem_event(&mut self.unit, &elem_id, &events, m),
-                            ConsoleModel::Fw1082(m) =>
-                                self.card_cntr.dispatch_elem_event(&mut self.unit, &elem_id, &events, m),
-                        };
-                    } else {
-                        let mut elem_value = ElemValue::new();
-                        if self.card_cntr.card.read_elem_value(&elem_id, &mut elem_value).is_ok() {
-                            let mut vals = [false];
-                            elem_value.get_bool(&mut vals);
-                            if vals[0] {
-                                let _ = self.start_interval_timer();
-                            } else {
-                                self.stop_interval_timer();
-                            }
-                        }
-                    }
-                }
-                ConsoleUnitEvent::Interval => {
-                    match &mut self.model {
-                        ConsoleModel::Fw1884(m) =>{
-                            let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems, m);
-                        }
-                        ConsoleModel::Fw1082(m) => {
-                            let _ = self.card_cntr.measure_elems(&mut self.unit, &self.measure_elems, m);
-                        }
-                    };
-                }
-                ConsoleUnitEvent::SeqAppl(data) => {
-                    let _ = match &mut self.model {
-                        ConsoleModel::Fw1884(m) => m.dispatch_appl_event(
-                            &mut self.unit,
-                            &mut self.seq_cntr,
-                            &data,
-                        ),
-                        ConsoleModel::Fw1082(m) => m.dispatch_appl_event(
-                            &mut self.unit,
-                            &mut self.seq_cntr,
-                            &data,
-                        ),
-                    };
-                }
-                ConsoleUnitEvent::Surface((index, before, after)) => {
-                    let image = self.unit.get_state().map(|s| s.to_vec())?;
-
-                    let _ = match &mut self.model {
-                        ConsoleModel::Fw1884(m) => m.dispatch_surface_event(
-                            &mut self.unit,
-                            &mut self.seq_cntr,
-                            &image,
-                            index,
-                            before,
-                            after,
-                        ),
-                        ConsoleModel::Fw1082(m) => m.dispatch_surface_event(
-                            &mut self.unit,
-                            &mut self.seq_cntr,
-                            &image,
-                            index,
-                            before,
-                            after,
-                        ),
-                    };
-                }
-            }
-        }
-
-        Ok(())
     }
 }

--- a/libs/tascam/runtime/src/isoch_ctls.rs
+++ b/libs/tascam/runtime/src/isoch_ctls.rs
@@ -528,7 +528,7 @@ fn optical_output_source_to_str(src: &OpticalOutputSource) -> &'static str {
     }
 }
 
-pub trait IsochOpticalCtl<T: IsochOpticalOperation> {
+pub trait IsochOpticalCtlOperation<T: IsochOpticalOperation> {
     const SPDIF_INPUT_SOURCES: [SpdifCaptureSource; 2] =
         [SpdifCaptureSource::Coaxial, SpdifCaptureSource::Optical];
 

--- a/libs/tascam/runtime/src/isoch_ctls.rs
+++ b/libs/tascam/runtime/src/isoch_ctls.rs
@@ -625,9 +625,10 @@ pub trait IsochOpticalCtlOperation<T: IsochOpticalOperation> {
 const MASTER_FADER_ASSIGN_NAME: &str = "master-fader-assign";
 const HOST_MODE_NAME: &str = "host-mode";
 
-pub trait IsochConsoleCtl<T: IsochConsoleOperation>:
-    AsRef<IsochConsoleState> + AsMut<IsochConsoleState>
-{
+pub trait IsochConsoleCtlOperation<T: IsochConsoleOperation> {
+    fn state(&self) -> &IsochConsoleState;
+    fn state_mut(&mut self) -> &mut IsochConsoleState;
+
     fn load_params(
         &mut self,
         card_cntr: &mut CardCntr,
@@ -649,13 +650,13 @@ pub trait IsochConsoleCtl<T: IsochConsoleOperation>:
     }
 
     fn parse_states(&mut self, image: &[u32]) -> Result<(), Error> {
-        T::parse_console_state(self.as_mut(), image)
+        T::parse_console_state(self.state_mut(), image)
     }
 
     fn read_states(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
             HOST_MODE_NAME => {
-                elem_value.set_bool(&[self.as_ref().host_mode]);
+                elem_value.set_bool(&[self.state().host_mode]);
                 Ok(true)
             }
             _ => Ok(false),

--- a/libs/tascam/runtime/src/isoch_ctls.rs
+++ b/libs/tascam/runtime/src/isoch_ctls.rs
@@ -291,7 +291,7 @@ fn coaxial_output_source_to_str(src: &CoaxialOutputSource) -> &str {
     }
 }
 
-pub trait IsochCommonCtl<T: IsochCommonOperation> {
+pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
     const CLOCK_RATES: [ClkRate; 4] = [
         ClkRate::R44100,
         ClkRate::R48000,

--- a/libs/tascam/runtime/src/lib.rs
+++ b/libs/tascam/runtime/src/lib.rs
@@ -29,7 +29,7 @@ use tascam_protocols::{config_rom::*, *};
 use seq_cntr::*;
 
 use isoch_console_runtime::*;
-use isoch_rack_runtime::IsochRackRuntime;
+use isoch_rack_runtime::*;
 use asynch_runtime::AsynchRuntime;
 
 use std::convert::TryFrom;
@@ -37,7 +37,7 @@ use std::convert::TryFrom;
 pub enum TascamRuntime {
     Fw1884(Fw1884Runtime),
     Fw1082(Fw1082Runtime),
-    IsochRack(IsochRackRuntime),
+    Fw1804(Fw1804Runtime),
     Asynch(AsynchRuntime),
 }
 
@@ -73,8 +73,8 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
                         Ok(Self::Fw1082(runtime))
                     }
                     (TASCAM_OUI, FW1804_SW_VERSION) => {
-                        let runtime = IsochRackRuntime::new(unit, unit_data.model_name, sysnum)?;
-                        Ok(Self::IsochRack(runtime))
+                        let runtime = Fw1804Runtime::new(unit, unit_data.model_name, sysnum)?;
+                        Ok(Self::Fw1804(runtime))
                     }
                     _ => Err(Error::new(FileError::Noent, "Not supported")),
                 }
@@ -111,7 +111,7 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
         match self {
             Self::Fw1884(runtime) => runtime.listen(),
             Self::Fw1082(runtime) => runtime.listen(),
-            Self::IsochRack(unit) => unit.listen(),
+            Self::Fw1804(runtime) => runtime.listen(),
             Self::Asynch(unit) => unit.listen(),
         }
     }
@@ -120,7 +120,7 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
         match self {
             Self::Fw1884(runtime) => runtime.run(),
             Self::Fw1082(runtime) => runtime.run(),
-            Self::IsochRack(unit) => unit.run(),
+            Self::Fw1804(runtime) => runtime.run(),
             Self::Asynch(unit) => unit.run(),
         }
     }

--- a/libs/tascam/runtime/src/lib.rs
+++ b/libs/tascam/runtime/src/lib.rs
@@ -30,7 +30,7 @@ use seq_cntr::*;
 
 use isoch_console_runtime::*;
 use isoch_rack_runtime::*;
-use asynch_runtime::AsynchRuntime;
+use asynch_runtime::*;
 
 use std::convert::TryFrom;
 
@@ -38,7 +38,7 @@ pub enum TascamRuntime {
     Fw1884(Fw1884Runtime),
     Fw1082(Fw1082Runtime),
     Fw1804(Fw1804Runtime),
-    Asynch(AsynchRuntime),
+    Fe8(Fe8Runtime),
 }
 
 const TASCAM_OUI: u32 = 0x00022e;
@@ -94,8 +94,8 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
                 match (unit_data.specifier_id, unit_data.version) {
                     (TASCAM_OUI, FE8_SW_VERSION) => {
                         let name = unit_data.model_name.to_string();
-                        let runtime = AsynchRuntime::new(node, name)?;
-                        Ok(Self::Asynch(runtime))
+                        let runtime = Fe8Runtime::new(node, name)?;
+                        Ok(Self::Fe8(runtime))
                     }
                     _ => Err(Error::new(FileError::Noent, "Not supported")),
                 }
@@ -112,7 +112,7 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
             Self::Fw1884(runtime) => runtime.listen(),
             Self::Fw1082(runtime) => runtime.listen(),
             Self::Fw1804(runtime) => runtime.listen(),
-            Self::Asynch(unit) => unit.listen(),
+            Self::Fe8(runtime) => runtime.listen(),
         }
     }
 
@@ -121,7 +121,7 @@ impl RuntimeOperation<(String, u32)> for TascamRuntime {
             Self::Fw1884(runtime) => runtime.run(),
             Self::Fw1082(runtime) => runtime.run(),
             Self::Fw1804(runtime) => runtime.run(),
-            Self::Asynch(unit) => unit.run(),
+            Self::Fe8(runtime) => runtime.run(),
         }
     }
 }


### PR DESCRIPTION
This patchset is to refactor runtime crate of dg00x, efw, and tascam. Especially, generic structure is heavily used
to abstract runtime structure.

```
Takashi Sakamoto (13):
  tascam-runtime: isoch_ctls: obsolete AsRef/AsMut implementation in meter control
  tascam-runtime: isoch_ctls: rename trait of common control for naming consistency
  tascam-runtime: isoch_ctls: rename trait of optical interface control for naming consistency
  tascam-runtime: isoch_ctls: obsolete AsRef/AsMut implementation in console control
  tascam-runtime: isoch_ctls: obsolete AsRef/AsMut implementation in rack control
  tascam-runtime: isoch_ctls: obsolete AsRef/AsMut implementation in surface event dispatcher
  tascam-runtime: minor code refactoring for isoch console runtime
  tascam-runtime: use generic structure for runtime of isoch console unit
  tascam-runtime: minor code refactoring for isoch rack runtime
  tascam-runtime: use generic structure for runtime of isoch rack unit
  tascam-runtime: minor code refactoring for asynch runtime
  tascam-runtime: use generic structure for runtime of asynch unit
  tascam-runtime: use within-region allocator for asynch runtime

 libs/tascam/runtime/src/asynch_runtime.rs     | 221 ++++++-----
 libs/tascam/runtime/src/fe8_model.rs          |  19 +-
 libs/tascam/runtime/src/fw1082_model.rs       |  32 +-
 libs/tascam/runtime/src/fw1804_model.rs       |  24 +-
 libs/tascam/runtime/src/fw1884_model.rs       |  34 +-
 .../runtime/src/isoch_console_runtime.rs      | 345 ++++++++----------
 libs/tascam/runtime/src/isoch_ctls.rs         |  65 ++--
 libs/tascam/runtime/src/isoch_rack_runtime.rs | 215 +++++------
 libs/tascam/runtime/src/lib.rs                |  70 ++--
 9 files changed, 494 insertions(+), 531 deletions(-)
```