### PR TITLE
[PATCH 00/21] dice-protocols/dice-runtime: add support for Focusrite Saffire Pro 14, 24, and 24 DSP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,7 @@ your device, please contact to developer.
   * Lexicon I-ONIX FW810s
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
+  * Focusrite Saffire Pro 24
   * Focusrite Saffire Pro 14
   * Focusrite Saffire Pro 26
   * PreSonus FireStudio

--- a/README.rst
+++ b/README.rst
@@ -175,6 +175,7 @@ your device, please contact to developer.
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
   * Focusrite Saffire Pro 24
+  * Focusrite Saffire Pro 24 DSP
   * Focusrite Saffire Pro 14
   * Focusrite Saffire Pro 26
   * PreSonus FireStudio

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2021/10/07
+2021/11/06
 Takashi Sakamoto
 
 Introduction
@@ -174,6 +174,7 @@ your device, please contact to developer.
   * Lexicon I-ONIX FW810s
   * Focusrite Saffire Pro 40
   * Focusrite Liquid Saffire 56
+  * Focusrite Saffire Pro 14
   * Focusrite Saffire Pro 26
   * PreSonus FireStudio
   * PreSonus FireStudio Project

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -8,6 +8,7 @@
 
 pub mod spro40;
 pub mod liquids56;
+pub mod spro24;
 pub mod spro14;
 pub mod spro26;
 

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -8,6 +8,7 @@
 
 pub mod spro40;
 pub mod liquids56;
+pub mod spro14;
 pub mod spro26;
 
 use glib::Error;

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -9,6 +9,7 @@
 pub mod spro40;
 pub mod liquids56;
 pub mod spro24;
+pub mod spro24dsp;
 pub mod spro14;
 pub mod spro26;
 

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -78,7 +78,9 @@ impl Tcd22xxSpecOperation for LiquidS56Protocol {
     ];
 }
 
-const SW_NOTICE_OFFSET: usize = 0x02c8;
+impl SaffireproSwNoticeOperation for LiquidS56Protocol {
+    const SW_NOTICE_OFFSET: usize = 0x02c8;
+}
 
 const SRC_SW_NOTICE: u32 = 0x00000001;
 const DIM_MUTE_SW_NOTICE: u32 = 0x00000003;
@@ -94,7 +96,6 @@ impl SaffireproOutGroupOperation for LiquidS56Protocol {
     const ENTRY_COUNT: usize = 10;
     const HAS_VOL_HWCTL: bool = true;
     const OUT_CTL_OFFSET: usize = 0x000c;
-    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
 
     const SRC_NOTICE: u32 = SRC_SW_NOTICE;
     const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;
@@ -247,25 +248,6 @@ impl LedState {
 
 /// The trait to represent protocol specific to Saffire Pro 26.
 impl LiquidS56Protocol {
-    fn write_sw_notice(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        notice: u32,
-        timeout_ms: u32
-    ) -> Result<(), Error> {
-        let mut raw = [0; 4];
-        notice.build_quadlet(&mut raw);
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            SW_NOTICE_OFFSET,
-            &mut raw,
-            timeout_ms
-        )
-    }
-
     pub fn read_analog_out_0_1_pad_offset(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/libs/dice/protocols/src/focusrite/spro14.rs
+++ b/libs/dice/protocols/src/focusrite/spro14.rs
@@ -78,7 +78,7 @@
 //!
 //! ```
 
-use crate::tcat::{extension::*, tcd22xx_spec::*};
+use crate::{focusrite::*, tcat::{extension::*, tcd22xx_spec::*}};
 
 /// The structure for protocol implementation specific to Saffire Pro 14.
 #[derive(Debug)]
@@ -111,4 +111,9 @@ impl SaffireproOutGroupOperation for SPro14Protocol {
 
     const SRC_NOTICE: u32 = 0x00000001;
     const DIM_MUTE_NOTICE: u32 = 0x00000002;
+}
+
+impl SaffireproInputOperation for SPro14Protocol {
+    const MIC_INPUT_OFFSET: usize = 0x005c;
+    const LINE_INPUT_OFFSET: usize = 0x0060;
 }

--- a/libs/dice/protocols/src/focusrite/spro14.rs
+++ b/libs/dice/protocols/src/focusrite/spro14.rs
@@ -99,3 +99,16 @@ impl Tcd22xxSpecOperation for SPro14Protocol {
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
     ];
 }
+
+impl SaffireproSwNoticeOperation for SPro14Protocol {
+    const SW_NOTICE_OFFSET: usize = 0x000c;
+}
+
+impl SaffireproOutGroupOperation for SPro14Protocol {
+    const ENTRY_COUNT: usize = 4;
+    const HAS_VOL_HWCTL: bool = false;
+    const OUT_CTL_OFFSET: usize = 0x0010;
+
+    const SRC_NOTICE: u32 = 0x00000001;
+    const DIM_MUTE_NOTICE: u32 = 0x00000002;
+}

--- a/libs/dice/protocols/src/focusrite/spro14.rs
+++ b/libs/dice/protocols/src/focusrite/spro14.rs
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire Pro 14.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 14.
+//!
+//! ## Diagram of internal signal flow for Saffire Pro 14.
+//!
+//! I note that optical input interface is available exclusively for ADAT input and S/PDIF input.
+//!
+//! ```text
+//!                        ++===========++
+//! mixer-input-0/1 -----> ||           || -> mixer-output-0/1
+//! mixer-input-2/3 -----> ||           || -> mixer-output-2/3
+//! mixer-input-4/5 -----> ||           || -> mixer-output-4/5
+//! mixer-input-6/7 -----> ||   mixer   || -> mixer-output-6/7
+//! mixer-input-8/9 -----> ||           || -> mixer-output-8/9
+//! mixer-input-10/11 ---> ||  18 x 16  || -> mixer-output-10/11
+//! mixer-input-12/13 ---> ||           || -> mixer-output-12/13
+//! mixer-input-14/15 ---> ||           || -> mixer-output-14/15
+//! mixer-input-16/17 ---> ||           ||
+//!                        ++===========++
+//!
+//!                        ++===========++
+//! mic-input-0/1 -------> ||           || -> mixer-input-0/1
+//! line-input-0/1 ------> ||           || -> mixer-input-2/3
+//! spdif-input-0/1 -----> ||           || -> mixer-input-4/5
+//!                        ||  mixer    || -> mixer-input-6/7
+//! stream-input-0/1 ----> ||  input    || -> mixer-input-8/9
+//! stream-input-2/3 ----> ||  router   || -> mixer-input-10/11
+//! stream-input-4/5 ----> ||           || -> mixer-input-12/13
+//! stream-input-6/7 ----> ||   x 18    || -> mixer-input-14/15
+//! stream-input-8/9 ----> ||           || -> mixer-input-16/17
+//! stream-input-10/11 --> ||           ||
+//!                        ++===========++
+//!
+//!                        ++===========++
+//! mic-input-0/1 -------> ||           ||
+//! line-input-0/1 ------> ||           ||
+//! spdif-input-0/1 -----> ||           ||
+//!                        ||  stream   ||
+//! mixer-output-0/1 ----> ||  capture  || -> stream-output-0/1
+//! mixer-output-2/3 ----> ||  router   || -> stream-output-2/3
+//! mixer-output-4/5 ----> ||           || -> stream-output-4/5
+//! mixer-output-6/7 ----> ||    x 8    || -> stream-output-6/7
+//! mixer-output-8/9 ----> ||           ||
+//! mixer-output-10/11 --> ||           ||
+//! mixer-output-12/13 --> ||           ||
+//! mixer-output-14/15 --> ||           ||
+//!                        ++===========++
+//!
+//!                        ++===========++
+//! mic-input-0/1 -------> ||           ||
+//! line-input-0/1 ------> ||           ||
+//! spdif-input-0/1 -----> ||           ||
+//!                        ||           ||
+//! stream-input-0/1 ----> ||           ||
+//! stream-input-2/3 ----> ||           ||
+//! stream-input-4/5 ----> ||           ||
+//! stream-input-6/7 ----> ||           ||
+//! stream-input-8/9 ----> ||  physical ||
+//! stream-input-10/11 --> ||  output   || -> analog-output-0/1
+//! stream-input-12/13 --> ||  router   || -> analog-output-2/3
+//! stream-input-14/15 --> ||           || -> spdif-output-0/1
+//! stream-input-16/17 --> ||   x 6     ||
+//!                        ||           ||
+//! mixer-output-0/1 ----> ||           ||
+//! mixer-output-2/3 ----> ||           ||
+//! mixer-output-4/5 ----> ||           ||
+//! mixer-output-6/7 ----> ||           ||
+//! mixer-output-8/9 ----> ||           ||
+//! mixer-output-10/11 --> ||           ||
+//! mixer-output-12/13 --> ||           ||
+//! mixer-output-14/15 --> ||           ||
+//!                        ++===========++
+//!
+//! ```
+
+use crate::tcat::{extension::*, tcd22xx_spec::*};
+
+/// The structure for protocol implementation specific to Saffire Pro 14.
+#[derive(Debug)]
+pub struct SPro14Protocol;
+
+impl Tcd22xxSpecOperation for SPro14Protocol {
+    const INPUTS: &'static [Input] = &[
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 4, label: None},
+        Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF")},
+    ];
+    const OUTPUTS: &'static [Output] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 4, label: None},
+        Output{id: DstBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF")},
+    ];
+    // NOTE: The first 2 entries in router section are used to display signal detection.
+    const FIXED: &'static [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+    ];
+}

--- a/libs/dice/protocols/src/focusrite/spro24.rs
+++ b/libs/dice/protocols/src/focusrite/spro24.rs
@@ -48,3 +48,8 @@ impl SaffireproOutGroupOperation for SPro24Protocol {
     const SRC_NOTICE: u32 = 0x00000001;
     const DIM_MUTE_NOTICE: u32 = 0x00000002;
 }
+
+impl SaffireproInputOperation for SPro24Protocol {
+    const MIC_INPUT_OFFSET: usize = 0x0058;
+    const LINE_INPUT_OFFSET: usize = 0x005c;
+}

--- a/libs/dice/protocols/src/focusrite/spro24.rs
+++ b/libs/dice/protocols/src/focusrite/spro24.rs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire Pro 24.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 24.
+
+use crate::{tcat::{extension::*, tcd22xx_spec::*}};
+
+/// The structure for protocol implementation specific to Saffire Pro 24.
+#[derive(Debug)]
+pub struct SPro24Protocol;
+
+impl Tcd22xxSpecOperation for SPro24Protocol {
+    const INPUTS: &'static [Input] = &[
+        Input{id: SrcBlkId::Ins0, offset: 2, count: 2, label: Some("Mic")},
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: Some("Line")},
+        Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-coax")},
+        // NOTE: share the same optical interface.
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
+    ];
+
+    const OUTPUTS: &'static [Output] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
+        Output{id: DstBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-coax")},
+    ];
+
+    // NOTE: The first 4 entries in router section are used to display hardware metering.
+    const FIXED: &'static [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+    ];
+}

--- a/libs/dice/protocols/src/focusrite/spro24.rs
+++ b/libs/dice/protocols/src/focusrite/spro24.rs
@@ -6,7 +6,7 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Focusrite for Saffire Pro 24.
 
-use crate::{tcat::{extension::*, tcd22xx_spec::*}};
+use crate::{focusrite::*, tcat::{extension::*, tcd22xx_spec::*}};
 
 /// The structure for protocol implementation specific to Saffire Pro 24.
 #[derive(Debug)]
@@ -34,4 +34,17 @@ impl Tcd22xxSpecOperation for SPro24Protocol {
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
     ];
+}
+
+impl SaffireproSwNoticeOperation for SPro24Protocol {
+    const SW_NOTICE_OFFSET: usize = 0x0068;
+}
+
+impl SaffireproOutGroupOperation for SPro24Protocol {
+    const ENTRY_COUNT: usize = 6;
+    const HAS_VOL_HWCTL: bool = false;
+    const OUT_CTL_OFFSET: usize = 0x000c;
+
+    const SRC_NOTICE: u32 = 0x00000001;
+    const DIM_MUTE_NOTICE: u32 = 0x00000002;
 }

--- a/libs/dice/protocols/src/focusrite/spro24.rs
+++ b/libs/dice/protocols/src/focusrite/spro24.rs
@@ -5,6 +5,86 @@
 //!
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Focusrite for Saffire Pro 24.
+//!
+//! ## Diagram of internal signal flow for Saffire Pro 24.
+//!
+//! I note that optical input interface is available exclusively for ADAT input and S/PDIF input.
+//!
+//! ```text
+//!                          ++===========++
+//! mixer-input-0/1 -------> ||           || -> mixer-output-0/1
+//! mixer-input-2/3 -------> ||           || -> mixer-output-2/3
+//! mixer-input-4/5 -------> ||           || -> mixer-output-4/5
+//! mixer-input-6/7 -------> ||   mixer   || -> mixer-output-6/7
+//! mixer-input-8/9 -------> ||           || -> mixer-output-8/9
+//! mixer-input-10/11 -----> ||  18 x 16  || -> mixer-output-10/11
+//! mixer-input-12/13 -----> ||           || -> mixer-output-12/13
+//! mixer-input-14/15 -----> ||           || -> mixer-output-14/15
+//! mixer-input-16/17 -----> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           || -> mixer-input-0/1
+//! adat-input-0/1 --------> ||           || -> mixer-input-2/3
+//! adat-input-2/3 --------> ||           || -> mixer-input-4/5
+//! adat-input-4/5 --------> ||  mixer    || -> mixer-input-6/7
+//! adat-input-6/7 --------> ||  input    || -> mixer-input-8/9
+//! spdif-opt-input-0/1 ---> ||  router   || -> mixer-input-10/11
+//!                          ||           || -> mixer-input-12/13
+//! stream-input-0/1 ------> ||   x 18    || -> mixer-input-14/15
+//! stream-input-2/3 ------> ||           || -> mixer-input-16/17
+//! stream-input-4/5 ------> ||           ||
+//! stream-input-6/7 ------> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           ||
+//! adat-input-0/1 --------> ||           ||
+//! adat-input-2/3 --------> ||           || -> stream-output-0/1
+//! adat-input-4/5 --------> ||           || -> stream-output-2/3
+//! adat-input-6/7 --------> ||           || -> stream-output-4/5
+//! spdif-opt-input-0/1 ---> ||  stream   || -> stream-output-6/7
+//!                          ||  capture  || -> stream-output-8/9
+//! mixer-output-0/1 ------> ||  router   || -> stream-output-10/11
+//! mixer-output-2/3 ------> ||           || -> stream-output-12/13
+//! mixer-output-4/5 ------> ||   x 16    || -> stream-output-14/15
+//! mixer-output-6/7 ------> ||           ||
+//! mixer-output-8/9 ------> ||           ||
+//! mixer-output-10/11 ----> ||           ||
+//! mixer-output-12/13 ----> ||           ||
+//! mixer-output-14/15 ----> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           ||
+//! adat-input-0/1 --------> ||           ||
+//! adat-input-2/3 --------> ||           ||
+//! adat-input-4/5 --------> ||           ||
+//! adat-input-6/7 --------> ||           ||
+//! spdif-opt-input-0/1 ---> ||           ||
+//!                          ||  physical ||
+//! stream-input-0/1 ------> ||  output   || -> analog-output-0/1
+//! stream-input-2/3 ------> ||  router   || -> analog-output-2/3
+//! stream-input-4/5 ------> ||           || -> analog-output-4/5
+//! stream-input-6/7 ------> ||    x 8    || -> spdif-output-0/1
+//!                          ||           ||
+//! mixer-output-0/1 ------> ||           ||
+//! mixer-output-2/3 ------> ||           ||
+//! mixer-output-4/5 ------> ||           ||
+//! mixer-output-6/7 ------> ||           ||
+//! mixer-output-8/9 ------> ||           ||
+//! mixer-output-10/11 ----> ||           ||
+//! mixer-output-12/13 ----> ||           ||
+//! mixer-output-14/15 ----> ||           ||
+//!                          ++===========++
+//!
+//! ```
 
 use crate::{focusrite::*, tcat::{extension::*, tcd22xx_spec::*}};
 

--- a/libs/dice/protocols/src/focusrite/spro24dsp.rs
+++ b/libs/dice/protocols/src/focusrite/spro24dsp.rs
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+//! Protocol specific to Focusrite Saffire Pro 24 DSP.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 24 DSP.
+//!
+//! ## Diagram of internal signal flow for Saffire Pro 24 DSP.
+//!
+//! I note that optical input interface is available exclusively for ADAT input and S/PDIF input.
+//!
+//! ```text
+//!                          ++===========++
+//!                          || equalizer ||
+//! ch-strip-input-0/1 ----> ||     &     || -> ch-strip-output-0/1
+//!                          ||compressor ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! reverb-input-0/1 ------> ||  reverb   || -> reverb-output-0/1
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mixer-input-0/1 -------> ||           || -> mixer-output-0/1
+//! mixer-input-2/3 -------> ||           || -> mixer-output-2/3
+//! mixer-input-4/5 -------> ||           || -> mixer-output-4/5
+//! mixer-input-6/7 -------> ||   mixer   || -> mixer-output-6/7
+//! mixer-input-8/9 -------> ||           || -> mixer-output-8/9
+//! mixer-input-10/11 -----> ||  18 x 16  || -> mixer-output-10/11
+//! mixer-input-12/13 -----> ||           || -> mixer-output-12/13
+//! mixer-input-14/15 -----> ||           || -> mixer-output-14/15
+//! mixer-input-16/17 -----> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           ||
+//! adat-input-0/1 --------> ||           ||
+//! adat-input-2/3 --------> ||           || -> mixer-input-0/1
+//! adat-input-4/5 --------> ||  mixer    || -> mixer-input-2/3
+//! adat-input-6/7 --------> ||  input    || -> mixer-input-4/5
+//! spdif-opt-input-0/1 ---> ||  router   || -> mixer-input-6/7
+//!                          ||           || -> mixer-input-8/9
+//! stream-input-0/1 ------> ||   x 18    || -> mixer-input-10/11
+//! stream-input-2/3 ------> ||           || -> mixer-input-12/13
+//! stream-input-4/5 ------> ||           || -> mixer-input-14/15
+//! stream-input-6/7 ------> ||           || -> mixer-input-16/17
+//!                          ||           ||
+//! ch-strip-output-0/1 ---> ||           ||
+//! reverb-output-0/1 -----> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           ||
+//! adat-input-0/1 --------> ||           ||
+//! adat-input-2/3 --------> ||           ||
+//! adat-input-4/5 --------> ||           ||
+//! adat-input-6/7 --------> ||           || -> stream-output-0/1
+//! spdif-opt-input-0/1 ---> ||  stream   || -> stream-output-2/3
+//!                          ||  capture  || -> stream-output-4/5
+//! mixer-output-0/1 ------> ||  router   || -> stream-output-6/7
+//! mixer-output-2/3 ------> ||           || -> stream-output-8/9
+//! mixer-output-4/5 ------> ||   x 16    || -> stream-output-10/11
+//! mixer-output-6/7 ------> ||           || -> stream-output-12/13
+//! mixer-output-8/9 ------> ||           || -> stream-output-14/15
+//! mixer-output-10/11 ----> ||           ||
+//! mixer-output-12/13 ----> ||           ||
+//! mixer-output-14/15 ----> ||           ||
+//!                          ||           ||
+//! ch-strip-0/1 ----------> ||           ||
+//! reverb-0/1 ------------> ||           ||
+//!                          ++===========++
+//!
+//!                          ++===========++
+//! mic-input-0/1 ---------> ||           ||
+//! line-input-0/1 --------> ||           ||
+//! spdif-coax-input-0/1 --> ||           ||
+//! adat-input-0/1 --------> ||           ||
+//! adat-input-2/3 --------> ||           ||
+//! adat-input-4/5 --------> ||           ||
+//! adat-input-6/7 --------> ||           ||
+//! spdif-opt-input-0/1 ---> ||           ||
+//!                          ||           ||
+//! stream-input-0/1 ------> ||           || -> analog-output-0/1
+//! stream-input-2/3 ------> ||  physical || -> analog-output-2/3
+//! stream-input-4/5 ------> ||  output   || -> analog-output-4/5
+//! stream-input-6/7 ------> ||  router   || -> spdif-output-0/1
+//!                          ||           ||
+//! mixer-output-0/1 ------> ||   x 12    || -> ch-strip-input-0/1
+//! mixer-output-2/3 ------> ||           || -> reverb-input-0/1
+//! mixer-output-4/5 ------> ||           ||
+//! mixer-output-6/7 ------> ||           ||
+//! mixer-output-8/9 ------> ||           ||
+//! mixer-output-10/11 ----> ||           ||
+//! mixer-output-12/13 ----> ||           ||
+//! mixer-output-14/15 ----> ||           ||
+//!                          ||           ||
+//! ch-strip-output-0/1 ---> ||           ||
+//! reverb-output-0/1 -----> ||           ||
+//!                          ++===========++
+//!
+//! ```
+
+use crate::tcat::{extension::*, tcd22xx_spec::*};
+
+/// The structure to represent state of TCD22xx on Saffire Pro 24 DSP.
+#[derive(Debug)]
+pub struct SPro24DspState;
+
+impl Tcd22xxSpecOperation for SPro24DspState {
+    const INPUTS: &'static [Input] = &[
+        Input{id: SrcBlkId::Ins0, offset: 2, count: 2, label: Some("Mic")},
+        Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: Some("Line")},
+        // NOTE: share the same optical interface.
+        Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
+        Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
+    ];
+
+    const OUTPUTS: &'static [Output] = &[
+        Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
+        Output{id: DstBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-coax")},
+    ];
+
+    // NOTE: The first 4 entries in router section are used to display hardware metering.
+    const FIXED: &'static [SrcBlk] = &[
+        SrcBlk{id: SrcBlkId::Ins0, ch: 2},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 3},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 0},
+        SrcBlk{id: SrcBlkId::Ins0, ch: 1},
+    ];
+}

--- a/libs/dice/protocols/src/focusrite/spro24dsp.rs
+++ b/libs/dice/protocols/src/focusrite/spro24dsp.rs
@@ -105,13 +105,13 @@
 //!
 //! ```
 
-use crate::tcat::{extension::*, tcd22xx_spec::*};
+use crate::{focusrite::*, tcat::{extension::*, tcd22xx_spec::*}};
 
-/// The structure to represent state of TCD22xx on Saffire Pro 24 DSP.
+/// The structure for protocol implementation specific to Saffire Pro 24 DSP.
 #[derive(Debug)]
-pub struct SPro24DspState;
+pub struct SPro24DspProtocol;
 
-impl Tcd22xxSpecOperation for SPro24DspState {
+impl Tcd22xxSpecOperation for SPro24DspProtocol {
     const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 2, count: 2, label: Some("Mic")},
         Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: Some("Line")},
@@ -132,4 +132,17 @@ impl Tcd22xxSpecOperation for SPro24DspState {
         SrcBlk{id: SrcBlkId::Ins0, ch: 0},
         SrcBlk{id: SrcBlkId::Ins0, ch: 1},
     ];
+}
+
+impl SaffireproSwNoticeOperation for SPro24DspProtocol {
+    const SW_NOTICE_OFFSET: usize = 0x05ec;
+}
+
+impl SaffireproOutGroupOperation for SPro24DspProtocol {
+    const ENTRY_COUNT: usize = 6;
+    const HAS_VOL_HWCTL: bool = false;
+    const OUT_CTL_OFFSET: usize = 0x000c;
+
+    const SRC_NOTICE: u32 = 0x00000001;
+    const DIM_MUTE_NOTICE: u32 = 0x00000002;
 }

--- a/libs/dice/protocols/src/focusrite/spro24dsp.rs
+++ b/libs/dice/protocols/src/focusrite/spro24dsp.rs
@@ -104,6 +104,89 @@
 //!                          ++===========++
 //!
 //! ```
+//!
+//! ## Data layout in TCAT application section for DSP effect
+//!
+//! The offset of TCAT application section is 0x6dd4. Any change by write transaction is firstly
+//! effective when software message is written to 0x5ec.
+//!
+//! ### Data Layout for DSP effect
+//!
+//! * 0x000: DSP enable/disable (sw msg: 0x1c)
+//! * 0x008: flags for channel strip effects (sw msg: 0x05)
+//!     * 0x00000001: ch 0 equalizer enable
+//!     * 0x00010000: ch 1 equalizer enable
+//!     * 0x00000002: ch 0 compressor enable
+//!     * 0x00020000: ch 1 compressor enable
+//!     * 0x00000004: ch 0 equalizer after compressor
+//!     * 0x00040000: ch 1 equalizer after compressor
+//!
+//! blk 0 | blk 2 | blk 4 | blk 6 | count   | purpose                         | sw msg |
+//! ----- | ----- | ----- | ----- | --------| ------------------------------- | ------ |
+//! 0x120 | 0x230 | 0x340 | 0x450 | 6 quads | ch 0 comp                       |   0x06 |
+//! 0x138 | 0x248 | 0x358 | 0x468 | 2 quads | ch 0/ch 1 eq output             |   0z09 |
+//! 0x140 | 0x250 | 0x360 | 0x470 | 5 quads | ch 0 eq low freq filter         |   0x0c |
+//! 0x154 | 0x264 | 0x374 | 0x484 | 5 quads | ch 0 eq low-middle freq filter  |   0x0f |
+//! 0x168 | 0x278 | 0x388 | 0x498 | 5 quads | ch 0 eq high-middle freq filter |   0x12 |
+//! 0x17c | 0x28c | 0x39c | 0x4ac | 5 quads | ch 0 eq high freq filter        |   0x15 |
+//! 0x190 | 0x2a0 | 0x3b0 | 0x4c0 | 6 quads | ch 0 reverb                     |   0x1a |
+//!
+//! blk 1 | blk 3 | blk 5 | blk 7 | count   | purpose                         | sw msg |
+//! ----- | ----- | ----- | ----- | --------| ------------------------------- | ------ |
+//! 0x1a8 | 0x2b8 | 0x3c8 | 0x4d8 | 6 quads | ch 1 comp                       |   0x07 |
+//! 0x1c0 | 0x2d0 | 0x3e0 | 0x4f0 | 2 quads | ch 0/ch 1 eq output             |   0x0a |
+//! 0x1c8 | 0x2d8 | 0x3e8 | 0x4f8 | 5 quads | ch 1 eq low freq filter         |   0x0d |
+//! 0x1dc | 0x2ec | 0x3fc | 0x50c | 5 quads | ch 1 eq low-middle freq filter  |   0x10 |
+//! 0x1f0 | 0x300 | 0x410 | 0x520 | 5 quads | ch 1 eq high-middle freq filter |   0x13 |
+//! 0x204 | 0x314 | 0x424 | 0x534 | 5 quads | ch 1 eq high freq filter        |   0x16 |
+//! 0x218 | 0x328 | 0x438 | 0x548 | 6 quads | ch 1 reverb                     |   0x1a |
+//!
+//! ### Compressor coefficients (6 quadlets)
+//!
+//! Actually change to block 2 is effective.
+//!
+//! quad | purpose          | min value  | max value  | min repr | max repr |
+//! ---- | -------------    | ---------- | ---------- | -------- | -------- |
+//!    0 | unknown          | 0x3f800000 | 0x3f800000 |    -     |    -     |
+//!    1 | output volume    | 0x00000000 | 0x42800000 | -36.0 dB | +36.0 dB |
+//!    2 | threshold        | 0xbfa00000 | 0x00000000 | -80.0 dB |   0.0 dB |
+//!    3 | ratio            | 0x3d000000 | 0x3f000000 |  1.1:1   |  inf:1   |
+//!    4 | attack           | 0xbf700000 | 0xbf800000 |   2ms    |  100ms   |
+//!    5 | release          | 0x3f700000 | 0x3f800000 |  100ms   |   3s     |
+//!
+//! ### Equalizer output coefficients (2 quadlets)
+//!
+//! Actually change to block 2 is effective.
+//!
+//! quad | purpose          | min value  | max value  | min repr | max repr |
+//! ---- | ---------------- | ---------- | ---------- | -------- | -------- |
+//!    0 | left volume      | 0x00000000 | 0x3f800000 | -36.0 dB | +36.0 dB |
+//!    1 | right volume     | 0x00000000 | 0x3f800000 | -36.0 dB | +36.0 dB |
+//!
+//! ### Equalizer coefficients (5 quadlets)
+//!
+//! Actually change to block 2 is effective.
+//!
+//! quad | purpose          | min value  | max value  | min repr | max repr |
+//! ---- | ---------------- | ---------- | ---------- | -------- | -------- |
+//!    0 | unknown          |     -      |     -      |    -     |    -     |
+//!    1 | unknown          |     -      |     -      |    -     |    -     |
+//!    2 | unknown          |     -      |     -      |    -     |    -     |
+//!    3 | unknown          |     -      |     -      |    -     |    -     |
+//!    4 | unknown          |     -      |     -      |    -     |    -     |
+//!
+//! ### Reverb coefficients (6 quadlets)
+//!
+//! Actually change to block 3 is effective.
+//!
+//! quad | purpose          | min value  | max value  | min repr | max repr |
+//! ---- | ---------------- | ---------- | ---------- | -------- | -------- |
+//!    0 | room size        | 0x00000000 | 0x3f800000 | 0 %      | 100 %    |
+//!    1 | air              | 0x00000000 | 0x3f800000 | 100 %    | 0 %      |
+//!    2 | enabled          | 0x00000000 | 0x3f800000 | false    | true     |
+//!    3 | disabled         | 0x00000000 | 0x3f800000 | false    | true     |
+//!    4 | pre filter value | 0x00000000 | 0x3f800000 | 5.0      | 0.0      |
+//!    5 | pre filter sign  | 0x00000000 | 0x3f800000 | negative | positive |
 
 use crate::{focusrite::*, tcat::{extension::*, tcd22xx_spec::*}};
 
@@ -115,6 +198,11 @@ impl Tcd22xxSpecOperation for SPro24DspProtocol {
     const INPUTS: &'static [Input] = &[
         Input{id: SrcBlkId::Ins0, offset: 2, count: 2, label: Some("Mic")},
         Input{id: SrcBlkId::Ins0, offset: 0, count: 2, label: Some("Line")},
+        Input{id: SrcBlkId::Ins0, offset: 8, count: 2, label: Some("Ch-strip")},
+        // Input{id: SrcBlkId::Ins0, offset: 4, count: 2, label: Some("Ch-strip")}, at 88.2/96.0 kHz.
+        Input{id: SrcBlkId::Ins0, offset: 14, count: 2, label: Some("Reverb")},
+        // Input{id: SrcBlkId::Ins0, offset: 6, count: 2, label: Some("Reverb")}, at 88.2/96.0 kHz.
+        Input{id: SrcBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-coax")},
         // NOTE: share the same optical interface.
         Input{id: SrcBlkId::Adat, offset: 0, count: 8, label: None},
         Input{id: SrcBlkId::Aes, offset: 4, count: 2, label: Some("S/PDIF-opt")},
@@ -123,6 +211,10 @@ impl Tcd22xxSpecOperation for SPro24DspProtocol {
     const OUTPUTS: &'static [Output] = &[
         Output{id: DstBlkId::Ins0, offset: 0, count: 6, label: None},
         Output{id: DstBlkId::Aes, offset: 6, count: 2, label: Some("S/PDIF-coax")},
+        Output{id: DstBlkId::Ins0, offset: 8, count: 2, label: Some("Ch-strip")},
+        // Output{id: DstBlkId::Ins0, offset: 4, count: 2, label: Some("Ch-strip")}, at 88.2/96.0 kHz.
+        Output{id: DstBlkId::Ins0, offset: 14, count: 2, label: Some("Reverb")},
+        // Output{id: DstBlkId::Ins0, offset: 6, count: 2, label: Some("Reverb")}, at 88.2/96.0 kHz.
     ];
 
     // NOTE: The first 4 entries in router section are used to display hardware metering.
@@ -150,4 +242,599 @@ impl SaffireproOutGroupOperation for SPro24DspProtocol {
 impl SaffireproInputOperation for SPro24DspProtocol {
     const MIC_INPUT_OFFSET: usize = 0x0058;
     const LINE_INPUT_OFFSET: usize = 0x005c;
+}
+
+// When VRM mode is enabled, write 0x00000001 to the offset
+#[allow(dead_code)]
+const DSP_ENABLE_OFFSET: usize = 0x0070;      // sw notice: 0x1c.
+const CH_STRIP_FLAG_OFFSET: usize = 0x0078;
+const   CH_STRIP_FLAG_EQ_ENABLE: u16 = 0x0001;
+const   CH_STRIP_FLAG_COMP_ENABLE: u16 = 0x0002;
+const   CH_STRIP_FLAG_EQ_AFTER_COMP: u16 = 0x0004;
+
+const CH_STRIP_FLAG_SW_NOTICE: u32 = 0x00000005;
+
+const COEF_OFFSET: usize = 0x0190;
+const COEF_BLOCK_SIZE: usize = 0x88;
+const COEF_BLOCK_COUNT: usize = 8;
+
+const EQ_COEF_COUNT: usize = 5;
+
+const COMP_OUTPUT_OFFSET: usize = 0x04;
+const COMP_THRESHOLD_OFFSET: usize = 0x08;
+const COMP_RATIO_OFFSET: usize = 0x0c;
+const COMP_ATTACK_OFFSET: usize = 0x10;
+const COMP_RELEASE_OFFSET: usize = 0x14;
+
+const COMP_CH0_SW_NOTICE: u32 = 0x00000006;
+const COMP_CH1_SW_NOTICE: u32 = 0x00000007;
+
+const EQ_OUTPUT_OFFSET: usize = 0x18;
+const EQ_LOW_FREQ_OFFSET: usize = 0x20;
+const EQ_LOW_MIDDLE_FREQ_OFFSET: usize = 0x34;
+const EQ_HIGH_MIDDLE_FREQ_OFFSET: usize = 0x48;
+const EQ_HIGH_FREQ_OFFSET: usize = 0x5c;
+
+const EQ_OUTPUT_CH0_SW_NOTICE: u32 = 0x09;
+const EQ_OUTPUT_CH1_SW_NOTICE: u32 = 0x0a;
+const EQ_LOW_FREQ_CH0_SW_NOTICE: u32 = 0x0c;
+const EQ_LOW_FREQ_CH1_SW_NOTICE: u32 = 0x0c;
+const EQ_LOW_MIDDLE_FREQ_CH0_SW_NOTICE: u32 = 0x0f;
+const EQ_LOW_MIDDLE_FREQ_CH1_SW_NOTICE: u32 = 0x10;
+const EQ_HIGH_MIDDLE_FREQ_CH0_SW_NOTICE: u32 = 0x12;
+const EQ_HIGH_MIDDLE_FREQ_CH1_SW_NOTICE: u32 = 0x13;
+const EQ_HIGH_FREQ_CH0_SW_NOTICE: u32 = 0x15;
+const EQ_HIGH_FREQ_CH1_SW_NOTICE: u32 = 0x16;
+
+const REVERB_SIZE_OFFSET: usize = 0x70;
+const REVERB_AIR_OFFSET: usize = 0x74;
+const REVERB_ENABLE_OFFSET: usize = 0x78;
+const REVERB_DISABLE_OFFSET: usize = 0x7c;
+const REVERB_PRE_FILTER_VALUE_OFFSET: usize = 0x80;
+const REVERB_PRE_FILTER_SIGN_OFFSET: usize = 0x84;
+
+const REVERB_SW_NOTICE: u32 = 0x0000001a;
+
+trait QuadletConvert {
+    fn parse(&mut self, quads: &[f32]);
+    fn build(&self, quads: &mut [f32]);
+}
+
+/// The structure for state of compressor effect.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Spro24DspCompressorState {
+    /// The volume of output, between 0.0 to 64.0.
+    pub output: [f32; 2],
+    /// The threshold, between -1.25 to 0.0.
+    pub threshold: [f32; 2],
+    /// The ratio, between 0.03125 to 0.5.
+    pub ratio: [f32; 2],
+    /// The attack, between -0.9375 to -1.0.
+    pub attack: [f32; 2],
+    /// The release, between 0.9375 to 1.0.
+    pub release: [f32; 2],
+}
+
+/// The structure for coefficients per frequency band.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Spro24DspEqualizerFrequencyBandState([f32; EQ_COEF_COUNT]);
+
+/// The structure for state of equalizer effect.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Spro24DspEqualizerState {
+    /// The volume of output, between 0.0 to 1.0.
+    pub output: [f32; 2],
+    // TODO: how to convert these coefficients to friendly parameter.
+    pub low_coef: [Spro24DspEqualizerFrequencyBandState; 2],
+    pub low_middle_coef: [Spro24DspEqualizerFrequencyBandState; 2],
+    pub high_middle_coef: [Spro24DspEqualizerFrequencyBandState; 2],
+    pub high_coef: [Spro24DspEqualizerFrequencyBandState; 2],
+}
+
+/// The structure for state of reverb effect.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Spro24DspReverbState {
+    /// The size of room, between 0.0 to 1.0.
+    pub size: f32,
+    /// The amount to reduce dumping, between 0.0 to 1.0.
+    pub air: f32,
+    /// Whether the reverb effect is enabled or not.
+    pub enabled: bool,
+    /// The ratio of high-pass/low-pass filter, between -1.0 to 1.0.
+    pub pre_filter: f32,
+}
+
+const COEF_BLOCK_COMP: usize = 2;
+const COEF_BLOCK_EQ: usize = 2;
+const COEF_BLOCK_REVERB: usize = 3;
+
+impl QuadletConvert for Spro24DspCompressorState {
+    fn parse(&mut self, quads: &[f32]) {
+        (0..2)
+            .for_each(|ch| {
+                let base_offset = (COEF_BLOCK_COMP + ch) * COEF_BLOCK_SIZE;
+
+                let pos = (base_offset + COMP_OUTPUT_OFFSET) / 4;
+                self.output[ch] = quads[pos];
+
+                let pos = (base_offset + COMP_THRESHOLD_OFFSET) / 4;
+                self.threshold[ch] = quads[pos];
+
+                let pos = (base_offset + COMP_RATIO_OFFSET) / 4;
+                self.ratio[ch] = quads[pos];
+
+                let pos = (base_offset + COMP_ATTACK_OFFSET) / 4;
+                self.attack[ch] = quads[pos];
+
+                let pos = (base_offset + COMP_RELEASE_OFFSET) / 4;
+                self.release[ch] = quads[pos];
+            });
+    }
+
+    fn build(&self, quads: &mut [f32]) {
+        (0..COEF_BLOCK_COUNT)
+            .for_each(|i| {
+                let ch = i % 2;
+                let base_offset = i * COEF_BLOCK_SIZE;
+
+                let pos = (base_offset + COMP_OUTPUT_OFFSET) / 4;
+                quads[pos] = self.output[ch];
+
+                let pos = (base_offset + COMP_THRESHOLD_OFFSET) / 4;
+                quads[pos] = self.threshold[ch];
+
+                let pos = (base_offset + COMP_RATIO_OFFSET) / 4;
+                quads[pos] = self.ratio[ch];
+
+                let pos = (base_offset + COMP_ATTACK_OFFSET) / 4;
+                quads[pos] = self.attack[ch];
+
+                let pos = (base_offset + COMP_RELEASE_OFFSET) / 4;
+                quads[pos] = self.release[ch];
+            });
+    }
+}
+
+impl QuadletConvert for Spro24DspEqualizerState {
+    fn parse(&mut self, quads: &[f32]) {
+        (0..2)
+            .for_each(|ch| {
+                let base_offset = (COEF_BLOCK_EQ + ch) * COEF_BLOCK_SIZE;
+
+                let pos = (base_offset + EQ_OUTPUT_OFFSET) / 4;
+                self.output[ch] = quads[pos];
+
+                let pos = (base_offset + EQ_LOW_FREQ_OFFSET) / 4;
+                self.low_coef[ch].0.copy_from_slice(&quads[pos..(pos + EQ_COEF_COUNT)]);
+
+                let pos = (base_offset + EQ_LOW_MIDDLE_FREQ_OFFSET) / 4;
+                self.low_middle_coef[ch].0.copy_from_slice(&quads[pos..(pos + EQ_COEF_COUNT)]);
+
+                let pos = (base_offset + EQ_HIGH_MIDDLE_FREQ_OFFSET) / 4;
+                self.high_middle_coef[ch].0.copy_from_slice(&quads[pos..(pos + EQ_COEF_COUNT)]);
+
+                let pos = (base_offset + EQ_HIGH_FREQ_OFFSET) / 4;
+                self.high_coef[ch].0.copy_from_slice(&quads[pos..(pos + EQ_COEF_COUNT)]);
+
+            });
+    }
+
+    fn build(&self, quads: &mut [f32]) {
+        (0..COEF_BLOCK_COUNT)
+            .for_each(|i| {
+                let ch = i % 2;
+                let base_offset = (COEF_BLOCK_EQ + ch) * COEF_BLOCK_SIZE;
+
+                let pos = (base_offset + EQ_OUTPUT_OFFSET) / 4;
+                quads[pos] = self.output[ch];
+
+                let pos = (base_offset + EQ_LOW_FREQ_OFFSET) / 4;
+                quads[pos..(pos + EQ_COEF_COUNT)].copy_from_slice(&self.low_coef[ch].0);
+
+                let pos = (base_offset + EQ_LOW_MIDDLE_FREQ_OFFSET) / 4;
+                quads[pos..(pos + EQ_COEF_COUNT)].copy_from_slice(&self.low_middle_coef[ch].0);
+
+                let pos = (base_offset + EQ_HIGH_MIDDLE_FREQ_OFFSET) / 4;
+                quads[pos..(pos + EQ_COEF_COUNT)].copy_from_slice(&self.high_middle_coef[ch].0);
+
+                let pos = (base_offset + EQ_HIGH_FREQ_OFFSET) / 4;
+                quads[pos..(pos + EQ_COEF_COUNT)].copy_from_slice(&self.high_coef[ch].0);
+            });
+    }
+}
+
+impl QuadletConvert for Spro24DspReverbState {
+    fn parse(&mut self, quads: &[f32]) {
+        let base_offset = COEF_BLOCK_REVERB * COEF_BLOCK_SIZE;
+
+        let pos = (base_offset + REVERB_SIZE_OFFSET) / 4;
+        self.size = quads[pos];
+
+        let pos = (base_offset + REVERB_AIR_OFFSET) / 4;
+        self.air = quads[pos];
+
+        let pos = (base_offset + REVERB_ENABLE_OFFSET) / 4;
+        self.enabled = quads[pos] > 0.0;
+
+        let pos = (base_offset + REVERB_PRE_FILTER_VALUE_OFFSET) / 4;
+        let mut val = quads[pos];
+        let pos = (base_offset + REVERB_PRE_FILTER_SIGN_OFFSET) / 4;
+        if quads[pos] == 0.0 {
+            val *= -1.0;
+        }
+        self.pre_filter = val;
+    }
+
+    fn build(&self, quads: &mut [f32]) {
+        (0..COEF_BLOCK_COUNT)
+            .for_each(|i| {
+                let base_offset = i * COEF_BLOCK_SIZE;
+
+                let pos = (base_offset + REVERB_SIZE_OFFSET) / 4;
+                quads[pos] = self.size;
+
+                let pos = (base_offset + REVERB_AIR_OFFSET) / 4;
+                quads[pos] = self.air;
+
+                let enable_pos = (base_offset + REVERB_ENABLE_OFFSET) / 4;
+                let disable_pos = (base_offset + REVERB_DISABLE_OFFSET) / 4;
+                if self.enabled {
+                    quads[enable_pos] = 1.0;
+                    quads[disable_pos] = 0.0
+                } else {
+                    quads[enable_pos] = 0.0;
+                    quads[disable_pos] = 1.0
+                }
+
+                let mut val = self.pre_filter;
+                let pos = (base_offset + REVERB_PRE_FILTER_SIGN_OFFSET) / 4;
+                quads[pos] = if val > 0.0 { 1.0 } else { 0.0 };
+
+                if val < 0.0 {
+                    val *= -1.0;
+                }
+                let pos = (base_offset + REVERB_PRE_FILTER_VALUE_OFFSET) / 4;
+                quads[pos] = val;
+        });
+    }
+}
+
+/// The state of effect.
+#[derive(Default, Debug, Copy, Clone, PartialEq)]
+pub struct Spro24DspEffectState {
+    pub eq_after_comp: [bool; 2],
+    pub comp_enable: [bool; 2],
+    pub eq_enable: [bool; 2],
+    pub comp: Spro24DspCompressorState,
+    pub eq: Spro24DspEqualizerState,
+    pub reverb: Spro24DspReverbState,
+}
+
+impl SPro24DspProtocol {
+    pub const COMPRESSOR_OUTPUT_MIN: f32 = 0.0;
+    pub const COMPRESSOR_OUTPUT_MAX: f32 = 64.0;
+
+    pub const COMPRESSOR_THRESHOLD_MIN: f32 = -1.25;
+    pub const COMPRESSOR_THRESHOLD_MAX: f32 = 0.0;
+
+    pub const COMPRESSOR_RATIO_MIN: f32 = 0.03125;
+    pub const COMPRESSOR_RATIO_MAX: f32 = 0.5;
+
+    pub const COMPRESSOR_ATTACK_MIN: f32 = -0.9375;
+    pub const COMPRESSOR_ATTACK_MAX: f32 = -1.0;
+
+    pub const COMPRESSOR_RELEASE_MIN: f32 = 0.9375;
+    pub const COMPRESSOR_RELEASE_MAX: f32 = 1.0;
+
+    pub const EQUALIZER_OUTPUT_MIN: f32 = 0.0;
+    pub const EQUALIZER_OUTPUT_MAX: f32 = 1.0;
+
+    pub const REVERB_SIZE_MIN: f32 = 0.0;
+    pub const REVERB_SIZE_MAX: f32 = 1.0;
+
+    pub const REVERB_AIR_MIN: f32 = 0.0;
+    pub const REVERB_AIR_MAX: f32 = 1.0;
+
+    pub const REVERB_PRE_FILTER_MIN: f32 = -1.0;
+    pub const REVERB_PRE_FILTER_MAX: f32 = 1.0;
+
+    pub fn read_effect_state(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut raw = [0; 4];
+        ApplSectionProtocol::read_appl_data(
+            req,
+            node,
+            sections,
+            CH_STRIP_FLAG_OFFSET,
+            &mut raw,
+            timeout_ms
+        )
+            .map(|_| {
+                let val = u32::from_be_bytes(raw);
+                (0..2)
+                    .for_each(|i| {
+                        let flags = (val >> (i * 16)) as u16;
+                        state.eq_after_comp[i] = flags & CH_STRIP_FLAG_EQ_AFTER_COMP > 0;
+                        state.comp_enable[i] = flags & CH_STRIP_FLAG_COMP_ENABLE > 0;
+                        state.eq_enable[i] = flags & CH_STRIP_FLAG_EQ_ENABLE > 0;
+                    });
+            })?;
+
+        let mut raw = vec![0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        ApplSectionProtocol::read_appl_data(
+            req,
+            node,
+            sections,
+            COEF_OFFSET,
+            &mut raw,
+            timeout_ms
+        )
+            .map(|_| {
+                let mut quad = [0; 4];
+                let quads: Vec<f32> = (0..raw.len())
+                    .step_by(4)
+                    .map(|pos| {
+                        quad.copy_from_slice(&raw[pos..(pos + 4)]);
+                        f32::from_be_bytes(quad)
+                    })
+                    .collect();
+
+                state.comp.parse(&quads);
+                state.eq.parse(&quads);
+                state.reverb.parse(&quads);
+            })
+    }
+
+    pub fn write_eq_after_comp(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        eq_after_comp: &[bool],
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_flags(
+            req,
+            node,
+            sections,
+            eq_after_comp,
+            &state.comp_enable,
+            &state.eq_enable,
+            timeout_ms
+        )
+            .map(|_| state.eq_after_comp.copy_from_slice(eq_after_comp))
+    }
+
+    pub fn write_comp_enable(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        comp_enable: &[bool],
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_flags(
+            req,
+            node,
+            sections,
+            &state.eq_after_comp,
+            comp_enable,
+            &state.eq_enable,
+            timeout_ms
+        )
+            .map(|_| state.comp_enable.copy_from_slice(comp_enable))
+    }
+
+    pub fn write_eq_enable(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        eq_enable: &[bool],
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_flags(
+            req,
+            node,
+            sections,
+            &state.eq_after_comp,
+            &state.comp_enable,
+            eq_enable,
+            timeout_ms
+        )
+            .map(|_| state.eq_enable.copy_from_slice(eq_enable))
+    }
+
+    fn write_flags(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        eq_after_comp: &[bool],
+        comp_enable: &[bool],
+        eq_enable: &[bool],
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        assert_eq!(eq_after_comp.len(), 2);
+        assert_eq!(comp_enable.len(), 2);
+        assert_eq!(eq_enable.len(), 2);
+
+        let val = (0..2)
+            .fold(0u32, |mut val, i| {
+                let shift = i * 16;
+
+                if eq_after_comp[i] {
+                    val |= (CH_STRIP_FLAG_EQ_AFTER_COMP as u32) << shift;
+                }
+                if comp_enable[i] {
+                    val |= (CH_STRIP_FLAG_COMP_ENABLE as u32) << shift;
+                }
+                if eq_enable[i] {
+                    val |= (CH_STRIP_FLAG_EQ_ENABLE as u32) << shift;
+                }
+                val
+            });
+
+        ApplSectionProtocol::write_appl_data(
+            req,
+            node,
+            sections,
+            CH_STRIP_FLAG_OFFSET,
+            &mut val.to_be_bytes(),
+            timeout_ms
+        )?;
+        Self::write_sw_notice(req, node, sections, CH_STRIP_FLAG_SW_NOTICE, timeout_ms)
+    }
+
+    pub fn write_comp_effect(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        comp: &Spro24DspCompressorState,
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_effect(req, node, sections, comp, &state.comp, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, COMP_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, COMP_CH1_SW_NOTICE, timeout_ms)?;
+        state.comp = *comp;
+        Ok(())
+    }
+
+    pub fn write_eq_effect(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        eq: &Spro24DspEqualizerState,
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_effect(req, node, sections, eq, &state.eq, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_OUTPUT_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_OUTPUT_CH1_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_LOW_FREQ_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_LOW_FREQ_CH1_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_LOW_MIDDLE_FREQ_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_LOW_MIDDLE_FREQ_CH1_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_HIGH_MIDDLE_FREQ_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_HIGH_MIDDLE_FREQ_CH1_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_HIGH_FREQ_CH0_SW_NOTICE, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, EQ_HIGH_FREQ_CH1_SW_NOTICE, timeout_ms)?;
+        state.eq = *eq;
+        Ok(())
+    }
+
+    pub fn write_reverb_effect(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        reverb: &Spro24DspReverbState,
+        state: &mut Spro24DspEffectState,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        Self::write_effect(req, node, sections, reverb, &state.reverb, timeout_ms)?;
+        Self::write_sw_notice(req, node, sections, REVERB_SW_NOTICE, timeout_ms)?;
+        state.reverb = *reverb;
+        Ok(())
+    }
+
+    fn write_effect<T: QuadletConvert>(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        new: &T,
+        old: &T,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        let mut new_quads = [0.0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        let mut old_quads = [0.0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        new.build(&mut new_quads);
+        old.build(&mut old_quads);
+
+        new_quads
+            .iter()
+            .zip(old_quads.iter())
+            .enumerate()
+            .filter(|(_, (n, o))| *n != *o)
+            .try_for_each(|(i, (val, _))| {
+                let pos = COEF_OFFSET + i * 4;
+                ApplSectionProtocol::write_appl_data(
+                    req,
+                    node,
+                    sections,
+                    pos,
+                    &mut val.to_be_bytes(),
+                    timeout_ms
+                )
+            })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn comp_state() {
+        let orig = Spro24DspCompressorState {
+            output: [0.04, 0.05],
+            threshold: [0.16, 0.17],
+            ratio: [0.20, 0.21],
+            attack: [0.32, 0.33],
+            release: [0.44, 0.45],
+        };
+        let mut new_quads = [0.0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        orig.build(&mut new_quads);
+
+        let mut curr = Spro24DspCompressorState::default();
+        curr.parse(&new_quads);
+
+        assert_eq!(orig, curr);
+    }
+
+    #[test]
+    fn eq_state() {
+        let orig = Spro24DspEqualizerState {
+            output: [0.06, 0.07],
+            low_coef: [
+                Spro24DspEqualizerFrequencyBandState([0.00, 0.01, 0.02, 0.03, 0.04]),
+                Spro24DspEqualizerFrequencyBandState([0.10, 0.11, 0.12, 0.13, 0.14]),
+            ],
+            low_middle_coef: [
+                Spro24DspEqualizerFrequencyBandState([0.20, 0.21, 0.22, 0.23, 0.24]),
+                Spro24DspEqualizerFrequencyBandState([0.30, 0.31, 0.32, 0.33, 0.34]),
+            ],
+            high_middle_coef: [
+                Spro24DspEqualizerFrequencyBandState([0.40, 0.41, 0.42, 0.43, 0.44]),
+                Spro24DspEqualizerFrequencyBandState([0.50, 0.51, 0.52, 0.53, 0.54]),
+            ],
+            high_coef: [
+                Spro24DspEqualizerFrequencyBandState([0.60, 0.61, 0.62, 0.63, 0.64]),
+                Spro24DspEqualizerFrequencyBandState([0.70, 0.71, 0.72, 0.73, 0.74]),
+            ],
+        };
+        let mut new_quads = [0.0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        orig.build(&mut new_quads);
+
+        let mut curr = Spro24DspEqualizerState::default();
+        curr.parse(&new_quads);
+
+        assert_eq!(orig, curr);
+    }
+
+    #[test]
+    fn reverb_state() {
+        let orig = Spro24DspReverbState { size: 0.04, air: 0.14, enabled: false, pre_filter: -0.1 };
+        let mut new_quads = [0.0; COEF_BLOCK_SIZE * COEF_BLOCK_COUNT];
+        orig.build(&mut new_quads);
+
+        let mut curr = Spro24DspReverbState::default();
+        curr.parse(&new_quads);
+
+        assert_eq!(orig, curr);
+    }
 }

--- a/libs/dice/protocols/src/focusrite/spro24dsp.rs
+++ b/libs/dice/protocols/src/focusrite/spro24dsp.rs
@@ -146,3 +146,8 @@ impl SaffireproOutGroupOperation for SPro24DspProtocol {
     const SRC_NOTICE: u32 = 0x00000001;
     const DIM_MUTE_NOTICE: u32 = 0x00000002;
 }
+
+impl SaffireproInputOperation for SPro24DspProtocol {
+    const MIC_INPUT_OFFSET: usize = 0x0058;
+    const LINE_INPUT_OFFSET: usize = 0x005c;
+}

--- a/libs/dice/protocols/src/focusrite/spro26.rs
+++ b/libs/dice/protocols/src/focusrite/spro26.rs
@@ -39,7 +39,9 @@ impl Tcd22xxSpecOperation for SPro26Protocol {
     ];
 }
 
-const SW_NOTICE_OFFSET: usize = 0x000c;
+impl SaffireproSwNoticeOperation for SPro26Protocol {
+    const SW_NOTICE_OFFSET: usize = 0x000c;
+}
 
 const SRC_SW_NOTICE: u32 = 0x00000001;
 const DIM_MUTE_SW_NOTICE: u32 = 0x00000002;
@@ -48,7 +50,6 @@ impl SaffireproOutGroupOperation for SPro26Protocol {
     const ENTRY_COUNT: usize = 6;
     const HAS_VOL_HWCTL: bool = false;
     const OUT_CTL_OFFSET: usize = 0x0010;
-    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
 
     const SRC_NOTICE: u32 = SRC_SW_NOTICE;
     const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -49,7 +49,9 @@ impl Tcd22xxSpecOperation for SPro40Protocol {
     ];
 }
 
-const SW_NOTICE_OFFSET: usize = 0x0068;
+impl SaffireproSwNoticeOperation for SPro40Protocol {
+    const SW_NOTICE_OFFSET: usize = 0x0068;
+}
 
 const SRC_SW_NOTICE: u32 = 0x00000001;
 const DIM_MUTE_SW_NOTICE: u32 = 0x00000002;
@@ -60,7 +62,6 @@ impl SaffireproOutGroupOperation for SPro40Protocol {
     const ENTRY_COUNT: usize = 10;
     const HAS_VOL_HWCTL: bool = true;
     const OUT_CTL_OFFSET: usize = 0x000c;
-    const SW_NOTICE_OFFSET: usize = SW_NOTICE_OFFSET;
 
     const SRC_NOTICE: u32 = SRC_SW_NOTICE;
     const DIM_MUTE_NOTICE: u32 = DIM_MUTE_SW_NOTICE;
@@ -81,25 +82,6 @@ impl Default for OptOutIfaceMode {
 
 /// The trait to represent protocol specific to Saffire Pro 26.
 impl SPro40Protocol {
-    fn write_sw_notice(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        notice: u32,
-        timeout_ms: u32
-    ) -> Result<(), Error> {
-        let mut raw = [0; 4];
-        notice.build_quadlet(&mut raw);
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            SW_NOTICE_OFFSET,
-            &mut raw,
-            timeout_ms
-        )
-    }
-
     pub fn read_analog_out_0_1_pad(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -3,6 +3,7 @@
 
 pub mod spro40_model;
 pub mod liquids56_model;
+pub mod spro24_model;
 pub mod spro14_model;
 pub mod spro26_model;
 

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -4,6 +4,7 @@
 pub mod spro40_model;
 pub mod liquids56_model;
 pub mod spro24_model;
+pub mod spro24dsp_model;
 pub mod spro14_model;
 pub mod spro26_model;
 

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -3,6 +3,7 @@
 
 pub mod spro40_model;
 pub mod liquids56_model;
+pub mod spro14_model;
 pub mod spro26_model;
 
 use glib::Error;

--- a/libs/dice/runtime/src/focusrite/spro14_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro14_model.rs
@@ -20,6 +20,7 @@ pub struct SPro14Model {
     ctl: CommonCtl,
     tcd22xx_ctl: SPro14Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl,
+    input_ctl: InputCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -78,6 +79,8 @@ impl CtlModel<SndDice> for SPro14Model {
             TIMEOUT_MS
         )?;
 
+        self.input_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -99,6 +102,15 @@ impl CtlModel<SndDice> for SPro14Model {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -125,6 +137,15 @@ impl CtlModel<SndDice> for SPro14Model {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else if self.input_ctl.write(
             unit,
             &mut self.req,
             &self.extension_sections,
@@ -221,3 +242,8 @@ impl OutGroupCtlOperation<SPro14Protocol> for OutGroupCtl {
         &mut self.0
     }
 }
+
+#[derive(Default)]
+struct InputCtl;
+
+impl SaffireproInputCtlOperation<SPro14Protocol> for InputCtl {}

--- a/libs/dice/runtime/src/focusrite/spro14_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro14_model.rs
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+use {
+    glib::Error,
+    alsactl::{ElemId, ElemValue},
+    hinawa::FwReq,
+    hinawa::{SndDice, SndUnitExt},
+    core::card_cntr::*,
+    dice_protocols::tcat::{extension::*, global_section::*, *},
+    dice_protocols::focusrite::spro14::*,
+    crate::{common_ctl::*, tcd22xx_ctl::*},
+};
+
+#[derive(Default)]
+pub struct SPro14Model {
+    req: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: SPro14Tcd22xxCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for SPro14Model {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let mut node = unit.get_node();
+
+        self.sections = GeneralProtocol::read_general_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        let caps = GlobalSectionProtocol::read_clock_caps(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        let src_labels = GlobalSectionProtocol::read_clock_source_labels(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = ProtocolExtension::read_extension_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        self.tcd22xx_ctl.load(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            &caps,
+            &src_labels,
+            TIMEOUT_MS,
+            card_cntr
+        )?;
+
+        self.tcd22xx_ctl.cache(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS
+        )?;
+
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.read(unit, &mut self.req, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.write(unit, &mut self.req, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            old,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for SPro14Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &mut self.req, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS,
+            *msg
+        )?;
+        Ok(())
+    }
+
+    fn read_notified_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<SndDice> for SPro14Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &mut self.req, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &mut self.req, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(&mut self, _: &SndDice, elem_id: &ElemId, elem_value: &mut ElemValue)
+        -> Result<bool, Error>
+    {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default)]
+struct SPro14Tcd22xxCtl(Tcd22xxCtl);
+
+impl Tcd22xxCtlOperation<SPro14Protocol> for SPro14Tcd22xxCtl {
+    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
+        &self.0
+    }
+
+    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
+        &mut self.0
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro24_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24_model.rs
@@ -20,6 +20,7 @@ pub struct SPro24Model {
     ctl: CommonCtl,
     tcd22xx_ctl: SPro24Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl,
+    input_ctl: InputCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -78,6 +79,8 @@ impl CtlModel<SndDice> for SPro24Model {
             TIMEOUT_MS
         )?;
 
+        self.input_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -99,6 +102,15 @@ impl CtlModel<SndDice> for SPro24Model {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -125,6 +137,15 @@ impl CtlModel<SndDice> for SPro24Model {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else if self.input_ctl.write(
             unit,
             &mut self.req,
             &self.extension_sections,
@@ -237,3 +258,8 @@ impl OutGroupCtlOperation<SPro24Protocol> for OutGroupCtl {
         &mut self.0
     }
 }
+
+#[derive(Default)]
+struct InputCtl;
+
+impl SaffireproInputCtlOperation<SPro24Protocol> for InputCtl {}

--- a/libs/dice/runtime/src/focusrite/spro24_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24_model.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+use {
+    glib::Error,
+    alsactl::{ElemId, ElemValue},
+    hinawa::FwReq,
+    hinawa::{SndDice, SndUnitExt},
+    core::card_cntr::*,
+    dice_protocols::tcat::{extension::*, global_section::*, *},
+    dice_protocols::focusrite::spro24::*,
+    crate::{common_ctl::*, tcd22xx_ctl::*},
+};
+
+#[derive(Default)]
+pub struct SPro24Model {
+    req: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: SPro24Tcd22xxCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for SPro24Model {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let mut node = unit.get_node();
+
+        self.sections = GeneralProtocol::read_general_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        let caps = GlobalSectionProtocol::read_clock_caps(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        let src_labels = GlobalSectionProtocol::read_clock_source_labels(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = ProtocolExtension::read_extension_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        self.tcd22xx_ctl.load(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            &caps,
+            &src_labels,
+            TIMEOUT_MS,
+            card_cntr
+        )?;
+
+        self.tcd22xx_ctl.cache(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS
+        )?;
+
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.read(unit, &mut self.req, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.write(unit, &mut self.req, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            old,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for SPro24Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &mut self.req, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS,
+            *msg
+        )?;
+        Ok(())
+    }
+
+    fn read_notified_elem(
+        &mut self,
+        _: &SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<SndDice> for SPro24Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &mut self.req, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &mut self.req, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(
+        &mut self,
+        _: &SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default)]
+struct SPro24Tcd22xxCtl(Tcd22xxCtl);
+
+impl Tcd22xxCtlOperation<SPro24Protocol> for SPro24Tcd22xxCtl {
+    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
+        &self.0
+    }
+
+    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
+        &mut self.0
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -20,6 +20,7 @@ pub struct SPro24DspModel {
     ctl: CommonCtl,
     tcd22xx_ctl: SPro24DspTcd22xxCtl,
     out_grp_ctl: OutGroupCtl,
+    input_ctl: InputCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -79,6 +80,8 @@ impl CtlModel<SndDice> for SPro24DspModel {
         )
             .map(|mut elem_id_list| self.out_grp_ctl.1.append(&mut elem_id_list))?;
 
+        self.input_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -100,6 +103,15 @@ impl CtlModel<SndDice> for SPro24DspModel {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -126,6 +138,15 @@ impl CtlModel<SndDice> for SPro24DspModel {
         )? {
             Ok(true)
         } else if self.out_grp_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else if self.input_ctl.write(
             unit,
             &mut self.req,
             &self.extension_sections,
@@ -238,3 +259,8 @@ impl OutGroupCtlOperation<SPro24DspProtocol> for OutGroupCtl {
         &mut self.0
     }
 }
+
+#[derive(Default)]
+struct InputCtl;
+
+impl SaffireproInputCtlOperation<SPro24DspProtocol> for InputCtl {}

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2021 Takashi Sakamoto
+
+use {
+    glib::Error,
+    alsactl::{ElemId, ElemValue},
+    hinawa::FwReq,
+    hinawa::{SndDice, SndUnitExt},
+    core::card_cntr::*,
+    dice_protocols::tcat::{extension::*, global_section::*, *},
+    dice_protocols::focusrite::spro24dsp::*,
+    crate::{common_ctl::*, tcd22xx_ctl::*},
+};
+
+#[derive(Default)]
+pub struct SPro24DspModel {
+    req: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    ctl: CommonCtl,
+    tcd22xx_ctl: SPro24DspTcd22xxCtl,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<SndDice> for SPro24DspModel {
+    fn load(&mut self, unit: &mut SndDice, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let mut node = unit.get_node();
+
+        self.sections = GeneralProtocol::read_general_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        let caps = GlobalSectionProtocol::read_clock_caps(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        let src_labels = GlobalSectionProtocol::read_clock_source_labels(
+            &mut self.req,
+            &mut node,
+            &self.sections,
+            TIMEOUT_MS
+        )?;
+        self.ctl.load(card_cntr, &caps, &src_labels)?;
+
+        self.extension_sections = ProtocolExtension::read_extension_sections(
+            &mut self.req,
+            &mut node,
+            TIMEOUT_MS
+        )?;
+        self.tcd22xx_ctl.load(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            &caps,
+            &src_labels,
+            TIMEOUT_MS,
+            card_cntr
+        )?;
+
+        self.tcd22xx_ctl.cache(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS
+        )?;
+
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.read(unit, &mut self.req, &self.sections, elem_id, elem_value, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut SndDice,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.write(unit, &mut self.req, &self.sections, elem_id, old, new, TIMEOUT_MS)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            old,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<SndDice, u32> for SPro24DspModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
+        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
+        self.ctl.parse_notification(unit, &mut self.req, &self.sections, *msg, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.parse_notification(
+            unit,
+            &mut self.req,
+            &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS,
+            *msg
+        )?;
+        Ok(())
+    }
+
+    fn read_notified_elem(
+        &mut self,
+        _: &SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<SndDice> for SPro24DspModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.ctl.measured_elem_list);
+        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &mut SndDice) -> Result<(), Error> {
+        self.ctl.measure_states(unit, &mut self.req, &self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctl.measure_states(unit, &mut self.req, &self.extension_sections, TIMEOUT_MS)?;
+        Ok(())
+    }
+
+    fn measure_elem(
+        &mut self,
+        _: &SndDice,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue
+    ) -> Result<bool, Error> {
+        if self.ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+#[derive(Default)]
+struct SPro24DspTcd22xxCtl(Tcd22xxCtl);
+
+impl Tcd22xxCtlOperation<SPro24DspProtocol> for SPro24DspTcd22xxCtl {
+    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
+        &self.0
+    }
+
+    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
+        &mut self.0
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -21,6 +21,7 @@ pub struct SPro24DspModel {
     tcd22xx_ctl: SPro24DspTcd22xxCtl,
     out_grp_ctl: OutGroupCtl,
     input_ctl: InputCtl,
+    effect_ctl: EffectCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -82,6 +83,8 @@ impl CtlModel<SndDice> for SPro24DspModel {
 
         self.input_ctl.load(card_cntr)?;
 
+        self.effect_ctl.load(card_cntr, unit, &mut self.req, &self.extension_sections, TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -112,6 +115,8 @@ impl CtlModel<SndDice> for SPro24DspModel {
             elem_value,
             TIMEOUT_MS
         )? {
+            Ok(true)
+        } else if self.effect_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -147,6 +152,15 @@ impl CtlModel<SndDice> for SPro24DspModel {
         )? {
             Ok(true)
         } else if self.input_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
+        } else if self.effect_ctl.write(
             unit,
             &mut self.req,
             &self.extension_sections,
@@ -264,3 +278,451 @@ impl OutGroupCtlOperation<SPro24DspProtocol> for OutGroupCtl {
 struct InputCtl;
 
 impl SaffireproInputCtlOperation<SPro24DspProtocol> for InputCtl {}
+
+#[derive(Default)]
+struct EffectCtl(Spro24DspEffectState, Vec<ElemId>);
+
+const CH_STRIP_ORDER_NAME: &str = "ch-strip-order";
+const COMPRESSOR_ENABLE_NAME: &str = "compressor-enable";
+const EQUALIZER_ENABLE_NAME: &str = "equalizer-enable";
+
+const COMPRESSOR_OUTPUT_NAME: &str = "compressor-output-volume";
+const COMPRESSOR_THRESHOLD_NAME: &str = "compressor-threshold";
+const COMPRESSOR_RATIO_NAME: &str = "compressor-ratio";
+const COMPRESSOR_ATTACK_NAME: &str = "compressor-attack";
+const COMPRESSOR_RELEASE_NAME: &str = "compressor-release";
+
+const EQUALIZER_OUTPUT_NAME: &str = "equalizer-output-volume";
+
+const REVERB_SIZE_NAME: &str = "reverb-size";
+const REVERB_AIR_NAME: &str = "reverb-air";
+const REVERB_ENABLE_NAME: &str = "reverb-enable";
+const REVERB_PRE_FILTER_NAME: &str = "reverb-pre-filter";
+
+impl EffectCtl {
+    const CH_STRIP_ORDERS: [&'static str; 2] = [
+        "compressor-after-equalizer",
+        "equalizer-after-compressor",
+    ];
+    const F32_CONVERT_SCALE: f32 = 1000000.0;
+
+    fn load(
+        &mut self,
+        card_cntr: &mut CardCntr,
+        unit: &mut SndDice,
+        req: &mut FwReq,
+        sections: &ExtensionSections,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
+        SPro24DspProtocol::read_effect_state(
+            req,
+            &mut unit.get_node(),
+            sections,
+            &mut self.0,
+            timeout_ms
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, CH_STRIP_ORDER_NAME, 0);
+        let _ = card_cntr.add_enum_elems(
+            &elem_id,
+            1,
+            self.0.eq_after_comp.len(),
+            &Self::CH_STRIP_ORDERS,
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_ENABLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.0.comp_enable.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQUALIZER_ENABLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.0.eq_enable.len(), true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_OUTPUT_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::COMPRESSOR_OUTPUT_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::COMPRESSOR_OUTPUT_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.comp.output.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_THRESHOLD_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::COMPRESSOR_THRESHOLD_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::COMPRESSOR_THRESHOLD_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.comp.threshold.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_RATIO_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::COMPRESSOR_RATIO_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::COMPRESSOR_RATIO_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.comp.ratio.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_ATTACK_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::COMPRESSOR_ATTACK_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::COMPRESSOR_ATTACK_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.comp.attack.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMPRESSOR_RELEASE_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::COMPRESSOR_RELEASE_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::COMPRESSOR_RELEASE_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.comp.release.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQUALIZER_OUTPUT_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::EQUALIZER_OUTPUT_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::EQUALIZER_OUTPUT_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            self.0.eq.output.len(),
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_SIZE_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::REVERB_SIZE_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::REVERB_SIZE_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            1,
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_AIR_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::REVERB_AIR_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::REVERB_AIR_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            1,
+            None,
+            true
+        )?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_ENABLE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_PRE_FILTER_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            (SPro24DspProtocol::REVERB_PRE_FILTER_MIN * Self::F32_CONVERT_SCALE) as i32,
+            (SPro24DspProtocol::REVERB_PRE_FILTER_MAX * Self::F32_CONVERT_SCALE) as i32,
+            1,
+            1,
+            None,
+            true
+        )?;
+
+        Ok(())
+    }
+
+    fn convert_from_f32_array(elem_value: &mut ElemValue, raw: &[f32]) {
+        let vals: Vec<i32> = raw
+            .iter()
+            .map(|&r| (r * Self::F32_CONVERT_SCALE) as i32)
+            .collect();
+        elem_value.set_int(&vals);
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            CH_STRIP_ORDER_NAME => {
+                let vals: Vec<u32> = self.0.eq_after_comp
+                    .iter()
+                    .map(|enable| *enable as u32)
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
+            COMPRESSOR_ENABLE_NAME => {
+                elem_value.set_bool(&self.0.comp_enable);
+                Ok(true)
+            }
+            EQUALIZER_ENABLE_NAME => {
+                elem_value.set_bool(&self.0.eq_enable);
+                Ok(true)
+            }
+            COMPRESSOR_OUTPUT_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.comp.output);
+                Ok(true)
+            }
+            COMPRESSOR_THRESHOLD_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.comp.threshold);
+                Ok(true)
+            }
+            COMPRESSOR_RATIO_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.comp.ratio);
+                Ok(true)
+            }
+            COMPRESSOR_ATTACK_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.comp.attack);
+                Ok(true)
+            }
+            COMPRESSOR_RELEASE_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.comp.release);
+                Ok(true)
+            }
+            EQUALIZER_OUTPUT_NAME => {
+                Self::convert_from_f32_array(elem_value, &self.0.eq.output);
+                Ok(true)
+            }
+            REVERB_SIZE_NAME => {
+                Self::convert_from_f32_array(elem_value, &[self.0.reverb.size]);
+                Ok(true)
+            }
+            REVERB_AIR_NAME => {
+                Self::convert_from_f32_array(elem_value, &[self.0.reverb.air]);
+                Ok(true)
+            }
+            REVERB_ENABLE_NAME => {
+                elem_value.set_bool(&[self.0.reverb.enabled]);
+                Ok(true)
+            }
+            REVERB_PRE_FILTER_NAME => {
+                Self::convert_from_f32_array(elem_value, &[self.0.reverb.pre_filter]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn convert_to_f32_array(elem_value: &ElemValue, raw: &mut [f32]) {
+        let mut vals = vec![0; raw.len()];
+        elem_value.get_int(&mut vals);
+        raw
+            .iter_mut()
+            .zip(vals.iter())
+            .for_each(|(r, &val)| *r = (val as f32) / Self::F32_CONVERT_SCALE);
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut SndDice,
+        req: &mut FwReq,
+        sections: &ExtensionSections,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32
+    ) -> Result<bool, Error> {
+        match elem_id.get_name().as_str() {
+            CH_STRIP_ORDER_NAME => {
+                let mut vals = vec![0; self.0.eq_after_comp.len()];
+                elem_value.get_enum(&mut vals);
+                let eq_after_comp: Vec<bool> = vals
+                    .iter()
+                    .map(|&val| val > 0)
+                    .collect();
+                SPro24DspProtocol::write_eq_after_comp(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &eq_after_comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_ENABLE_NAME => {
+                let mut vals = vec![false; self.0.comp_enable.len()];
+                elem_value.get_bool(&mut vals);
+                SPro24DspProtocol::write_comp_enable(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &vals,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            EQUALIZER_ENABLE_NAME => {
+                let mut vals = vec![false; self.0.eq_enable.len()];
+                elem_value.get_bool(&mut vals);
+                SPro24DspProtocol::write_eq_enable(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &vals,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_OUTPUT_NAME => {
+                let mut comp = self.0.comp.clone();
+                Self::convert_to_f32_array(elem_value, &mut comp.output);
+                SPro24DspProtocol::write_comp_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_THRESHOLD_NAME => {
+                let mut comp = self.0.comp.clone();
+                Self::convert_to_f32_array(elem_value, &mut comp.threshold);
+                SPro24DspProtocol::write_comp_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_RATIO_NAME => {
+                let mut comp = self.0.comp.clone();
+                Self::convert_to_f32_array(elem_value, &mut comp.ratio);
+                SPro24DspProtocol::write_comp_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_ATTACK_NAME => {
+                let mut comp = self.0.comp.clone();
+                Self::convert_to_f32_array(elem_value, &mut comp.attack);
+                SPro24DspProtocol::write_comp_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            COMPRESSOR_RELEASE_NAME => {
+                let mut comp = self.0.comp.clone();
+                Self::convert_to_f32_array(elem_value, &mut comp.release);
+                SPro24DspProtocol::write_comp_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &comp,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            EQUALIZER_OUTPUT_NAME => {
+                let mut eq = self.0.eq.clone();
+                Self::convert_to_f32_array(elem_value, &mut eq.output);
+                SPro24DspProtocol::write_eq_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &eq,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            REVERB_SIZE_NAME => {
+                let mut vals = [0.0];
+                Self::convert_to_f32_array(elem_value, &mut vals);
+                let mut reverb = self.0.reverb.clone();
+                reverb.size = vals[0];
+                SPro24DspProtocol::write_reverb_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &reverb,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            REVERB_AIR_NAME => {
+                let mut vals = [0.0];
+                Self::convert_to_f32_array(elem_value, &mut vals);
+                let mut reverb = self.0.reverb.clone();
+                reverb.air = vals[0];
+                SPro24DspProtocol::write_reverb_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &reverb,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            REVERB_ENABLE_NAME => {
+                let mut vals = [false];
+                elem_value.get_bool(&mut vals);
+                let mut reverb = self.0.reverb.clone();
+                reverb.enabled = vals[0];
+                SPro24DspProtocol::write_reverb_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &reverb,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            REVERB_PRE_FILTER_NAME => {
+                let mut vals = [0.0];
+                Self::convert_to_f32_array(elem_value, &mut vals);
+                let mut reverb = self.0.reverb.clone();
+                reverb.pre_filter = vals[0];
+                SPro24DspProtocol::write_reverb_effect(
+                    req,
+                    &mut unit.get_node(),
+                    sections,
+                    &reverb,
+                    &mut self.0,
+                    timeout_ms
+                )
+                    .map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -9,7 +9,7 @@ use {
     core::card_cntr::*,
     dice_protocols::tcat::{extension::*, global_section::*, *},
     dice_protocols::focusrite::spro24dsp::*,
-    crate::{common_ctl::*, tcd22xx_ctl::*},
+    crate::{common_ctl::*, focusrite::*, tcd22xx_ctl::*},
 };
 
 #[derive(Default)]
@@ -19,6 +19,7 @@ pub struct SPro24DspModel {
     extension_sections: ExtensionSections,
     ctl: CommonCtl,
     tcd22xx_ctl: SPro24DspTcd22xxCtl,
+    out_grp_ctl: OutGroupCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -69,6 +70,15 @@ impl CtlModel<SndDice> for SPro24DspModel {
             TIMEOUT_MS
         )?;
 
+        self.out_grp_ctl.load(
+            card_cntr,
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            TIMEOUT_MS
+        )
+            .map(|mut elem_id_list| self.out_grp_ctl.1.append(&mut elem_id_list))?;
+
         Ok(())
     }
 
@@ -88,6 +98,8 @@ impl CtlModel<SndDice> for SPro24DspModel {
             elem_value,
             TIMEOUT_MS
         )? {
+            Ok(true)
+        } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -113,6 +125,15 @@ impl CtlModel<SndDice> for SPro24DspModel {
             TIMEOUT_MS
         )? {
             Ok(true)
+        } else if self.out_grp_ctl.write(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS
+        )? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -123,6 +144,7 @@ impl NotifyModel<SndDice, u32> for SPro24DspModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.ctl.notified_elem_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
+        elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
 
     fn parse_notification(&mut self, unit: &mut SndDice, msg: &u32) -> Result<(), Error> {
@@ -134,6 +156,13 @@ impl NotifyModel<SndDice, u32> for SPro24DspModel {
             &self.extension_sections,
             TIMEOUT_MS,
             *msg
+        )?;
+        self.out_grp_ctl.parse_notification(
+            unit,
+            &mut self.req,
+            &self.extension_sections,
+            *msg,
+            TIMEOUT_MS
         )?;
         Ok(())
     }
@@ -147,6 +176,8 @@ impl NotifyModel<SndDice, u32> for SPro24DspModel {
         if self.ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.out_grp_ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -191,6 +222,19 @@ impl Tcd22xxCtlOperation<SPro24DspProtocol> for SPro24DspTcd22xxCtl {
     }
 
     fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
+        &mut self.0
+    }
+}
+
+#[derive(Default)]
+struct OutGroupCtl(OutGroupState, Vec<ElemId>);
+
+impl OutGroupCtlOperation<SPro24DspProtocol> for OutGroupCtl {
+    fn state(&self) -> &OutGroupState {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut OutGroupState {
         &mut self.0
     }
 }

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -29,6 +29,7 @@ use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
 use super::focusrite::spro24_model::*;
+use super::focusrite::spro24dsp_model::*;
 use super::focusrite::spro14_model::*;
 use super::focusrite::spro26_model::*;
 use super::presonus::fstudioproject_model::*;
@@ -53,6 +54,7 @@ enum Model {
     FocusriteSPro40(SPro40Model),
     FocusriteLiquidS56(LiquidS56Model),
     FocusriteSPro24(SPro24Model),
+    FocusriteSPro24Dsp(SPro24DspModel),
     FocusriteSPro14(SPro14Model),
     FocusriteSPro26(SPro26Model),
     PresonusFStudioProject(FStudioProjectModel),
@@ -100,6 +102,7 @@ impl DiceModel {
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
             (0x00130e, 0x000007) => Model::FocusriteSPro24(Default::default()),
+            (0x00130e, 0x000008) => Model::FocusriteSPro24Dsp(Default::default()),
             (0x00130e, 0x000009) => Model::FocusriteSPro14(Default::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
@@ -154,6 +157,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro24(m) => m.load(unit, card_cntr),
+            Model::FocusriteSPro24Dsp(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro14(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
@@ -179,6 +183,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro24(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro24Dsp(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro14(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioProject(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -204,6 +209,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro24(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro24Dsp(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro14(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioProject(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -236,6 +242,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro24(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro24Dsp(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro14(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -265,6 +272,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro24(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteSPro24Dsp(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro14(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -294,6 +302,7 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro24(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro24Dsp(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro14(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -28,6 +28,7 @@ use super::mbox3_model::*;
 use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
+use super::focusrite::spro24_model::*;
 use super::focusrite::spro14_model::*;
 use super::focusrite::spro26_model::*;
 use super::presonus::fstudioproject_model::*;
@@ -51,6 +52,7 @@ enum Model {
     LoudBlackbird(BlackbirdModel),
     FocusriteSPro40(SPro40Model),
     FocusriteLiquidS56(LiquidS56Model),
+    FocusriteSPro24(SPro24Model),
     FocusriteSPro14(SPro14Model),
     FocusriteSPro26(SPro26Model),
     PresonusFStudioProject(FStudioProjectModel),
@@ -97,6 +99,7 @@ impl DiceModel {
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
+            (0x00130e, 0x000007) => Model::FocusriteSPro24(Default::default()),
             (0x00130e, 0x000009) => Model::FocusriteSPro14(Default::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
@@ -150,6 +153,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
+            Model::FocusriteSPro24(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro14(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
@@ -174,6 +178,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro24(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro14(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioProject(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -198,6 +203,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro24(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro14(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioProject(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -229,6 +235,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro24(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro14(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -257,6 +264,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteSPro24(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro14(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -285,6 +293,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro24(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro14(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -28,6 +28,7 @@ use super::mbox3_model::*;
 use super::blackbird_model::*;
 use super::focusrite::spro40_model::*;
 use super::focusrite::liquids56_model::*;
+use super::focusrite::spro14_model::*;
 use super::focusrite::spro26_model::*;
 use super::presonus::fstudioproject_model::*;
 use super::presonus::fstudiomobile_model::*;
@@ -50,6 +51,7 @@ enum Model {
     LoudBlackbird(BlackbirdModel),
     FocusriteSPro40(SPro40Model),
     FocusriteLiquidS56(LiquidS56Model),
+    FocusriteSPro14(SPro14Model),
     FocusriteSPro26(SPro26Model),
     PresonusFStudioProject(FStudioProjectModel),
     PresonusFStudioMobile(FStudioMobileModel),
@@ -95,6 +97,7 @@ impl DiceModel {
             (0x000ff2, 0x000007) => Model::LoudBlackbird(BlackbirdModel::default()),
             (0x00130e, 0x000005) => Model::FocusriteSPro40(SPro40Model::default()),
             (0x00130e, 0x000006) => Model::FocusriteLiquidS56(LiquidS56Model::default()),
+            (0x00130e, 0x000009) => Model::FocusriteSPro14(Default::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
             (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
@@ -147,6 +150,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro40(m) => m.load(unit, card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(unit, card_cntr),
+            Model::FocusriteSPro14(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioMobile(m) => m.load(unit, card_cntr),
@@ -170,6 +174,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro14(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro26(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioProject(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioMobile(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -193,6 +198,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro14(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro26(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioProject(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioMobile(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -223,6 +229,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro14(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioMobile(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
@@ -250,6 +257,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
+            Model::FocusriteSPro14(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
             Model::PresonusFStudioMobile(m) => card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m),
@@ -277,6 +285,7 @@ impl DiceModel {
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro14(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro26(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::PresonusFStudioProject(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::PresonusFStudioMobile(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),


### PR DESCRIPTION
Hi,

This patchset adds support for below models based on TCD2220:

 * Focusrite Saffire Pro 14
 * Focusrite Saffire Pro 24
 * Focusrite Saffire Pro 24 DSP

Especially, for Pro 24 DSP, channel strip and reverb effects are partially supported.

```
Takashi Sakamoto (21):
  dice-protocols: focusrite: add trait and implementation for software notice protocol
  dice-protocols: focusrite: add protocol implementation for Focusrite Saffire Pro 14
  dice-protocols: focusrite: add implementaion of output group protocol for Pro 14
  dice-protocols: focusrite: add trait and implementation for input protocol for Pro 14 and 24
  dice-protocols: focusrite: add protocol implementation for Focusrite Saffire Pro 24
  dice-protocols: focusrite: add implementaion of output group protocol for Pro 24
  dice-protocols: focusrite: add implementation of input protocol for Pro 24
  dice-protocols: focusrite: add protocol implementation for Focusrite Saffire Pro 24 DSP
  dice-protocols: focusrite: add implementaion of output group protocol for Pro 24 DSP
  dice-protocols: focusrite: add implementation of input protocol for Pro 24 DSP
  dice-runtime: focusrite: add support for Saffire Pro 14
  dice-runtime: focusrite: add implementation of output group control for Pro 14
  dice-runtime: focusrite: add trait and implementation for input control in Pro 14
  dice-runtime: focusrite: add support for Saffire Pro 24
  dice-runtime: focusrite: add implementation of output group control for Pro 24
  dice-runtime: focusrite: add trait implementation for input control in Pro 24
  dice-runtime: focusrite: add support for Saffire Pro 24 DSP
  dice-runtime: focusrite: add implementation of output group control for Pro 24 DSP
  dice-runtime: focusrite: add trait implementation for input control in Pro 24 DSP
  dice-protocols: focusrite: add protocol implementation of DSP effect in Pro 24 DSP
  dice-runtime: focusrite: add implementation of effect control for Pro 24 DSP

 README.rst                                    |   3 +
 libs/dice/protocols/src/focusrite.rs          | 233 ++++-
 .../dice/protocols/src/focusrite/liquids56.rs |  24 +-
 libs/dice/protocols/src/focusrite/spro14.rs   | 119 +++
 libs/dice/protocols/src/focusrite/spro24.rs   | 135 +++
 .../dice/protocols/src/focusrite/spro24dsp.rs | 840 ++++++++++++++++++
 libs/dice/protocols/src/focusrite/spro26.rs   |   5 +-
 libs/dice/protocols/src/focusrite/spro40.rs   |  24 +-
 libs/dice/runtime/src/focusrite.rs            | 170 +++-
 .../runtime/src/focusrite/spro14_model.rs     | 249 ++++++
 .../runtime/src/focusrite/spro24_model.rs     | 265 ++++++
 .../runtime/src/focusrite/spro24dsp_model.rs  | 728 +++++++++++++++
 libs/dice/runtime/src/model.rs                |  27 +
 13 files changed, 2751 insertions(+), 71 deletions(-)
 create mode 100644 libs/dice/protocols/src/focusrite/spro14.rs
 create mode 100644 libs/dice/protocols/src/focusrite/spro24.rs
 create mode 100644 libs/dice/protocols/src/focusrite/spro24dsp.rs
 create mode 100644 libs/dice/runtime/src/focusrite/spro14_model.rs
 create mode 100644 libs/dice/runtime/src/focusrite/spro24_model.rs
 create mode 100644 libs/dice/runtime/src/focusrite/spro24dsp_model.rs
```