### PR TITLE
all: migrate to crates based on glib crate v0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 libc = "0.2"
-glib = "0.10"
-alsactl = "0.3"
-alsaseq = "0.3"
-hinawa = "0.5"
-hitaki = "0.1"
+glib = "0.15"
+alsactl = "0.4"
+alsaseq = "0.4"
+hinawa = "0.7"
+hitaki = "0.2"
 core = { path = "libs/core" }
 dg00x-runtime = { path = "libs/dg00x/runtime" }
 tascam-runtime = { path = "libs/tascam/runtime" }
@@ -52,10 +52,6 @@ members = [
 
 # They have plans to be published into crates.io.
 [patch.crates-io]
-hinawa = { git = "https://github.com/alsa-project/hinawa-rs.git", tag = "v0.5.2" }
-hitaki = { git = "https://github.com/alsa-project/hitaki-rs.git", tag = "v0.1.0" }
-alsactl = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.3.0" }
-alsaseq = { git = "https://github.com/alsa-project/alsa-gobject-rs.git", tag = "v0.3.0" }
 alsa-ctl-tlv-codec = { path = "libs/alsa-ctl-tlv-codec" }
 ieee1212-config-rom = { path = "libs/ieee1212-config-rom" }
 ta1394 = { path = "libs/ta1394" }

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2022/06/30
+2022/07/14
 Takashi Sakamoto
 
 Introduction
@@ -44,16 +44,17 @@ Build dependencies
 * Cargo
 * Some crates and their dependencies
 
-  * glib crate v0.10 and its dependencies `<https://gtk-rs.org/>`_
-  * hinawa crate v0.5.2 and its dependencies `<https://github.com/alsa-project/hinawa-rs/>`_
-  * hitaki crate v0.1 and its dependencies `<https://github.com/alsa-project/hitaki-rs/>`_
-  * alsactl/alsatimer/alsaseq crates v0.3 and its dependencies `<https://github.com/alsa-project/alsa-gobject-rs/>`_
+ * glib crate v0.15 and its dependencies `<https://gtk-rs.org/>`_
+ * hinawa crate v0.7 and its dependencies `<https://github.com/alsa-project/hinawa-rs/>`_
+ * hitaki crate v0.2 and its dependencies `<https://github.com/alsa-project/hitaki-rs/>`_
+ * alsactl/alsaseq crates v0.4 and their dependencies `<https://github.com/alsa-project/alsa-gobject-rs/>`_
 
 Runtime dependencies
 ====================
 
+
 * glib `<https://developer.gnome.org/glib/>`_
-* libhinawa v2.4 or later `<https://github.com/alsa-project/libhinawa>`_
+* libhinawa v2.5 or later `<https://github.com/alsa-project/libhinawa>`_
 * libhitaki v0.1 or later `<https://github.com/alsa-project/libhitaki>`_
 * alsa-gobject v0.3 or later `<https://github.com/alsa-project/alsa-gobject/>`_
 

--- a/libs/bebob/protocols/Cargo.toml
+++ b/libs/bebob/protocols/Cargo.toml
@@ -13,6 +13,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"
 ta1394 = "0.1"

--- a/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
+++ b/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
@@ -3,8 +3,7 @@
 
 use glib::{FileError, MainContext, MainLoop};
 
-use hinawa::FwReq;
-use hinawa::{FwNode, FwNodeError, FwNodeExt};
+use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq};
 
 use bebob_protocols::bridgeco::*;
 

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1470,7 +1470,7 @@ pub struct BcoImageInformation {
 impl Default for BcoImageInformation {
     fn default() -> Self {
         Self {
-            timestamp: glib::DateTime::new_now_utc(),
+            timestamp: glib::DateTime::now_utc().unwrap(),
             id: Default::default(),
             version: Default::default(),
         }
@@ -1503,7 +1503,7 @@ impl Default for BcoBootloaderInformation {
             software: Default::default(),
             image_base_address: Default::default(),
             image_maximum_size: Default::default(),
-            bootloader_timestamp: glib::DateTime::new_now_utc(),
+            bootloader_timestamp: glib::DateTime::now_utc().unwrap(),
             debugger: Default::default(),
         }
     }
@@ -1652,23 +1652,23 @@ fn parse_tstamp(buf: &[u8]) -> Result<glib::DateTime, Error> {
             Error::new(FileError::Nxio, &msg)
         })?;
 
-        let seconds = u16::from_str_radix(&literal[4..6], 10).map_err(|err| {
+        u16::from_str_radix(&literal[4..6], 10).map_err(|err| {
             let msg = format!("{}", err);
             Error::new(FileError::Nxio, &msg)
-        })?;
-        Ok((hour, minute, seconds))
+        })
+            .map(|seconds| (hour, minute, seconds))
     } else {
         Ok((0, 0, 0))
     }?;
 
-    let tstamp = glib::DateTime::new_utc(
+    let tstamp = glib::DateTime::from_utc(
         year as i32,
         month as i32,
         day as i32,
         hour as i32,
         minute as i32,
         seconds as f64,
-    );
+    ).unwrap();
 
     Ok(tstamp)
 }

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -24,7 +24,7 @@ pub mod yamaha_terratec;
 use {
     self::bridgeco::{ExtendedStreamFormatSingle, *},
     glib::{Error, FileError},
-    hinawa::{FwFcp, FwNode, FwReq, FwReqExtManual, FwTcode},
+    hinawa::{prelude::FwReqExtManual, FwFcp, FwNode, FwReq, FwTcode},
     ta1394::{amdtp::*, audio::*, ccm::*, general::*, *},
 };
 

--- a/libs/bebob/runtime/Cargo.toml
+++ b/libs/bebob/runtime/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394 = "0.1"

--- a/libs/bebob/runtime/src/apogee/ensemble_model.rs
+++ b/libs/bebob/runtime/src/apogee/ensemble_model.rs
@@ -390,7 +390,7 @@ impl MeterCtl {
     }
 
     fn read_state(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             KNOB_IN_TARGET_NAME => {
                 let idx = Self::KNOB_INPUT_TARGETS
                     .iter()
@@ -531,7 +531,7 @@ impl ConvertCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             FORMAT_CONVERT_TARGET_NAME => {
                 let pos = Self::FORMAT_CONVERT_TARGETS
                     .iter()
@@ -571,9 +571,9 @@ impl ConvertCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             FORMAT_CONVERT_TARGET_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &target = Self::FORMAT_CONVERT_TARGETS
                     .iter()
                     .nth(val as usize)
@@ -588,12 +588,12 @@ impl ConvertCtl {
             }
             CD_MODE_NAME => {
                 let mut params = self.0.clone();
-                params.cd_mode = elem_value.get_bool()[0];
+                params.cd_mode = elem_value.boolean()[0];
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             RATE_CONVERT_TARGET_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &target = Self::RATE_CONVERT_TARGETS
                     .iter()
                     .nth(val as usize)
@@ -607,7 +607,7 @@ impl ConvertCtl {
                     .map(|_| true)
             }
             RATE_CONVERT_RATE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &converted_rate = Self::RATE_CONVERT_RATES
                     .iter()
                     .nth(val as usize)
@@ -670,7 +670,7 @@ impl DisplayCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DISPLAY_ENABLE_NAME => {
                 elem_value.set_bool(&[self.0.enabled]);
                 Ok(true)
@@ -702,21 +702,21 @@ impl DisplayCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DISPLAY_ENABLE_NAME => {
                 let mut params = self.0.clone();
-                params.enabled = elem_value.get_bool()[0];
+                params.enabled = elem_value.boolean()[0];
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             DISPLAY_ILLUMINATE_NAME => {
                 let mut params = self.0.clone();
-                params.illuminate = elem_value.get_bool()[0];
+                params.illuminate = elem_value.boolean()[0];
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             DISPLAY_TARGET_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &target = Self::DISPLAY_METER_TARGETS
                     .iter()
                     .nth(val as usize)
@@ -731,7 +731,7 @@ impl DisplayCtl {
             }
             DISPLAY_OVERHOLD_NAME => {
                 let mut params = self.0.clone();
-                params.overhold = elem_value.get_bool()[0];
+                params.overhold = elem_value.boolean()[0];
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
@@ -828,7 +828,7 @@ impl InputCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_LIMIT_NAME => {
                 elem_value.set_bool(&self.0.limits);
                 Ok(true)
@@ -875,19 +875,19 @@ impl InputCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_LIMIT_NAME => {
                 let mut params = self.0.clone();
                 params
                     .limits
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             INPUT_LEVEL_NAME => {
-                let vals = &elem_value.get_enum()[..Self::INPUT_LABELS.len()];
+                let vals = &elem_value.enumerated()[..Self::INPUT_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .levels
@@ -907,7 +907,7 @@ impl InputCtl {
                     .map(|_| true)
             }
             MIC_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..Self::MIC_LABELS.len()];
+                let vals = &elem_value.int()[..Self::MIC_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .gains
@@ -922,7 +922,7 @@ impl InputCtl {
                 params
                     .phantoms
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -932,13 +932,13 @@ impl InputCtl {
                 params
                     .polarities
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             INPUT_OPT_IFACE_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = OPT_IFACE_MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index of optical iface mode: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -1035,7 +1035,7 @@ impl<'a> OutputCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, Self::OUT_LABELS.len(), |i| {
                     let pos = Self::NOMINAL_LEVELS
@@ -1079,9 +1079,9 @@ impl<'a> OutputCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_LEVEL_NAME => {
-                let vals = &elem_value.get_enum()[..Self::OUT_LABELS.len()];
+                let vals = &elem_value.enumerated()[..Self::OUT_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .levels
@@ -1105,12 +1105,12 @@ impl<'a> OutputCtl {
             }
             OUTPUT_VOL_NAME => {
                 let mut params = self.0.clone();
-                params.vol = elem_value.get_int()[0] as u8;
+                params.vol = elem_value.int()[0] as u8;
                 avc.update_params(&params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             HP_VOL_NAME => {
-                let vals = &elem_value.get_int()[..Self::HP_LABELS.len()];
+                let vals = &elem_value.int()[..Self::HP_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .headphone_vols
@@ -1121,7 +1121,7 @@ impl<'a> OutputCtl {
                     .map(|_| true)
             }
             OUTPUT_OPT_IFACE_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let mut params = self.0.clone();
                 let &mode = OPT_IFACE_MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for index of input nominal level: {}", val);
@@ -1299,7 +1299,7 @@ impl RouteCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_SRC_NAME => {
                 let vals: Vec<u32> = self
                     .0
@@ -1341,9 +1341,9 @@ impl RouteCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_SRC_NAME => {
-                let vals = &elem_value.get_enum()[..Self::OUTPUT_LABELS.len()];
+                let vals = &elem_value.enumerated()[..Self::OUTPUT_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .output_sources
@@ -1354,7 +1354,7 @@ impl RouteCtl {
                     .map(|_| true)
             }
             CAPTURE_SOURCE_NAME => {
-                let vals = &elem_value.get_enum()[..Self::CAPTURE_LABELS.len()];
+                let vals = &elem_value.enumerated()[..Self::CAPTURE_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .capture_sources
@@ -1365,7 +1365,7 @@ impl RouteCtl {
                     .map(|_| true)
             }
             HP_SRC_NAME => {
-                let vals = &elem_value.get_enum()[..Self::HEADPHONE_LABELS.len()];
+                let vals = &elem_value.enumerated()[..Self::HEADPHONE_LABELS.len()];
                 let mut params = self.0.clone();
                 params
                     .headphone_sources
@@ -1461,9 +1461,9 @@ impl MixerCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.0.src_gains[index]
                     .iter()
                     .map(|&val| val as i32)
@@ -1482,11 +1482,11 @@ impl MixerCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..Self::MIXER_SRC_LABELS.len()];
+                let vals = &elem_value.int()[..Self::MIXER_SRC_LABELS.len()];
 
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
 
                 let mut params = self.0.clone();
                 params.src_gains[index]
@@ -1539,7 +1539,7 @@ impl StreamCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STREAM_MODE_NAME => {
                 let pos = Self::STREAM_MODES
                     .iter()
@@ -1560,9 +1560,9 @@ impl StreamCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STREAM_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::STREAM_MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index of mode of stream: {}", val);
                     Error::new(FileError::Inval, &msg)

--- a/libs/bebob/runtime/src/common_ctls.rs
+++ b/libs/bebob/runtime/src/common_ctls.rs
@@ -18,7 +18,7 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::read_clk_freq(avc, timeout_ms).map(|idx| idx as u32)
             })
@@ -36,7 +36,7 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 unit.lock()?;
                 let res = ElemValueAccessor::<u32>::get_val(new, |val| {
@@ -80,7 +80,7 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::read_clk_src(avc, timeout_ms).map(|idx| idx as u32)
             })
@@ -98,7 +98,7 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => {
                 unit.lock()?;
                 let res = ElemValueAccessor::<u32>::get_val(new, |val| {
@@ -158,7 +158,7 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::LEVEL_NAME {
+        if elem_id.name().as_str() == Self::LEVEL_NAME {
             ElemValueAccessor::<i32>::set_vals(elem_value, T::ENTRIES.len(), |idx| {
                 T::read_level(avc, idx, timeout_ms).map(|level| level as i32)
             })
@@ -176,7 +176,7 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::LEVEL_NAME {
+        if elem_id.name().as_str() == Self::LEVEL_NAME {
             ElemValueAccessor::<i32>::get_vals(new, old, T::ENTRIES.len(), |idx, val| {
                 T::write_level(avc, idx, val as i16, timeout_ms)
             })
@@ -219,7 +219,7 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLevelOperation + AvcLrBalanceOperation>
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::BALANCE_NAME {
+        if elem_id.name().as_str() == Self::BALANCE_NAME {
             ElemValueAccessor::<i32>::set_vals(elem_value, T::ENTRIES.len(), |idx| {
                 T::read_lr_balance(avc, idx, timeout_ms).map(|balance| balance as i32)
             })
@@ -237,7 +237,7 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLevelOperation + AvcLrBalanceOperation>
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::BALANCE_NAME {
+        if elem_id.name().as_str() == Self::BALANCE_NAME {
             ElemValueAccessor::<i32>::get_vals(new, old, T::ENTRIES.len(), |idx, val| {
                 T::write_lr_balance(avc, idx, val as i16, timeout_ms)
             })
@@ -267,7 +267,7 @@ pub trait AvcMuteCtlOperation<T: AvcLevelOperation + AvcMuteOperation>:
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::MUTE_NAME {
+        if elem_id.name().as_str() == Self::MUTE_NAME {
             ElemValueAccessor::<bool>::set_vals(elem_value, T::ENTRIES.len(), |idx| {
                 T::read_mute(avc, idx, timeout_ms)
             })
@@ -285,7 +285,7 @@ pub trait AvcMuteCtlOperation<T: AvcLevelOperation + AvcMuteOperation>:
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::MUTE_NAME {
+        if elem_id.name().as_str() == Self::MUTE_NAME {
             ElemValueAccessor::<bool>::get_vals(new, old, T::ENTRIES.len(), |idx, val| {
                 T::write_mute(avc, idx, val, timeout_ms)
             })
@@ -331,7 +331,7 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SELECTOR_NAME {
+        if elem_id.name().as_str() == Self::SELECTOR_NAME {
             ElemValueAccessor::<u32>::set_vals(elem_value, Self::CH_COUNT, |idx| {
                 T::read_selector(avc, idx, timeout_ms).map(|val| val as u32)
             })
@@ -349,7 +349,7 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SELECTOR_NAME {
+        if elem_id.name().as_str() == Self::SELECTOR_NAME {
             ElemValueAccessor::<u32>::get_vals(new, old, Self::CH_COUNT, |idx, val| {
                 T::write_selector(avc, idx, val as usize, timeout_ms)
             })

--- a/libs/bebob/runtime/src/focusrite.rs
+++ b/libs/bebob/runtime/src/focusrite.rs
@@ -31,7 +31,7 @@ trait SaffireProMediaClkFreqCtlOperation<T: SaffireProioMediaClockFrequencyOpera
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::read_clk_freq(req, &unit.1, timeout_ms).map(|idx| idx as u32)
             })
@@ -48,7 +48,7 @@ trait SaffireProMediaClkFreqCtlOperation<T: SaffireProioMediaClockFrequencyOpera
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 unit.0.lock()?;
                 let res = ElemValueAccessor::<u32>::get_val(elem_value, |val| {
@@ -97,7 +97,7 @@ trait SaffireProSamplingClkSrcCtlOperation<T: SaffireProioSamplingClockSourceOpe
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::read_clk_src(req, &unit.1, timeout_ms).map(|idx| idx as u32)
             })
@@ -114,7 +114,7 @@ trait SaffireProSamplingClkSrcCtlOperation<T: SaffireProioSamplingClockSourceOpe
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => {
                 unit.0.lock()?;
                 let res = ElemValueAccessor::<u32>::get_val(elem_value, |val| {
@@ -185,7 +185,7 @@ trait SaffireProioMeterCtlOperation<T: SaffireProioMeterOperation>:
     }
 
     fn read_state(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_KNOB_VALUE_NAME => {
                 elem_value.set_int(&[self.as_ref().monitor_knob as i32]);
                 Ok(true)
@@ -301,7 +301,7 @@ trait SaffireOutputCtlOperation<T: SaffireOutputOperation>:
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_MUTE_NAME => {
                 elem_value.set_bool(&self.as_ref().mutes);
                 Ok(true)
@@ -335,26 +335,26 @@ trait SaffireOutputCtlOperation<T: SaffireOutputOperation>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_MUTE_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().mutes.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().mutes.len()];
                 T::write_mutes(req, &unit.1, &vals, self.as_mut(), timeout_ms).map(|_| true)
             }
             OUT_VOL_NAME => {
-                let vals = &elem_value.get_int()[..self.as_ref().vols.len()];
+                let vals = &elem_value.int()[..self.as_ref().vols.len()];
                 let vols: Vec<u8> = vals.iter().map(|&vol| vol as u8).collect();
                 T::write_vols(req, &unit.1, &vols, self.as_mut(), timeout_ms).map(|_| true)
             }
             OUT_HWCTL_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().hwctls.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().hwctls.len()];
                 T::write_hwctls(req, &unit.1, &vals, self.as_mut(), timeout_ms).map(|_| true)
             }
             OUT_DIM_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().dims.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().dims.len()];
                 T::write_dims(req, &unit.1, &vals, self.as_mut(), timeout_ms).map(|_| true)
             }
             OUT_PAD_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().pads.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().pads.len()];
                 T::write_pads(req, &unit.1, &vals, self.as_mut(), timeout_ms).map(|_| true)
             }
             _ => Ok(false),
@@ -445,7 +445,7 @@ trait SaffireMixerCtlOperation<T: SaffireMixerOperation>:
     }
 
     fn read_src_levels(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        let name = elem_id.get_name();
+        let name = elem_id.name();
 
         if name.as_str() == Self::PHYS_INPUT_GAIN_NAME {
             read_mixer_src_levels(elem_value, elem_id, &self.as_ref().phys_inputs)
@@ -467,7 +467,7 @@ trait SaffireMixerCtlOperation<T: SaffireMixerOperation>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        let name = &elem_id.get_name();
+        let name = &elem_id.name();
 
         if name.as_str() == Self::PHYS_INPUT_GAIN_NAME {
             if Self::MIXER_MODE != mixer_mode {
@@ -476,12 +476,12 @@ trait SaffireMixerCtlOperation<T: SaffireMixerOperation>:
                     "Not available at current mixer mode",
                 ))
             } else {
-                let vals = &elem_value.get_int()[..T::PHYS_INPUT_COUNT];
+                let vals = &elem_value.int()[..T::PHYS_INPUT_COUNT];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &v| {
                     levels.push(v as i16);
                     levels
                 });
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 T::write_phys_inputs(req, &unit.1, index, &levels, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
@@ -492,12 +492,12 @@ trait SaffireMixerCtlOperation<T: SaffireMixerOperation>:
                     "Not available at current mixer mode",
                 ))
             } else {
-                let vals = &elem_value.get_int()[..T::REVERB_RETURN_COUNT];
+                let vals = &elem_value.int()[..T::REVERB_RETURN_COUNT];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &v| {
                     levels.push(v as i16);
                     levels
                 });
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 T::write_reverb_returns(req, &unit.1, index, &levels, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
@@ -508,12 +508,12 @@ trait SaffireMixerCtlOperation<T: SaffireMixerOperation>:
                     "Not available at current mixer mode",
                 ))
             } else {
-                let vals = &elem_value.get_int()[..T::STREAM_INPUT_COUNT];
+                let vals = &elem_value.int()[..T::STREAM_INPUT_COUNT];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &v| {
                     levels.push(v as i16);
                     levels
                 });
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 T::write_stream_inputs(req, &unit.1, index, &levels, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
@@ -528,7 +528,7 @@ fn read_mixer_src_levels(
     elem_id: &ElemId,
     levels_list: &[Vec<i16>],
 ) -> Result<bool, Error> {
-    let index = elem_id.get_index() as usize;
+    let index = elem_id.index() as usize;
     levels_list
         .iter()
         .nth(index)
@@ -568,7 +568,7 @@ trait SaffireThroughCtlOperation<T: SaffireThroughOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIDI_THROUGH_NAME => {
                 let mut val = false;
                 T::read_midi_through(req, &unit.1, &mut val, timeout_ms)?;
@@ -593,13 +593,13 @@ trait SaffireThroughCtlOperation<T: SaffireThroughOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIDI_THROUGH_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_midi_through(req, &unit.1, val, timeout_ms).map(|_| true)
             }
             AC3_THROUGH_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_ac3_through(req, &unit.1, val, timeout_ms).map(|_| true)
             }
             _ => Ok(false),
@@ -674,9 +674,9 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol>:
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRO_MONITOR_ANALOG_INPUT_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 let vals: Vec<i32> = self.as_ref().analog_inputs[idx]
                     .iter()
                     .map(|&val| val as i32)
@@ -685,7 +685,7 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol>:
                 Ok(true)
             }
             PRO_MONITOR_SPDIF_INPUT_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 let vals: Vec<i32> = self.as_ref().spdif_inputs[idx]
                     .iter()
                     .map(|&val| val as i32)
@@ -695,7 +695,7 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol>:
             }
             PRO_MONITOR_ADAT_INPUT_NAME => {
                 if let Some(adat_inputs) = self.as_ref().adat_inputs {
-                    let idx = elem_id.get_index() as usize;
+                    let idx = elem_id.index() as usize;
                     let vals: Vec<i32> = adat_inputs[idx].iter().map(|&val| val as i32).collect();
                     elem_value.set_int(&vals);
                     Ok(true)
@@ -715,26 +715,26 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRO_MONITOR_ANALOG_INPUT_NAME => {
-                let idx = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..self.as_ref().analog_inputs[idx].len()];
+                let idx = elem_id.index() as usize;
+                let vals = &elem_value.int()[..self.as_ref().analog_inputs[idx].len()];
                 let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
                 T::write_analog_inputs(req, &unit.1, idx, &levels, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
             PRO_MONITOR_SPDIF_INPUT_NAME => {
-                let idx = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..self.as_ref().spdif_inputs[idx].len()];
+                let idx = elem_id.index() as usize;
+                let vals = &elem_value.int()[..self.as_ref().spdif_inputs[idx].len()];
                 let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
                 T::write_spdif_inputs(req, &unit.1, idx, &levels, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
             PRO_MONITOR_ADAT_INPUT_NAME => {
                 if T::HAS_ADAT {
-                    let vals = &elem_value.get_int()[..16];
+                    let vals = &elem_value.int()[..16];
                     let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
-                    let idx = elem_id.get_index() as usize;
+                    let idx = elem_id.index() as usize;
                     T::write_adat_inputs(req, &unit.1, idx, &levels, self.as_mut(), timeout_ms)
                         .map(|_| true)
                 } else {
@@ -814,7 +814,7 @@ impl SaffireProioMixerCtl {
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRO_MIXER_MONITOR_SRC_NAME => {
                 let vals: Vec<i32> = self
                     .0
@@ -857,9 +857,9 @@ impl SaffireProioMixerCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRO_MIXER_MONITOR_SRC_NAME => {
-                let vals = &elem_value.get_int()[..self.0.monitor_sources.len()];
+                let vals = &elem_value.int()[..self.0.monitor_sources.len()];
                 let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
                 SaffireProioMixerProtocol::write_monitor_sources(
                     req,
@@ -871,7 +871,7 @@ impl SaffireProioMixerCtl {
                 .map(|_| true)
             }
             PRO_MIXER_STREAM_SRC_PAIR_0_NAME => {
-                let vals = &elem_value.get_int()[..self.0.stream_source_pair0.len()];
+                let vals = &elem_value.int()[..self.0.stream_source_pair0.len()];
                 let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
                 SaffireProioMixerProtocol::write_stream_source_pair0(
                     req,
@@ -883,7 +883,7 @@ impl SaffireProioMixerCtl {
                 .map(|_| true)
             }
             PRO_MIXER_STREAM_SRC_NAME => {
-                let vals = &elem_value.get_int()[..self.0.stream_sources.len()];
+                let vals = &elem_value.int()[..self.0.stream_sources.len()];
                 let levels: Vec<i16> = vals.iter().map(|&level| level as i16).collect();
                 SaffireProioMixerProtocol::write_stream_sources(
                     req,
@@ -959,7 +959,7 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation>:
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             HEAD_ROOM_NAME => {
                 elem_value.set_bool(&[self.as_ref().head_room]);
                 Ok(true)
@@ -1000,22 +1000,22 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             HEAD_ROOM_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_head_room(req, &unit.1, val, self.as_mut(), timeout_ms).map(|_| true)
             }
             PHANTOM_POWERING_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().phantom_powerings.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().phantom_powerings.len()];
                 T::write_phantom_powerings(req, &unit.1, &vals, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }
             INSERT_SWAP_NAME => {
-                let vals = &elem_value.get_bool()[..self.as_ref().insert_swaps.len()];
+                let vals = &elem_value.boolean()[..self.as_ref().insert_swaps.len()];
                 T::write_insert_swaps(req, &unit.1, &vals, self.as_mut(), timeout_ms).map(|_| true)
             }
             STANDALONE_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::STANDALONE_MODES
                     .iter()
                     .nth(val as usize)
@@ -1027,11 +1027,11 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation>:
                     .map(|_| true)
             }
             ADAT_ENABLE_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_adat_enable(req, &unit.1, val, self.as_mut(), timeout_ms).map(|_| true)
             }
             DIRECT_MONITORING_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_direct_monitoring(req, &unit.1, val, self.as_mut(), timeout_ms)
                     .map(|_| true)
             }

--- a/libs/bebob/runtime/src/focusrite/saffire_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffire_model.rs
@@ -382,7 +382,7 @@ impl MeterCtl {
     }
 
     fn read_meter(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_METER_NAME => {
                 elem_value.set_int(&self.1.phys_inputs);
                 Ok(true)
@@ -459,7 +459,7 @@ impl SpecificCtl {
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MODE_192_KHZ_NAME => {
                 elem_value.set_bool(&[self.0.mode_192khz]);
                 Ok(true)
@@ -494,9 +494,9 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MODE_192_KHZ_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 SaffireSpecificProtocol::write_192khz_mode(
                     req,
                     &unit.1,
@@ -507,7 +507,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             INPUT_PAIR_1_SRC_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = Self::INPUT_PAIR_1_SRCS
                     .iter()
                     .nth(val as usize)
@@ -525,7 +525,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             MIXER_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::MIXER_MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index for mode of mixer: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -614,7 +614,7 @@ impl ReverbCtl {
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_AMOUNT_NAME => {
                 elem_value.set_int(&self.0.amounts);
                 Ok(true)
@@ -643,9 +643,9 @@ impl ReverbCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_AMOUNT_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 SaffireReverbProtocol::write_amounts(
                     req,
                     &mut unit.1,
@@ -656,7 +656,7 @@ impl ReverbCtl {
                 .map(|_| true)
             }
             REVERB_ROOM_SIZE_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 SaffireReverbProtocol::write_room_sizes(
                     req,
                     &mut unit.1,
@@ -667,7 +667,7 @@ impl ReverbCtl {
                 .map(|_| true)
             }
             REVERB_DIFFUSION_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 SaffireReverbProtocol::write_diffusions(
                     req,
                     &mut unit.1,
@@ -678,7 +678,7 @@ impl ReverbCtl {
                 .map(|_| true)
             }
             REVERB_TONE_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 SaffireReverbProtocol::write_tones(req, &mut unit.1, &vals, &mut self.0, timeout_ms)
                     .map(|_| true)
             }

--- a/libs/bebob/runtime/src/focusrite/saffirele_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffirele_model.rs
@@ -353,7 +353,7 @@ impl MeterCtl {
     }
 
     fn read_meter(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_METER_NAME => {
                 elem_value.set_int(&self.1.phys_inputs);
                 Ok(true)
@@ -392,7 +392,7 @@ impl SpecificCtl {
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_INPUT_2_3_HIGH_GAIN => {
                 elem_value.set_bool(&self.0.analog_input_2_3_high_gains);
                 Ok(true)
@@ -409,9 +409,9 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_INPUT_2_3_HIGH_GAIN => {
-                let vals = &elem_value.get_bool()[..2];
+                let vals = &elem_value.boolean()[..2];
                 SaffireLeSpecificProtocol::write_analog_input_high_gains(
                     req,
                     &unit.1,
@@ -471,7 +471,7 @@ impl MixerLowRateCtl {
     }
 
     fn read_src_gains(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PHYS_SRC_GAIN_NAME => read_mixer_src_gains(elem_value, elem_id, &self.0.phys_src_gains),
             STREAM_SRC_GAIN_NAME => {
                 read_mixer_src_gains(elem_value, elem_id, &self.0.stream_src_gains)
@@ -488,10 +488,10 @@ impl MixerLowRateCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PHYS_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..self.0.phys_src_gains[0].len()];
+                let index = elem_id.index() as usize;
+                let vals = &elem_value.int()[..self.0.phys_src_gains[0].len()];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &level| {
                     levels.push(level as i16);
                     levels
@@ -507,8 +507,8 @@ impl MixerLowRateCtl {
                 .map(|_| true)
             }
             STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..self.0.stream_src_gains[0].len()];
+                let index = elem_id.index() as usize;
+                let vals = &elem_value.int()[..self.0.stream_src_gains[0].len()];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &level| {
                     levels.push(level as i16);
                     levels
@@ -596,7 +596,7 @@ impl MixerMiddleRateCtl {
     }
 
     fn read_src_gains(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIDDLE_MONITOR_PHYS_SRC_GAIN_NAME => {
                 let gains: Vec<i32> = self
                     .0
@@ -625,9 +625,9 @@ impl MixerMiddleRateCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIDDLE_MONITOR_PHYS_SRC_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..self.0.monitor_src_phys_input_gains.len()];
+                let vals = &elem_value.int()[..self.0.monitor_src_phys_input_gains.len()];
                 let gains: Vec<i16> = vals.iter().fold(Vec::new(), |mut gains, &gain| {
                     gains.push(gain as i16);
                     gains
@@ -642,8 +642,8 @@ impl MixerMiddleRateCtl {
                 .map(|_| true)
             }
             MIDDLE_MONITOR_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..1];
+                let index = elem_id.index() as usize;
+                let vals = &elem_value.int()[..1];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &level| {
                     levels.push(level as i16);
                     levels
@@ -659,8 +659,8 @@ impl MixerMiddleRateCtl {
                 .map(|_| true)
             }
             MIDDLE_STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let vals = &elem_value.get_int()[..2];
+                let index = elem_id.index() as usize;
+                let vals = &elem_value.int()[..2];
                 let levels: Vec<i16> = vals.iter().fold(Vec::new(), |mut levels, &level| {
                     levels.push(level as i16);
                     levels
@@ -688,7 +688,7 @@ fn read_mixer_src_gains<T>(
 where
     T: AsRef<[i16]>,
 {
-    let index = elem_id.get_index() as usize;
+    let index = elem_id.index() as usize;
     levels_list
         .iter()
         .nth(index)

--- a/libs/bebob/runtime/src/maudio.rs
+++ b/libs/bebob/runtime/src/maudio.rs
@@ -194,7 +194,7 @@ where
     fn read_meter(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         let meter = self.as_ref();
 
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_METER_NAME => {
                 elem_value.set_int(&meter.phys_inputs);
                 Ok(true)
@@ -268,7 +268,7 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SWITCH_NAME => {
                 if O::HAS_SWITCH {
                     if let Some(switch) = &mut self.as_mut().switch {
@@ -350,8 +350,8 @@ pub trait MaudioNormalMixerCtlOperation<O: MaudioNormalMixerOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::MIXER_NAME {
-            let dst_idx = elem_id.get_index() as usize;
+        if elem_id.name().as_str() == Self::MIXER_NAME {
+            let dst_idx = elem_id.index() as usize;
             ElemValueAccessor::<bool>::set_vals(elem_value, Self::SRC_COUNT, |src_idx| {
                 O::read_mixer_src(avc, dst_idx, src_idx, timeout_ms)
             })
@@ -369,8 +369,8 @@ pub trait MaudioNormalMixerCtlOperation<O: MaudioNormalMixerOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::MIXER_NAME {
-            let dst_idx = elem_id.get_index() as usize;
+        if elem_id.name().as_str() == Self::MIXER_NAME {
+            let dst_idx = elem_id.index() as usize;
             ElemValueAccessor::<bool>::get_vals(new, old, Self::SRC_COUNT, |src_idx, val| {
                 O::write_mixer_src(avc, dst_idx, src_idx, val, timeout_ms)
             })

--- a/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
@@ -248,7 +248,7 @@ impl MeterCtl {
     }
 
     fn read_state(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DETECTED_RATE_NAME => {
                 let freq = Self::DETECTED_INPUT_FREQ_LIST
                     .iter()
@@ -295,7 +295,7 @@ impl InputParamsCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ADAT_MUTE_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, 4, |idx| Ok(self.0.adat_mute[idx]))
                     .map(|_| true)
@@ -321,9 +321,9 @@ impl InputParamsCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ADAT_MUTE_NAME => {
-                if unit.0.get_property_is_locked() {
+                if unit.0.is_locked() {
                     Err(Error::new(FileError::Again, "Packet streaming started"))?;
                 }
 
@@ -345,7 +345,7 @@ impl InputParamsCtl {
                 })
             }
             SPDIF_MUTE_NAME => {
-                if unit.0.get_property_is_locked() {
+                if unit.0.is_locked() {
                     Err(Error::new(FileError::Again, "Packet streaming started"))?;
                 }
 

--- a/libs/bebob/runtime/src/presonus/firebox_model.rs
+++ b/libs/bebob/runtime/src/presonus/firebox_model.rs
@@ -473,7 +473,7 @@ trait SwitchCtlOperation<T: AvcSelectorOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SWITCH_NAME {
+        if elem_id.name().as_str() == Self::SWITCH_NAME {
             ElemValueAccessor::<bool>::set_vals(elem_value, Self::CH_COUNT, |idx| {
                 T::read_selector(avc, idx, timeout_ms).map(|val| val > 0)
             })
@@ -491,7 +491,7 @@ trait SwitchCtlOperation<T: AvcSelectorOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SWITCH_NAME {
+        if elem_id.name().as_str() == Self::SWITCH_NAME {
             ElemValueAccessor::<bool>::get_vals(new, old, Self::CH_COUNT, |idx, val| {
                 T::write_selector(avc, idx, val as usize, timeout_ms)
             })

--- a/libs/bebob/runtime/src/presonus/inspire1394_model.rs
+++ b/libs/bebob/runtime/src/presonus/inspire1394_model.rs
@@ -579,7 +579,7 @@ trait MeterCtlOperation<T: Inspire1394MeterOperation>:
     }
 
     fn read_meter(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_METER_NAME => {
                 elem_value.set_int(&self.as_ref().phys_inputs);
                 Ok(true)
@@ -615,7 +615,7 @@ trait SwitchCtlOperation<T: PresonusSwitchOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SWITCH_NAME {
+        if elem_id.name().as_str() == Self::SWITCH_NAME {
             ElemValueAccessor::<bool>::set_vals(elem_value, T::CH_COUNT, |idx| {
                 T::read_switch(avc, idx, timeout_ms)
             })
@@ -633,7 +633,7 @@ trait SwitchCtlOperation<T: PresonusSwitchOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == Self::SWITCH_NAME {
+        if elem_id.name().as_str() == Self::SWITCH_NAME {
             ElemValueAccessor::<bool>::get_vals(new, old, T::CH_COUNT, |idx, val| {
                 T::write_switch(avc, idx, val, timeout_ms)
             })

--- a/libs/bebob/runtime/src/roland.rs
+++ b/libs/bebob/runtime/src/roland.rs
@@ -32,7 +32,7 @@ impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
         _: &ElemValue,
         _: u32,
     ) -> Result<bool, Error> {
-        if elem_id.get_name().as_str() == CLK_RATE_NAME {
+        if elem_id.name().as_str() == CLK_RATE_NAME {
             Err(Error::new(
                 FileError::Nxio,
                 "Sampling rate is immutable from software",

--- a/libs/core/Cargo.toml
+++ b/libs/core/Cargo.toml
@@ -12,8 +12,8 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
-alsaseq = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
+alsaseq = "0.4"

--- a/libs/core/src/dispatcher.rs
+++ b/libs/core/src/dispatcher.rs
@@ -3,11 +3,11 @@
 
 use {
     super::*,
-    alsactl::{Card, CardExt},
-    alsaseq::{UserClient, UserClientExt},
+    alsactl::{Card, prelude::CardExt},
+    alsaseq::{UserClient, prelude::UserClientExt},
     glib::{source, IsA, MainContext, MainLoop, Source},
-    hinawa::{FwNode, FwNodeExt},
-    hitaki::{AlsaFirewire, AlsaFirewireExt},
+    hinawa::{FwNode, prelude::FwNodeExt},
+    hitaki::{AlsaFirewire, prelude::AlsaFirewireExt},
     nix::sys::signal,
     std::{sync::Arc, thread, time::Duration},
 };
@@ -61,7 +61,7 @@ impl Dispatcher {
     }
 
     fn attach_src_to_ctx(&mut self, src: &Source) {
-        let ctx = self.ev_loop.get_context();
+        let ctx = self.ev_loop.context();
         src.attach(Some(&ctx));
     }
 
@@ -105,7 +105,7 @@ impl Dispatcher {
     {
         let src = unit.create_source()?;
 
-        unit.connect_property_is_disconnected_notify(disconnect_cb);
+        unit.connect_is_disconnected_notify(disconnect_cb);
 
         self.attach_src_to_ctx(&src);
 
@@ -130,8 +130,7 @@ impl Dispatcher {
     where
         F: FnMut() -> source::Continue + Send + 'static,
     {
-        let msec = interval_msec.as_millis() as u32;
-        let src = source::timeout_source_new(msec, None, source::PRIORITY_DEFAULT_IDLE, cb);
+        let src = source::timeout_source_new(interval_msec, None, source::PRIORITY_DEFAULT_IDLE, cb);
 
         self.attach_src_to_ctx(&src);
     }

--- a/libs/core/src/elem_value_accessor.rs
+++ b/libs/core/src/elem_value_accessor.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    alsactl::{ElemValue, ElemValueExt, ElemValueExtManual},
+    alsactl::{prelude::*, ElemValue},
     glib::IsA,
 };
 
@@ -68,7 +68,7 @@ impl ElemValueAccessor<bool> for ElemValue {
     where
         F: FnMut(&[bool]) -> Result<(), Error>,
     {
-        cb(&self.get_bool()[..len])
+        cb(&self.boolean()[..len])
     }
 }
 
@@ -81,7 +81,7 @@ impl ElemValueAccessor<u8> for ElemValue {
     where
         F: FnMut(&[u8]) -> Result<(), Error>,
     {
-        cb(&self.get_bytes()[..len])
+        cb(&self.bytes()[..len])
     }
 }
 
@@ -94,7 +94,7 @@ impl ElemValueAccessor<i32> for ElemValue {
     where
         F: FnMut(&[i32]) -> Result<(), Error>,
     {
-        cb(&self.get_int()[..len])
+        cb(&self.int()[..len])
     }
 }
 
@@ -107,7 +107,7 @@ impl ElemValueAccessor<u32> for ElemValue {
     where
         F: FnMut(&[u32]) -> Result<(), Error>,
     {
-        cb(&self.get_enum()[..len])
+        cb(&self.enumerated()[..len])
     }
 }
 
@@ -120,6 +120,6 @@ impl ElemValueAccessor<i64> for ElemValue {
     where
         F: FnMut(&[i64]) -> Result<(), Error>,
     {
-        cb(&self.get_int64()[..len])
+        cb(&self.int64()[..len])
     }
 }

--- a/libs/dg00x/protocols/Cargo.toml
+++ b/libs/dg00x/protocols/Cargo.toml
@@ -12,5 +12,5 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"

--- a/libs/dg00x/protocols/src/lib.rs
+++ b/libs/dg00x/protocols/src/lib.rs
@@ -7,7 +7,7 @@
 
 use glib::{Error, FileError};
 
-use hinawa::{FwNode, FwReq, FwReqExtManual, FwTcode};
+use hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode};
 
 /// The protocol implementation for Digi 002.
 #[derive(Default)]

--- a/libs/dg00x/runtime/Cargo.toml
+++ b/libs/dg00x/runtime/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394 = "0.1"

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -13,8 +13,8 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use glib::FileError;
 
-use hinawa::{FwNode, FwNodeError, FwNodeExt, FwNodeExtManual};
+use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
 
 use dice_protocols::tcat::config_rom::*;
 use ieee1212_config_rom::*;
@@ -60,7 +60,7 @@ fn main() {
                     )
                 })?;
 
-                node.get_config_rom()
+                node.config_rom()
                     .map_err(|e| format!("Fail to get content of configuration ROM: {}", e))
                     .map(|raw| raw.to_vec())
             }

--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -4,7 +4,7 @@
 use glib::{Error, FileError, MainContext, MainLoop};
 
 use hinawa::FwReq;
-use hinawa::{FwNode, FwNodeError, FwNodeExt};
+use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
 
 use dice_protocols::tcat::extension::current_config_section::*;
 use dice_protocols::tcat::extension::peak_section::*;

--- a/libs/dice/protocols/src/bin/tcat-general-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-general-parser.rs
@@ -4,7 +4,7 @@
 use glib::{Error, FileError, MainContext, MainLoop};
 
 use hinawa::FwReq;
-use hinawa::{FwNode, FwNodeError, FwNodeExt};
+use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
 
 use dice_protocols::tcat::{
     ext_sync_section::*, global_section::*, rx_stream_format_section::*,

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -105,7 +105,7 @@ pub mod config_rom;
 use {
     super::*,
     glib::{error::ErrorDomain, Quark},
-    hinawa::{FwReqExtManual, FwTcode},
+    hinawa::{prelude::FwReqExtManual, FwTcode},
     std::convert::TryFrom,
 };
 
@@ -187,7 +187,7 @@ impl std::fmt::Display for GeneralProtocolError {
 
 impl ErrorDomain for GeneralProtocolError {
     fn domain() -> Quark {
-        Quark::from_string("tcat-general-protocol-error-quark")
+        Quark::from_str("tcat-general-protocol-error-quark")
     }
 
     fn code(self) -> i32 {

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -101,7 +101,7 @@ impl std::fmt::Display for ProtocolExtensionError {
 
 impl ErrorDomain for ProtocolExtensionError {
     fn domain() -> Quark {
-        Quark::from_string("tcat-protocol-extension-error-quark")
+        Quark::from_str("tcat-protocol-extension-error-quark")
     }
 
     fn code(self) -> i32 {

--- a/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
@@ -127,8 +127,8 @@ impl RxStreamFormatSectionProtocol {
                 .map_err(|e| Error::new(GeneralProtocolError::RxStreamFormat, &e.to_string()))?;
             entries.push(entry);
             Ok(())
-        })?;
-        Ok(entries)
+        })
+            .map(|_| entries)
     }
 
     pub fn write_entries(
@@ -184,8 +184,6 @@ impl RxStreamFormatSectionProtocol {
             }
 
             Ok(())
-        })?;
-
-        Ok(())
+        })
     }
 }

--- a/libs/dice/runtime/Cargo.toml
+++ b/libs/dice/runtime/Cargo.toml
@@ -11,11 +11,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.10"
+glib = "0.15"
 nix = "0.17"
-alsactl = "0.3"
-hinawa = "0.5"
-hitaki = "0.1"
+alsactl = "0.4"
+hinawa = "0.7"
+hitaki = "0.2"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 dice-protocols = "0.1"

--- a/libs/dice/runtime/src/common_ctl.rs
+++ b/libs/dice/runtime/src/common_ctl.rs
@@ -99,7 +99,7 @@ impl CommonCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 let config = GlobalSectionProtocol::read_clock_config(
                     req,
@@ -184,7 +184,7 @@ impl CommonCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 unit.0.lock()?;
                 let res = GlobalSectionProtocol::read_clock_config(
@@ -234,7 +234,7 @@ impl CommonCtl {
             })
             .map(|_| true),
             NICKNAME => {
-                let vals = &new.get_bytes()[..NICKNAME_MAX_SIZE];
+                let vals = &new.bytes()[..NICKNAME_MAX_SIZE];
                 std::str::from_utf8(vals)
                     .map_err(|e| {
                         let msg = format!("Invalid bytes for string: {}", e);
@@ -290,7 +290,7 @@ impl CommonCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.curr_rate_idx))
                     .map(|_| true)
@@ -323,7 +323,7 @@ impl CommonCtl {
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SLIPPED_CLK_SRC_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.ext_srcs.len(), |idx| {
                     Ok(self.ext_srcs[idx].is_slipped(&self.ext_src_states))

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -93,7 +93,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             VOL_MUTE_NAME => {
                 elem_value.set_bool(&self.state().vol_mutes);
                 Ok(true)
@@ -123,7 +123,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MUTE_NAME => ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                 T::write_out_group_mute(
                     req,
@@ -147,7 +147,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
             })
             .map(|_| true),
             VOL_NAME => {
-                let vals = &elem_value.get_int()[..T::ENTRY_COUNT];
+                let vals = &elem_value.int()[..T::ENTRY_COUNT];
                 let vols: Vec<i8> = vals.iter().map(|&v| (Self::LEVEL_MAX - v) as i8).collect();
                 T::write_out_group_vols(
                     req,
@@ -160,7 +160,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
                 .map(|_| true)
             }
             VOL_MUTE_NAME => {
-                let vol_mutes = &elem_value.get_bool()[..T::ENTRY_COUNT];
+                let vol_mutes = &elem_value.boolean()[..T::ENTRY_COUNT];
                 let vol_hwctls = self.state().vol_hwctls.clone();
                 T::write_out_group_vol_mute_hwctls(
                     req,
@@ -174,7 +174,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
                 .map(|_| true)
             }
             VOL_HWCTL_NAME => {
-                let vol_hwctls = &elem_value.get_bool()[..T::ENTRY_COUNT];
+                let vol_hwctls = &elem_value.boolean()[..T::ENTRY_COUNT];
                 let vol_mutes = vec![false; T::ENTRY_COUNT];
                 T::write_out_group_vol_mute_hwctls(
                     req,
@@ -188,7 +188,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
                 .map(|_| true)
             }
             DIM_HWCTL_NAME => {
-                let dim_hwctls = &elem_value.get_bool()[..T::ENTRY_COUNT];
+                let dim_hwctls = &elem_value.boolean()[..T::ENTRY_COUNT];
                 let mute_hwctls = self.state().mute_hwctls.clone();
                 T::write_out_group_dim_mute_hwctls(
                     req,
@@ -202,7 +202,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
                 Ok(true)
             }
             MUTE_HWCTL_NAME => {
-                let mute_hwctls = &elem_value.get_bool()[..T::ENTRY_COUNT];
+                let mute_hwctls = &elem_value.boolean()[..T::ENTRY_COUNT];
                 let dim_hwctls = self.state().dim_hwctls.clone();
                 T::write_out_group_dim_mute_hwctls(
                     req,
@@ -251,7 +251,7 @@ trait OutGroupCtlOperation<T: SaffireproOutGroupOperation> {
     }
 
     fn read_notified_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MUTE_NAME => {
                 elem_value.set_bool(&[self.state().mute_enabled]);
                 Ok(true)
@@ -330,7 +330,7 @@ trait SaffireproInputCtlOperation<T: SaffireproInputOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_INPUT_LEVEL_NAME => {
                 let mut levels = vec![SaffireproMicInputLevel::default(); T::MIC_INPUT_COUNT];
                 T::read_mic_level(req, &mut unit.1, sections, &mut levels, timeout_ms)?;
@@ -368,9 +368,9 @@ trait SaffireproInputCtlOperation<T: SaffireproInputOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_INPUT_LEVEL_NAME => {
-                let vals = &elem_value.get_enum()[..T::MIC_INPUT_COUNT];
+                let vals = &elem_value.enumerated()[..T::MIC_INPUT_COUNT];
                 let mut levels = vec![SaffireproMicInputLevel::default(); T::MIC_INPUT_COUNT];
                 vals.iter().enumerate().try_for_each(|(i, &val)| {
                     Self::MIC_LEVELS
@@ -385,7 +385,7 @@ trait SaffireproInputCtlOperation<T: SaffireproInputOperation> {
                 T::write_mic_level(req, &mut unit.1, sections, &levels, timeout_ms).map(|_| true)
             }
             LINE_INPUT_LEVEL_NAME => {
-                let vals = &elem_value.get_enum()[..T::LINE_INPUT_COUNT];
+                let vals = &elem_value.enumerated()[..T::LINE_INPUT_COUNT];
                 let mut levels = vec![SaffireproLineInputLevel::default(); T::LINE_INPUT_COUNT];
                 vals.iter().enumerate().try_for_each(|(i, &val)| {
                     Self::LINE_LEVELS

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -458,7 +458,7 @@ impl SpecificCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::ANALOG_OUT_0_1_PAD_NAME => {
                 let enabled = LiquidS56Protocol::read_analog_out_0_1_pad_offset(
                     req,
@@ -608,9 +608,9 @@ impl SpecificCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::ANALOG_OUT_0_1_PAD_NAME => {
-                let val = new.get_bool()[0];
+                let val = new.boolean()[0];
                 LiquidS56Protocol::write_analog_out_0_1_pad_offset(
                     req,
                     &mut unit.1,
@@ -621,7 +621,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             Self::OPT_OUT_IFACE_MODE_NAME => {
-                let val = new.get_enum()[0];
+                let val = new.enumerated()[0];
                 let &mode = Self::OPT_OUT_IFACE_MODES
                     .iter()
                     .nth(val as usize)
@@ -653,7 +653,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             Self::ANALOG_INPUT_LEVEL_NAME => {
-                let vals = &new.get_enum()[..8];
+                let vals = &new.enumerated()[..8];
                 let mut levels = [AnalogInputLevel::Reserved(0); 8];
                 levels
                     .iter_mut()
@@ -732,7 +732,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             Self::LED_STATE_NAME => {
-                let vals = &new.get_bool()[..4];
+                let vals = &new.boolean()[..4];
                 let state = LedState {
                     adat1: vals[0],
                     adat2: vals[1],
@@ -743,7 +743,7 @@ impl SpecificCtl {
                     .map(|_| true)
             }
             Self::METER_DISPLAY_TARGETS_NAME => {
-                let vals = &new.get_enum()[..8];
+                let vals = &new.enumerated()[..8];
                 let mut targets = [0; 8];
                 targets
                     .iter_mut()

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -469,7 +469,7 @@ impl EffectCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CH_STRIP_ORDER_NAME => {
                 let vals: Vec<u32> = self
                     .0
@@ -533,7 +533,7 @@ impl EffectCtl {
     }
 
     fn convert_to_f32_array(elem_value: &ElemValue, raw: &mut [f32]) {
-        let vals = &elem_value.get_int()[..raw.len()];
+        let vals = &elem_value.int()[..raw.len()];
         raw.iter_mut()
             .zip(vals)
             .for_each(|(r, val)| *r = (*val as f32) / Self::F32_CONVERT_SCALE);
@@ -548,9 +548,9 @@ impl EffectCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CH_STRIP_ORDER_NAME => {
-                let vals = &elem_value.get_enum()[..self.0.eq_after_comp.len()];
+                let vals = &elem_value.enumerated()[..self.0.eq_after_comp.len()];
                 let eq_after_comp: Vec<bool> = vals.iter().map(|&val| val > 0).collect();
                 SPro24DspProtocol::write_eq_after_comp(
                     req,
@@ -563,7 +563,7 @@ impl EffectCtl {
                 .map(|_| true)
             }
             COMPRESSOR_ENABLE_NAME => {
-                let vals = &elem_value.get_bool()[..self.0.comp_enable.len()];
+                let vals = &elem_value.boolean()[..self.0.comp_enable.len()];
                 SPro24DspProtocol::write_comp_enable(
                     req,
                     &mut unit.1,
@@ -575,7 +575,7 @@ impl EffectCtl {
                 .map(|_| true)
             }
             EQUALIZER_ENABLE_NAME => {
-                let vals = &elem_value.get_bool()[..self.0.eq_enable.len()];
+                let vals = &elem_value.boolean()[..self.0.eq_enable.len()];
                 SPro24DspProtocol::write_eq_enable(
                     req,
                     &mut unit.1,
@@ -695,7 +695,7 @@ impl EffectCtl {
                 .map(|_| true)
             }
             REVERB_ENABLE_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 let mut reverb = self.0.reverb.clone();
                 reverb.enabled = val;
                 SPro24DspProtocol::write_reverb_effect(

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -312,7 +312,7 @@ impl SpecificCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::ANALOG_OUT_0_1_PAD_NAME => {
                 let enabled = SPro40Protocol::read_analog_out_0_1_pad(
                     req,
@@ -350,9 +350,9 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::ANALOG_OUT_0_1_PAD_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 SPro40Protocol::write_analog_out_0_1_pad(
                     req,
                     &mut unit.1,
@@ -363,7 +363,7 @@ impl SpecificCtl {
                 .map(|_| true)
             }
             Self::OPT_OUT_IFACE_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::OPT_OUT_IFACE_MODES
                     .iter()
                     .nth(val as usize)

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -212,7 +212,7 @@ impl MeterCtl {
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::SPDIF_INPUT_NAME => {
                 elem_value.set_int(&self.meters.spdif_inputs);
                 Ok(true)
@@ -340,9 +340,9 @@ impl MixerCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::BUS_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
                     IonixProtocol::read_mixer_bus_src_gain(
                         req,
@@ -356,7 +356,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::MAIN_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
                     IonixProtocol::read_mixer_main_src_gain(
                         req,
@@ -370,7 +370,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::REVERB_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, Self::MIXER_SRCS.len(), |idx| {
                     IonixProtocol::read_mixer_reverb_src_gain(
                         req,
@@ -396,9 +396,9 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::BUS_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
                     IonixProtocol::write_mixer_bus_src_gain(
                         req,
@@ -412,7 +412,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::MAIN_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
                     IonixProtocol::write_mixer_main_src_gain(
                         req,
@@ -426,7 +426,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::REVERB_SRC_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, Self::MIXER_SRCS.len(), |idx, val| {
                     IonixProtocol::write_mixer_reverb_src_gain(
                         req,

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -341,7 +341,7 @@ impl StandaloneCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::USE_CASE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let usecase = Mbox3Protocol::read_standalone_use_case(
                     req,
@@ -367,7 +367,7 @@ impl StandaloneCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::USE_CASE_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 let &usecase = Self::USE_CASES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for standalone usecase: {}", val);
@@ -451,7 +451,7 @@ impl HwCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MASTER_KNOB_ASSIGN_NAME => {
                 let mut assigns = MasterKnobAssigns::default();
                 Mbox3Protocol::read_master_knob_assign(
@@ -508,12 +508,12 @@ impl HwCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MASTER_KNOB_ASSIGN_NAME => {
                 let mut assign = MasterKnobAssigns::default();
                 assign
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Mbox3Protocol::write_master_knob_assign(
                     req,
@@ -541,7 +541,7 @@ impl HwCtl {
             Self::INPUT_HPF_NAME => {
                 let mut vals = [false; Self::INPUT_COUNT];
                 vals.iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Mbox3Protocol::write_hpf_enable(req, &mut unit.1, sections, vals, timeout_ms)?;
                 Ok(true)
@@ -650,7 +650,7 @@ impl ReverbCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::TYPE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let reverb_type =
                     Mbox3Protocol::read_reverb_type(req, &mut unit.1, sections, timeout_ms)?;
@@ -687,7 +687,7 @@ impl ReverbCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::TYPE_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 let &reverb_type = Self::TYPES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for index of reverb type: {}", val);
@@ -826,7 +826,7 @@ impl ButtonCtl {
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MUTE_BUTTON_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::MUTE_LED_STATES
                     .iter()
@@ -864,7 +864,7 @@ impl ButtonCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MUTE_BUTTON_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 let mut state = self.0.clone();
                 state.mute = Self::MUTE_LED_STATES

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -51,7 +51,7 @@ pub struct DiceModel {
 
 impl DiceModel {
     pub fn new(node: &FwNode) -> Result<DiceModel, Error> {
-        let raw = node.get_config_rom()?;
+        let raw = node.config_rom()?;
         let config_rom = ConfigRom::try_from(&raw[..]).map_err(|e| {
             let msg = format!("Malformed configuration ROM detected: {}", e);
             Error::new(FileError::Nxio, &msg)

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -544,7 +544,7 @@ trait SpecificCtlOperation<T: PfireSpecificOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_KNOB_NAME => {
                 T::read_knob_assign(
                     req,
@@ -589,7 +589,7 @@ trait SpecificCtlOperation<T: PfireSpecificOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_KNOB_NAME => {
                 ElemValueAccessor::<bool>::get_vals(new, old, T::KNOB_COUNT, |idx, val| {
                     self.state_mut()[idx] = val;

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -251,7 +251,7 @@ impl MeterCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::ANALOG_INPUT_NAME => {
                 let vals: Vec<i32> = self.0.analog_inputs.iter().map(|&l| l as i32).collect();
                 elem_value.set_int(&vals);
@@ -406,7 +406,7 @@ impl OutputCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::VOL_NAME => {
                 let vals: Vec<i32> = self.0.vols.iter().map(|&vol| vol as i32).collect();
                 elem_value.set_int(&vals);
@@ -451,20 +451,20 @@ impl OutputCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::VOL_NAME => {
-                let vals = &elem_value.get_int()[..self.0.vols.len()];
+                let vals = &elem_value.int()[..self.0.vols.len()];
                 let vols: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
                 FStudioProtocol::write_output_vols(req, &mut unit.1, &mut self.0, &vols, timeout_ms)
                     .map(|_| true)
             }
             Self::MUTE_NAME => {
-                let vals = &elem_value.get_bool()[..self.0.mutes.len()];
+                let vals = &elem_value.boolean()[..self.0.mutes.len()];
                 FStudioProtocol::write_output_mute(req, &mut unit.1, &mut self.0, &vals, timeout_ms)
                     .map(|_| true)
             }
             Self::SRC_NAME => {
-                let vals = &elem_value.get_enum()[..self.0.srcs.len()];
+                let vals = &elem_value.enumerated()[..self.0.srcs.len()];
 
                 let mut srcs = self.0.srcs.clone();
                 vals.iter().enumerate().try_for_each(|(i, &val)| {
@@ -481,12 +481,12 @@ impl OutputCtl {
                     .map(|_| true)
             }
             Self::LINK_NAME => {
-                let vals = &elem_value.get_bool()[..self.0.links.len()];
+                let vals = &elem_value.boolean()[..self.0.links.len()];
                 FStudioProtocol::write_output_link(req, &mut unit.1, &mut self.0, &vals, timeout_ms)
                     .map(|_| true)
             }
             Self::TERMINATE_BNC_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 FStudioProtocol::write_bnc_terminalte(req, &mut unit.1, val, timeout_ms)
                     .map(|_| true)
             }
@@ -554,7 +554,7 @@ impl AssignCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MAIN_NAME => {
                 let target =
                     FStudioProtocol::read_main_assign_target(req, &mut unit.1, timeout_ms)?;
@@ -582,9 +582,9 @@ impl AssignCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::MAIN_NAME => {
-                let val = new.get_enum()[0];
+                let val = new.enumerated()[0];
                 let target = Self::TARGETS.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for index of assignment target: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -824,55 +824,55 @@ impl MixerCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::PHYS_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.phys_src_params[index];
                 let vals: Vec<i32> = params.gains.iter().map(|&gain| gain as i32).collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             Self::PHYS_SRC_PAN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.phys_src_params[index];
                 let vals: Vec<i32> = params.pans.iter().map(|&pan| pan as i32).collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             Self::PHYS_SRC_MUTE_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.phys_src_params[index];
                 elem_value.set_bool(&params.mutes);
                 Ok(true)
             }
             Self::PHYS_SRC_LINK_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let links = &self.phys_src_links[index];
                 elem_value.set_bool(links);
                 Ok(true)
             }
             Self::STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.stream_src_params[index];
                 let vals: Vec<i32> = params.gains.iter().map(|&gain| gain as i32).collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             Self::STREAM_SRC_PAN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.stream_src_params[index];
                 let vals: Vec<i32> = params.pans.iter().map(|&pan| pan as i32).collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             Self::STREAM_SRC_MUTE_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &self.stream_src_params[index];
                 elem_value.set_bool(&params.mutes);
                 Ok(true)
             }
             Self::STREAM_SRC_LINK_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let links = &self.stream_src_links[index];
                 elem_value.set_bool(links);
                 Ok(true)
@@ -908,11 +908,11 @@ impl MixerCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::PHYS_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.phys_src_params[index];
-                let vals = &elem_value.get_int()[..params.gains.len()];
+                let vals = &elem_value.int()[..params.gains.len()];
                 let gains: Vec<u8> = vals.iter().map(|&v| v as u8).collect();
                 FStudioProtocol::write_mixer_phys_src_gains(
                     req,
@@ -925,9 +925,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::PHYS_SRC_PAN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.phys_src_params[index];
-                let vals = &elem_value.get_int()[..params.pans.len()];
+                let vals = &elem_value.int()[..params.pans.len()];
                 let pans: Vec<u8> = vals.iter().map(|&v| v as u8).collect();
                 FStudioProtocol::write_mixer_phys_src_pans(
                     req,
@@ -940,9 +940,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::PHYS_SRC_MUTE_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.phys_src_params[index];
-                let vals = &elem_value.get_bool()[..params.mutes.len()];
+                let vals = &elem_value.boolean()[..params.mutes.len()];
                 FStudioProtocol::write_mixer_phys_src_mutes(
                     req,
                     &mut unit.1,
@@ -954,9 +954,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::PHYS_SRC_LINK_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let links = &mut self.phys_src_links[index];
-                let vals = &elem_value.get_bool()[..links.len()];
+                let vals = &elem_value.boolean()[..links.len()];
                 FStudioProtocol::write_mixer_phys_src_links(
                     req,
                     &mut unit.1,
@@ -967,9 +967,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.stream_src_params[index];
-                let vals = &elem_value.get_int()[..params.gains.len()];
+                let vals = &elem_value.int()[..params.gains.len()];
                 let gains: Vec<u8> = vals.iter().map(|&v| v as u8).collect();
                 FStudioProtocol::write_mixer_stream_src_gains(
                     req,
@@ -982,9 +982,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::STREAM_SRC_PAN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.stream_src_params[index];
-                let vals = &elem_value.get_int()[..params.pans.len()];
+                let vals = &elem_value.int()[..params.pans.len()];
                 let pans: Vec<u8> = vals.iter().map(|&v| v as u8).collect();
                 FStudioProtocol::write_mixer_stream_src_pans(
                     req,
@@ -997,9 +997,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::STREAM_SRC_MUTE_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let params = &mut self.stream_src_params[index];
-                let vals = &elem_value.get_bool()[..params.mutes.len()];
+                let vals = &elem_value.boolean()[..params.mutes.len()];
                 FStudioProtocol::write_mixer_stream_src_mutes(
                     req,
                     &mut unit.1,
@@ -1011,9 +1011,9 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::STREAM_SRC_LINK_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let links = &mut self.stream_src_links[index];
-                let vals = &elem_value.get_bool()[..links.len()];
+                let vals = &elem_value.boolean()[..links.len()];
                 FStudioProtocol::write_mixer_stream_src_links(
                     req,
                     &mut unit.1,
@@ -1024,7 +1024,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::OUT_VOL_NAME => {
-                let vals = &elem_value.get_int()[..self.outs.vols.len()];
+                let vals = &elem_value.int()[..self.outs.vols.len()];
                 let vols: Vec<u8> = vals.iter().map(|&v| v as u8).collect();
                 FStudioProtocol::write_mixer_out_vol(
                     req,
@@ -1036,7 +1036,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::OUT_MUTE_NAME => {
-                let vals = &elem_value.get_bool()[..self.outs.mutes.len()];
+                let vals = &elem_value.boolean()[..self.outs.mutes.len()];
                 FStudioProtocol::write_mixer_out_mute(
                     req,
                     &mut unit.1,
@@ -1047,7 +1047,7 @@ impl MixerCtl {
                 .map(|_| true)
             }
             Self::EXPANSION_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::EXPANSION_MODES
                     .iter()
                     .nth(val as usize)

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -165,7 +165,7 @@ where
     }
 
     fn measure_elem_meter(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_METER_NAME => {
                 elem_value.set_int(&self.tcd22xx_ctl().meter_ctl.real_meter);
                 Ok(true)
@@ -314,7 +314,7 @@ where
     }
 
     fn read_router(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ROUTER_OUT_SRC_NAME => {
                 let ctls = self.tcd22xx_ctl();
                 Self::read_elem_src(
@@ -369,7 +369,7 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ROUTER_OUT_SRC_NAME => {
                 let ctls = self.tcd22xx_ctl_mut();
                 Self::write_elem_src(
@@ -579,9 +579,9 @@ where
     }
 
     fn read_mixer(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
-                let dst_ch = elem_id.get_index() as usize;
+                let dst_ch = elem_id.index() as usize;
                 let res = self
                     .tcd22xx_ctl()
                     .state
@@ -609,10 +609,10 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
                 let ctls = &mut self.tcd22xx_ctl_mut();
-                let dst_ch = elem_id.get_index() as usize;
+                let dst_ch = elem_id.index() as usize;
                 let mut cache = ctls.state.mixer_cache.clone();
                 let res = match cache.iter_mut().nth(dst_ch) {
                     Some(entries) => {
@@ -773,7 +773,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STANDALONE_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let src = StandaloneSectionProtocol::read_standalone_clock_source(
                     req, node, sections, timeout_ms,
@@ -871,7 +871,7 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STANDALONE_CLK_SRC_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 let &src = self
                     .tcd22xx_ctl()

--- a/libs/dice/runtime/src/tcelectronic/ch_strip_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/ch_strip_ctl.rs
@@ -458,7 +458,7 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_TYPE_NAME => {
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: u32| {
                     state.src_type = Self::SRC_TYPES
@@ -504,13 +504,13 @@ where
                 })
             }
             COMP_CTL_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: i32| {
                     state.comp.ctl[idx] = val as u32
                 })
             }
             COMP_LEVEL_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: i32| {
                     state.comp.level[idx] = val as u32
                 })
@@ -521,25 +521,25 @@ where
                 })
             }
             EQ_ENABLE_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: bool| {
                     state.eq[idx].enabled = val
                 })
             }
             EQ_BANDWIDTH_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: i32| {
                     state.eq[idx].bandwidth = val as u32
                 })
             }
             EQ_GAIN_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: i32| {
                     state.eq[idx].gain = val as u32
                 })
             }
             EQ_FREQ_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_write_elem(unit, req, old, new, timeout_ms, |state, val: i32| {
                     state.eq[idx].freq = val as u32
                 })
@@ -602,7 +602,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_TYPE_NAME => self
                 .state_read_elem(elem_value, |state| {
                     Self::SRC_TYPES
@@ -625,30 +625,30 @@ where
                 self.state_read_elem(elem_value, |state| state.comp.full_band_enabled)
             }
             COMP_CTL_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |entry| entry.comp.ctl[idx] as i32)
             }
             COMP_LEVEL_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |entry| entry.comp.level[idx] as i32)
             }
             DEESSER_RATIO_NAME => {
                 self.state_read_elem(elem_value, |state| state.deesser.ratio as i32)
             }
             EQ_ENABLE_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |state| state.eq[idx].enabled)
             }
             EQ_BANDWIDTH_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |state| state.eq[idx].bandwidth as i32)
             }
             EQ_GAIN_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |state| state.eq[idx].gain as i32)
             }
             EQ_FREQ_NAME => {
-                let idx = elem_id.get_index() as usize;
+                let idx = elem_id.index() as usize;
                 self.state_read_elem(elem_value, |state| state.eq[idx].freq as i32)
             }
             LIMITTER_THRESHOLD_NAME => {
@@ -663,12 +663,12 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_METER_NAME => self.meter_read_elem(elem_value, |meter| meter.input),
             LIMIT_METER_NAME => self.meter_read_elem(elem_value, |meter| meter.limit),
             OUTPUT_METER_NAME => self.meter_read_elem(elem_value, |meter| meter.output),
             GAIN_METER_NAME => {
-                let idx = match elem_id.get_index() {
+                let idx = match elem_id.index() {
                     2 => 2,
                     1 => 1,
                     _ => 0,

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -319,7 +319,7 @@ impl HwStateCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             METER_TARGET_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::METER_TARGETS
                     .iter()
@@ -384,7 +384,7 @@ impl HwStateCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             METER_TARGET_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     Self::METER_TARGETS
@@ -759,7 +759,7 @@ impl MixerCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_MIC_INST_SRC_LEVEL_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, 2, |idx| {
                     Ok(self.0.data.mic_inst_level[idx])
@@ -829,7 +829,7 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_MIC_INST_SRC_LEVEL_NAME => {
                 ElemValueAccessor::<i32>::get_vals(new, old, 2, |idx, val| {
                     self.0.data.mic_inst_level[idx] = val;
@@ -1040,7 +1040,7 @@ impl PanelCtl {
         if self.read_firewire_led(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 PANEL_BUTTON_COUNT_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
                     Ok(self.0.data.panel_button_count as i32)
                 })
@@ -1081,7 +1081,7 @@ impl PanelCtl {
         if self.write_firewire_led(unit, req, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 REVERB_LED_STATE_NAME => {
                     ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                         self.0.data.reverb_led_on = val;
@@ -1186,7 +1186,7 @@ impl MeterCtl {
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_IN_NAME => {
                 elem_value.set_int(&self.0.data.analog_inputs);
                 Ok(true)

--- a/libs/dice/runtime/src/tcelectronic/fw_led_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/fw_led_ctl.rs
@@ -45,7 +45,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::STATES
                     .iter()
@@ -66,7 +66,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STATE_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     Self::STATES

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -296,7 +296,7 @@ impl KnobCtl {
         if self.read_knob_target(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 CLK_RECOVERY_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
                     Ok(self.0.data.clock_recovery)
                 })
@@ -318,7 +318,7 @@ impl KnobCtl {
         if self.write_knob_target(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 CLK_RECOVERY_NAME => {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         self.0.data.clock_recovery = val;
@@ -478,7 +478,7 @@ impl ConfigCtl {
         } else if self.read_standalone(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUT_SRC_NAME => ElemValueAccessor::<u32>::set_vals(
                     elem_value,
                     ITWIN_PHYS_OUT_PAIR_COUNT,
@@ -510,7 +510,7 @@ impl ConfigCtl {
         } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUT_SRC_NAME => {
                     ElemValueAccessor::<u32>::get_vals(
                         new,
@@ -633,7 +633,7 @@ impl MixerCtl {
         if self.read_mixer(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::set_val(elem_value, || Ok(self.0.data.enabled))
                         .map(|_| true)
@@ -655,7 +655,7 @@ impl MixerCtl {
         if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         self.0.data.enabled = val;
@@ -789,7 +789,7 @@ impl HwStateCtl {
         if self.read_hw_state(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 LISTENING_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::LISTENING_MODES
                         .iter()
@@ -815,7 +815,7 @@ impl HwStateCtl {
         if self.write_hw_state(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 LISTENING_MODE_NAME => {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         Self::LISTENING_MODES

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -479,7 +479,7 @@ impl ConfigCtl {
         } else if self.read_standalone(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUT_23_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = PHYS_OUT_SRCS
                         .iter()
@@ -509,7 +509,7 @@ impl ConfigCtl {
         } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUT_23_SRC_NAME => {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         PHYS_OUT_SRCS
@@ -657,7 +657,7 @@ impl MixerCtl {
         } else if self.read_reverb_return(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::set_val(elem_value, || Ok(self.0.data.enabled))
                         .map(|_| true)
@@ -691,7 +691,7 @@ impl MixerCtl {
         } else if self.write_reverb_return(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         self.0.data.enabled = val;

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -492,7 +492,7 @@ impl MixerCtl {
         if self.read_mixer(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::set_val(elem_value, || Ok(self.0.data.enabled))
                         .map(|_| true)
@@ -514,7 +514,7 @@ impl MixerCtl {
         if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         self.0.data.enabled = val;
@@ -630,7 +630,7 @@ impl HwStateCtl {
         if self.read_hw_state(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 AUX_IN_ENABLED_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
                     Ok(self.0.data.aux_input_enabled)
                 })

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -353,7 +353,7 @@ impl KnobCtl {
         } else if self.read_prog(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUTPUT_IMPEDANCE_NAME => ElemValueAccessor::<u32>::set_vals(elem_value, 2, |idx| {
                     let pos = Self::OUTPUT_IMPEDANCES
                         .iter()
@@ -383,7 +383,7 @@ impl KnobCtl {
         } else if self.write_prog(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUTPUT_IMPEDANCE_NAME => {
                     ElemValueAccessor::<u32>::get_vals(new, old, 2, |idx, val| {
                         Self::OUTPUT_IMPEDANCES
@@ -585,7 +585,7 @@ impl ConfigCtl {
         } else if self.write_midi_sender(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OUT_01_SRC_NAME => {
                     ElemValueAccessor::<u32>::get_val(new, |val| {
                         PHYS_OUT_SRCS
@@ -805,7 +805,7 @@ impl MixerCtl {
         } else if self.read_reverb_return(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::set_val(elem_value, || Ok(self.0.data.enabled))
                         .map(|_| true)
@@ -855,7 +855,7 @@ impl MixerCtl {
         } else if self.write_reverb_return(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
                     ElemValueAccessor::<bool>::get_val(new, |val| {
                         self.0.data.enabled = val;

--- a/libs/dice/runtime/src/tcelectronic/midi_send_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/midi_send_ctl.rs
@@ -47,7 +47,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             NORMAL_EVENT_CH_NAME => {
                 ElemValueAccessor::<u8>::set_val(elem_value, || Ok(self.midi_sender().normal.ch))
                     .map(|_| true)
@@ -84,7 +84,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             NORMAL_EVENT_CH_NAME => ElemValueAccessor::<u8>::get_val(elem_value, |val| {
                 self.state_write(unit, req, timeout_ms, |state| {
                     state.normal.ch = val;

--- a/libs/dice/runtime/src/tcelectronic/prog_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/prog_ctl.rs
@@ -24,7 +24,7 @@ where
     }
 
     fn read_prog(&mut self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LOADED_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 if self.prog().0 >= Self::PROG_LABELS.len() as u32 {
                     let msg = format!("Unexpected index of program: {}", self.prog().0);
@@ -46,7 +46,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LOADED_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     if val >= Self::PROG_LABELS.len() as u32 {

--- a/libs/dice/runtime/src/tcelectronic/reverb_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/reverb_ctl.rs
@@ -378,7 +378,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_INPUT_LEVEL_NAME => {
                 self.state_write_elem(unit, req, elem_value, timeout_ms, |state, val| {
                     state.input_level = val
@@ -492,7 +492,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_INPUT_LEVEL_NAME => self.state_read_elem(elem_value, |state| state.input_level),
             REVERB_BYPASS_NAME => self.state_read_elem(elem_value, |state| state.bypass),
             REVERB_KILL_WET => self.state_read_elem(elem_value, |state| state.kill_wet),
@@ -531,7 +531,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_OUTPUT_METER_NAME => {
                 elem_value.set_int(&self.meter().outputs);
                 Ok(true)

--- a/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
@@ -66,7 +66,7 @@ where
         if self.read_firewire_led(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 ANALOG_JACK_STATE_NAME => ElemValueAccessor::<u32>::set_vals(
                     elem_value,
                     SHELL_ANALOG_JACK_STATE_COUNT,
@@ -323,7 +323,7 @@ where
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_STREAM_SRC_PAIR_GAIN_NAME => {
                 self.state_write(unit, req, new, timeout_ms, |state, val| {
                     state.stream.left.gain_to_mixer = val;
@@ -474,7 +474,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_STREAM_SRC_PAIR_GAIN_NAME => {
                 elem_value.set_int(&[self.state().stream.left.gain_to_mixer]);
                 Ok(true)
@@ -538,7 +538,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             STREAM_IN_METER_NAME => {
                 elem_value.set_int(&self.meter().stream_inputs);
                 Ok(true)
@@ -692,7 +692,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             USE_AS_PLUGIN_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
                 Ok(self.reverb_return().plugin_mode)
             })
@@ -709,7 +709,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             USE_AS_PLUGIN_NAME => {
                 ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                     self.reverb_return_mut().plugin_mode = val;
@@ -740,7 +740,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             GAIN_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
                 Ok(self.reverb_return().return_gain)
             })
@@ -787,7 +787,7 @@ where
     }
 
     fn read_standalone(&mut self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = S::STANDALONE_CLOCK_SOURCES
                     .iter()
@@ -808,7 +808,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     S::STANDALONE_CLOCK_SOURCES
@@ -878,7 +878,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_STREAM_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::MIXER_STREAM_SRC_PAIRS
                     .iter()
@@ -900,7 +900,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_STREAM_SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     Self::MIXER_STREAM_SRC_PAIRS
@@ -964,7 +964,7 @@ where
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             COAX_OUT_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = PHYS_OUT_SRCS
                     .iter()
@@ -985,7 +985,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             COAX_OUT_SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     PHYS_OUT_SRCS
@@ -1071,7 +1071,7 @@ where
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_FMT_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::IN_FMTS
                     .iter()
@@ -1108,7 +1108,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_FMT_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     Self::IN_FMTS
@@ -1177,7 +1177,7 @@ where
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             TARGET_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let state = self.knob_target();
                 if state.0 >= Self::TARGETS.len() as u32 {
@@ -1200,7 +1200,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             TARGET_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     if val >= Self::TARGETS.len() as u32 {
@@ -1242,7 +1242,7 @@ where
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             KNOB2_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let state = self.knob2_target();
                 if state.0 >= Self::TARGETS.len() as u32 {
@@ -1265,7 +1265,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             KNOB2_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     if val >= Self::TARGETS.len() as u32 {

--- a/libs/dice/runtime/src/tcelectronic/standalone_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/standalone_ctl.rs
@@ -46,7 +46,7 @@ where
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::RATES
                     .iter()
@@ -67,7 +67,7 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     Self::RATES

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -336,7 +336,7 @@ impl LineoutCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LINE_OUT_45_LEVEL_NAME => Self::read_as_index(elem_value, self.0.data.line_45),
             LINE_OUT_67_LEVEL_NAME => Self::read_as_index(elem_value, self.0.data.line_67),
             LINE_OUT_89_LEVEL_NAME => Self::read_as_index(elem_value, self.0.data.line_89),
@@ -364,7 +364,7 @@ impl LineoutCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LINE_OUT_45_LEVEL_NAME => {
                 self.write_as_index(unit, req, elem_value, timeout_ms, |data, level| {
                     data.line_45 = level
@@ -556,7 +556,7 @@ impl RemoteCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             USER_ASSIGN_NAME => ElemValueAccessor::<u32>::set_vals(
                 elem_value,
                 STUDIO_REMOTE_USER_ASSIGN_COUNT,
@@ -610,7 +610,7 @@ impl RemoteCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             USER_ASSIGN_NAME => {
                 ElemValueAccessor::<u32>::get_vals(
                     new,
@@ -815,7 +815,7 @@ impl ConfigCtl {
         } else if self.read_midi_sender(elem_id, elem_value)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OPT_IFACE_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pos = Self::OPT_IFACE_MODES
                         .iter()
@@ -854,7 +854,7 @@ impl ConfigCtl {
         } else if self.write_midi_sender(unit, req, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 OPT_IFACE_MODE_NAME => {
                     ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                         Self::OPT_IFACE_MODES
@@ -1244,7 +1244,7 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_PAIR_MODE_NAME => {
                 let state = &mut self.0.data;
                 ElemValueAccessor::<u32>::get_vals(new, old, state.src_pairs.len(), |idx, val| {
@@ -1325,7 +1325,7 @@ impl MixerCtl {
                     .data
                     .mutes
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -1353,7 +1353,7 @@ impl MixerCtl {
                     .data
                     .reverb_return_mute
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -1363,7 +1363,7 @@ impl MixerCtl {
                     .data
                     .reverb_return_gain
                     .iter_mut()
-                    .zip(new.get_int())
+                    .zip(new.int())
                     .for_each(|(d, s)| *d = *s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -1373,7 +1373,7 @@ impl MixerCtl {
                     .data
                     .ch_strip_as_plugin
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -1407,7 +1407,7 @@ impl MixerCtl {
                     .data
                     .post_fader
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -1477,7 +1477,7 @@ impl MixerCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_PAIR_MODE_NAME => {
                 let pair_count = self.0.data.src_pairs.len();
                 ElemValueAccessor::<u32>::set_vals(elem_value, pair_count, |idx| {
@@ -1565,7 +1565,7 @@ impl MixerCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_INPUT_METER_NAME => {
                 elem_value.set_int(&self.1.data.src_inputs);
                 Ok(true)
@@ -1982,7 +1982,7 @@ impl PhysOutCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_OUT_DIM_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
                 Ok(self.0.data.master_out.dim_enabled)
             })
@@ -2025,7 +2025,7 @@ impl PhysOutCtl {
             OUT_GRP_SRC_TRIM_NAME => self.read_out_src_param(elem_value, |param| Ok(param.vol)),
             OUT_GRP_SRC_DELAY_NAME => self.read_out_src_param(elem_value, |param| Ok(param.delay)),
             OUT_GRP_SRC_ASSIGN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 elem_value.set_bool(&self.0.data.out_grps[index].assigned_phys_outs);
                 Ok(true)
             }
@@ -2109,7 +2109,7 @@ impl PhysOutCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_OUT_DIM_NAME => {
                 ElemValueAccessor::<bool>::get_val(new, |val| {
                     self.0.data.master_out.dim_enabled = val;
@@ -2152,7 +2152,7 @@ impl PhysOutCtl {
                     .data
                     .out_mutes
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -2171,7 +2171,7 @@ impl PhysOutCtl {
                 })
             }
             OUT_GRP_SELECT_NAME => {
-                self.0.data.selected_out_grp = new.get_enum()[0] as usize;
+                self.0.data.selected_out_grp = new.enumerated()[0] as usize;
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
@@ -2180,7 +2180,7 @@ impl PhysOutCtl {
                     .data
                     .out_assign_to_grp
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
@@ -2198,7 +2198,7 @@ impl PhysOutCtl {
                 })
             }
             OUT_GRP_SRC_ASSIGN_NAME => {
-                let vals = &new.get_bool()[..(STUDIO_PHYS_OUT_PAIR_COUNT * 2)];
+                let vals = &new.boolean()[..(STUDIO_PHYS_OUT_PAIR_COUNT * 2)];
                 let count = vals.iter().filter(|&v| *v).count();
                 if count > STUDIO_MAX_SURROUND_CHANNELS {
                     let msg = format!(
@@ -2207,7 +2207,7 @@ impl PhysOutCtl {
                     );
                     Err(Error::new(FileError::Inval, &msg))?;
                 }
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 self.0.data.out_grps[index]
                     .assigned_phys_outs
                     .copy_from_slice(&vals);
@@ -2540,7 +2540,7 @@ impl HwStateCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_JACK_STATE_NAME => ElemValueAccessor::<u32>::set_vals(
                 elem_value,
                 STUDIO_ANALOG_JACK_STATE_COUNT,

--- a/libs/efw/protocols/Cargo.toml
+++ b/libs/efw/protocols/Cargo.toml
@@ -12,6 +12,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"

--- a/libs/efw/protocols/src/flash.rs
+++ b/libs/efw/protocols/src/flash.rs
@@ -476,7 +476,9 @@ mod test {
             F: Fn(&Self, u32, u32, u32, u32, EfwProtocolError, &[u32]) + 'static,
         {
             // Dummy.
-            SignalHandlerId::from_glib(0)
+            unsafe {
+                SignalHandlerId::from_glib(0)
+            }
         }
     }
 }

--- a/libs/efw/protocols/src/lib.rs
+++ b/libs/efw/protocols/src/lib.rs
@@ -20,7 +20,7 @@ pub mod transport;
 
 use {
     glib::{Error, FileError},
-    hitaki::{EfwProtocolError, EfwProtocolExtManual},
+    hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
 };
 
 /// The enumeration to express source of sampling clock.

--- a/libs/efw/runtime/Cargo.toml
+++ b/libs/efw/runtime/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394 = "0.1"

--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -86,7 +86,7 @@ impl ClkCtl {
     }
 
     pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 Ok(self.srcs.iter().position(|s| self.curr_src.eq(s)).unwrap() as u32)
             })
@@ -111,7 +111,7 @@ impl ClkCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             SRC_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     if let Some(&src) = self.srcs.iter().nth(val as usize) {

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -55,7 +55,7 @@ impl GuitarCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MANUAL_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::set_val(elem_value, || {
                     unit.get_charge_state(timeout_ms).map(|s| s.manual_charge)
@@ -87,7 +87,7 @@ impl GuitarCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MANUAL_CHARGE_NAME => {
                 ElemValueAccessor::<bool>::get_val(new, |val| {
                     let mut state = unit.get_charge_state(timeout_ms)?;

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -41,7 +41,7 @@ impl Iec60958Ctl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DEFAULT_NAME => {
                 let mut val = [0; 24];
                 let flags = unit.get_flags(timeout_ms)?;
@@ -80,9 +80,9 @@ impl Iec60958Ctl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DEFAULT_NAME => {
-                let vals = new.get_iec60958_channel_status();
+                let vals = new.iec60958_channel_status();
 
                 let mut enable = vec![];
                 let mut disable = vec![];

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -75,7 +75,7 @@ impl InputCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, self.phys_inputs, |idx| {
                     if let Some(cache) = &self.cache {
@@ -106,7 +106,7 @@ impl InputCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             IN_NOMINAL_NAME => {
                 ElemValueAccessor::<u32>::get_vals(new, old, self.phys_inputs, |idx, val| {
                     if let Some(&level) = Self::IN_NOMINAL_LEVELS.iter().nth(val as usize) {

--- a/libs/efw/runtime/src/meter_ctl.rs
+++ b/libs/efw/runtime/src/meter_ctl.rs
@@ -124,7 +124,7 @@ impl MeterCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_DETECT_NAME => {
                 if let Some(meters) = &self.meters {
                     let vals: Vec<bool> = meters

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -118,7 +118,7 @@ impl MixerCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PLAYBACK_VOL_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.playbacks, |idx| {
                     unit.get_playback_vol(idx, timeout_ms)
@@ -138,7 +138,7 @@ impl MixerCtl {
                 Ok(true)
             }
             MONITOR_GAIN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_vol(dst, src, timeout_ms)?;
                     Ok(val)
@@ -146,7 +146,7 @@ impl MixerCtl {
                 Ok(true)
             }
             MONITOR_MUTE_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_mute(dst, src, timeout_ms)?;
                     Ok(val)
@@ -154,7 +154,7 @@ impl MixerCtl {
                 Ok(true)
             }
             MONITOR_SOLO_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<bool>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_solo(dst, src, timeout_ms)?;
                     Ok(val)
@@ -162,7 +162,7 @@ impl MixerCtl {
                 Ok(true)
             }
             MONITOR_PAN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.captures, |src| {
                     let val = unit.get_monitor_pan(dst, src, timeout_ms)? as i32;
                     Ok(val)
@@ -191,7 +191,7 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PLAYBACK_VOL_NAME => {
                 ElemValueAccessor::<i32>::get_vals(new, old, self.playbacks, |idx, val| {
                     unit.set_playback_vol(idx, val, timeout_ms)
@@ -211,28 +211,28 @@ impl MixerCtl {
                 Ok(true)
             }
             MONITOR_GAIN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_vol(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
             MONITOR_MUTE_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<bool>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_mute(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
             MONITOR_SOLO_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<bool>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_solo(dst, src, val, timeout_ms)
                 })?;
                 Ok(true)
             }
             MONITOR_PAN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, self.captures, |src, val| {
                     unit.set_monitor_pan(dst, src, val as u8, timeout_ms)
                 })?;

--- a/libs/efw/runtime/src/output_ctl.rs
+++ b/libs/efw/runtime/src/output_ctl.rs
@@ -85,7 +85,7 @@ impl OutputCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_VOL_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, self.phys_outputs, |idx| {
                     unit.get_vol(idx, timeout_ms)
@@ -121,7 +121,7 @@ impl OutputCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUT_VOL_NAME => {
                 ElemValueAccessor::<i32>::get_vals(new, old, self.phys_outputs, |idx, val| {
                     unit.set_vol(idx, val, timeout_ms)

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -79,7 +79,7 @@ fn enum_values_from_entries(elem_value: &mut ElemValue, entries: &[Option<usize>
 }
 
 fn enum_values_to_entries(elem_value: &ElemValue, entries: &mut [Option<usize>]) {
-    let vals = &elem_value.get_enum()[..entries.len()];
+    let vals = &elem_value.enumerated()[..entries.len()];
     entries
         .iter_mut()
         .zip(vals)
@@ -256,7 +256,7 @@ impl PortCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CONTROL_ROOM_SOURCE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let pair = unit.get_control_room_source(timeout_ms)?;
@@ -290,7 +290,7 @@ impl PortCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RX_MAP_NAME => {
                 enum_values_from_entries(elem_value, &self.rx_stream_map);
                 Ok(true)
@@ -311,7 +311,7 @@ impl PortCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CONTROL_ROOM_SOURCE_NAME => {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     unit.set_control_room_source(val as usize, timeout_ms)

--- a/libs/ff/protocols/Cargo.toml
+++ b/libs/ff/protocols/Cargo.toml
@@ -12,8 +12,8 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
+++ b/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use glib::FileError;
 
-use hinawa::{FwNode, FwNodeError, FwNodeExt, FwNodeExtManual};
+use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
 
 use ff_protocols::*;
 use ieee1212_config_rom::*;
@@ -60,7 +60,7 @@ fn main() {
                     )
                 })?;
 
-                node.get_config_rom()
+                node.config_rom()
                     .map_err(|e| format!("Fail to get content of configuration ROM: {}", e))
                     .map(|raw| raw.to_vec())
             }

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -6,11 +6,11 @@
 pub mod ff400;
 pub mod ff800;
 
-use glib::Error;
-
-use hinawa::{FwNode, FwReq, FwReqExtManual, FwTcode};
-
-use super::*;
+use {
+    glib::Error,
+    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
+    super::*,
+};
 
 /// The structure to represent state of hardware meter.
 ///

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -3,11 +3,11 @@
 
 //! Protocol defined by RME GmbH for Fireface 400.
 
-use glib::Error;
-
-use hinawa::{FwNode, FwReq, FwReqExtManual, FwTcode};
-
-use super::*;
+use {
+    glib::Error,
+    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
+    super::*,
+};
 
 /// The structure to represent unique protocol for Fireface 400.
 #[derive(Default)]

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -6,10 +6,11 @@
 pub mod ff802;
 pub mod ucx;
 
-use glib::Error;
-use hinawa::{FwNode, FwReq, FwReqExtManual, FwTcode};
-
-use super::*;
+use {
+    glib::Error,
+    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
+    super::*,
+};
 
 const CFG_OFFSET: usize = 0xffff00000014;
 const DSP_OFFSET: usize = 0xffff0000001c;

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -3,8 +3,10 @@
 
 //! Protocol defined by RME GmbH for Fireface 802.
 
-use super::*;
-use crate::*;
+use {
+    super::*,
+    crate::*,
+};
 
 /// The structure to represent unique protocol for Fireface 802.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -3,8 +3,10 @@
 
 //! Protocol defined by RME GmbH for Fireface UCX.
 
-use super::*;
-use crate::*;
+use {
+    super::*,
+    crate::*,
+};
 
 /// The structure to represent unique protocol for Fireface UCX.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]

--- a/libs/ff/runtime/Cargo.toml
+++ b/libs/ff/runtime/Cargo.toml
@@ -11,11 +11,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.10"
+glib = "0.15"
 nix = "0.17"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ff-protocols = "0.1"

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -237,7 +237,7 @@ impl InputGainCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_GAIN_NAME => {
                 let vals: Vec<i32> = self.status.mic.iter().map(|&gain| gain as i32).collect();
                 elem_value.set_int(&vals);
@@ -260,9 +260,9 @@ impl InputGainCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 let gains: Vec<i8> = vals.iter().map(|&val| val as i8).collect();
                 Ff400Protocol::write_input_mic_gains(
                     req,
@@ -274,7 +274,7 @@ impl InputGainCtl {
                 .map(|_| true)
             }
             LINE_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..2];
+                let vals = &elem_value.int()[..2];
                 let gains: Vec<i8> = vals.iter().map(|&val| val as i8).collect();
                 Ff400Protocol::write_input_line_gains(
                     req,
@@ -401,7 +401,7 @@ impl StatusCtl {
     }
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.lock.spdif,
@@ -615,7 +615,7 @@ impl CfgCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => {
                 let pos = Self::CLK_SRCS
                     .iter()
@@ -713,7 +713,7 @@ impl CfgCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 Self::CLK_SRCS
                     .iter()
@@ -747,7 +747,7 @@ impl CfgCtl {
                 cfg.analog_in
                     .phantom_powering
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Ok(())
             })
@@ -756,7 +756,7 @@ impl CfgCtl {
                 cfg.analog_in
                     .insts
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Ok(())
             })
@@ -765,7 +765,7 @@ impl CfgCtl {
                 cfg.analog_in
                     .pad
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Ok(())
             })

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -283,7 +283,7 @@ impl StatusCtl {
     }
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.lock.spdif,
@@ -492,7 +492,7 @@ impl CfgCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::CLK_SRCS
                     .iter()
@@ -594,7 +594,7 @@ impl CfgCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                 ElemValueAccessor::<u32>::get_val(new, |val| {
                     let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
@@ -635,7 +635,7 @@ impl CfgCtl {
                 cfg.analog_in
                     .phantom_powering
                     .iter_mut()
-                    .zip(new.get_bool())
+                    .zip(new.boolean())
                     .for_each(|(d, s)| *d = s);
                 Ok(())
             })

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -252,7 +252,7 @@ impl CfgCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::CLK_SRCS
                     .iter()
@@ -305,7 +305,7 @@ impl CfgCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
@@ -347,7 +347,7 @@ impl CfgCtl {
             })
             .map(|_| true),
             EFFECT_ON_INPUT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                cfg.effect_on_inputs = elem_value.get_bool()[0];
+                cfg.effect_on_inputs = elem_value.boolean()[0];
                 Ok(())
             })
             .map(|_| true),
@@ -467,7 +467,7 @@ impl StatusCtl {
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.ext_lock.adat_a,

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -44,7 +44,7 @@ pub trait FormerOutputCtlOperation<T: RmeFormerOutputOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             VOL_NAME => {
                 elem_value.set_int(&self.state().0);
                 Ok(true)
@@ -61,9 +61,9 @@ pub trait FormerOutputCtlOperation<T: RmeFormerOutputOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             VOL_NAME => {
-                let vals = &new.get_int()[..self.state().0.len()];
+                let vals = &new.int()[..self.state().0.len()];
                 T::write_output_vols(req, &mut unit.1, self.state_mut(), &vals, timeout_ms)
                     .map(|_| true)
             }
@@ -174,24 +174,24 @@ pub trait FormerMixerCtlOperation<T: RmeFormerMixerOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 elem_value.set_int(&self.state().0[index].analog_gains);
                 Ok(true)
             }
             SPDIF_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 elem_value.set_int(&self.state().0[index].spdif_gains);
                 Ok(true)
             }
             ADAT_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 elem_value.set_int(&self.state().0[index].adat_gains);
                 Ok(true)
             }
             STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 elem_value.set_int(&self.state().0[index].stream_gains);
                 Ok(true)
             }
@@ -207,10 +207,10 @@ pub trait FormerMixerCtlOperation<T: RmeFormerMixerOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let gains = &new.get_int()[..self.state_mut().0[index].analog_gains.len()];
+                let index = elem_id.index() as usize;
+                let gains = &new.int()[..self.state_mut().0[index].analog_gains.len()];
                 T::write_mixer_analog_gains(
                     req,
                     &mut unit.1,
@@ -222,8 +222,8 @@ pub trait FormerMixerCtlOperation<T: RmeFormerMixerOperation> {
                 .map(|_| true)
             }
             SPDIF_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let gains = &new.get_int()[..self.state_mut().0[index].spdif_gains.len()];
+                let index = elem_id.index() as usize;
+                let gains = &new.int()[..self.state_mut().0[index].spdif_gains.len()];
                 T::write_mixer_spdif_gains(
                     req,
                     &mut unit.1,
@@ -235,8 +235,8 @@ pub trait FormerMixerCtlOperation<T: RmeFormerMixerOperation> {
                 .map(|_| true)
             }
             ADAT_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let gains = &new.get_int()[..self.state_mut().0[index].adat_gains.len()];
+                let index = elem_id.index() as usize;
+                let gains = &new.int()[..self.state_mut().0[index].adat_gains.len()];
                 T::write_mixer_adat_gains(
                     req,
                     &mut unit.1,
@@ -248,8 +248,8 @@ pub trait FormerMixerCtlOperation<T: RmeFormerMixerOperation> {
                 .map(|_| true)
             }
             STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
-                let gains = &new.get_int()[..self.state_mut().0[index].stream_gains.len()];
+                let index = elem_id.index() as usize;
+                let gains = &new.int()[..self.state_mut().0[index].stream_gains.len()];
                 T::write_mixer_stream_gains(
                     req,
                     &mut unit.1,
@@ -336,7 +336,7 @@ pub trait FormerMeterCtlOperation<T: RmeFfFormerMeterOperation> {
     }
 
     fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_INPUT_NAME => {
                 elem_value.set_int(&self.meter().analog_inputs);
                 Ok(true)

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -85,7 +85,7 @@ pub trait FfLatterMeterCtlOperation<T: RmeFfLatterMeterOperation> {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LINE_INPUT_METER => {
                 elem_value.set_int(&self.meter().line_inputs);
                 Ok(true)
@@ -207,7 +207,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
     }
 
     fn read_input(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_STEREO_LINK_NAME => {
                 elem_value.set_bool(&self.state().input.stereo_links);
                 Ok(true)
@@ -261,13 +261,13 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_STEREO_LINK_NAME => {
                 let mut state = self.state().input.clone();
                 state
                     .stereo_links
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -276,13 +276,13 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
                 state
                     .line_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
             INPUT_LINE_LEVEL_NAME => {
                 let mut state = self.state().input.clone();
-                let vals = &elem_value.get_enum()[..state.line_levels.len()];
+                let vals = &elem_value.enumerated()[..state.line_levels.len()];
                 vals.iter().enumerate().try_for_each(|(i, &pos)| {
                     Self::LINE_LEVELS
                         .iter()
@@ -300,7 +300,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
                 state
                     .mic_powers
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -309,7 +309,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
                 state
                     .mic_insts
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -318,7 +318,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
                 state
                     .invert_phases
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -411,7 +411,7 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
     }
 
     fn read_output(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             VOL_NAME => {
                 let vals: Vec<i32> = self
                     .state()
@@ -468,13 +468,13 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             VOL_NAME => {
                 let mut state = self.state().output.clone();
                 state
                     .vols
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_output(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -483,7 +483,7 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
                 state
                     .stereo_balance
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_output(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -492,7 +492,7 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
                 state
                     .stereo_links
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_output(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
@@ -501,13 +501,13 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
                 state
                     .invert_phases
                     .iter_mut()
-                    .zip(elem_value.get_bool())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
                 T::write_output(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
             LINE_LEVEL_NAME => {
                 let mut state = self.state().output.clone();
-                let vals = elem_value.get_enum();
+                let vals = elem_value.enumerated();
                 vals.iter().enumerate().try_for_each(|(i, &pos)| {
                     Self::LINE_LEVELS
                         .iter()
@@ -634,9 +634,9 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
     }
 
     fn read_mixer(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_LINE_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.state().mixer[index]
                     .line_gains
                     .iter()
@@ -646,7 +646,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                 Ok(true)
             }
             MIXER_MIC_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.state().mixer[index]
                     .mic_gains
                     .iter()
@@ -656,7 +656,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                 Ok(true)
             }
             MIXER_SPDIF_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.state().mixer[index]
                     .spdif_gains
                     .iter()
@@ -666,7 +666,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                 Ok(true)
             }
             MIXER_ADAT_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.state().mixer[index]
                     .adat_gains
                     .iter()
@@ -676,7 +676,7 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                 Ok(true)
             }
             MIXER_STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let vals: Vec<i32> = self.state().mixer[index]
                     .stream_gains
                     .iter()
@@ -697,11 +697,11 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_LINE_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let mut state = self.state().mixer[index].clone();
-                let vals = &new.get_int()[..state.line_gains.len()];
+                let vals = &new.int()[..state.line_gains.len()];
                 state
                     .line_gains
                     .iter_mut()
@@ -711,9 +711,9 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                     .map(|_| true)
             }
             MIXER_MIC_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let mut state = self.state().mixer[index].clone();
-                let vals = &new.get_int()[..state.mic_gains.len()];
+                let vals = &new.int()[..state.mic_gains.len()];
                 state
                     .mic_gains
                     .iter_mut()
@@ -723,9 +723,9 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                     .map(|_| true)
             }
             MIXER_SPDIF_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let mut state = self.state().mixer[index].clone();
-                let vals = &new.get_int()[..state.spdif_gains.len()];
+                let vals = &new.int()[..state.spdif_gains.len()];
                 state
                     .spdif_gains
                     .iter_mut()
@@ -735,9 +735,9 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                     .map(|_| true)
             }
             MIXER_ADAT_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let mut state = self.state().mixer[index].clone();
-                let vals = &new.get_int()[..state.adat_gains.len()];
+                let vals = &new.int()[..state.adat_gains.len()];
                 state
                     .adat_gains
                     .iter_mut()
@@ -747,9 +747,9 @@ pub trait FfLatterMixerCtlOperation<T: RmeFfLatterMixerOperation>:
                     .map(|_| true)
             }
             MIXER_STREAM_SRC_GAIN_NAME => {
-                let index = elem_id.get_index() as usize;
+                let index = elem_id.index() as usize;
                 let mut state = self.state().mixer[index].clone();
-                let vals = &new.get_int()[..state.stream_gains.len()];
+                let vals = &new.int()[..state.stream_gains.len()];
                 state
                     .stream_gains
                     .iter_mut()
@@ -1141,7 +1141,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        let n = elem_id.get_name();
+        let n = elem_id.name();
 
         if n == Self::HPF_ACTIVATE_NAME {
             elem_value.set_bool(&T::ch_strip(self.state()).hpf.activates);
@@ -1388,23 +1388,23 @@ where
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        let n = elem_id.get_name();
+        let n = elem_id.name();
 
         if n == Self::HPF_ACTIVATE_NAME {
-            let vals = &elem_value.get_bool()[..T::ch_strip(self.state()).hpf.activates.len()];
+            let vals = &elem_value.boolean()[..T::ch_strip(self.state()).hpf.activates.len()];
             self.update_hpf(unit, req, timeout_ms, |state| {
                 Ok(state.activates.copy_from_slice(&vals))
             })
             .map(|_| true)
         } else if n == Self::HPF_CUT_OFF_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).hpf.cut_offs.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).hpf.cut_offs.len()];
             let cut_offs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_hpf(unit, req, timeout_ms, |state| {
                 Ok(state.cut_offs.copy_from_slice(&cut_offs))
             })
             .map(|_| true)
         } else if n == Self::HPF_ROLL_OFF_NAME {
-            let vals = &elem_value.get_enum()[..T::ch_strip(self.state()).hpf.roll_offs.len()];
+            let vals = &elem_value.enumerated()[..T::ch_strip(self.state()).hpf.roll_offs.len()];
             let mut roll_offs = Vec::new();
             vals.iter().try_for_each(|&pos| {
                 Self::HPF_ROLL_OFF_LEVELS
@@ -1421,13 +1421,13 @@ where
             })
             .map(|_| true)
         } else if n == Self::EQ_ACTIVATE_NAME {
-            let vals = &elem_value.get_bool()[..T::ch_strip(self.state()).eq.activates.len()];
+            let vals = &elem_value.boolean()[..T::ch_strip(self.state()).eq.activates.len()];
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.activates.copy_from_slice(vals))
             })
             .map(|_| true)
         } else if n == Self::EQ_LOW_TYPE_NAME {
-            let vals = &elem_value.get_enum()[..T::ch_strip(self.state()).eq.low_types.len()];
+            let vals = &elem_value.enumerated()[..T::ch_strip(self.state()).eq.low_types.len()];
             let mut eq_types = Vec::new();
             vals.iter().try_for_each(|&pos| {
                 Self::EQ_TYPES
@@ -1444,7 +1444,7 @@ where
             })
             .map(|_| true)
         } else if n == Self::EQ_HIGH_TYPE_NAME {
-            let vals = &elem_value.get_enum()[..T::ch_strip(self.state()).eq.high_types.len()];
+            let vals = &elem_value.enumerated()[..T::ch_strip(self.state()).eq.high_types.len()];
             let mut eq_types = Vec::new();
             vals.iter().try_for_each(|&pos| {
                 Self::EQ_TYPES
@@ -1461,97 +1461,97 @@ where
             })
             .map(|_| true)
         } else if n == Self::EQ_LOW_GAIN_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.low_gains.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.low_gains.len()];
             let gains: Vec<i16> = vals.iter().map(|&val| val as i16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.low_gains.copy_from_slice(&gains))
             })
             .map(|_| true)
         } else if n == Self::EQ_MIDDLE_GAIN_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.middle_gains.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.middle_gains.len()];
             let gains: Vec<i16> = vals.iter().map(|&val| val as i16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.middle_gains.copy_from_slice(&gains))
             })
             .map(|_| true)
         } else if n == Self::EQ_HIGH_GAIN_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.high_gains.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.high_gains.len()];
             let gains: Vec<i16> = vals.iter().map(|&val| val as i16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.high_gains.copy_from_slice(&gains))
             })
             .map(|_| true)
         } else if n == Self::EQ_LOW_FREQ_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.low_freqs.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.low_freqs.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.low_freqs.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::EQ_MIDDLE_FREQ_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.middle_freqs.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.middle_freqs.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.middle_freqs.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::EQ_HIGH_FREQ_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.high_freqs.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.high_freqs.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.high_freqs.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::EQ_LOW_QUALITY_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.low_qualities.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.low_qualities.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.low_qualities.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::EQ_MIDDLE_QUALITY_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.middle_qualities.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.middle_qualities.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.middle_qualities.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::EQ_HIGH_QUALITY_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).eq.high_qualities.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).eq.high_qualities.len()];
             let freqs: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_eq(unit, req, timeout_ms, |state| {
                 Ok(state.high_qualities.copy_from_slice(&freqs))
             })
             .map(|_| true)
         } else if n == Self::DYN_ACTIVATE_NAME {
-            let vals = &elem_value.get_bool()[..T::ch_strip(self.state()).dynamics.activates.len()];
+            let vals = &elem_value.boolean()[..T::ch_strip(self.state()).dynamics.activates.len()];
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.activates.copy_from_slice(&vals))
             })
             .map(|_| true)
         } else if n == Self::DYN_GAIN_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).dynamics.gains.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).dynamics.gains.len()];
             let gains: Vec<i16> = vals.iter().map(|&val| val as i16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.gains.copy_from_slice(&gains))
             })
             .map(|_| true)
         } else if n == Self::DYN_ATTACK_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).dynamics.attacks.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).dynamics.attacks.len()];
             let attacks: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.attacks.copy_from_slice(&attacks))
             })
             .map(|_| true)
         } else if n == Self::DYN_RELEASE_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).dynamics.releases.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).dynamics.releases.len()];
             let release: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.releases.copy_from_slice(&release))
             })
             .map(|_| true)
         } else if n == Self::DYN_COMP_THRESHOLD_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state())
+            let vals = &elem_value.int()[..T::ch_strip(self.state())
                 .dynamics
                 .compressor_thresholds
                 .len()];
@@ -1562,14 +1562,14 @@ where
             .map(|_| true)
         } else if n == Self::DYN_COMP_RATIO_NAME {
             let vals =
-                &elem_value.get_int()[..T::ch_strip(self.state()).dynamics.compressor_ratios.len()];
+                &elem_value.int()[..T::ch_strip(self.state()).dynamics.compressor_ratios.len()];
             let ratios: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.compressor_ratios.copy_from_slice(&ratios))
             })
             .map(|_| true)
         } else if n == Self::DYN_EX_THRESHOLD_NAME {
-            let vals = &elem_value.get_int()
+            let vals = &elem_value.int()
                 [..T::ch_strip(self.state()).dynamics.expander_thresholds.len()];
             let ths: Vec<i16> = vals.iter().map(|&val| val as i16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
@@ -1578,7 +1578,7 @@ where
             .map(|_| true)
         } else if n == Self::DYN_EX_RATIO_NAME {
             let vals =
-                &elem_value.get_int()[..T::ch_strip(self.state()).dynamics.compressor_ratios.len()];
+                &elem_value.int()[..T::ch_strip(self.state()).dynamics.compressor_ratios.len()];
             let ratios: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_dynamics(unit, req, timeout_ms, |state| {
                 Ok(state.expander_ratios.copy_from_slice(&ratios))
@@ -1586,20 +1586,20 @@ where
             .map(|_| true)
         } else if n == Self::AUTOLEVEL_ACTIVATE_NAME {
             let activates =
-                &elem_value.get_bool()[..T::ch_strip(self.state()).autolevel.activates.len()];
+                &elem_value.boolean()[..T::ch_strip(self.state()).autolevel.activates.len()];
             self.update_autolevel(unit, req, timeout_ms, |state| {
                 Ok(state.activates.copy_from_slice(&activates))
             })
             .map(|_| true)
         } else if n == Self::AUTOLEVEL_MAX_GAIN_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).autolevel.max_gains.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).autolevel.max_gains.len()];
             let gains: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_autolevel(unit, req, timeout_ms, |state| {
                 Ok(state.max_gains.copy_from_slice(&gains))
             })
             .map(|_| true)
         } else if n == Self::AUTOLEVEL_HEAD_ROOM_NAME {
-            let vals = &elem_value.get_int()[..T::ch_strip(self.state()).autolevel.headrooms.len()];
+            let vals = &elem_value.int()[..T::ch_strip(self.state()).autolevel.headrooms.len()];
             let rooms: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_autolevel(unit, req, timeout_ms, |state| {
                 Ok(state.headrooms.copy_from_slice(&rooms))
@@ -1607,7 +1607,7 @@ where
             .map(|_| true)
         } else if n == Self::AUTOLEVEL_RISE_TIME_NAME {
             let vals =
-                &elem_value.get_int()[..T::ch_strip(self.state()).autolevel.rise_times.len()];
+                &elem_value.int()[..T::ch_strip(self.state()).autolevel.rise_times.len()];
             let times: Vec<u16> = vals.iter().map(|&val| val as u16).collect();
             self.update_autolevel(unit, req, timeout_ms, |state| {
                 Ok(state.rise_times.copy_from_slice(&times))
@@ -2148,7 +2148,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
     }
 
     fn read_fx(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LINE_SRC_GAIN_NAME => {
                 let vals: Vec<i32> = self
                     .state()
@@ -2356,13 +2356,13 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             LINE_SRC_GAIN_NAME => {
                 let mut state = self.state().fx.clone();
                 state
                     .line_input_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_input_gains(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2372,7 +2372,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .mic_input_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_input_gains(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2382,7 +2382,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .spdif_input_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_input_gains(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2392,7 +2392,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .adat_input_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_input_gains(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2402,7 +2402,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .stream_input_gains
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
                 T::write_fx_input_gains(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2412,7 +2412,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .line_output_vols
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_output_volumes(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2422,7 +2422,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .hp_output_vols
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_output_volumes(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2432,7 +2432,7 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .spdif_output_vols
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_output_volumes(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
@@ -2442,19 +2442,19 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
                 state
                     .adat_output_vols
                     .iter_mut()
-                    .zip(elem_value.get_int())
+                    .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
                 T::write_fx_output_volumes(req, &mut unit.1, self.state_mut(), state, timeout_ms)
                     .map(|_| true)
             }
             REVERB_ACTIVATE_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.activate = elem_value.get_bool()[0];
+                    state.activate = elem_value.boolean()[0];
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_TYPE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let reverb_type = Self::REVERB_TYPES
                     .iter()
                     .nth(val as usize)
@@ -2471,84 +2471,84 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
             }
             REVERB_PRE_DELAY_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.pre_delay = elem_value.get_int()[0] as u16;
+                    state.pre_delay = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_PRE_HPF_FREQ_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.pre_hpf = elem_value.get_int()[0] as u16;
+                    state.pre_hpf = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_ROOM_SCALE_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.room_scale = elem_value.get_int()[0] as u16;
+                    state.room_scale = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_ATTACK_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.attack = elem_value.get_int()[0] as u16;
+                    state.attack = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_HOLD_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.hold = elem_value.get_int()[0] as u16;
+                    state.hold = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_RELEASE_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.release = elem_value.get_int()[0] as u16;
+                    state.release = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_POST_LPF_FREQ_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.post_lpf = elem_value.get_int()[0] as u16;
+                    state.post_lpf = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_TIME_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.time = elem_value.get_int()[0] as u16;
+                    state.time = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_DAMPING_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.damping = elem_value.get_int()[0] as u16;
+                    state.damping = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_SMOOTH_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.smooth = elem_value.get_int()[0] as u16;
+                    state.smooth = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_VOL_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.volume = elem_value.get_int()[0] as i16;
+                    state.volume = elem_value.int()[0] as i16;
                     Ok(())
                 })
                 .map(|_| true),
             REVERB_STEREO_WIDTH_NAME => self
                 .update_reverb(unit, req, timeout_ms, |state| {
-                    state.stereo_width = elem_value.get_int()[0] as u16;
+                    state.stereo_width = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             ECHO_ACTIVATE_NAME => self
                 .update_echo(unit, req, timeout_ms, |state| {
-                    state.activate = elem_value.get_bool()[0];
+                    state.activate = elem_value.boolean()[0];
                     Ok(())
                 })
                 .map(|_| true),
             ECHO_TYPE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let echo_type = Self::ECHO_TYPES
                     .iter()
                     .nth(val as usize)
@@ -2565,18 +2565,18 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
             }
             ECHO_DELAY_NAME => self
                 .update_echo(unit, req, timeout_ms, |state| {
-                    state.delay = elem_value.get_int()[0] as u16;
+                    state.delay = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             ECHO_FEEDBACK_NAME => self
                 .update_echo(unit, req, timeout_ms, |state| {
-                    state.feedback = elem_value.get_int()[0] as u16;
+                    state.feedback = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),
             ECHO_LPF_FREQ_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let lpf = Self::ECHO_LPF_FREQS
                     .iter()
                     .nth(val as usize)
@@ -2593,13 +2593,13 @@ pub trait FfLatterFxCtlOperation<T: RmeFfLatterFxOperation>: FfLatterDspCtlOpera
             }
             ECHO_VOL_NAME => self
                 .update_echo(unit, req, timeout_ms, |state| {
-                    state.volume = elem_value.get_int()[0] as i16;
+                    state.volume = elem_value.int()[0] as i16;
                     Ok(())
                 })
                 .map(|_| true),
             ECHO_STEREO_WIDTH_NAME => self
                 .update_echo(unit, req, timeout_ms, |state| {
-                    state.stereo_width = elem_value.get_int()[0] as u16;
+                    state.stereo_width = elem_value.int()[0] as u16;
                     Ok(())
                 })
                 .map(|_| true),

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -12,11 +12,11 @@ mod former_ctls;
 mod latter_ctls;
 
 use {
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
-    hinawa::{FwNode, FwNodeExt, FwNodeExtManual, FwReq},
-    hitaki::*,
+    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hitaki::{prelude::*, *},
     model::*,
     nix::sys::signal,
     std::sync::mpsc,
@@ -46,11 +46,11 @@ impl RuntimeOperation<u32> for FfRuntime {
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path, 0)?;
 
-        let cdev = format!("/dev/{}", unit.get_property_node_device().unwrap());
+        let cdev = format!("/dev/{}", unit.node_device().unwrap());
         let node = FwNode::new();
         node.open(&cdev)?;
 
-        let rom = node.get_config_rom()?;
+        let rom = node.config_rom()?;
         let model = FfModel::new(&rom)?;
 
         let card_cntr = CardCntr::default();
@@ -98,7 +98,7 @@ impl RuntimeOperation<u32> for FfRuntime {
                         println!("IEEE 1394 bus is updated: {}", generation);
                     }
                     Event::Elem(elem_id, events) => {
-                        if elem_id.get_name() != Self::TIMER_NAME {
+                        if elem_id.name() != Self::TIMER_NAME {
                             let _ = self.model.dispatch_elem_event(
                                 &mut self.unit,
                                 &mut self.card_cntr,
@@ -112,7 +112,7 @@ impl RuntimeOperation<u32> for FfRuntime {
                                 .card
                                 .read_elem_value(&elem_id, &mut elem_value)
                                 .map(|_| {
-                                    let val = elem_value.get_bool()[0];
+                                    let val = elem_value.boolean()[0];
                                     if val {
                                         let _ = self.start_interval_timer();
                                     } else {
@@ -172,7 +172,7 @@ impl<'a> FfRuntime {
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+            let _ = tx.send(Event::BusReset(node.generation()));
         });
 
         self.dispatchers.push(dispatcher);

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -237,7 +237,7 @@ impl CfgCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = Self::CLK_SRCS
                     .iter()
@@ -286,7 +286,7 @@ impl CfgCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
@@ -315,7 +315,7 @@ impl CfgCtl {
             })
             .map(|_| true),
             EFFECT_ON_INPUT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                cfg.effect_on_inputs = elem_value.get_bool()[0];
+                cfg.effect_on_inputs = elem_value.boolean()[0];
                 Ok(())
             })
             .map(|_| true),
@@ -438,7 +438,7 @@ impl StatusCtl {
     }
 
     fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
                     self.status.ext_lock.coax_iface,

--- a/libs/motu/protocols/Cargo.toml
+++ b/libs/motu/protocols/Cargo.toml
@@ -12,7 +12,7 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
 ieee1212-config-rom = "0.1"

--- a/libs/motu/protocols/src/command_dsp.rs
+++ b/libs/motu/protocols/src/command_dsp.rs
@@ -8,7 +8,7 @@
 
 use {
     super::*,
-    hinawa::{FwResp, FwRespExt},
+    hinawa::{prelude::FwRespExt, FwResp},
 };
 
 const DSP_CMD_OFFSET: u64 = 0xffff00010000;
@@ -1809,7 +1809,7 @@ pub trait CommandDspOperation {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if !resp.get_property_is_reserved() {
+        if !resp.is_reserved() {
             resp.reserve_within_region(
                 node,
                 MSG_DST_OFFSET_BEGIN,
@@ -1818,8 +1818,8 @@ pub trait CommandDspOperation {
             )?;
         }
 
-        let local_node_id = node.get_property_local_node_id() as u64;
-        let addr = (local_node_id << 48) | resp.get_property_offset();
+        let local_node_id = node.local_node_id() as u64;
+        let addr = (local_node_id << 48) | resp.offset();
 
         let high = (addr >> 32) as u32;
         write_quad(req, node, DSP_MSG_DST_HIGH_OFFSET, high, timeout_ms)?;
@@ -1864,7 +1864,7 @@ pub trait CommandDspOperation {
         write_quad(req, node, DSP_MSG_DST_HIGH_OFFSET, 0, timeout_ms)?;
         write_quad(req, node, DSP_MSG_DST_LOW_OFFSET, 0, timeout_ms)?;
 
-        if resp.get_property_is_reserved() {
+        if resp.is_reserved() {
             resp.release();
         }
 

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -14,7 +14,7 @@ pub mod version_3;
 
 use {
     glib::{Error, FileError},
-    hinawa::{FwNode, FwNodeExt, FwReq, FwReqExtManual, FwTcode},
+    hinawa::{prelude::{FwNodeExt, FwReqExtManual}, FwNode, FwReq, FwTcode},
     std::{thread, time},
 };
 

--- a/libs/motu/protocols/src/register_dsp.rs
+++ b/libs/motu/protocols/src/register_dsp.rs
@@ -71,10 +71,10 @@ pub trait RegisterDspMixerOutputOperation {
         state: &mut RegisterDspMixerOutputState,
         param: &SndMotuRegisterDspParameter,
     ) {
-        let vols = param.get_mixer_output_paired_volume();
+        let vols = param.mixer_output_paired_volume();
         state.volume.copy_from_slice(vols);
 
-        let flags = param.get_mixer_output_paired_flag();
+        let flags = param.mixer_output_paired_flag();
         state
             .mute
             .iter_mut()
@@ -312,20 +312,20 @@ pub trait RegisterDspMixerMonauralSourceOperation {
         param: &SndMotuRegisterDspParameter,
     ) {
         state.0.iter_mut().enumerate().for_each(|(i, src)| {
-            let gains = param.get_mixer_source_gain(i);
+            let gains = param.mixer_source_gain(i);
             src.gain
                 .iter_mut()
                 .zip(gains)
                 .for_each(|(dst, src)| *dst = *src);
 
-            let pans = param.get_mixer_source_pan(i);
+            let pans = param.mixer_source_pan(i);
             src.pan
                 .iter_mut()
                 .zip(pans)
                 .for_each(|(dst, src)| *dst = *src);
 
             let flags: Vec<u32> = param
-                .get_mixer_source_flag(i)
+                .mixer_source_flag(i)
                 .iter()
                 .map(|&flag| (flag as u32) << 16)
                 .collect();
@@ -585,20 +585,20 @@ pub trait RegisterDspMixerStereoSourceOperation {
         param: &SndMotuRegisterDspParameter,
     ) {
         state.0.iter_mut().enumerate().for_each(|(i, src)| {
-            let gains = param.get_mixer_source_gain(i);
+            let gains = param.mixer_source_gain(i);
             src.gain
                 .iter_mut()
                 .zip(gains)
                 .for_each(|(dst, src)| *dst = *src);
 
-            let pans = param.get_mixer_source_pan(i);
+            let pans = param.mixer_source_pan(i);
             src.pan
                 .iter_mut()
                 .zip(pans)
                 .for_each(|(dst, src)| *dst = *src);
 
             let flags: Vec<u32> = param
-                .get_mixer_source_flag(i)
+                .mixer_source_flag(i)
                 .iter()
                 .map(|&flag| (flag as u32) << 16)
                 .collect();
@@ -905,8 +905,8 @@ pub trait RegisterDspOutputOperation {
         state: &mut RegisterDspOutputState,
         param: &SndMotuRegisterDspParameter,
     ) {
-        state.master_volume = param.get_main_output_paired_volume();
-        state.phone_volume = param.get_headphone_output_paired_volume();
+        state.master_volume = param.main_output_paired_volume();
+        state.phone_volume = param.headphone_output_paired_volume();
     }
 
     fn parse_dsp_event(state: &mut RegisterDspOutputState, event: &RegisterDspEvent) -> bool {
@@ -1004,7 +1004,7 @@ pub trait Traveler828mk2LineInputOperation {
         state: &mut RegisterDspLineInputState,
         param: &SndMotuRegisterDspParameter,
     ) {
-        let flags = param.get_line_input_nominal_level_flag();
+        let flags = param.line_input_nominal_level_flag();
         state.level.iter_mut().enumerate().for_each(|(i, level)| {
             let shift = i + Self::CH_OFFSET;
             *level = if flags & (1 << shift) > 0 {
@@ -1014,7 +1014,7 @@ pub trait Traveler828mk2LineInputOperation {
             };
         });
 
-        let flags = param.get_line_input_boost_flag();
+        let flags = param.line_input_boost_flag();
         state.boost.iter_mut().enumerate().for_each(|(i, boost)| {
             let shift = i + Self::CH_OFFSET;
             *boost = flags & (1 << shift) > 0;
@@ -1184,7 +1184,7 @@ pub trait RegisterDspMonauralInputOperation {
         state: &mut RegisterDspMonauralInputState,
         param: &SndMotuRegisterDspParameter,
     ) {
-        let vals = param.get_input_gain_and_invert();
+        let vals = param.input_gain_and_invert();
         state
             .gain
             .iter_mut()
@@ -1327,7 +1327,7 @@ pub trait RegisterDspStereoInputOperation {
         state: &mut RegisterDspStereoInputState,
         param: &SndMotuRegisterDspParameter,
     ) {
-        let vals = param.get_input_gain_and_invert();
+        let vals = param.input_gain_and_invert();
         state
             .gain
             .iter_mut()
@@ -1339,7 +1339,7 @@ pub trait RegisterDspStereoInputOperation {
             .zip(vals)
             .for_each(|(invert, val)| *invert = val & STEREO_INPUT_INVERT_FLAG > 0);
 
-        let flags = param.get_input_flag();
+        let flags = param.input_flag();
         state
             .phantom
             .iter_mut()

--- a/libs/motu/runtime/Cargo.toml
+++ b/libs/motu/runtime/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 motu-protocols = "0.1"

--- a/libs/motu/runtime/src/command_dsp_ctls.rs
+++ b/libs/motu/runtime/src/command_dsp_ctls.rs
@@ -213,7 +213,7 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_ENABLE => {
                 elem_value.set_bool(&[self.state().enable]);
                 Ok(true)
@@ -297,13 +297,13 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             REVERB_ENABLE => self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-                state.enable = elem_value.get_bool()[0];
+                state.enable = elem_value.boolean()[0];
                 Ok(())
             }),
             REVERB_SPLIT_POINT_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &split_point =
                     Self::SPLIT_POINTS.iter().nth(val as usize).ok_or_else(|| {
                         let msg = format!("Invalid index for split points: {}", val);
@@ -316,30 +316,30 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
             }
             REVERB_PRE_DELAY_NAME => {
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-                    state.pre_delay = elem_value.get_int()[0] as u32;
+                    state.pre_delay = elem_value.int()[0] as u32;
                     Ok(())
                 })
             }
             REVERB_SHELF_FILTER_FREQ_NAME => {
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-                    state.shelf_filter_freq = elem_value.get_int()[0] as u32;
+                    state.shelf_filter_freq = elem_value.int()[0] as u32;
                     Ok(())
                 })
             }
             REVERB_SHELF_FILTER_ATTR_NAME => {
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-                    state.shelf_filter_attenuation = elem_value.get_int()[0];
+                    state.shelf_filter_attenuation = elem_value.int()[0];
                     Ok(())
                 })
             }
             REVERB_DECAY_TIME_NAME => {
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-                    state.decay_time = elem_value.get_int()[0] as u32;
+                    state.decay_time = elem_value.int()[0] as u32;
                     Ok(())
                 })
             }
             REVERB_FREQ_TIME_NAME => {
-                let vals = &elem_value.get_int()[..T::FREQ_TIME_COUNT];
+                let vals = &elem_value.int()[..T::FREQ_TIME_COUNT];
                 let raw: Vec<u32> = vals.iter().map(|&val| val as u32).collect();
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.freq_time.copy_from_slice(&raw);
@@ -347,7 +347,7 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
                 })
             }
             REVERB_FREQ_CROSSOVER_NAME => {
-                let vals = &elem_value.get_int()[..T::FREQ_CROSSOVER_COUNT];
+                let vals = &elem_value.int()[..T::FREQ_CROSSOVER_COUNT];
                 let raw: Vec<u32> = vals.iter().map(|&val| val as u32).collect();
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.freq_crossover.copy_from_slice(&raw);
@@ -355,14 +355,14 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
                 })
             }
             REVERB_WIDTH_NAME => {
-                let val = (elem_value.get_int()[0] as f32) / Self::F32_CONVERT_SCALE;
+                let val = (elem_value.int()[0] as f32) / Self::F32_CONVERT_SCALE;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.width = val;
                     Ok(())
                 })
             }
             REVERB_REFLECTION_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::ROOM_SHAPES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index for reflection modes: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -373,14 +373,14 @@ pub trait CommandDspReverbCtlOperation<T: CommandDspReverbOperation> {
                 })
             }
             REVERB_REFLECTION_SIZE_NAME => {
-                let val = elem_value.get_int()[0];
+                let val = elem_value.int()[0];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.reflection_size = val as u32;
                     Ok(())
                 })
             }
             REVERB_REFLECTION_LEVEL_NAME => {
-                let val = (elem_value.get_int()[0] as f32) / Self::F32_CONVERT_SCALE;
+                let val = (elem_value.int()[0] as f32) / Self::F32_CONVERT_SCALE;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.reflection_level = val;
                     Ok(())
@@ -469,7 +469,7 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_VOLUME_NAME => {
                 let val = (self.state().main_volume * Self::F32_CONVERT_SCALE) as i32;
                 elem_value.set_int(&[val]);
@@ -506,9 +506,9 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_VOLUME_NAME => {
-                let val = (elem_value.get_int()[0] as f32) / Self::F32_CONVERT_SCALE;
+                let val = (elem_value.int()[0] as f32) / Self::F32_CONVERT_SCALE;
                 let mut state = self.state().clone();
                 state.main_volume = val;
                 T::write_monitor_state(
@@ -523,7 +523,7 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
             }
             TALKBACK_ENABLE_NAME => {
                 let mut state = self.state().clone();
-                state.talkback_enable = elem_value.get_bool()[0];
+                state.talkback_enable = elem_value.boolean()[0];
                 T::write_monitor_state(
                     req,
                     &mut unit.1,
@@ -536,7 +536,7 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
             }
             LISTENBACK_ENABLE_NAME => {
                 let mut state = self.state().clone();
-                state.listenback_enable = elem_value.get_bool()[0];
+                state.listenback_enable = elem_value.boolean()[0];
                 T::write_monitor_state(
                     req,
                     &mut unit.1,
@@ -549,7 +549,7 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
             }
             TALKBACK_VOLUME_NAME => {
                 let mut state = self.state().clone();
-                state.talkback_volume = (elem_value.get_int()[0] as f32) / Self::F32_CONVERT_SCALE;
+                state.talkback_volume = (elem_value.int()[0] as f32) / Self::F32_CONVERT_SCALE;
                 T::write_monitor_state(
                     req,
                     &mut unit.1,
@@ -563,7 +563,7 @@ pub trait CommandDspMonitorCtlOperation<T: CommandDspMonitorOperation> {
             LISTENBACK_VOLUME_NAME => {
                 let mut state = self.state().clone();
                 state.listenback_volume =
-                    (elem_value.get_int()[0] as f32) / Self::F32_CONVERT_SCALE;
+                    (elem_value.int()[0] as f32) / Self::F32_CONVERT_SCALE;
                 T::write_monitor_state(
                     req,
                     &mut unit.1,
@@ -791,7 +791,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_OUTPUT_DESTINATION_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, T::MIXER_COUNT, |idx| {
                     let pos = T::OUTPUT_PORTS
@@ -814,25 +814,25 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
                 Self::read_f32_values(elem_value, &self.state().reverb_return)
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().source[mixer].mute);
                 Ok(true)
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().source[mixer].solo);
                 Ok(true)
             }
             MIXER_SOURCE_PAN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 Self::read_f32_values(elem_value, &self.state().source[mixer].pan)
             }
             MIXER_SOURCE_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 Self::read_f32_values(elem_value, &self.state().source[mixer].gain)
             }
             MIXER_SOURCE_STEREO_PAIR_MODE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 ElemValueAccessor::<u32>::set_vals(elem_value, T::SOURCE_PORTS.len(), |idx| {
                     let pos = Self::SOURCE_STEREO_PAIR_MODES
                         .iter()
@@ -843,11 +843,11 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
                 .map(|_| true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 Self::read_f32_values(elem_value, &self.state().source[mixer].stereo_balance)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 Self::read_f32_values(elem_value, &self.state().source[mixer].stereo_width)
             }
             _ => Ok(false),
@@ -855,7 +855,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
     }
 
     fn f32_array_from_i32_values(elem_value: &ElemValue, count: usize) -> Vec<f32> {
-        let vals = &elem_value.get_int()[..count];
+        let vals = &elem_value.int()[..count];
         vals.iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
             .collect()
@@ -870,9 +870,9 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_OUTPUT_DESTINATION_NAME => {
-                let vals = &elem_value.get_enum()[..T::MIXER_COUNT];
+                let vals = &elem_value.enumerated()[..T::MIXER_COUNT];
                 let mut dsts = Vec::new();
                 vals.iter().try_for_each(|&val| {
                     T::OUTPUT_PORTS
@@ -890,7 +890,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
                 })
             }
             MIXER_OUTPUT_MUTE_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIXER_COUNT];
+                let vals = &elem_value.boolean()[..T::MIXER_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.output_mute.copy_from_slice(&vals);
                     Ok(())
@@ -918,16 +918,16 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
                 })
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let vals = &elem_value.get_bool()[..T::SOURCE_PORTS.len()];
-                let mixer = elem_id.get_index() as usize;
+                let vals = &elem_value.boolean()[..T::SOURCE_PORTS.len()];
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].mute.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let vals = &elem_value.get_bool()[..T::SOURCE_PORTS.len()];
-                let mixer = elem_id.get_index() as usize;
+                let vals = &elem_value.boolean()[..T::SOURCE_PORTS.len()];
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].solo.copy_from_slice(&vals);
                     Ok(())
@@ -935,7 +935,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
             }
             MIXER_SOURCE_PAN_NAME => {
                 let vals = Self::f32_array_from_i32_values(elem_value, T::SOURCE_PORTS.len());
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].pan.copy_from_slice(&vals);
                     Ok(())
@@ -943,14 +943,14 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
             }
             MIXER_SOURCE_GAIN_NAME => {
                 let vals = Self::f32_array_from_i32_values(elem_value, T::SOURCE_PORTS.len());
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].gain.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIXER_SOURCE_STEREO_PAIR_MODE_NAME => {
-                let vals = &elem_value.get_enum()[..T::SOURCE_PORTS.len()];
+                let vals = &elem_value.enumerated()[..T::SOURCE_PORTS.len()];
                 let mut stereo_modes = Vec::new();
                 vals.iter().try_for_each(|&val| {
                     Self::SOURCE_STEREO_PAIR_MODES
@@ -962,7 +962,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
                         })
                         .map(|&mode| stereo_modes.push(mode))
                 })?;
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer]
                         .stereo_mode
@@ -972,7 +972,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
                 let vals = Self::f32_array_from_i32_values(elem_value, T::SOURCE_PORTS.len());
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].stereo_balance.copy_from_slice(&vals);
                     Ok(())
@@ -980,7 +980,7 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
                 let vals = Self::f32_array_from_i32_values(elem_value, T::SOURCE_PORTS.len());
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.source[mixer].stereo_width.copy_from_slice(&vals);
                     Ok(())
@@ -1358,7 +1358,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        let name = elem_id.get_name();
+        let name = elem_id.name();
 
         if name == Self::ENABLE_NAME {
             Self::read_bool_values(elem_value, &self.state().enable)
@@ -1441,7 +1441,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[bool]),
     {
-        let vals = &elem_value.get_bool()[..Self::CH_COUNT];
+        let vals = &elem_value.boolean()[..Self::CH_COUNT];
         self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -1460,7 +1460,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[i32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -1479,7 +1479,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[u32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         let raw: Vec<u32> = vals.iter().map(|&val| val as u32).collect();
         self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &raw);
@@ -1499,7 +1499,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[f32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         let raw: Vec<f32> = vals
             .iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
@@ -1522,7 +1522,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[RollOffLevel]),
     {
-        let vals = &elem_value.get_enum()[..Self::CH_COUNT];
+        let vals = &elem_value.enumerated()[..Self::CH_COUNT];
         let mut levels = Vec::new();
         vals.iter().try_for_each(|&val| {
             Self::ROLL_OFF_LEVELS
@@ -1552,7 +1552,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[FilterType5]),
     {
-        let vals = &elem_value.get_enum()[..Self::CH_COUNT];
+        let vals = &elem_value.enumerated()[..Self::CH_COUNT];
         let mut filter_types = Vec::new();
         vals.iter().try_for_each(|&val| {
             Self::FILTER_TYPE_5
@@ -1582,7 +1582,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspEqualizerState, &[FilterType4]),
     {
-        let vals = &elem_value.get_enum()[..Self::CH_COUNT];
+        let vals = &elem_value.enumerated()[..Self::CH_COUNT];
         let mut filter_types = Vec::new();
         vals.iter().try_for_each(|&val| {
             Self::FILTER_TYPE_4
@@ -1609,7 +1609,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        let name = elem_id.get_name();
+        let name = elem_id.name();
 
         if name == Self::ENABLE_NAME {
             self.write_bool_values(
@@ -2213,7 +2213,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        let name = elem_id.get_name();
+        let name = elem_id.name();
 
         if name == Self::ENABLE_NAME {
             Self::read_bool_values(elem_value, &self.state().enable)
@@ -2256,7 +2256,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[bool]),
     {
-        let vals = &elem_value.get_bool()[..Self::CH_COUNT];
+        let vals = &elem_value.boolean()[..Self::CH_COUNT];
         self.write_dynamics_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -2275,7 +2275,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[i32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         self.write_dynamics_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -2294,7 +2294,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[u32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         let raw: Vec<u32> = vals.iter().map(|&val| val as u32).collect();
         self.write_dynamics_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &raw);
@@ -2314,7 +2314,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[f32]),
     {
-        let vals = &elem_value.get_int()[..Self::CH_COUNT];
+        let vals = &elem_value.int()[..Self::CH_COUNT];
         let raw: Vec<f32> = vals
             .iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
@@ -2337,7 +2337,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[LevelDetectMode]),
     {
-        let vals = &elem_value.get_enum()[..Self::CH_COUNT];
+        let vals = &elem_value.enumerated()[..Self::CH_COUNT];
         let mut modes = Vec::new();
         vals.iter().try_for_each(|&val| {
             Self::LEVEL_DETECT_MODES
@@ -2367,7 +2367,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
     where
         F: Fn(&mut CommandDspDynamicsState, &[LevelerMode]),
     {
-        let vals = &elem_value.get_enum()[..Self::CH_COUNT];
+        let vals = &elem_value.enumerated()[..Self::CH_COUNT];
         let mut modes = Vec::new();
         vals.iter().try_for_each(|&val| {
             Self::LEVELER_MODES
@@ -2394,7 +2394,7 @@ pub trait CommandDspDynamicsCtlOperation<T: CommandDspOperation, U: Default> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        let name = elem_id.get_name();
+        let name = elem_id.name();
 
         if name == Self::ENABLE_NAME {
             self.write_bool_values(
@@ -2683,7 +2683,7 @@ pub trait CommandDspInputCtlOperation<T: CommandDspInputOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_PHASE_NAME => {
                 elem_value.set_bool(&self.state().phase);
                 Ok(true)
@@ -2740,7 +2740,7 @@ pub trait CommandDspInputCtlOperation<T: CommandDspInputOperation> {
     }
 
     fn f32_array_from_i32_values(elem_value: &ElemValue) -> Vec<f32> {
-        let vals = &elem_value.get_int()[..T::INPUT_PORTS.len()];
+        let vals = &elem_value.int()[..T::INPUT_PORTS.len()];
         vals.iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
             .collect()
@@ -2755,37 +2755,37 @@ pub trait CommandDspInputCtlOperation<T: CommandDspInputOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_PHASE_NAME => {
-                let vals = &elem_value.get_bool()[..T::INPUT_PORTS.len()];
+                let vals = &elem_value.boolean()[..T::INPUT_PORTS.len()];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.phase.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             INPUT_PAIR_NAME => {
-                let vals = &elem_value.get_bool()[..T::INPUT_PORTS.len()];
+                let vals = &elem_value.boolean()[..T::INPUT_PORTS.len()];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.pair.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             INPUT_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..T::INPUT_PORTS.len()];
+                let vals = &elem_value.int()[..T::INPUT_PORTS.len()];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.gain.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             INPUT_SWAP_NAME => {
-                let vals = &elem_value.get_bool()[..T::INPUT_PORTS.len()];
+                let vals = &elem_value.boolean()[..T::INPUT_PORTS.len()];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.swap.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             INPUT_STEREO_MODE_NAME => {
-                let vals = &elem_value.get_enum()[..T::INPUT_PORTS.len()];
+                let vals = &elem_value.enumerated()[..T::INPUT_PORTS.len()];
                 let mut modes = Vec::new();
                 vals.iter().try_for_each(|&val| {
                     Self::STEREO_PAIR_MODES
@@ -2824,35 +2824,35 @@ pub trait CommandDspInputCtlOperation<T: CommandDspInputOperation> {
                 })
             }
             MIC_PAD_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIC_COUNT];
+                let vals = &elem_value.boolean()[..T::MIC_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.pad.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIC_PHANTOM_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIC_COUNT];
+                let vals = &elem_value.boolean()[..T::MIC_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.phantom.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIC_LIMITTER_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIC_COUNT];
+                let vals = &elem_value.boolean()[..T::MIC_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.limitter.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIC_LOOKAHEAD_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIC_COUNT];
+                let vals = &elem_value.boolean()[..T::MIC_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.lookahead.copy_from_slice(&vals);
                     Ok(())
                 })
             }
             MIC_SOFT_CLIP_NAME => {
-                let vals = &elem_value.get_bool()[..T::MIC_COUNT];
+                let vals = &elem_value.boolean()[..T::MIC_COUNT];
                 self.write_state(sequence_number, unit, req, timeout_ms, |state| {
                     state.soft_clip.copy_from_slice(&vals);
                     Ok(())
@@ -3094,7 +3094,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_REVERB_SEND_NAME => Self::read_f32_values(elem_value, &self.state().reverb_send),
             OUTPUT_REVERB_RETURN_NAME => {
                 Self::read_f32_values(elem_value, &self.state().reverb_return)
@@ -3124,7 +3124,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     where
         F: Fn(&mut CommandDspOutputState, &[bool]),
     {
-        let vals = &elem_value.get_bool()[..T::OUTPUT_PORTS.len()];
+        let vals = &elem_value.boolean()[..T::OUTPUT_PORTS.len()];
         self.write_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -3143,7 +3143,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     where
         F: Fn(&mut CommandDspOutputState, &[i32]),
     {
-        let vals = &elem_value.get_int()[..T::OUTPUT_PORTS.len()];
+        let vals = &elem_value.int()[..T::OUTPUT_PORTS.len()];
         self.write_state(sequence_number, unit, req, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
@@ -3162,7 +3162,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     where
         F: Fn(&mut CommandDspOutputState, &[f32]),
     {
-        let vals = &elem_value.get_int()[..T::OUTPUT_PORTS.len()];
+        let vals = &elem_value.int()[..T::OUTPUT_PORTS.len()];
         let raw: Vec<f32> = vals
             .iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
@@ -3182,7 +3182,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_REVERB_SEND_NAME => self.write_f32_values(
                 sequence_number,
                 unit,
@@ -3422,7 +3422,7 @@ pub trait CommandDspResourcebCtlOperation {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RESOURCE_USAGE_NAME => {
                 let val = *self.state() as i32;
                 elem_value.set_int(&[val]);
@@ -3500,7 +3500,7 @@ pub trait CommandDspMeterCtlOperation<T: CommandDspMeterOperation> {
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_METER_NAME => {
                 let levels: Vec<i32> = self
                     .state()

--- a/libs/motu/runtime/src/command_dsp_runtime.rs
+++ b/libs/motu/runtime/src/command_dsp_runtime.rs
@@ -6,10 +6,10 @@ pub use {
         command_dsp_ctls::*, f828mk3::*, f828mk3_hybrid::*, track16::*, traveler_mk3::*,
         ultralite_mk3::*, ultralite_mk3_hybrid::*, *,
     },
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*},
     glib::source,
-    hinawa::{FwRcode, FwResp, FwRespExtManual, FwTcode},
+    hinawa::{prelude::FwRespExtManual, FwRcode, FwResp, FwTcode},
     motu_protocols::{command_dsp::*, version_3::*},
     nix::sys::signal::Signal,
     std::{
@@ -132,7 +132,7 @@ where
         let tx = self.tx.clone();
         let handler = self.msg_handler.clone();
         // TODO: bus reset can cause change of node ID by updating bus topology.
-        let peer_node_id = self.unit.1.get_property_node_id();
+        let peer_node_id = self.unit.1.node_id();
         self.model.prepare_message_handler(
             &mut self.unit,
             move |_, tcode, _, src, _, _, _, frame| {
@@ -217,7 +217,7 @@ where
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != TIMER_NAME {
+                    if elem_id.name() != TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
                             &mut self.unit,
                             &elem_id,
@@ -231,7 +231,7 @@ where
                             .card
                             .read_elem_value(&elem_id, &mut elem_value)
                             .map(|_| {
-                                let val = elem_value.get_bool()[0];
+                                let val = elem_value.boolean()[0];
                                 if val {
                                     let _ = self.start_interval_timer();
                                 } else {
@@ -298,7 +298,7 @@ where
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+            let _ = tx.send(Event::BusReset(node.generation()));
         });
 
         self.dispatchers.push(dispatcher);

--- a/libs/motu/runtime/src/common_ctls.rs
+++ b/libs/motu/runtime/src/common_ctls.rs
@@ -41,7 +41,7 @@ pub trait PhoneAssignCtlOperation<T: AssignOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PHONE_ASSIGN_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || Ok(*self.state() as u32))
                     .map(|_| true)
@@ -58,7 +58,7 @@ pub trait PhoneAssignCtlOperation<T: AssignOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PHONE_ASSIGN_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 T::set_phone_assign(req, &mut unit.1, val as usize, timeout_ms)
                     .map(|_| *self.state_mut() = val as usize)
@@ -114,7 +114,7 @@ pub trait WordClkCtlOperation<T: WordClkOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             WORD_OUT_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let pos = WORD_OUT_MODES
                     .iter()
@@ -135,7 +135,7 @@ pub trait WordClkCtlOperation<T: WordClkOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             WORD_OUT_MODE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 let &mode = WORD_OUT_MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid argument for index of word clock speed: {}", val);
@@ -182,7 +182,7 @@ pub trait AesebuRateConvertCtlOperation<T: AesebuRateConvertOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             AESEBU_RATE_CONVERT_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_aesebu_rate_convert_mode(req, &mut unit.1, timeout_ms).map(|val| val as u32)
             })
@@ -199,7 +199,7 @@ pub trait AesebuRateConvertCtlOperation<T: AesebuRateConvertOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             AESEBU_RATE_CONVERT_MODE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 T::set_aesebu_rate_convert_mode(req, &mut unit.1, val as usize, timeout_ms)
             })
@@ -316,7 +316,7 @@ pub trait LevelMetersCtlOperation<T: LevelMetersOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PEAK_HOLD_TIME_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_level_meters_peak_hold_time_mode(req, &mut unit.1, timeout_ms)
                     .map(|val| val as u32)
@@ -332,7 +332,7 @@ pub trait LevelMetersCtlOperation<T: LevelMetersOperation> {
     }
 
     fn refer(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             AESEBU_MODE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.state().0 as u32))
                     .map(|_| true)
@@ -353,7 +353,7 @@ pub trait LevelMetersCtlOperation<T: LevelMetersOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             PEAK_HOLD_TIME_MODE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 T::set_level_meters_peak_hold_time_mode(req, &mut unit.1, val as usize, timeout_ms)
             })

--- a/libs/motu/runtime/src/f828.rs
+++ b/libs/motu/runtime/src/f828.rs
@@ -142,7 +142,7 @@ impl SpecificCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_IFACE_MODE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 F828Protocol::get_optical_input_iface_mode(req, &mut unit.1, timeout_ms)
                     .map(|val| val as u32)
@@ -165,7 +165,7 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_IFACE_MODE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 unit.0.lock()?;
                 let res = F828Protocol::set_optical_input_iface_mode(

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -33,8 +33,8 @@ use {
     self::{command_dsp_runtime::*, register_dsp_runtime::*, v1_runtime::*},
     core::RuntimeOperation,
     glib::{Error, FileError},
-    hinawa::{FwNode, FwNodeExt, FwNodeExtManual},
-    hitaki::{traits::*, *},
+    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode},
+    hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     motu_protocols::{config_rom::*, *},
     std::convert::TryFrom,
@@ -64,11 +64,11 @@ impl RuntimeOperation<u32> for MotuRuntime {
         let unit = SndMotu::new();
         unit.open(&cdev, 0)?;
 
-        let cdev = format!("/dev/{}", unit.get_property_node_device().unwrap());
+        let cdev = format!("/dev/{}", unit.node_device().unwrap());
         let node = FwNode::new();
         node.open(&cdev)?;
 
-        let data = node.get_config_rom()?;
+        let data = node.config_rom()?;
         let unit_data = ConfigRom::try_from(data)
             .map_err(|e| {
                 let msg = format!("Malformed configuration ROM detected: {}", e);

--- a/libs/motu/runtime/src/register_dsp_ctls.rs
+++ b/libs/motu/runtime/src/register_dsp_ctls.rs
@@ -7,7 +7,7 @@ pub trait RegisterDspPhoneAssignCtlOperation<T: AssignOperation>:
     PhoneAssignCtlOperation<T>
 {
     fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
-        let idx = params.get_headphone_output_paired_assignment() as usize;
+        let idx = params.headphone_output_paired_assignment() as usize;
         if idx < T::ASSIGN_PORTS.len() {
             *self.state_mut() = idx;
         }
@@ -79,7 +79,7 @@ pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation>
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_OUTPUT_VOLUME_NAME => {
                 copy_int_to_elem_value(elem_value, &self.state().volume);
                 Ok(true)
@@ -110,20 +110,20 @@ pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation>
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_OUTPUT_VOLUME_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_COUNT];
+                let vals = &elem_value.int()[..T::MIXER_COUNT];
                 let vols: Vec<u8> = vals.iter().map(|&vol| vol as u8).collect();
                 T::write_mixer_output_volume(req, &mut unit.1, &vols, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
             MIXER_OUTPUT_MUTE_NAME => {
-                let mute = &elem_value.get_bool()[..T::MIXER_COUNT];
+                let mute = &elem_value.boolean()[..T::MIXER_COUNT];
                 T::write_mixer_output_mute(req, &mut unit.1, &mute, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
             MIXER_OUTPUT_DST_NAME => {
-                let vals = &elem_value.get_enum()[..T::MIXER_COUNT];
+                let vals = &elem_value.enumerated()[..T::MIXER_COUNT];
                 let mut dst = Vec::new();
                 vals.iter().try_for_each(|&val| {
                     T::OUTPUT_DESTINATIONS
@@ -177,7 +177,7 @@ pub trait RegisterDspMixerReturnCtlOperation<T: RegisterDspMixerReturnOperation>
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_RETURN_ENABLE_NAME => {
                 elem_value.set_bool(&[*self.state()]);
                 Ok(true)
@@ -194,9 +194,9 @@ pub trait RegisterDspMixerReturnCtlOperation<T: RegisterDspMixerReturnOperation>
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_RETURN_ENABLE_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::write_mixer_return_enable(req, &mut unit.1, val, timeout_ms).map(|_| true)
             }
             _ => Ok(false),
@@ -275,24 +275,24 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].gain);
                 Ok(true)
             }
             MIXER_SOURCE_PAN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].pan);
                 Ok(true)
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().0[mixer].mute);
                 Ok(true)
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().0[mixer].solo);
                 Ok(true)
             }
@@ -308,11 +308,11 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCES.len()];
+                let vals = &elem_value.int()[..T::MIXER_SOURCES.len()];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_monaural_source_gain(
                     req,
                     &mut unit.1,
@@ -324,9 +324,9 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
                 .map(|_| true)
             }
             MIXER_SOURCE_PAN_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCES.len()];
+                let vals = &elem_value.int()[..T::MIXER_SOURCES.len()];
                 let pan: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_monaural_source_pan(
                     req,
                     &mut unit.1,
@@ -338,8 +338,8 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
                 .map(|_| true)
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let mute = &elem_value.get_bool()[..T::MIXER_SOURCES.len()];
-                let mixer = elem_id.get_index() as usize;
+                let mute = &elem_value.boolean()[..T::MIXER_SOURCES.len()];
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_monaural_source_mute(
                     req,
                     &mut unit.1,
@@ -351,8 +351,8 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
                 .map(|_| true)
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let solo = &elem_value.get_bool()[..T::MIXER_SOURCES.len()];
-                let mixer = elem_id.get_index() as usize;
+                let solo = &elem_value.boolean()[..T::MIXER_SOURCES.len()];
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_monaural_source_solo(
                     req,
                     &mut unit.1,
@@ -487,34 +487,34 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].gain);
                 Ok(true)
             }
             MIXER_SOURCE_PAN_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].pan);
                 Ok(true)
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().0[mixer].mute);
                 Ok(true)
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 elem_value.set_bool(&self.state().0[mixer].solo);
                 Ok(true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].balance);
                 Ok(true)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 copy_int_to_elem_value(elem_value, &self.state().0[mixer].width);
                 Ok(true)
             }
@@ -530,11 +530,11 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCES.len()];
+                let vals = &elem_value.int()[..T::MIXER_SOURCES.len()];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_gain(
                     req,
                     &mut unit.1,
@@ -546,9 +546,9 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 .map(|_| true)
             }
             MIXER_SOURCE_PAN_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCES.len()];
+                let vals = &elem_value.int()[..T::MIXER_SOURCES.len()];
                 let pan: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_pan(
                     req,
                     &mut unit.1,
@@ -560,8 +560,8 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 .map(|_| true)
             }
             MIXER_SOURCE_MUTE_NAME => {
-                let mute = &elem_value.get_bool()[..T::MIXER_SOURCES.len()];
-                let mixer = elem_id.get_index() as usize;
+                let mute = &elem_value.boolean()[..T::MIXER_SOURCES.len()];
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_mute(
                     req,
                     &mut unit.1,
@@ -573,8 +573,8 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 .map(|_| true)
             }
             MIXER_SOURCE_SOLO_NAME => {
-                let solo = &elem_value.get_bool()[..T::MIXER_SOURCES.len()];
-                let mixer = elem_id.get_index() as usize;
+                let solo = &elem_value.boolean()[..T::MIXER_SOURCES.len()];
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_mute(
                     req,
                     &mut unit.1,
@@ -586,9 +586,9 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 .map(|_| true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCE_PAIR_COUNT];
+                let vals = &elem_value.int()[..T::MIXER_SOURCE_PAIR_COUNT];
                 let balance: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_balance(
                     req,
                     &mut unit.1,
@@ -600,9 +600,9 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 .map(|_| true)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
-                let vals = &elem_value.get_int()[..T::MIXER_SOURCE_PAIR_COUNT];
+                let vals = &elem_value.int()[..T::MIXER_SOURCE_PAIR_COUNT];
                 let width: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                let mixer = elem_id.get_index() as usize;
+                let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_width(
                     req,
                     &mut unit.1,
@@ -683,7 +683,7 @@ pub trait RegisterDspOutputCtlOperation<T: RegisterDspOutputOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_OUTPUT_VOLUME_NAME => {
                 elem_value.set_int(&[self.state().master_volume as i32]);
                 Ok(true)
@@ -704,9 +704,9 @@ pub trait RegisterDspOutputCtlOperation<T: RegisterDspOutputOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_OUTPUT_VOLUME_NAME => {
-                let val = elem_value.get_int()[0];
+                let val = elem_value.int()[0];
                 T::write_output_master_volume(
                     req,
                     &mut unit.1,
@@ -717,7 +717,7 @@ pub trait RegisterDspOutputCtlOperation<T: RegisterDspOutputOperation> {
                 .map(|_| true)
             }
             PHONE_VOLUME_NAME => {
-                let val = elem_value.get_int()[0];
+                let val = elem_value.int()[0];
                 T::write_output_phone_volume(
                     req,
                     &mut unit.1,
@@ -783,7 +783,7 @@ pub trait RegisterDspLineInputCtlOperation<T: Traveler828mk2LineInputOperation> 
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_NOMINAL_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, T::LINE_INPUT_COUNT, |idx| {
                     let pos = Self::NOMINAL_LEVELS
@@ -810,9 +810,9 @@ pub trait RegisterDspLineInputCtlOperation<T: Traveler828mk2LineInputOperation> 
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_NOMINAL_LEVEL_NAME => {
-                let vals = &elem_value.get_enum()[..T::LINE_INPUT_COUNT];
+                let vals = &elem_value.enumerated()[..T::LINE_INPUT_COUNT];
                 let mut level = Vec::new();
                 vals.iter().try_for_each(|&val| {
                     Self::NOMINAL_LEVELS
@@ -828,7 +828,7 @@ pub trait RegisterDspLineInputCtlOperation<T: Traveler828mk2LineInputOperation> 
                     .map(|_| true)
             }
             INPUT_BOOST_NAME => {
-                let vals = &elem_value.get_bool()[..T::LINE_INPUT_COUNT];
+                let vals = &elem_value.boolean()[..T::LINE_INPUT_COUNT];
                 T::write_line_input_boost(req, &mut unit.1, &vals, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
@@ -899,7 +899,7 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
                 copy_int_to_elem_value(elem_value, &self.state().gain);
                 Ok(true)
@@ -920,15 +920,15 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..T::INPUT_COUNT];
+                let vals = &elem_value.int()[..T::INPUT_COUNT];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
                 T::write_monaural_input_gain(req, &mut unit.1, &gain, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
             INPUT_INVERT_NAME => {
-                let invert = &elem_value.get_bool()[..T::INPUT_COUNT];
+                let invert = &elem_value.boolean()[..T::INPUT_COUNT];
                 T::write_monaural_input_invert(
                     req,
                     &mut unit.1,
@@ -1018,7 +1018,7 @@ pub trait RegisterDspStereoInputCtlOperation<T: RegisterDspStereoInputOperation>
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
                 copy_int_to_elem_value(elem_value, &self.state().gain);
                 Ok(true)
@@ -1055,15 +1055,15 @@ pub trait RegisterDspStereoInputCtlOperation<T: RegisterDspStereoInputOperation>
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..T::INPUT_COUNT];
+                let vals = &elem_value.int()[..T::INPUT_COUNT];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
                 T::write_stereo_input_gain(req, &mut unit.1, &gain, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
             INPUT_INVERT_NAME => {
-                let invert = &elem_value.get_bool()[..T::INPUT_COUNT];
+                let invert = &elem_value.boolean()[..T::INPUT_COUNT];
                 T::write_stereo_input_invert(
                     req,
                     &mut unit.1,
@@ -1074,16 +1074,16 @@ pub trait RegisterDspStereoInputCtlOperation<T: RegisterDspStereoInputOperation>
                 .map(|_| true)
             }
             MIC_PHANTOM_NAME => {
-                let phantom = &elem_value.get_bool()[..T::MIC_COUNT];
+                let phantom = &elem_value.boolean()[..T::MIC_COUNT];
                 T::write_mic_phantom(req, &mut unit.1, &phantom, self.state_mut(), timeout_ms)
                     .map(|_| true)
             }
             MIC_PAD_NAME => {
-                let pad = &elem_value.get_bool()[..T::MIC_COUNT];
+                let pad = &elem_value.boolean()[..T::MIC_COUNT];
                 T::write_mic_pad(req, &mut unit.1, &pad, self.state_mut(), timeout_ms).map(|_| true)
             }
             INPUT_PAIRED_NAME => {
-                let paired = &elem_value.get_bool()[..T::INPUT_PAIR_COUNT];
+                let paired = &elem_value.boolean()[..T::INPUT_PAIR_COUNT];
                 T::write_stereo_input_paired(
                     req,
                     &mut unit.1,
@@ -1183,7 +1183,7 @@ pub trait RegisterDspMeterCtlOperation<T: RegisterDspMeterOperation> {
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_METER_NAME => {
                 copy_int_to_elem_value(elem_value, &self.state().inputs);
                 Ok(true)
@@ -1216,10 +1216,10 @@ pub trait RegisterDspMeterCtlOperation<T: RegisterDspMeterOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_METER_TARGET_NAME => {
                 if T::SELECTABLE {
-                    let target = elem_value.get_enum()[0] as usize;
+                    let target = elem_value.enumerated()[0] as usize;
                     if target < T::OUTPUT_PORT_PAIRS.len() {
                         T::select_output(req, &mut unit.1, target, self.state_mut(), timeout_ms)
                             .map(|_| true)

--- a/libs/motu/runtime/src/register_dsp_runtime.rs
+++ b/libs/motu/runtime/src/register_dsp_runtime.rs
@@ -7,7 +7,7 @@ pub use {
         register_dsp_ctls::*, traveler::*, ultralite::*, v2_ctls::*, v3_ctls::*, *,
     },
     alsa_ctl_tlv_codec::DbInterval,
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*},
     glib::source,
     hinawa::FwReq,
@@ -157,7 +157,7 @@ where
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != TIMER_NAME {
+                    if elem_id.name() != TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
                             &mut self.unit,
                             &elem_id,
@@ -171,7 +171,7 @@ where
                             .card
                             .read_elem_value(&elem_id, &mut elem_value)
                             .map(|_| {
-                                let val = elem_value.get_bool()[0];
+                                let val = elem_value.boolean()[0];
                                 if val {
                                     let _ = self.start_interval_timer();
                                 } else {
@@ -257,7 +257,7 @@ where
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+            let _ = tx.send(Event::BusReset(node.generation()));
         });
 
         self.dispatchers.push(dispatcher);
@@ -276,8 +276,8 @@ where
         });
 
         let tx = self.tx.clone();
-        self.unit.0.connect_property_is_locked_notify(move |unit| {
-            let is_locked = unit.get_property_is_locked();
+        self.unit.0.connect_is_locked_notify(move |unit| {
+            let is_locked = unit.is_locked();
             let _ = tx.send(Event::LockNotify(is_locked));
         });
 

--- a/libs/motu/runtime/src/traveler.rs
+++ b/libs/motu/runtime/src/traveler.rs
@@ -503,7 +503,7 @@ impl MicInputCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_GAIN_NAME => {
                 let vals: Vec<i32> = self.0.gain.iter().map(|&val| val as i32).collect();
                 elem_value.set_int(&vals);
@@ -525,15 +525,15 @@ impl MicInputCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIC_GAIN_NAME => {
-                let vals = &elem_value.get_int()[..TravelerProtocol::MIC_INPUT_COUNT];
+                let vals = &elem_value.int()[..TravelerProtocol::MIC_INPUT_COUNT];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
                 TravelerProtocol::write_mic_gain(req, &mut unit.1, &gain, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             MIC_PAD_NAME => {
-                let pad = &elem_value.get_bool()[..TravelerProtocol::MIC_INPUT_COUNT];
+                let pad = &elem_value.boolean()[..TravelerProtocol::MIC_INPUT_COUNT];
                 TravelerProtocol::write_mic_pad(req, &mut unit.1, &pad, &mut self.0, timeout_ms)
                     .map(|_| true)
             }

--- a/libs/motu/runtime/src/ultralite.rs
+++ b/libs/motu/runtime/src/ultralite.rs
@@ -410,7 +410,7 @@ impl MainAssignCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_ASSIGNMENT_NAME => {
                 elem_value.set_enum(&[self.0 as u32]);
                 Ok(true)
@@ -427,7 +427,7 @@ impl MainAssignCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_ASSIGNMENT_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 UltraliteProtocol::set_main_assign(req, &mut unit.1, val as usize, timeout_ms)
                     .map(|_| self.0 = val as usize)

--- a/libs/motu/runtime/src/v1_ctls.rs
+++ b/libs/motu/runtime/src/v1_ctls.rs
@@ -44,7 +44,7 @@ pub trait V1ClkCtlOperation<T: V1ClkOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
             })
@@ -65,7 +65,7 @@ pub trait V1ClkCtlOperation<T: V1ClkOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 unit.0.lock()?;
                 let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
@@ -106,7 +106,7 @@ pub trait V1MonitorInputCtlOperation<T: V1MonitorInputOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_INPUT_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_monitor_input(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
             })
@@ -123,7 +123,7 @@ pub trait V1MonitorInputCtlOperation<T: V1MonitorInputOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_INPUT_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
                 T::set_monitor_input(req, &mut unit.1, val as usize, timeout_ms)
             })

--- a/libs/motu/runtime/src/v1_runtime.rs
+++ b/libs/motu/runtime/src/v1_runtime.rs
@@ -3,7 +3,7 @@
 
 pub use {
     super::{f828::*, f896::*, v1_ctls::*, *},
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*},
     glib::source,
     motu_protocols::version_1::*,
@@ -146,7 +146,7 @@ where
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+            let _ = tx.send(Event::BusReset(node.generation()));
         });
 
         self.dispatchers.push(dispatcher);

--- a/libs/motu/runtime/src/v2_ctls.rs
+++ b/libs/motu/runtime/src/v2_ctls.rs
@@ -39,7 +39,7 @@ pub trait V2ClkCtlOperation<T: V2ClkOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
             })
@@ -66,7 +66,7 @@ pub trait V2ClkCtlOperation<T: V2ClkOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 unit.0.lock()?;
                 let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
@@ -150,7 +150,7 @@ pub trait V2OptIfaceCtlOperation<T: V2OptIfaceOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_IFACE_MODE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || Ok(self.state().0 as u32))
                     .map(|_| true)
@@ -171,7 +171,7 @@ pub trait V2OptIfaceCtlOperation<T: V2OptIfaceOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IN_IFACE_MODE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 unit.0.lock()?;
                 let res = T::set_opt_in_iface_mode(req, &mut unit.1, val as usize, timeout_ms);

--- a/libs/motu/runtime/src/v3_ctls.rs
+++ b/libs/motu/runtime/src/v3_ctls.rs
@@ -38,7 +38,7 @@ pub trait V3ClkCtlOperation<T: V3ClkOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|val| val as u32)
             })
@@ -64,7 +64,7 @@ pub trait V3ClkCtlOperation<T: V3ClkOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 unit.0.lock()?;
                 let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
@@ -143,7 +143,7 @@ pub trait V3PortAssignCtlOperation<T: V3PortAssignOperation> {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_ASSIGN_NAME => {
                 elem_value.set_enum(&[self.state().0 as u32]);
                 Ok(true)
@@ -164,7 +164,7 @@ pub trait V3PortAssignCtlOperation<T: V3PortAssignOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MAIN_ASSIGN_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                 T::set_main_assign(req, &mut unit.1, val as usize, timeout_ms)
                     .map(|_| self.state_mut().0 = val as usize)
@@ -212,7 +212,7 @@ pub trait V3OptIfaceCtlOperation<T: V3OptIfaceOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IFACE_IN_MODE_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, T::TARGETS.len(), |idx| {
                     T::get_opt_input_iface_mode(req, &mut unit.1, T::TARGETS[idx], timeout_ms)
@@ -240,7 +240,7 @@ pub trait V3OptIfaceCtlOperation<T: V3OptIfaceOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_IFACE_IN_MODE_NAME => {
                 unit.0.lock()?;
                 let res =

--- a/libs/oxfw/protocols/Cargo.toml
+++ b/libs/oxfw/protocols/Cargo.toml
@@ -12,6 +12,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"
 ta1394 = "0.1"

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -505,23 +505,23 @@ impl DuetFwInputProtocol {
                 };
 
                 let mut op = ApogeeCmd::new(VendorCmd::XlrIsConsumerLevel(i, Default::default()));
-                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
-                let is_consumer_level = match &op.cmd {
-                    VendorCmd::XlrIsConsumerLevel(_, enabled) => *enabled,
-                    _ => unreachable!(),
-                };
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)
+                    .map(|_| {
+                        let is_consumer_level = match &op.cmd {
+                            VendorCmd::XlrIsConsumerLevel(_, enabled) => *enabled,
+                            _ => unreachable!(),
+                        };
 
-                *level = if is_mic_level {
-                    DuetFwInputXlrNominalLevel::Microphone
-                } else {
-                    if is_consumer_level {
-                        DuetFwInputXlrNominalLevel::Consumer
-                    } else {
-                        DuetFwInputXlrNominalLevel::Professional
-                    }
-                };
-
-                Ok(())
+                        *level = if is_mic_level {
+                            DuetFwInputXlrNominalLevel::Microphone
+                        } else {
+                            if is_consumer_level {
+                                DuetFwInputXlrNominalLevel::Consumer
+                            } else {
+                                DuetFwInputXlrNominalLevel::Professional
+                            }
+                        };
+                    })
             })?;
 
         params

--- a/libs/oxfw/protocols/src/bin/oxfw-info.rs
+++ b/libs/oxfw/protocols/src/bin/oxfw-info.rs
@@ -4,7 +4,7 @@
 use glib::{FileError, MainContext, MainLoop};
 
 use hinawa::FwReq;
-use hinawa::{FwNode, FwNodeError, FwNodeExt};
+use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
 
 use oxfw_protocols::oxford::*;
 

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -15,6 +15,6 @@ pub mod tascam;
 
 use {
     glib::{Error, FileError},
-    hinawa::{FwFcp, FwNode, FwReq, FwReqExtManual, FwTcode},
+    hinawa::{prelude::FwReqExtManual, FwFcp, FwNode, FwReq, FwTcode},
     ta1394::{audio::*, ccm::*, general::*, *},
 };

--- a/libs/oxfw/runtime/Cargo.toml
+++ b/libs/oxfw/runtime/Cargo.toml
@@ -12,10 +12,10 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
 ieee1212-config-rom = "0.1"
 ta1394 = "0.1"
 oxfw-protocols = "0.1"

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -276,7 +276,7 @@ impl MeterCtl {
     }
 
     fn read_state(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             ANALOG_INPUT_METER_NAME => {
                 elem_value.set_int(&self.0 .0);
                 Ok(true)
@@ -337,7 +337,7 @@ impl KnobCtl {
     }
 
     fn read_state(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             KNOB_TARGET_NAME => {
                 let pos = Self::KNOB_TARGETS
                     .iter()
@@ -462,7 +462,7 @@ impl OutputCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_SRC_NAME => {
                 let mut src = DuetFwOutputSource::default();
                 DuetFwOutputProtocol::read_src(avc, &mut src, timeout_ms)?;
@@ -503,7 +503,7 @@ impl OutputCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_MUTE_NAME => {
                 elem_value.set_bool(&[self.0]);
                 Ok(true)
@@ -523,7 +523,7 @@ impl OutputCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OUTPUT_MUTE_NAME => ElemValueAccessor::<bool>::get_val(elem_value, |val| {
                 DuetFwOutputProtocol::write_mute(avc, val, timeout_ms)
             })
@@ -658,7 +658,7 @@ impl InputCtl {
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_POLARITY_NAME => {
                 elem_value.set_bool(&self.0.polarities);
                 Ok(true)
@@ -698,7 +698,7 @@ impl InputCtl {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
                 let vals: Vec<i32> = self.0.gains.iter().map(|&val| val as i32).collect();
                 elem_value.set_int(&vals);
@@ -716,7 +716,7 @@ impl InputCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => ElemValueAccessor::<i32>::get_vals(new, old, 2, |idx, val| {
                 DuetFwInputProtocol::write_gain(avc, idx, val as u8, &mut self.0, timeout_ms)
             })
@@ -757,7 +757,7 @@ impl InputCtl {
             })
             .map(|_| true),
             INPUT_CLICKLESS_NAME => {
-                let val = new.get_bool()[0];
+                let val = new.boolean()[0];
                 DuetFwInputProtocol::write_clickless(avc, val, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
@@ -803,9 +803,9 @@ impl MixerCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::set_vals(elem_value, Self::SRC_LABELS.len(), |src| {
                     let mut gain = 0;
                     DuetFwMixerProtocol::read_source_gain(avc, dst, src, &mut gain, timeout_ms)
@@ -825,9 +825,9 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
-                let dst = elem_id.get_index() as usize;
+                let dst = elem_id.index() as usize;
                 ElemValueAccessor::<i32>::get_vals(new, old, Self::SRC_LABELS.len(), |src, gain| {
                     DuetFwMixerProtocol::write_source_gain(avc, dst, src, gain as u16, timeout_ms)
                 })
@@ -909,7 +909,7 @@ impl DisplayCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DISPLAY_TARGET_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
                 let mut target = DuetFwDisplayTarget::default();
                 DuetFwDisplayProtocol::read_target(avc, &mut target, timeout_ms)
@@ -939,9 +939,9 @@ impl DisplayCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             DISPLAY_TARGET_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &target = Self::TARGETS.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index for display targets: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -949,7 +949,7 @@ impl DisplayCtl {
                 DuetFwDisplayProtocol::write_target(avc, target, timeout_ms).map(|_| true)
             }
             DISPLAY_MODE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::MODES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index for display modes: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -957,7 +957,7 @@ impl DisplayCtl {
                 DuetFwDisplayProtocol::write_mode(avc, mode, timeout_ms).map(|_| true)
             }
             DISPLAY_OVERHOLDS_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &mode = Self::OVERHOLDS.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid index for display overholds: {}", val);
                     Error::new(FileError::Inval, &msg)

--- a/libs/oxfw/runtime/src/common_ctl.rs
+++ b/libs/oxfw/runtime/src/common_ctl.rs
@@ -108,7 +108,7 @@ impl<'a> CommonCtl {
     where
         O: Ta1394Avc,
     {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::CLK_RATE_NAME => {
                 ElemValueAccessor::<u32>::set_val(elem_value, || {
                     let idx = self.read_freq(avc, timeout_ms)?;
@@ -228,7 +228,7 @@ impl<'a> CommonCtl {
     where
         O: Ta1394Avc,
     {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             Self::CLK_RATE_NAME => {
                 ElemValueAccessor::<u32>::get_val(elem_value, |val| {
                     unit.0.lock()?;

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -29,10 +29,10 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 
         // NOTE: I have a plan to remove control functionality from ALSA oxfw driver for future.
-        let elem_id_list = card_cntr.card.get_elem_id_list()?;
+        let elem_id_list = card_cntr.card.elem_id_list()?;
         self.voluntary = elem_id_list
             .iter()
-            .find(|elem_id| elem_id.get_name().as_str() == VOL_NAME)
+            .find(|elem_id| elem_id.name().as_str() == VOL_NAME)
             .is_none();
         if self.voluntary {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, VOL_NAME, 0);
@@ -66,7 +66,7 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         {
             Ok(true)
         } else if self.voluntary {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 VOL_NAME => {
                     ElemValueAccessor::<i32>::set_vals(elem_value, 6, |idx| {
                         let mut vol = 0;
@@ -103,7 +103,7 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         {
             Ok(true)
         } else if self.voluntary {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 VOL_NAME => {
                     ElemValueAccessor::<i32>::get_vals(new, old, 6, |idx, val| {
                         FirewaveProtocol::write_volume(

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -29,10 +29,10 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 
         // NOTE: I have a plan to remove control functionality from ALSA oxfw driver for future.
-        let elem_id_list = card_cntr.card.get_elem_id_list()?;
+        let elem_id_list = card_cntr.card.elem_id_list()?;
         self.voluntary = elem_id_list
             .iter()
-            .find(|elem_id| elem_id.get_name().as_str() == VOL_NAME)
+            .find(|elem_id| elem_id.name().as_str() == VOL_NAME)
             .is_none();
         if self.voluntary {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, VOL_NAME, 0);
@@ -66,7 +66,7 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         {
             Ok(true)
         } else if self.voluntary {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 VOL_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
                     let mut vol = 0;
                     FwSpeakersProtocol::read_volume(&mut self.avc, &mut vol, FCP_TIMEOUT_MS)
@@ -99,7 +99,7 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         {
             Ok(true)
         } else if self.voluntary {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 VOL_NAME => ElemValueAccessor::<i32>::get_val(new, |val| {
                     FwSpeakersProtocol::write_volume(&mut self.avc, val as i16, FCP_TIMEOUT_MS)
                 })

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -12,11 +12,11 @@ mod common_ctl;
 
 use {
     self::model::*,
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
-    hinawa::{FwFcp, FwFcpExt, FwNode, FwNodeExt, FwNodeExtManual, FwReq},
-    hitaki::*,
+    hinawa::{prelude::{FwFcpExt, FwNodeExt, FwNodeExtManual}, FwFcp, FwNode, FwReq},
+    hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     nix::sys::signal,
     std::{convert::TryFrom, sync::mpsc},
@@ -63,16 +63,16 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
         let unit = SndUnit::new();
         unit.open(&cdev, 0)?;
 
-        if unit.get_property_unit_type() != AlsaFirewireType::Oxfw {
+        if unit.unit_type() != AlsaFirewireType::Oxfw {
             let label = "ALSA oxfw driver is not bound to the unit.";
             return Err(Error::new(FileError::Inval, label));
         }
 
-        let cdev = format!("/dev/{}", unit.get_property_node_device().unwrap());
+        let cdev = format!("/dev/{}", unit.node_device().unwrap());
         let node = FwNode::new();
         node.open(&cdev)?;
 
-        let raw = node.get_config_rom()?;
+        let raw = node.config_rom()?;
         let config_rom = ConfigRom::try_from(raw).map_err(|e| {
             let label = format!("Malformed configuration ROM detected: {}", e);
             Error::new(FileError::Nxio, &label)
@@ -133,7 +133,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 Event::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != Self::TIMER_NAME {
+                    if elem_id.name() != Self::TIMER_NAME {
                         let _ = self.model.dispatch_elem_event(
                             &mut self.unit,
                             &mut self.card_cntr,
@@ -148,7 +148,7 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
                             .read_elem_value(&elem_id, &mut elem_value)
                             .is_ok()
                         {
-                            let val = elem_value.get_bool()[0];
+                            let val = elem_value.boolean()[0];
                             if val {
                                 let _ = self.start_interval_timer();
                             } else {
@@ -199,12 +199,12 @@ impl<'a> OxfwRuntime {
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let _ = tx.send(Event::BusReset(node.get_property_generation()));
+            let _ = tx.send(Event::BusReset(node.generation()));
         });
 
         let tx = self.tx.clone();
-        self.unit.0.connect_property_is_locked_notify(move |unit| {
-            let locked = unit.get_property_is_locked();
+        self.unit.0.connect_is_locked_notify(move |unit| {
+            let locked = unit.is_locked();
             let t = tx.clone();
             let _ = std::thread::spawn(move || {
                 // The notification of stream lock is not strictly corresponding to actual

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -120,7 +120,7 @@ impl SpecificCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CAPTURE_SOURCE_NAME => {
                 let mut src = LinkFwInputSource::default();
                 LinkFwProtocol::read_input_source(avc, &mut src, timeout_ms)?;
@@ -139,9 +139,9 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CAPTURE_SOURCE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = Self::SRCS.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for index of signal source: {}", val);
                     Error::new(FileError::Inval, &msg)

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -114,7 +114,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         {
             return Ok(true);
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 DISPLAY_MODE_NAME => {
                     let mut mode = FireoneDisplayMode::default();
                     FireoneProtocol::read_display_mode(&mut self.avc, &mut mode, FCP_TIMEOUT_MS)?;
@@ -174,9 +174,9 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         {
             return Ok(true);
         } else {
-            match elem_id.get_name().as_str() {
+            match elem_id.name().as_str() {
                 DISPLAY_MODE_NAME => {
-                    let val = new.get_enum()[0];
+                    let val = new.enumerated()[0];
                     let &mode = Self::DISPLAY_MODES
                         .iter()
                         .nth(val as usize)
@@ -188,7 +188,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
                         .map(|_| true)
                 }
                 MESSAGE_MODE_NAME => {
-                    let val = new.get_enum()[0];
+                    let val = new.enumerated()[0];
                     let &mode = Self::MESSAGE_MODES
                         .iter()
                         .nth(val as usize)
@@ -200,7 +200,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
                         .map(|_| true)
                 }
                 INPUT_MODE_NAME => {
-                    let val = new.get_enum()[0];
+                    let val = new.enumerated()[0];
                     let &mode = Self::INPUT_MODES.iter().nth(val as usize).ok_or_else(|| {
                         let msg = format!("Invalid index for input modes: {}", val);
                         Error::new(FileError::Inval, &msg)

--- a/libs/ta1394/Cargo.toml
+++ b/libs/ta1394/Cargo.toml
@@ -12,6 +12,6 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
+glib = "0.15"
+hinawa = "0.7"
 ieee1212-config-rom = "0.1"

--- a/libs/ta1394/src/lib.rs
+++ b/libs/ta1394/src/lib.rs
@@ -9,7 +9,7 @@ pub mod stream_format;
 
 use glib::{Error, error::ErrorDomain, Quark};
 
-use hinawa::{FwFcp, FwFcpExtManual};
+use hinawa::{prelude::FwFcpExtManual, FwFcp};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AvcSubunitType {
@@ -290,7 +290,7 @@ pub enum Ta1394AvcError {
 
 impl ErrorDomain for Ta1394AvcError {
     fn domain() -> Quark {
-        Quark::from_string("ta1394-avc-error-quark")
+        Quark::from_str("ta1394-avc-error-quark")
     }
 
     fn code(self) -> i32 {

--- a/libs/tascam/protocols/Cargo.toml
+++ b/libs/tascam/protocols/Cargo.toml
@@ -12,9 +12,9 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
+++ b/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
@@ -3,7 +3,7 @@
 
 use glib::{FileError, MainContext, MainLoop};
 
-use hinawa::{FwNode, FwNodeError, FwNodeExt, FwNodeExtManual};
+use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
 
 use ieee1212_config_rom::*;
 
@@ -56,7 +56,7 @@ fn main() {
         let th = thread::spawn(move || d.run());
 
         let result = {
-            let data = node.get_config_rom().map_err(|e| e.to_string())?;
+            let data = node.config_rom().map_err(|e| e.to_string())?;
             let config_rom = ConfigRom::try_from(data).map_err(|e| e.to_string())?;
 
             config_rom

--- a/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
+++ b/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
@@ -3,7 +3,7 @@
 
 use glib::{FileError, MainContext, MainLoop};
 
-use hinawa::{FwNode, FwNodeError, FwNodeExt, FwReq};
+use hinawa::{prelude::FwNodeExt, FwReq, FwNode, FwNodeError};
 
 use tascam_protocols::*;
 

--- a/libs/tascam/protocols/src/lib.rs
+++ b/libs/tascam/protocols/src/lib.rs
@@ -68,7 +68,7 @@ pub mod config_rom;
 
 use {
     glib::{Error, FileError},
-    hinawa::*,
+    hinawa::{prelude::*, *},
 };
 
 const BASE_OFFSET: u64 = 0xffff00000000;

--- a/libs/tascam/runtime/Cargo.toml
+++ b/libs/tascam/runtime/Cargo.toml
@@ -12,11 +12,11 @@ publish = false
 
 [dependencies]
 nix = "0.17"
-glib = "0.10"
-hinawa = "0.5"
-hitaki = "0.1"
-alsactl = "0.3"
-alsaseq = "0.3"
+glib = "0.15"
+hinawa = "0.7"
+hitaki = "0.2"
+alsactl = "0.4"
+alsaseq = "0.4"
 ieee1212-config-rom = "0.1"
 alsa-ctl-tlv-codec = "0.1"
 tascam-protocols = "0.1"

--- a/libs/tascam/runtime/src/asynch_runtime.rs
+++ b/libs/tascam/runtime/src/asynch_runtime.rs
@@ -148,7 +148,7 @@ where
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let generation = node.get_property_generation();
+            let generation = node.generation();
             let _ = tx.send(AsyncUnitEvent::BusReset(generation));
         });
 

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{isoch_ctls::*, *},
-    alsactl::*,
+    alsactl::{prelude::*, *},
     tascam_protocols::isoch::{fw1884::*, *},
 };
 
@@ -352,7 +352,7 @@ impl SpecificCtl {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_ROTARY_ASSIGN_NAME => {
                 let target = Fw1884Protocol::get_monitor_knob_target(req, &mut unit.1, timeout_ms)?;
                 let pos = Self::MONITOR_ROTARY_ASSIGNS
@@ -374,9 +374,9 @@ impl SpecificCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_ROTARY_ASSIGN_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &target = Self::MONITOR_ROTARY_ASSIGNS
                     .iter()
                     .nth(val as usize)

--- a/libs/tascam/runtime/src/isoch_console_runtime.rs
+++ b/libs/tascam/runtime/src/isoch_console_runtime.rs
@@ -3,8 +3,8 @@
 
 use {
     super::{fw1082_model::*, fw1884_model::*, seq_cntr::*, *},
-    alsactl::*,
-    alsaseq::*,
+    alsactl::{prelude::*, *},
+    alsaseq::{prelude::*, *},
     core::dispatcher::*,
     nix::sys::signal,
     std::{marker::PhantomData, sync::mpsc, time::Duration},
@@ -127,7 +127,7 @@ where
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 ConsoleUnitEvent::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != TIMER_NAME {
+                    if elem_id.name() != TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
                             &mut self.unit,
                             &elem_id,
@@ -142,7 +142,7 @@ where
                             .read_elem_value(&elem_id, &mut elem_value)
                             .is_ok()
                         {
-                            let val = elem_value.get_bool()[0];
+                            let val = elem_value.boolean()[0];
                             if val {
                                 let _ = self.start_interval_timer();
                             } else {
@@ -202,7 +202,7 @@ where
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let generation = node.get_property_generation();
+            let generation = node.generation();
             let _ = tx.send(ConsoleUnitEvent::BusReset(generation));
         });
 

--- a/libs/tascam/runtime/src/isoch_ctls.rs
+++ b/libs/tascam/runtime/src/isoch_ctls.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {
-    super::*, alsa_ctl_tlv_codec::DbInterval, alsactl::*, core::elem_value_accessor::*,
+    super::*, alsa_ctl_tlv_codec::DbInterval, alsactl::{prelude::*, *}, core::elem_value_accessor::*,
     tascam_protocols::isoch::*,
 };
 
@@ -201,7 +201,7 @@ pub trait IsochMeterCtlOperation<T: IsochMeterOperation> {
     }
 
     fn read_state(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MONITOR_ROTARY_NAME => {
                 elem_value.set_int(&[self.meter().monitor as i32]);
                 Ok(true)
@@ -374,7 +374,7 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => {
                 let src = T::get_sampling_clock_source(req, node, timeout_ms)?;
                 let pos = T::SAMPLING_CLOCK_SOURCES
@@ -423,9 +423,9 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             CLK_SRC_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = T::SAMPLING_CLOCK_SOURCES
                     .iter()
                     .nth(val as usize)
@@ -439,7 +439,7 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
                 res.map(|_| true)
             }
             CLK_RATE_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &rate = Self::CLOCK_RATES.iter().nth(val as usize).ok_or_else(|| {
                     let msg = format!("Invalid value for index of clock rates: {}", val);
                     Error::new(FileError::Inval, &msg)
@@ -450,7 +450,7 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
                 res.map(|_| true)
             }
             SIGNAL_DETECTION_THRESHOLD_NAME => {
-                let val = elem_value.get_int()[0];
+                let val = elem_value.int()[0];
                 T::set_analog_input_threshold_for_signal_detection(
                     req,
                     &mut unit.1,
@@ -460,7 +460,7 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
                 .map(|_| true)
             }
             OVER_LEVEL_DETECTION_THRESHOLD_NAME => {
-                let val = elem_value.get_int()[0];
+                let val = elem_value.int()[0];
                 T::set_analog_input_threshold_for_over_level_detection(
                     req,
                     &mut unit.1,
@@ -470,7 +470,7 @@ pub trait IsochCommonCtlOperation<T: IsochCommonOperation> {
                 .map(|_| true)
             }
             COAX_OUT_SRC_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = Self::COAXIAL_OUTPUT_SOURCES
                     .iter()
                     .nth(val as usize)
@@ -536,7 +536,7 @@ pub trait IsochOpticalCtlOperation<T: IsochOpticalOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_OUT_SRC_NAME => {
                 let src = T::get_opt_output_source(req, node, timeout_ms)?;
                 let pos = Self::OPTICAL_OUTPUT_SOURCES
@@ -567,9 +567,9 @@ pub trait IsochOpticalCtlOperation<T: IsochOpticalOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             OPT_OUT_SRC_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = Self::OPTICAL_OUTPUT_SOURCES
                     .iter()
                     .nth(val as usize)
@@ -580,7 +580,7 @@ pub trait IsochOpticalCtlOperation<T: IsochOpticalOperation> {
                 T::set_opt_output_source(req, node, src, timeout_ms).map(|_| true)
             }
             SPDIF_IN_SRC_NAME => {
-                let val = elem_value.get_enum()[0];
+                let val = elem_value.enumerated()[0];
                 let &src = Self::SPDIF_INPUT_SOURCES
                     .iter()
                     .nth(val as usize)
@@ -627,7 +627,7 @@ pub trait IsochConsoleCtlOperation<T: IsochConsoleOperation> {
     }
 
     fn read_states(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             HOST_MODE_NAME => {
                 elem_value.set_bool(&[self.state().host_mode]);
                 Ok(true)
@@ -644,7 +644,7 @@ pub trait IsochConsoleCtlOperation<T: IsochConsoleOperation> {
         elem_value: &mut ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_FADER_ASSIGN_NAME => {
                 let enabled = T::get_master_fader_assign(req, node, timeout_ms)?;
                 elem_value.set_bool(&[enabled]);
@@ -662,9 +662,9 @@ pub trait IsochConsoleCtlOperation<T: IsochConsoleOperation> {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             MASTER_FADER_ASSIGN_NAME => {
-                let val = elem_value.get_bool()[0];
+                let val = elem_value.boolean()[0];
                 T::set_master_fader_assign(req, node, val, timeout_ms).map(|_| true)
             }
             _ => Ok(false),
@@ -726,7 +726,7 @@ pub trait IsochRackCtlOperation<T: IsochRackOperation> {
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
                 ElemValueAccessor::<i32>::set_vals(elem_value, Self::INPUT_LABELS.len(), |idx| {
                     Ok(T::get_input_gain(self.state(), idx) as i32)
@@ -758,7 +758,7 @@ pub trait IsochRackCtlOperation<T: IsochRackOperation> {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        match elem_id.get_name().as_str() {
+        match elem_id.name().as_str() {
             INPUT_GAIN_NAME => ElemValueAccessor::<i32>::get_vals(
                 new,
                 old,

--- a/libs/tascam/runtime/src/isoch_rack_runtime.rs
+++ b/libs/tascam/runtime/src/isoch_rack_runtime.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2021 Takashi Sakamoto
 use {
     super::{fw1804_model::*, *},
-    alsactl::*,
+    alsactl::{prelude::*, *},
     core::dispatcher::*,
     nix::sys::signal,
     std::{sync::mpsc, time::Duration},
@@ -104,7 +104,7 @@ impl<T: CtlModel<(SndTascam, FwNode)> + MeasureModel<(SndTascam, FwNode)> + Defa
                     println!("IEEE 1394 bus is updated: {}", generation);
                 }
                 RackUnitEvent::Elem((elem_id, events)) => {
-                    if elem_id.get_name() != TIMER_NAME {
+                    if elem_id.name() != TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
                             &mut self.unit,
                             &elem_id,
@@ -119,7 +119,7 @@ impl<T: CtlModel<(SndTascam, FwNode)> + MeasureModel<(SndTascam, FwNode)> + Defa
                             .read_elem_value(&elem_id, &mut elem_value)
                             .is_ok()
                         {
-                            let val = elem_value.get_bool()[0];
+                            let val = elem_value.boolean()[0];
                             if val {
                                 let _ = self.start_interval_timer();
                             } else {
@@ -157,7 +157,7 @@ impl<T: CtlModel<(SndTascam, FwNode)> + MeasureModel<(SndTascam, FwNode)> + Defa
 
         let tx = self.tx.clone();
         self.unit.1.connect_bus_update(move |node| {
-            let generation = node.get_property_generation();
+            let generation = node.generation();
             let _ = tx.send(RackUnitEvent::BusReset(generation));
         });
 

--- a/libs/tascam/runtime/src/seq_cntr.rs
+++ b/libs/tascam/runtime/src/seq_cntr.rs
@@ -23,7 +23,7 @@ impl SeqCntr {
         client.open(0)?;
 
         let info = ClientInfo::new();
-        info.set_property_name(Some(name));
+        info.set_name(Some(name));
         client.set_info(&info)?;
 
         let mut event = Event::new(EventType::Controller);
@@ -39,16 +39,16 @@ impl SeqCntr {
     pub fn open_port(&mut self) -> Result<(), Error> {
         let mut info = PortInfo::new();
         let attr_flags = PortAttrFlag::MIDI_GENERIC | PortAttrFlag::HARDWARE;
-        info.set_property_attrs(attr_flags);
+        info.set_attrs(attr_flags);
         let cap_flags = PortCapFlag::READ
             | PortCapFlag::SUBS_READ
             | PortCapFlag::WRITE
             | PortCapFlag::SUBS_WRITE;
-        info.set_property_caps(cap_flags);
-        info.set_property_name(Some(&Self::SEQ_PORT_NAME));
+        info.set_caps(cap_flags);
+        info.set_name(Some(&Self::SEQ_PORT_NAME));
         self.client.create_port(&mut info)?;
-        self.port_id = match info.get_property_addr() {
-            Some(addr) => addr.get_port_id(),
+        self.port_id = match info.addr() {
+            Some(addr) => addr.port_id(),
             None => {
                 let label = "Fail to get address for added port.";
                 return Err(Error::new(FileError::Io, &label));
@@ -59,7 +59,7 @@ impl SeqCntr {
     }
 
     pub fn schedule_event(&mut self, param: u32, val: i32) -> Result<(), Error> {
-        let mut data = self.event.get_ctl_data()?;
+        let mut data = self.event.ctl_data()?;
         data.set_channel(0);
         data.set_param(param);
         data.set_value(val);


### PR DESCRIPTION
The gtk-rs project releases several minor versions of glib crate. The
latest version is 0.15, while current implementation depends on 0.10
since hinawa/hitaki/alsactl/alsaseq crates depend on it.

Now new versions of these four crates are released in crates.io,
depending on glib crate v0.15. Let us migrate to them.

Signed-off-by: Takashi Sakamoto <o-takashi@sakamocchi.jp>