### PR TITLE
[PATCH 0/10] ieee1212-config-rom: enhancement for error reporting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2022/07/14
+2022/07/24
 Takashi Sakamoto
 
 Introduction
@@ -35,8 +35,8 @@ snd-fireface-ctl-service
 License
 =======
 
- * The `alsa-ctl-tlv-codec` and `ieee1212-config-rom` crates are released under MIT license.
- * The other crates are released under GNU General Public License Version 3.
+* The `alsa-ctl-tlv-codec` and `ieee1212-config-rom` crates are released under MIT license.
+* The other crates are released under GNU General Public License Version 3.
 
 Dependencies
 ============

--- a/libs/alsa-ctl-tlv-codec/README.md
+++ b/libs/alsa-ctl-tlv-codec/README.md
@@ -255,7 +255,7 @@ The calculation has no validated numerics.
 
 ## License
 
-The hinawa crate is released under [MIT license](https://spdx.org/licenses/MIT.html).
+The alsa-ctl-tlv-codec crate is released under [MIT license](https://spdx.org/licenses/MIT.html).
 
 ## Support
 

--- a/libs/ieee1212-config-rom/src/leaf.rs
+++ b/libs/ieee1212-config-rom/src/leaf.rs
@@ -44,6 +44,14 @@ where
     }
 }
 
+fn detect_leaf_from_entry<'a>(entry: &'a Entry<'a>) -> Option<&'a [u8]> {
+    if let EntryData::Leaf(leaf) = entry.data {
+        Some(leaf)
+    } else {
+        None
+    }
+}
+
 /// The structure expresss data of textual descriptor.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TextualDescriptorData<'a> {
@@ -140,14 +148,14 @@ impl<'a> TryFrom<&'a Entry<'a>> for DescriptorLeaf<'a> {
     type Error = LeafParseError<DescriptorLeafParseCtx>;
 
     fn try_from(entry: &'a Entry<'a>) -> Result<Self, Self::Error> {
-        if let EntryData::Leaf(leaf) = &entry.data {
-            Self::try_from(&leaf[..])
-        } else {
-            Err(Self::Error::new(
-                DescriptorLeafParseCtx::WrongDirectoryEntry,
-                format!("{} entry", entry_data_to_str(&entry.data)),
-            ))
-        }
+        detect_leaf_from_entry(entry)
+            .ok_or_else(|| {
+                Self::Error::new(
+                    DescriptorLeafParseCtx::WrongDirectoryEntry,
+                    format!("{} entry", entry_data_to_str(&entry.data)),
+                )
+            })
+            .and_then(|leaf| Self::try_from(leaf))
     }
 }
 
@@ -196,14 +204,14 @@ impl<'a> TryFrom<&Entry<'a>> for Eui64Leaf {
     type Error = LeafParseError<Eui64LeafParseCtx>;
 
     fn try_from(entry: &Entry<'a>) -> Result<Self, Self::Error> {
-        if let EntryData::Leaf(leaf) = &entry.data {
-            Eui64Leaf::try_from(&leaf[..])
-        } else {
-            Err(Self::Error::new(
-                Eui64LeafParseCtx::WrongDirectoryEntry,
-                format!("{} entry is not available", entry_data_to_str(&entry.data)),
-            ))
-        }
+        detect_leaf_from_entry(entry)
+            .ok_or_else(|| {
+                Self::Error::new(
+                    Eui64LeafParseCtx::WrongDirectoryEntry,
+                    format!("{} entry is not available", entry_data_to_str(&entry.data)),
+                )
+            })
+            .and_then(|leaf| Eui64Leaf::try_from(leaf))
     }
 }
 
@@ -265,14 +273,14 @@ impl<'a> TryFrom<&Entry<'a>> for UnitLocationLeaf {
     type Error = LeafParseError<UnitLocationParseCtx>;
 
     fn try_from(entry: &Entry<'a>) -> Result<Self, Self::Error> {
-        if let EntryData::Leaf(leaf) = &entry.data {
-            UnitLocationLeaf::try_from(&leaf[..])
-        } else {
-            Err(Self::Error::new(
-                UnitLocationParseCtx::WrongDirectoryEntry,
-                format!("{} entry is not available", entry_data_to_str(&entry.data)),
-            ))
-        }
+        detect_leaf_from_entry(entry)
+            .ok_or_else(|| {
+                Self::Error::new(
+                    UnitLocationParseCtx::WrongDirectoryEntry,
+                    format!("{} entry is not available", entry_data_to_str(&entry.data)),
+                )
+            })
+            .and_then(|leaf| UnitLocationLeaf::try_from(leaf))
     }
 }
 

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -190,10 +190,8 @@ fn get_directory_entry_list<'a>(
                     }
                 }
             }
-            _ => {
-                let msg = format!("Invalid type: {}", entry_type);
-                Err(ConfigRomParseError::new(ctx, msg))
-            }
+            // NOTE: The field of key has two bits, thus it can not be over 0x03.
+            _ => unreachable!(),
         }
         .map(|entry_data| {
             entries.push(Entry {

--- a/libs/ieee1212-config-rom/src/lib.rs
+++ b/libs/ieee1212-config-rom/src/lib.rs
@@ -132,7 +132,10 @@ fn get_directory_entry_list<'a>(
         match entry_type {
             0 => Ok(EntryData::Immediate(value)),
             1 => {
-                let offset = 0xfffff0000000 + (value as usize);
+                // NOTE: The maximum value of value field in directory entry is 0x00ffffff. The
+                // maximum value multipled by 4 is within 0x0fffffff, therefore no need to detect
+                // error.
+                let offset = 0xfffff0000000 + (4 * value as usize);
                 Ok(EntryData::CsrOffset(offset))
             }
             2 | 3 => {


### PR DESCRIPTION
Current implementation supports error reporting for failure to parse the content of
Configuration ROM, however it is not enough modern and friendly.

This patchset improves it as well as any bug-fixes.

```
Takashi Sakamoto (10):
  alsa-ctl-tlv-codec: fix copy-and-paste mistake
  ieee1212-config-rom: fix invalid operation for value of CSR Offset Leaf
  ieee1212-config-rom: replace hardcoded numeric value with named constants.
  ieee1212-config-rom: assert when the key of entry is beyond 0x3
  ieee1212-config-rom: code refactoring to keep parse cursor
  ieee1212-config-rom: add helper function to parse directory content
  ieee1212-config-rom: enhancement for error reporting of config rom parser
  ieee1212-config-rom: add helper function to detect leaf from entry
  ieee1212-config-rom: enhancement for error reporting of leaf parser
  fix wrong annotation for unordered list in README

 README.rst                           |   6 +-
 libs/alsa-ctl-tlv-codec/README.md    |   2 +-
 libs/ieee1212-config-rom/src/leaf.rs | 230 ++++++++----------
 libs/ieee1212-config-rom/src/lib.rs  | 337 +++++++++++++++++----------
 4 files changed, 317 insertions(+), 258 deletions(-)
```