### PR TITLE
ieee1212-config-rom: code refactoring for publishing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,7 +35,7 @@ snd-fireface-ctl-service
 License
 =======
 
- * The `alsa-ctl-tlv-codec` crate is released under MIT license.
+ * The `alsa-ctl-tlv-codec` and `ieee1212-config-rom` crates are released under MIT license.
  * The other crates are released under GNU General Public License Version 3.
 
 Dependencies

--- a/libs/ieee1212-config-rom/Cargo.toml
+++ b/libs/ieee1212-config-rom/Cargo.toml
@@ -4,9 +4,12 @@ name = "ieee1212-config-rom"
 version = "0.1.0"
 # For publishing.
 authors = ["Takashi Sakamoto"]
+categories = ["data-structures", "parser-implementations"]
 description = """
-Utilities for Configration ROM specification in IEEE 1222
+Decoder for content of Configuration ROM defined in IEEE 1212.
 """
+documentation = "https://docs.rs/ieee1212-config-rom/"
+keywords = ["ieee1212", "configuration rom"]
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
 license = "MIT"
 readme = "README.md"

--- a/libs/ieee1212-config-rom/Cargo.toml
+++ b/libs/ieee1212-config-rom/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Utilities for Configration ROM specification in IEEE 1222
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "MIT"
 readme = "README.md"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 

--- a/libs/ieee1212-config-rom/README.md
+++ b/libs/ieee1212-config-rom/README.md
@@ -21,6 +21,15 @@ each entry by key.
 
 ## Usage
 
+Add the following line to your Cargo.toml file:
+
+```toml
+[dependencies]
+ieee1212-config-rom = "0.1.0"
+```
+
+[`ConfigRom`] structure is a good start to use the crate.
+
 ```rust
 use ieee1212_config_rom::*;
 use std::convert::TryFrom;
@@ -66,7 +75,7 @@ assert_eq!("Juju", model_name);
 
 Some programs are available under `src/bin` directory.
 
-### src/bin/config-rom-parser
+### config-rom-parser.rs
 
 This program parses raw data of Configuration ROM from stdin, or image file as arguments of
 command line.
@@ -98,3 +107,11 @@ $ cat /sys/bus/firewire/devices/fw0/config_rom  | cargo run --bin config-rom-par
 ```
 
 In both cases, the content to be parsed should be aligned to big-endian order.
+
+## License
+
+The hinawa crate is released under [MIT license](https://spdx.org/licenses/MIT.html).
+
+## Support
+
+If finding issue, please file it to <https://github.com/alsa-project/snd-firewire-ctl-services/>.

--- a/libs/ieee1212-config-rom/src/entry.rs
+++ b/libs/ieee1212-config-rom/src/entry.rs
@@ -3,19 +3,19 @@
 
 //! For directory entries, the module includes structure, enumeration and trait implementation.
 //!
-//! Entry structure represents directory entry. KeyType enumerations represents key of entry.
-//! EntryData enumeration represents type of directory entry, including its content.
+//! Entry structure expresss directory entry. KeyType enumerations expresss key of entry.
+//! EntryData enumeration expresss type of directory entry, including its content.
 
 use super::*;
 
-/// The structure to represent directory entry.
+/// The structure to express directory entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Entry<'a> {
     pub key: KeyType,
     pub data: EntryData<'a>,
 }
 
-/// The enumeration to represent key of directory entry.
+/// The enumeration to express key of directory entry.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum KeyType {
     Descriptor,
@@ -65,7 +65,7 @@ impl From<u8> for KeyType {
     }
 }
 
-/// The enumeration to represent type of directory entry and its content.
+/// The enumeration to express type of directory entry and its content.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum EntryData<'a> {
     Immediate(u32),

--- a/libs/ieee1212-config-rom/src/leaf.rs
+++ b/libs/ieee1212-config-rom/src/leaf.rs
@@ -5,18 +5,18 @@
 //! implementation to parse it. The structure implements TryFrom trait to convert from the
 //! content of leaf entry.
 //!
-//! Descriptor structure represents descriptor itself. DescriptorData enumeration represents data
-//! of descriptor. At present, Textual descriptor is supported. TextualDescriptorData represents
+//! Descriptor structure expresss descriptor itself. DescriptorData enumeration expresss data
+//! of descriptor. At present, Textual descriptor is supported. TextualDescriptorData expresss
 //! the data of Texual descriptor.
 //!
-//! EUI-64 structure represents 64-bit EUI.
+//! EUI-64 structure expresss 64-bit EUI.
 //!
-//! Unit_Location structure represents a pair of base address and upper bound for data of specific
+//! Unit_Location structure expresss a pair of base address and upper bound for data of specific
 //! unit.
 
 use super::*;
 
-/// The structure to represent error cause.
+/// The structure to express error cause to parse leaf entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeafParseError<T>
 where
@@ -44,7 +44,7 @@ where
     }
 }
 
-/// The structure represents data of textual descriptor.
+/// The structure expresss data of textual descriptor.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TextualDescriptorData<'a> {
     pub width: u8,
@@ -80,7 +80,7 @@ impl<'a> TryFrom<&'a [u8]> for TextualDescriptorData<'a> {
     }
 }
 
-/// The enumeration represents data of descriptor according to its type.
+/// The enumeration expresss data of descriptor according to its type.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DescriptorData<'a> {
     Textual(TextualDescriptorData<'a>),
@@ -117,7 +117,7 @@ fn entry_data_to_str(data: &EntryData) -> &'static str {
     }
 }
 
-/// The structure represents descriptor in content of leaf.
+/// The structure expresss descriptor in content of leaf entry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DescriptorLeaf<'a> {
     pub spec_id: u32,
@@ -151,6 +151,7 @@ impl<'a> TryFrom<&'a Entry<'a>> for DescriptorLeaf<'a> {
     }
 }
 
+/// The context to parse leaf entry for descriptor data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DescriptorLeafParseCtx {
     InvalidTextString,
@@ -169,7 +170,7 @@ impl std::fmt::Display for DescriptorLeafParseCtx {
     }
 }
 
-/// The structure to represent data of EUI-64 leaf.
+/// The structure to express data of EUI-64 leaf.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Eui64Leaf(pub u64);
 
@@ -206,6 +207,7 @@ impl<'a> TryFrom<&Entry<'a>> for Eui64Leaf {
     }
 }
 
+/// The context to parse leaf entry with EUI64 data.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Eui64LeafParseCtx {
     TooShort,
@@ -222,7 +224,7 @@ impl std::fmt::Display for Eui64LeafParseCtx {
     }
 }
 
-/// The structure to represent data of unit location leaf.
+/// The structure to express data of unit location leaf.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct UnitLocationLeaf {
     pub base_addr: u64,

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -10,7 +10,7 @@ pub use {entry::*, leaf::*};
 
 use std::convert::TryFrom;
 
-/// The structure to represent content of configuration ROM in IEEE 1212.
+/// The structure to express content of configuration ROM in IEEE 1212.
 ///
 /// The structure implements std::convert::TryFrom<&[u8]> to parse raw data of configuration ROM.
 /// The structure refers to content of the raw data, thus has the same lifetime of the raw data.
@@ -22,7 +22,7 @@ pub struct ConfigRom<'a> {
     pub root: Vec<Entry<'a>>,
 }
 
-/// The structure to represent error cause to parse raw data of configuration ROM.
+/// The structure to express error cause to parse raw data of configuration ROM.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConfigRomParseError {
     pub ctx: Vec<ConfigRomParseCtx>,
@@ -56,7 +56,7 @@ impl std::fmt::Display for ConfigRomParseError {
     }
 }
 
-/// The enumeration to represent context of parsing.
+/// The context to parse configuration ROM.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConfigRomParseCtx {
     BusInfo,


### PR DESCRIPTION
This patchset is code refactoring for publishing ieee1212-config-rom crate.

Due to convention of Rust ecosystem, license is changed to MIT.

```
Takashi Sakamoto (4):
  ieee1212-config-rom: code refactoring to handle Result enumeration
  ieee1212-config-rom: change license to MIT
  ieee1212-config-rom: improve documentation
  ieee1212-config-rom: fulfill package section for publishing

 README.rst                            |   2 +-
 libs/ieee1212-config-rom/Cargo.toml   |   7 +-
 libs/ieee1212-config-rom/README.md    |  19 +++-
 libs/ieee1212-config-rom/src/entry.rs |  10 +-
 libs/ieee1212-config-rom/src/leaf.rs  | 115 ++++++++-----------
 libs/ieee1212-config-rom/src/lib.rs   | 155 ++++++++++++++------------
 6 files changed, 155 insertions(+), 153 deletions(-)
```