### PR TITLE
[PATCH 00/17] efw-protocols/efw-runtime: fix bug for protocol implementation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ your device, please contact to developer.
   * Tascam FW-1804
   * Tascam FE-8
 
-* snd-fireowrks-ctl-service
+* snd-fireworks-ctl-service
 
   * Mackie (Loud) Onyx 1200F
   * Mackie (Loud) Onyx 400F

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -24,10 +24,10 @@ pub enum HwCap {
     ChangeableRespAddr,
     /// Has control room for output mirror.
     MirrorOutput,
-    /// Has coaxial interface for S/PDIF signal.
-    SpdifCoax,
-    /// Has XLR interface for AES/EBU signal.
-    AesebuXlr,
+    /// S/PDIF signal is available for coaxial interface as option.
+    OptionalSpdifCoax,
+    /// S/PDIF signal is available for AES/EBU XLR interface as option.
+    OptionalAesebuXlr,
     /// Has DSP (Texas Instrument TMS320C67).
     Dsp,
     /// Has FPGA (Xilinx Spartan XC35250E).
@@ -38,10 +38,10 @@ pub enum HwCap {
     OutputMapping,
     /// The gain of physical input is adjustable.
     InputGain,
-    /// Has optical interface for S/PDIF.
-    SpdifOpt,
-    /// Has optical interface for ADAT.
-    AdatOpt,
+    /// S/PDIF signal is available for optical interface as option.
+    OptionalSpdifOpt,
+    /// ADAT signal is available for optical interface as option.
+    OptionalAdatOpt,
     /// The nominal level of input audio signal is selectable.
     NominalInput,
     /// The nominal level of output audio signal is selectable.
@@ -63,15 +63,15 @@ impl From<usize> for HwCap {
         match val {
             0 => HwCap::ChangeableRespAddr,
             1 => HwCap::MirrorOutput,
-            2 => HwCap::SpdifCoax,
-            3 => HwCap::AesebuXlr,
+            2 => HwCap::OptionalSpdifCoax,
+            3 => HwCap::OptionalAesebuXlr,
             4 => HwCap::Dsp,
             5 => HwCap::Fpga,
             6 => HwCap::PhantomPowering,
             7 => HwCap::OutputMapping,
             8 => HwCap::InputGain,
-            9 => HwCap::SpdifOpt,
-            10 => HwCap::AdatOpt,
+            9 => HwCap::OptionalSpdifOpt,
+            10 => HwCap::OptionalAdatOpt,
             11 => HwCap::NominalInput,
             12 => HwCap::NominalOutput,
             13 => HwCap::SoftClip,
@@ -174,6 +174,7 @@ impl Default for HwInfo {
 }
 
 // Known models.
+#[allow(dead_code)]
 const O400F: u32 = 0x0000400f;
 const O1200F: u32 = 0x0001200f;
 const AF2: u32 = 0x00000af2;
@@ -214,27 +215,11 @@ impl HwInfo {
             .collect();
 
         match hw_type {
-            O400F => caps.push(HwCap::SpdifCoax),
+            AF2 | AF4 | AF8 | AFP8 | AF12 => {
+                caps.push(HwCap::NominalInput);
+                caps.push(HwCap::NominalOutput);
+            }
             O1200F => caps.push(HwCap::MirrorOutput),
-            AF2 | AF4 => {
-                caps.push(HwCap::NominalInput);
-                caps.push(HwCap::NominalOutput);
-                caps.push(HwCap::SpdifCoax);
-            }
-            AF8 => {
-                caps.push(HwCap::NominalInput);
-                caps.push(HwCap::NominalOutput);
-                caps.push(HwCap::SpdifCoax);
-            }
-            AFP8 => {
-                caps.push(HwCap::NominalInput);
-                caps.push(HwCap::NominalOutput);
-                // It has flags for Coaxial/Optical interface for S/PDIF signal.
-            }
-            AF12 => {
-                caps.push(HwCap::NominalInput);
-                caps.push(HwCap::NominalOutput);
-            }
             _ => (),
         }
 

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -215,7 +215,7 @@ impl HwInfo {
 
         match hw_type {
             O400F => caps.push(HwCap::SpdifCoax),
-            O1200F => caps.push(HwCap::InputMapping),
+            O1200F => caps.push(HwCap::MirrorOutput),
             AF2 | AF4 => {
                 caps.push(HwCap::NominalInput);
                 caps.push(HwCap::NominalOutput);

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -5,6 +5,28 @@
 //!
 //! The crate includes protocol about hardware information defined by Echo Audio Digital Corporation
 //! for Fireworks board module.
+//!
+//! ## Table for capabilities retrieved from each Fireworks model
+//!
+//! capabilities       | 1200f | 400f | af12(old) | af12(new) | af8(old) | af9 | af4 | af2 | rip |
+//! ------------------ | ----- | ---- | --------- | --------- | -------- | --- | --- | --- | --- |
+//! ChangeableRespAddr |   *   |   *  |     *     |     *     |    *     |  *  |  *  |  *  |  *  |
+//! ControlRoom        |       |   *  |           |           |          |     |     |     |     |
+//! OptionalSpdifCoax  |   *   |      |           |           |          |  *  |     |     |     |
+//! OptionalAesebuXlr  |   *   |      |           |           |          |     |     |     |     |
+//! Dsp                |   *   |   *  |     *     |     *     |    *     |     |     |     |     |
+//! Fpga               |   *   |      |           |           |          |  *  |  *  |  *  |  *  |
+//! PhantomPowering    |       |      |           |           |          |     |  *  |     |     |
+//! OutputMapping      |       |      |           |           |          |     |  *  |  *  |     |
+//! InputGain          |       |      |           |     *     |          |     |     |     |     |
+//! OptionalSpdifOpt   |       |      |           |           |          |  *  |     |     |     |
+//! OptionalAdatOpt    |       |      |           |           |          |  *  |     |     |     |
+//! NominalInput       |       |      |           |           |          |     |     |     |     |
+//! NominalOutput      |       |      |           |           |          |     |     |     |     |
+//! SoftClip           |       |      |           |           |          |     |     |     |     |
+//! RobotGuitar        |       |      |           |           |          |     |     |     |  *  |
+//! GuitarCharging     |       |      |           |           |          |     |     |     |  *  |
+
 
 use glib::{Error, FileError};
 

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -23,7 +23,7 @@ pub enum HwCap {
     /// The address to which response of transaction is transmitted is configurable.
     ChangeableRespAddr,
     /// Has control room for output mirror.
-    MirrorOutput,
+    ControlRoom,
     /// S/PDIF signal is available for coaxial interface as option.
     OptionalSpdifCoax,
     /// S/PDIF signal is available for AES/EBU XLR interface as option.
@@ -62,7 +62,7 @@ impl From<usize> for HwCap {
     fn from(val: usize) -> Self {
         match val {
             0 => HwCap::ChangeableRespAddr,
-            1 => HwCap::MirrorOutput,
+            1 => HwCap::ControlRoom,
             2 => HwCap::OptionalSpdifCoax,
             3 => HwCap::OptionalAesebuXlr,
             4 => HwCap::Dsp,
@@ -219,7 +219,7 @@ impl HwInfo {
                 caps.push(HwCap::NominalInput);
                 caps.push(HwCap::NominalOutput);
             }
-            O1200F => caps.push(HwCap::MirrorOutput),
+            O1200F => caps.push(HwCap::ControlRoom),
             _ => (),
         }
 

--- a/libs/efw/protocols/src/lib.rs
+++ b/libs/efw/protocols/src/lib.rs
@@ -31,6 +31,12 @@ pub enum ClkSrc {
     Reserved(usize),
 }
 
+impl Default for ClkSrc {
+    fn default() -> Self {
+        Self::Reserved(usize::MAX)
+    }
+}
+
 impl From<ClkSrc> for usize {
     fn from(src: ClkSrc) -> Self {
         match src {

--- a/libs/efw/protocols/src/port_conf.rs
+++ b/libs/efw/protocols/src/port_conf.rs
@@ -132,20 +132,25 @@ pub trait PortConfProtocol: EfwProtocol {
 
     fn set_stream_map(
         &mut self,
+        rate: u32,
         rx_map: Option<Vec<usize>>,
         tx_map: Option<Vec<usize>>,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let mut args = [0; MAP_SIZE];
+        let mut args = [rate];
+        let mut params = [0; MAP_SIZE];
         self.transaction_sync(
             CATEGORY_PORT_CONF,
             CMD_GET_STREAM_MAP,
-            None,
             Some(&mut args),
+            Some(&mut params),
             timeout_ms,
         )?;
+        let mut args = [0; MAP_SIZE];
+        args[0] = rate;
         if let Some(entries) = rx_map {
             args[2] = entries.len() as u32;
+            args[3] = params[3];
             entries
                 .iter()
                 .enumerate()
@@ -153,6 +158,7 @@ pub trait PortConfProtocol: EfwProtocol {
         }
         if let Some(entries) = tx_map {
             args[36] = entries.len() as u32;
+            args[37] = params[37];
             entries
                 .iter()
                 .enumerate()
@@ -167,12 +173,17 @@ pub trait PortConfProtocol: EfwProtocol {
         )
     }
 
-    fn get_stream_map(&mut self, timeout_ms: u32) -> Result<(Vec<usize>, Vec<usize>), Error> {
+    fn get_stream_map(
+        &mut self,
+        rate: u32,
+        timeout_ms: u32
+    ) -> Result<(Vec<usize>, Vec<usize>), Error> {
+        let args = [rate];
         let mut params = [0; MAP_SIZE];
         self.transaction_sync(
             CATEGORY_PORT_CONF,
             CMD_GET_STREAM_MAP,
-            None,
+            Some(&args),
             Some(&mut params),
             timeout_ms,
         )

--- a/libs/efw/protocols/src/port_conf.rs
+++ b/libs/efw/protocols/src/port_conf.rs
@@ -65,17 +65,17 @@ const MAP_ENTRY_DISABLE: u32 = 0xffffffff;
 
 /// Protocol about port configuration for Fireworks board module.
 pub trait PortConfProtocol: EfwProtocol {
-    fn set_output_mirror(&mut self, pair: usize, timeout_ms: u32) -> Result<(), Error> {
+    fn set_control_room_source(&mut self, pair: usize, timeout_ms: u32) -> Result<(), Error> {
         self.transaction_sync(
             CATEGORY_PORT_CONF,
             CMD_SET_MIRROR,
-            Some(&[pair as u32]),
+            Some(&[(pair * 2) as u32]),
             None,
             timeout_ms,
         )
     }
 
-    fn get_output_mirror(&mut self, timeout_ms: u32) -> Result<usize, Error> {
+    fn get_control_room_source(&mut self, timeout_ms: u32) -> Result<usize, Error> {
         let mut params = [0];
         self.transaction_sync(
             CATEGORY_PORT_CONF,
@@ -84,7 +84,7 @@ pub trait PortConfProtocol: EfwProtocol {
             Some(&mut params),
             timeout_ms,
         )
-        .map(|_| params[0] as usize)
+        .map(|_| (params[0] / 2) as usize)
     }
 
     fn set_digital_mode(&mut self, mode: DigitalMode, timeout_ms: u32) -> Result<(), Error> {

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
 
-use core::card_cntr;
-use core::elem_value_accessor::ElemValueAccessor;
-
-use efw_protocols::hw_info::*;
-use efw_protocols::robot_guitar::*;
+use {
+    glib::Error,
+    hinawa::SndEfw,
+    alsactl::{ElemId, ElemIfaceType, ElemValue},
+    core::{card_cntr::*, elem_value_accessor::*},
+    efw_protocols::{hw_info::*, robot_guitar::*},
+};
 
 #[derive(Default)]
 pub struct GuitarCtl;
@@ -20,22 +21,20 @@ impl GuitarCtl {
     const MAX_SEC: i32 = 60 * 60;   // = One hour.
     const STEP_SEC: i32 = 1;
 
-    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
-        -> Result<(), Error>
-    {
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let has_guitar_charge = hwinfo.caps.iter().find(|&e| *e == HwCap::GuitarCharging).is_some();
 
         if has_guitar_charge {
-            let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, MANUAL_CHARGE_NAME, 0);
+            let elem_id = ElemId::new_by_name(
+                ElemIfaceType::Card, 0, 0, MANUAL_CHARGE_NAME, 0);
             let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-            let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, AUTO_CHARGE_NAME, 0);
+            let elem_id = ElemId::new_by_name(
+                ElemIfaceType::Card, 0, 0, AUTO_CHARGE_NAME, 0);
             let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-            let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Card, 0, 0, SUSPEND_TO_CHARGE, 0);
+            let elem_id = ElemId::new_by_name(
+                ElemIfaceType::Card, 0, 0, SUSPEND_TO_CHARGE, 0);
             let _ = card_cntr.add_int_elems(&elem_id, 1,
                 Self::MIN_SEC, Self::MAX_SEC, Self::STEP_SEC, 1, None, true)?;
         }
@@ -45,9 +44,9 @@ impl GuitarCtl {
 
     pub fn read(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        elem_value: &mut alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
@@ -78,10 +77,10 @@ impl GuitarCtl {
 
     pub fn write(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        _: &alsactl::ElemValue,
-        new: &alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        _: &ElemValue,
+        new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -6,7 +6,7 @@ use {
     hinawa::SndEfw,
     alsactl::{ElemId, ElemIfaceType, ElemValueExtManual, ElemValueExt, ElemValue},
     core::card_cntr::*,
-    efw_protocols::{hw_info::*, hw_ctl::*},
+    efw_protocols::{hw_info::*, hw_ctl::*, *},
 };
 
 #[derive(Default)]
@@ -20,7 +20,9 @@ impl Iec60958Ctl {
     const AES0_NONAUDIO: u8 = 0x2;
 
     pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::SpdifCoax).is_some() {
+        let has_spdif = hwinfo.clk_srcs.iter().find(|src| ClkSrc::Spdif.eq(src)).is_some();
+
+        if has_spdif {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, DEFAULT_NAME, 0);
             let _ = card_cntr.add_iec60958_elem(&elem_id, 1, true)?;
 

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
 
-use core::card_cntr;
-
-use alsactl::{ElemValueExt, ElemValueExtManual};
-
-use efw_protocols::hw_info::*;
-use efw_protocols::hw_ctl::*;
+use {
+    glib::Error,
+    hinawa::SndEfw,
+    alsactl::{ElemId, ElemIfaceType, ElemValueExtManual, ElemValueExt, ElemValue},
+    core::card_cntr::*,
+    efw_protocols::{hw_info::*, hw_ctl::*},
+};
 
 #[derive(Default)]
 pub struct Iec60958Ctl;
@@ -19,14 +19,12 @@ impl Iec60958Ctl {
     const AES0_PROFESSIONAL: u8 = 0x1;
     const AES0_NONAUDIO: u8 = 0x2;
 
-    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
-        -> Result<(), Error>
-    {
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut CardCntr) -> Result<(), Error> {
         if hwinfo.caps.iter().find(|&cap| *cap == HwCap::SpdifCoax).is_some() {
-            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, DEFAULT_NAME, 0);
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, DEFAULT_NAME, 0);
             let _ = card_cntr.add_iec60958_elem(&elem_id, 1, true)?;
 
-            let elem_id = alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Mixer, 0, 0, MASK_NAME, 0);
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MASK_NAME, 0);
             let _ = card_cntr.add_iec60958_elem(&elem_id, 1, false)?;
         }
 
@@ -35,9 +33,9 @@ impl Iec60958Ctl {
 
     pub fn read(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        elem_value: &mut alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
@@ -65,10 +63,10 @@ impl Iec60958Ctl {
 
     pub fn write(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        _: &alsactl::ElemValue,
-        new: &alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        _: &ElemValue,
+        new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::{Error, FileError};
 
-use core::card_cntr;
-use core::elem_value_accessor::ElemValueAccessor;
-
-use efw_protocols::NominalSignalLevel;
-use efw_protocols::hw_info::*;
-use efw_protocols::phys_input::*;
+use {
+    glib::{Error, FileError},
+    hinawa::SndEfw,
+    alsactl::{ElemId, ElemIfaceType, ElemValue},
+    core::{card_cntr::*, elem_value_accessor::*},
+    efw_protocols::{hw_info::*, phys_input::*, *},
+};
 
 #[derive(Default)]
 pub struct InputCtl {
@@ -24,15 +24,17 @@ impl InputCtl {
         NominalSignalLevel::Consumer,
     ];
 
-    pub fn load(&mut self, unit: &mut hinawa::SndEfw, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr,
-                timeout_ms: u32)
-        -> Result<(), Error>
-    {
+    pub fn load(
+        &mut self,
+        unit: &mut SndEfw,
+        hwinfo: &HwInfo,
+        card_cntr: &mut CardCntr,
+        timeout_ms: u32
+    ) -> Result<(), Error> {
         self.phys_inputs = hwinfo.phys_inputs.iter().fold(0, |accm, entry| accm + entry.group_count);
 
         if hwinfo.caps.iter().find(|&cap| *cap == HwCap::NominalInput).is_some() {
-            let elem_id = alsactl::ElemId::new_by_name(
-                alsactl::ElemIfaceType::Mixer, 0, 0, IN_NOMINAL_NAME, 0);
+            let elem_id = ElemId::new_by_name( ElemIfaceType::Mixer, 0, 0, IN_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
                 self.phys_inputs, &Self::IN_NOMINAL_LABELS, None, true)?;
 
@@ -53,9 +55,9 @@ impl InputCtl {
 
     pub fn read(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        elem_value: &mut alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
@@ -82,10 +84,10 @@ impl InputCtl {
 
     pub fn write(
         &mut self,
-        unit: &mut hinawa::SndEfw,
-        elem_id: &alsactl::ElemId,
-        old: &alsactl::ElemValue,
-        new: &alsactl::ElemValue,
+        unit: &mut SndEfw,
+        elem_id: &ElemId,
+        old: &ElemValue,
+        new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -35,18 +35,17 @@ impl InputCtl {
                 alsactl::ElemIfaceType::Mixer, 0, 0, IN_NOMINAL_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1,
                 self.phys_inputs, &Self::IN_NOMINAL_LABELS, None, true)?;
-        }
 
-        // FPGA models return invalid state of nominal level. Here, initialize them and cache the
-        // state instead.
-        let has_fpga = hwinfo.caps.iter().find(|&cap| *cap == HwCap::Fpga).is_some();
-        if has_fpga {
-            let cache = vec![NominalSignalLevel::Professional;self.phys_inputs];
-            cache.iter().enumerate()
-                .try_for_each( |(i, &level)| {
-                    unit.set_nominal(i, level, timeout_ms)
-                })?;
-            self.cache = Some(cache);
+            // FPGA models return invalid state of nominal level.
+            let has_fpga = hwinfo.caps.iter().find(|&cap| *cap == HwCap::Fpga).is_some();
+            if has_fpga {
+                let cache = vec![NominalSignalLevel::Professional;self.phys_inputs];
+                cache.iter().enumerate()
+                    .try_for_each( |(i, &level)| {
+                        unit.set_nominal(i, level, timeout_ms)
+                    })?;
+                self.cache = Some(cache);
+            }
         }
 
         Ok(())

--- a/libs/efw/runtime/src/lib.rs
+++ b/libs/efw/runtime/src/lib.rs
@@ -44,7 +44,7 @@ pub struct EfwRuntime {
     tx: mpsc::SyncSender<Event>,
     dispatchers: Vec<Dispatcher>,
     timer: Option<Dispatcher>,
-    measure_elems: Vec<ElemId>,
+    measured_elem_id_list: Vec<ElemId>,
 }
 
 impl Drop for EfwRuntime {
@@ -77,19 +77,15 @@ impl RuntimeOperation<u32> for EfwRuntime {
         // Use uni-directional channel for communication to child threads.
         let (tx, rx) = mpsc::sync_channel(32);
 
-        let dispatchers = Vec::new();
-        let timer = None;
-        let measure_elems = Vec::new();
-
         Ok(EfwRuntime {
             unit,
             model,
             card_cntr,
             rx,
             tx,
-            dispatchers,
-            timer,
-            measure_elems,
+            dispatchers: Default::default(),
+            timer: Default::default(),
+            measured_elem_id_list: Default::default(),
         })
     }
 
@@ -102,7 +98,7 @@ impl RuntimeOperation<u32> for EfwRuntime {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::TIMER_NAME, 0);
         let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        self.model.get_measure_elem_list(&mut self.measure_elems);
+        self.model.get_measure_elem_list(&mut self.measured_elem_id_list);
 
         Ok(())
     }
@@ -122,7 +118,7 @@ impl RuntimeOperation<u32> for EfwRuntime {
                 Event::Timer => {
                     let _ = self.card_cntr.measure_elems(
                         &mut self.unit,
-                        &self.measure_elems,
+                        &self.measured_elem_id_list,
                         &mut self.model,
                     );
                 }

--- a/libs/efw/runtime/src/meter_ctl.rs
+++ b/libs/efw/runtime/src/meter_ctl.rs
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::{Error, FileError};
 
-use core::card_cntr;
-
-use alsactl::{ElemId, ElemIfaceType, ElemValueExt, ElemValueExtManual};
-
-use efw_protocols::hw_info::*;
+use {
+    glib::{Error, FileError},
+    hinawa::SndEfw,
+    alsactl::{ElemId, ElemIfaceType, ElemValueExt, ElemValueExtManual, ElemValue},
+    core::card_cntr::*,
+    efw_protocols::hw_info::*,
+};
 
 #[derive(Default)]
 pub struct MeterCtl {
-    pub measure_elems: Vec<alsactl::ElemId>,
+    pub measure_elems: Vec<ElemId>,
     meters: Option<HwMeter>,
     midi_inputs: usize,
     midi_outputs: usize,
@@ -30,9 +31,7 @@ impl MeterCtl {
     const COEF_MAX: i32 = 0x007fffff;
     const COEF_STEP: i32 = 1;
 
-    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut card_cntr::CardCntr)
-        -> Result<(), Error>
-    {
+    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meters = Some(HwMeter::new(
             &hwinfo.clk_srcs,
             hwinfo.mixer_captures,
@@ -92,7 +91,7 @@ impl MeterCtl {
         Ok(())
     }
 
-    pub fn measure_states(&mut self, unit: &mut hinawa::SndEfw, timeout_ms: u32) -> Result<(), Error> {
+    pub fn measure_states(&mut self, unit: &mut SndEfw, timeout_ms: u32) -> Result<(), Error> {
         match &mut self.meters {
             Some(meters) => unit.get_hw_meter(meters, timeout_ms),
             None => {
@@ -102,7 +101,7 @@ impl MeterCtl {
         }
     }
 
-    pub fn measure_elem(&mut self, elem_id: &alsactl::ElemId, elem_value: &mut alsactl::ElemValue)
+    pub fn measure_elem(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue)
         -> Result<bool, Error>
     {
         match elem_id.get_name().as_str() {

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -76,7 +76,11 @@ impl MixerCtl {
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ENABLE_MIXER, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
-        self.has_fpga = hwinfo.caps.iter().find(|&cap| *cap == HwCap::Fpga).is_some();
+
+        // Onyx 1200f has both DSP and FPGA.
+        let has_dsp = hwinfo.caps.iter().find(|cap| HwCap::Dsp.eq(cap)).is_some();
+        let has_fpga = hwinfo.caps.iter().find(|cap| HwCap::Fpga.eq(cap)).is_some();
+        self.has_fpga = !has_dsp && has_fpga;
 
         Ok(())
     }

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -55,8 +55,10 @@ impl MixerCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, PLAYBACK_MUTE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, PLAYBACK_SOLO_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
+        if hwinfo.caps.iter().find(|cap| HwCap::ControlRoom.eq(cap)).is_none() {
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, PLAYBACK_SOLO_NAME, 0);
+            let _ = card_cntr.add_bool_elems(&elem_id, 1, self.playbacks, true)?;
+        }
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MONITOR_GAIN_NAME, 0);
         let _ = card_cntr.add_int_elems(&elem_id, self.playbacks,

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -170,11 +170,13 @@ impl MeasureModel<SndEfw> for EfwModel {
 impl NotifyModel<SndEfw, bool> for EfwModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.clk_ctl.notified_elem_id_list);
+        elem_id_list.extend_from_slice(&self.port_ctl.notified_elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut SndEfw, &locked: &bool) -> Result<(), Error> {
         if locked {
             self.clk_ctl.cache(unit, TIMEOUT_MS)?;
+            self.port_ctl.cache(unit, TIMEOUT_MS)?;
         }
         Ok(())
     }
@@ -186,6 +188,8 @@ impl NotifyModel<SndEfw, bool> for EfwModel {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -166,3 +166,21 @@ impl MeasureModel<SndEfw> for EfwModel {
         self.meter_ctl.measure_elem(elem_id, elem_value)
     }
 }
+
+impl NotifyModel<SndEfw, bool> for EfwModel {
+    fn get_notified_elem_list(&mut self, _: &mut Vec<ElemId>) {
+    }
+
+    fn parse_notification(&mut self, _: &mut SndEfw, _: &bool) -> Result<(), Error> {
+        Ok(())
+    }
+
+    fn read_notified_elem(
+        &mut self,
+        _: &SndEfw,
+        _: &ElemId,
+        _: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+}

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -92,7 +92,7 @@ impl CtlModel<SndEfw> for EfwModel {
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
         self.output_ctl.load(&hwinfo, card_cntr)?;
         self.input_ctl.load(unit, &hwinfo, card_cntr, TIMEOUT_MS)?;
-        self.port_ctl.load(&hwinfo, card_cntr, unit, TIMEOUT_MS)?;
+        self.port_ctl.load(&hwinfo, card_cntr, unit, self.clk_ctl.curr_rate, TIMEOUT_MS)?;
         self.meter_ctl.load(&hwinfo, card_cntr)?;
         self.guitar_ctl.load(&hwinfo, card_cntr)?;
         self.iec60958_ctl.load(&hwinfo, card_cntr)?;
@@ -176,7 +176,7 @@ impl NotifyModel<SndEfw, bool> for EfwModel {
     fn parse_notification(&mut self, unit: &mut SndEfw, &locked: &bool) -> Result<(), Error> {
         if locked {
             self.clk_ctl.cache(unit, TIMEOUT_MS)?;
-            self.port_ctl.cache(unit, TIMEOUT_MS)?;
+            self.port_ctl.cache(unit, self.clk_ctl.curr_rate, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -92,7 +92,7 @@ impl CtlModel<SndEfw> for EfwModel {
         self.mixer_ctl.load(&hwinfo, card_cntr)?;
         self.output_ctl.load(&hwinfo, card_cntr)?;
         self.input_ctl.load(unit, &hwinfo, card_cntr, TIMEOUT_MS)?;
-        self.port_ctl.load(&hwinfo, card_cntr)?;
+        self.port_ctl.load(&hwinfo, card_cntr, unit, TIMEOUT_MS)?;
         self.meter_ctl.load(&hwinfo, card_cntr)?;
         self.guitar_ctl.load(&hwinfo, card_cntr)?;
         self.iec60958_ctl.load(&hwinfo, card_cntr)?;

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -48,7 +48,7 @@ pub struct PortCtl {
     rx_stream_map: Vec<Option<usize>>,
 }
 
-const MIRROR_OUTPUT_NAME: &str = "mirror-output";
+const CONTROL_ROOM_SOURCE_NAME: &str = "control-room-source";
 const DIG_MODE_NAME: &str = "digital-mode";
 const PHANTOM_NAME: &str = "phantom-powering";
 const RX_MAP_NAME: &str = "stream-playback-routing";
@@ -102,7 +102,7 @@ impl PortCtl {
         curr_rate: u32,
         timeout_ms: u32
     ) -> Result<(), Error> {
-        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::MirrorOutput).is_some() {
+        if hwinfo.caps.iter().find(|&cap| *cap == HwCap::ControlRoom).is_some() {
             let labels = hwinfo.phys_outputs.iter()
                 .filter(|entry| entry.group_type != PhysGroupType::AnalogMirror)
                 .map(|entry| {
@@ -116,7 +116,7 @@ impl PortCtl {
                 .collect::<Vec<String>>();
 
             let elem_id = ElemId::new_by_name(
-                ElemIfaceType::Mixer, 0, 0, MIRROR_OUTPUT_NAME, 0);
+                ElemIfaceType::Mixer, 0, 0, CONTROL_ROOM_SOURCE_NAME, 0);
             let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
         }
 
@@ -226,9 +226,9 @@ impl PortCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            MIRROR_OUTPUT_NAME => {
+            CONTROL_ROOM_SOURCE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
-                    let pair = unit.get_output_mirror(timeout_ms)?;
+                    let pair = unit.get_control_room_source(timeout_ms)?;
                     Ok(pair as u32)
                 })?;
                 Ok(true)
@@ -281,9 +281,9 @@ impl PortCtl {
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.get_name().as_str() {
-            MIRROR_OUTPUT_NAME => {
+            CONTROL_ROOM_SOURCE_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
-                    unit.set_output_mirror(val as usize, timeout_ms)
+                    unit.set_control_room_source(val as usize, timeout_ms)
                 })?;
                 Ok(true)
             }

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -88,10 +88,10 @@ fn enum_values_to_entries(elem_value: &ElemValue, entries: &mut [Option<usize>])
 
 impl PortCtl {
     const DIG_MODES: [(HwCap, DigitalMode);4] = [
-        (HwCap::SpdifCoax, DigitalMode::SpdifCoax),
-        (HwCap::AesebuXlr, DigitalMode::AesebuXlr),
-        (HwCap::SpdifOpt, DigitalMode::SpdifOpt),
-        (HwCap::AdatOpt, DigitalMode::AdatOpt),
+        (HwCap::OptionalSpdifCoax, DigitalMode::SpdifCoax),
+        (HwCap::OptionalAesebuXlr, DigitalMode::AesebuXlr),
+        (HwCap::OptionalSpdifOpt, DigitalMode::SpdifOpt),
+        (HwCap::OptionalAdatOpt, DigitalMode::AdatOpt),
     ];
 
     pub fn load(


### PR DESCRIPTION
Current implementation of Fireworks protocol includes wrong interpretation for digital interface capabilities.
Additionally, stream map protocol requires sampling transfer frequency as its first argument.
Furthermore, reported at #50, Onyx 1200f/400f reject playback solo command.

This commit fixes the above items.

```
Takashi Sakamoto (17):
  efw-runtime: opt out Onyx 1200F from nominal input controls
  efw-protocols: fixup hardware information for Onyx 1200f
  efw-runtime: code refactoring to declare usage of modules
  efw-runtime: code refactoring for name of list for measured elements
  efw-runtime: add trait implementationn for stream lock notification
  efw-runtime: handle stream lock notification to update cache for clock controls
  efw-runtime: cache current state of stream map
  efw-runtime: handle stream lock notification to update cache for stream map controls
  efw-protocols: put current rate to frame for stream map command
  efw-protocols: integrate stream mapping protocol for disable entry
  efw-runtime: enumerate list of supported clock sources to detect S/PDIF input/output
  efw-protocols: fix interpretation of capabilities for digital input.output interface
  efw-protocols: fix source of control room
  efw-runtime: fix control to enable mixer for Onyx 1200f
  efw-protocols: add table for capabilities retrieved from each model
  efw-runtime: don't add playback solo controls for Onyx 1200f/400f
  fix type in README for snd-fireworks-ctl-service

 README.rst                           |   2 +-
 libs/efw/protocols/src/hw_info.rs    |  71 +++----
 libs/efw/protocols/src/lib.rs        |   6 +
 libs/efw/protocols/src/port_conf.rs  | 142 ++++++++++----
 libs/efw/runtime/src/clk_ctl.rs      | 100 +++++-----
 libs/efw/runtime/src/guitar_ctl.rs   |  43 ++---
 libs/efw/runtime/src/iec60958_ctl.rs |  40 ++--
 libs/efw/runtime/src/input_ctl.rs    |  63 +++---
 libs/efw/runtime/src/lib.rs          |  86 ++++++---
 libs/efw/runtime/src/meter_ctl.rs    |  23 ++-
 libs/efw/runtime/src/mixer_ctl.rs    |  68 ++++---
 libs/efw/runtime/src/model.rs        | 108 +++++++----
 libs/efw/runtime/src/output_ctl.rs   |  47 +++--
 libs/efw/runtime/src/port_ctl.rs     | 275 ++++++++++++++++++---------
 14 files changed, 654 insertions(+), 420 deletions(-)
```