### PR TITLE
[PATCH 00/15] ta1394: rework for AV/C operation trait

### DIFF
--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -1237,7 +1237,7 @@ impl AvcControl for EnsembleOperation {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands).map(|_| {
             // NOTE: parameters are retrieved by HwStatus command only.
             match &mut self.cmd {

--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -482,7 +482,7 @@ impl EnsembleParameterProtocol<EnsembleStreamParameters> for BebobAvc {
 }
 
 /// The trait for parameter protocol.
-pub trait EnsembleParameterProtocol<T>: Ta1394Avc
+pub trait EnsembleParameterProtocol<T>: Ta1394Avc<Error>
 where
     for<'a> Vec<EnsembleCmd>: From<&'a T>,
     T: Copy,
@@ -493,6 +493,7 @@ where
             .try_for_each(|cmd| {
                 let mut op = EnsembleOperation::new(cmd);
                 self.control(&AvcAddr::Unit, &mut op, timeout_ms)
+                    .map_err(|err| from_avc_err(err))
             })
     }
 
@@ -504,6 +505,7 @@ where
             .try_for_each(|(n, _)| {
                 let mut op = EnsembleOperation::new(n);
                 self.control(&AvcAddr::Unit, &mut op, timeout_ms)
+                    .map_err(|err| from_avc_err(err))
             })
             .map(|_| *old = *new)
     }

--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -1222,7 +1222,11 @@ impl AvcOp for EnsembleOperation {
 }
 
 impl AvcControl for EnsembleOperation {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.data = Into::<Vec<u8>>::into(&self.cmd);
 
         // At least, 6 bytes should be required to align to 3 quadlets. Unless, the target unit is freezed.

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -816,7 +816,11 @@ impl AvcOp for ExtendedPlugInfo {
 }
 
 impl AvcStatus for ExtendedPlugInfo {
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(Self::SUBFUNC);
         operands.extend_from_slice(&Into::<[u8; 5]>::into(&self.addr));
         operands.append(&mut Into::<Vec<u8>>::into(&self.info));
@@ -943,7 +947,11 @@ impl AvcOp for ExtendedSubunitInfo {
 }
 
 impl AvcStatus for ExtendedSubunitInfo {
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(self.page);
         operands.push(self.func_blk_type);
         operands.extend_from_slice(&[0xff; 25]);
@@ -1305,7 +1313,11 @@ impl BcoExtendedStreamFormat {
 }
 
 impl AvcStatus for BcoExtendedStreamFormat {
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(self.subfunc);
         operands.extend_from_slice(&Into::<[u8; 5]>::into(&self.plug_addr));
         operands.push(self.support_status.into());
@@ -1371,10 +1383,13 @@ impl AvcOp for ExtendedStreamFormatSingle {
 }
 
 impl AvcStatus for ExtendedStreamFormatSingle {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.support_status = SupportStatus::Reserved(0xff);
-        self.op.build_operands(addr, operands)?;
-        Ok(())
+        self.op.build_operands(addr, operands)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
@@ -1388,7 +1403,11 @@ impl AvcStatus for ExtendedStreamFormatSingle {
 }
 
 impl AvcControl for ExtendedStreamFormatSingle {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.support_status = SupportStatus::Active;
         self.op.build_operands(addr, operands)?;
         operands.append(&mut Into::<Vec<u8>>::into(&self.stream_format));
@@ -1434,7 +1453,11 @@ impl AvcOp for ExtendedStreamFormatList {
 }
 
 impl AvcStatus for ExtendedStreamFormatList {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.build_operands(addr, operands)?;
         operands.push(self.index);
         Ok(())

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1675,10 +1675,11 @@ fn parse_tstamp(buf: &[u8]) -> Result<glib::DateTime, Error> {
             Error::new(FileError::Nxio, &msg)
         })?;
 
-        u16::from_str_radix(&literal[4..6], 10).map_err(|err| {
-            let msg = format!("{}", err);
-            Error::new(FileError::Nxio, &msg)
-        })
+        u16::from_str_radix(&literal[4..6], 10)
+            .map_err(|err| {
+                let msg = format!("{}", err);
+                Error::new(FileError::Nxio, &msg)
+            })
             .map(|seconds| (hour, minute, seconds))
     } else {
         Ok((0, 0, 0))
@@ -1691,7 +1692,8 @@ fn parse_tstamp(buf: &[u8]) -> Result<glib::DateTime, Error> {
         hour as i32,
         minute as i32,
         seconds as f64,
-    ).unwrap();
+    )
+    .unwrap();
 
     Ok(tstamp)
 }

--- a/libs/bebob/protocols/src/focusrite.rs
+++ b/libs/bebob/protocols/src/focusrite.rs
@@ -421,7 +421,7 @@ impl AvcControl for SaffireAvcOperation {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)?;
         (0..self.offsets.len()).for_each(|i| {
             let data = &self.op.data[(5 + i * 8 + 4)..(5 + i * 8 + 8)];
@@ -453,7 +453,7 @@ impl AvcStatus for SaffireAvcOperation {
         AvcStatus::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcStatus::parse_operands(&mut self.op, addr, operands)?;
         (0..self.offsets.len()).for_each(|i| {
             let data = &self.op.data[(2 + i * 8 + 4)..(2 + i * 8 + 8)];

--- a/libs/bebob/protocols/src/focusrite.rs
+++ b/libs/bebob/protocols/src/focusrite.rs
@@ -399,7 +399,11 @@ const FOCUSRITE_CONTROL_ACTION: u8 = 0x01;
 const FOCUSRITE_STATUS_ACTION: u8 = 0x03;
 
 impl AvcControl for SaffireAvcOperation {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         assert!(self.offsets.len() <= MAXIMUM_OFFSET_COUNT);
         assert_eq!(self.offsets.len() * 4, self.buf.len());
 
@@ -429,7 +433,11 @@ impl AvcControl for SaffireAvcOperation {
 }
 
 impl AvcStatus for SaffireAvcOperation {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         assert!(self.offsets.len() <= MAXIMUM_OFFSET_COUNT);
         assert_eq!(self.offsets.len() * 4, self.buf.len());
 

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -63,11 +63,11 @@ impl Ta1394Avc for BebobAvc {
             .and_then(|len| {
                 if resp[1] != addr.into() {
                     let label = format!("Unexpected address in response: {}", resp[1]);
-                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
                 } else if resp[2] != opcode {
                     let label =
                         format!("Unexpected opcode in response: {} but {}", opcode, resp[2]);
-                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
                 } else {
                     let rcode = AvcRespCode::from(resp[0] & Self::RESP_CODE_MASK);
 
@@ -111,9 +111,10 @@ impl Ta1394Avc for BebobAvc {
                     O::OPCODE,
                     rcode
                 );
-                Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
             } else {
                 AvcControl::parse_operands(op, addr, &operands)
+                    .map_err(|err| Error::new(Ta1394AvcError::RespParse(err), ""))
             }
         })
     }

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -50,7 +50,7 @@ impl Ta1394Avc for BebobAvc {
         opcode: u8,
         operands: &[u8],
         timeout_ms: u32,
-    ) -> Result<(AvcRespCode, Vec<u8>), Error> {
+    ) -> Result<Vec<u8>, Error> {
         let mut cmd = Vec::new();
         cmd.push(ctype.into());
         cmd.push(addr.into());
@@ -60,22 +60,9 @@ impl Ta1394Avc for BebobAvc {
         let mut resp = vec![0; Self::FRAME_SIZE];
         self.0
             .avc_transaction(&cmd, &mut resp, timeout_ms)
-            .and_then(|len| {
-                if resp[1] != addr.into() {
-                    let label = format!("Unexpected address in response: {}", resp[1]);
-                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
-                } else if resp[2] != opcode {
-                    let label =
-                        format!("Unexpected opcode in response: {} but {}", opcode, resp[2]);
-                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
-                } else {
-                    let rcode = AvcRespCode::from(resp[0] & Self::RESP_CODE_MASK);
-
-                    resp.truncate(len);
-                    let operands = resp.split_off(3);
-
-                    Ok((rcode, operands))
-                }
+            .map(|len| {
+                resp.truncate(len);
+                resp
             })
     }
 
@@ -95,27 +82,25 @@ impl Ta1394Avc for BebobAvc {
             &mut operands,
             timeout_ms,
         )
-        .and_then(|(rcode, operands)| {
-            let expected = match O::OPCODE {
-                InputPlugSignalFormat::OPCODE
-                | OutputPlugSignalFormat::OPCODE
-                | SignalSource::OPCODE => {
-                    // NOTE: quirk.
-                    rcode == AvcRespCode::Accepted || rcode == AvcRespCode::Reserved(0x00)
-                }
-                _ => rcode == AvcRespCode::Accepted,
-            };
-            if !expected {
-                let label = format!(
-                    "Unexpected response code for control opcode {}: {:?}",
-                    O::OPCODE,
-                    rcode
-                );
-                Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
-            } else {
-                AvcControl::parse_operands(op, addr, &operands)
-                    .map_err(|err| Error::new(Ta1394AvcError::RespParse(err), ""))
-            }
+        .and_then(|response_frame| {
+            Self::detect_response_operands(&response_frame, addr, O::OPCODE)
+                .and_then(|(rcode, operands)| {
+                    let expected = match O::OPCODE {
+                        InputPlugSignalFormat::OPCODE
+                        | OutputPlugSignalFormat::OPCODE
+                        | SignalSource::OPCODE => {
+                            // NOTE: quirk.
+                            rcode == AvcRespCode::Accepted || rcode == AvcRespCode::Reserved(0x00)
+                        }
+                        _ => rcode == AvcRespCode::Accepted,
+                    };
+                    if !expected {
+                        Err(AvcRespParseError::UnexpectedStatus)
+                    } else {
+                        AvcControl::parse_operands(op, addr, &operands)
+                    }
+                })
+                .map_err(|err| Error::new(Ta1394AvcError::RespParse(err), ""))
         })
     }
 }

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -23,8 +23,8 @@ pub mod yamaha_terratec;
 
 use {
     self::bridgeco::{ExtendedStreamFormatSingle, *},
-    glib::{Error, FileError},
-    hinawa::{prelude::{FwFcpExtManual, FwReqExtManual}, FwFcp, FwNode, FwReq, FwTcode},
+    glib::{Error, FileError, IsA},
+    hinawa::{prelude::{FwFcpExtManual, FwFcpExt, FwReqExtManual}, FwFcp, FwNode, FwReq, FwTcode},
     ta1394::{amdtp::*, audio::*, ccm::*, general::*, *},
 };
 
@@ -38,12 +38,6 @@ pub const DM_BCO_BOOTLOADER_INFO_OFFSET: u64 = DM_BCO_OFFSET + 0x00020000;
 /// The structure for AV/C transaction helper with quirks specific to BeBoB solution.
 #[derive(Default, Debug)]
 pub struct BebobAvc(FwFcp);
-
-impl AsRef<FwFcp> for BebobAvc {
-    fn as_ref(&self) -> &FwFcp {
-        &self.0
-    }
-}
 
 impl Ta1394Avc for BebobAvc {
     fn transaction(
@@ -118,6 +112,12 @@ impl Ta1394Avc for BebobAvc {
                 AvcControl::parse_operands(op, addr, &operands)
             }
         })
+    }
+}
+
+impl BebobAvc {
+    pub fn bind(&self, node: &impl IsA<FwNode>) -> Result<(), Error> {
+        self.0.bind(node)
     }
 }
 

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -83,7 +83,8 @@ impl Ta1394Avc for BebobAvc {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let mut operands = Vec::new();
-        AvcControl::build_operands(op, addr, &mut operands)?;
+        AvcControl::build_operands(op, addr, &mut operands)
+            .map_err(|err| Error::new(Ta1394AvcError::CmdBuild(err), ""))?;
         self.transaction(
             AvcCmdType::Control,
             addr,

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -24,7 +24,10 @@ pub mod yamaha_terratec;
 use {
     self::bridgeco::{ExtendedStreamFormatSingle, *},
     glib::{Error, FileError, IsA},
-    hinawa::{prelude::{FwFcpExtManual, FwFcpExt, FwReqExtManual}, FwFcp, FwNode, FwReq, FwTcode},
+    hinawa::{
+        prelude::{FwFcpExtManual, FwFcpExt, FwReqExtManual},
+        FwFcp, FwNode, FwReq, FwTcode,
+    },
     ta1394::{amdtp::*, audio::*, ccm::*, general::*, *},
 };
 

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -24,7 +24,7 @@ pub mod yamaha_terratec;
 use {
     self::bridgeco::{ExtendedStreamFormatSingle, *},
     glib::{Error, FileError},
-    hinawa::{prelude::FwReqExtManual, FwFcp, FwNode, FwReq, FwTcode},
+    hinawa::{prelude::{FwFcpExtManual, FwReqExtManual}, FwFcp, FwNode, FwReq, FwTcode},
     ta1394::{amdtp::*, audio::*, ccm::*, general::*, *},
 };
 
@@ -46,6 +46,42 @@ impl AsRef<FwFcp> for BebobAvc {
 }
 
 impl Ta1394Avc for BebobAvc {
+    fn transaction(
+        &self,
+        ctype: AvcCmdType,
+        addr: &AvcAddr,
+        opcode: u8,
+        operands: &[u8],
+        timeout_ms: u32,
+    ) -> Result<(AvcRespCode, Vec<u8>), Error> {
+        let mut cmd = Vec::new();
+        cmd.push(ctype.into());
+        cmd.push(addr.into());
+        cmd.push(opcode);
+        cmd.extend_from_slice(operands);
+
+        let mut resp = vec![0; Self::FRAME_SIZE];
+        self.0
+            .avc_transaction(&cmd, &mut resp, timeout_ms)
+            .and_then(|len| {
+                if resp[1] != addr.into() {
+                    let label = format!("Unexpected address in response: {}", resp[1]);
+                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                } else if resp[2] != opcode {
+                    let label =
+                        format!("Unexpected opcode in response: {} but {}", opcode, resp[2]);
+                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                } else {
+                    let rcode = AvcRespCode::from(resp[0] & Self::RESP_CODE_MASK);
+
+                    resp.truncate(len);
+                    let operands = resp.split_off(3);
+
+                    Ok((rcode, operands))
+                }
+            })
+    }
+
     fn control<O: AvcOp + AvcControl>(
         &self,
         addr: &AvcAddr,

--- a/libs/bebob/protocols/src/maudio/normal.rs
+++ b/libs/bebob/protocols/src/maudio/normal.rs
@@ -730,7 +730,11 @@ impl AvcOp for AudiophileLedSwitch {
 }
 
 impl AvcControl for AudiophileLedSwitch {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.data[3] = self.state.into();
         AvcControl::build_operands(&mut self.op, addr, operands)
     }

--- a/libs/bebob/protocols/src/maudio/normal.rs
+++ b/libs/bebob/protocols/src/maudio/normal.rs
@@ -739,7 +739,7 @@ impl AvcControl for AudiophileLedSwitch {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)
     }
 }

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -137,7 +137,11 @@ impl AvcOp for MaudioSpecialLedSwitch {
 }
 
 impl AvcControl for MaudioSpecialLedSwitch {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.data[0] = self.state.into();
         AvcControl::build_operands(&mut self.op, addr, operands)
     }

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -146,7 +146,7 @@ impl AvcControl for MaudioSpecialLedSwitch {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)
     }
 }

--- a/libs/bebob/protocols/src/presonus/inspire1394.rs
+++ b/libs/bebob/protocols/src/presonus/inspire1394.rs
@@ -364,7 +364,11 @@ impl AvcOp for InputParameterOperation {
 }
 
 impl AvcControl for InputParameterOperation {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         match self.param {
             InputParameter::Analog34Phono(state) => {
                 self.op.data[0] = CMD_PHONO;
@@ -401,7 +405,11 @@ impl AvcControl for InputParameterOperation {
 }
 
 impl AvcStatus for InputParameterOperation {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         match self.param {
             InputParameter::Analog34Phono(_) => {
                 self.op.data[0] = CMD_PHONO;

--- a/libs/bebob/protocols/src/presonus/inspire1394.rs
+++ b/libs/bebob/protocols/src/presonus/inspire1394.rs
@@ -399,7 +399,7 @@ impl AvcControl for InputParameterOperation {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)
     }
 }
@@ -436,7 +436,7 @@ impl AvcStatus for InputParameterOperation {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)?;
         match &mut self.param {
             InputParameter::Analog34Phono(state) => {

--- a/libs/bebob/runtime/src/apogee/ensemble_model.rs
+++ b/libs/bebob/runtime/src/apogee/ensemble_model.rs
@@ -49,7 +49,7 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/behringer.rs
+++ b/libs/bebob/runtime/src/behringer.rs
@@ -30,7 +30,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/digidesign.rs
+++ b/libs/bebob/runtime/src/digidesign.rs
@@ -36,7 +36,7 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/esi.rs
+++ b/libs/bebob/runtime/src/esi.rs
@@ -67,7 +67,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/focusrite/saffire_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffire_model.rs
@@ -114,7 +114,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/focusrite/saffirele_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffirele_model.rs
@@ -75,7 +75,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/focusrite/saffirepro10io_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffirepro10io_model.rs
@@ -111,7 +111,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffirePro10ioModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/focusrite/saffirepro26io_model.rs
+++ b/libs/bebob/runtime/src/focusrite/saffirepro26io_model.rs
@@ -110,7 +110,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffirePro26ioModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/icon.rs
+++ b/libs/bebob/runtime/src/icon.rs
@@ -91,7 +91,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/lib.rs
+++ b/libs/bebob/runtime/src/lib.rs
@@ -23,7 +23,7 @@ use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
-    hinawa::{prelude::{FwFcpExt, FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
     hitaki::{prelude::*, *},
     ieee1212_config_rom::ConfigRom,
     model::*,

--- a/libs/bebob/runtime/src/maudio/audiophile_model.rs
+++ b/libs/bebob/runtime/src/maudio/audiophile_model.rs
@@ -162,7 +162,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/maudio/fw410_model.rs
+++ b/libs/bebob/runtime/src/maudio/fw410_model.rs
@@ -199,7 +199,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/maudio/ozonic_model.rs
+++ b/libs/bebob/runtime/src/maudio/ozonic_model.rs
@@ -98,7 +98,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
@@ -47,7 +47,7 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/maudio/solo_model.rs
+++ b/libs/bebob/runtime/src/maudio/solo_model.rs
@@ -108,7 +108,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/maudio/special_model.rs
+++ b/libs/bebob/runtime/src/maudio/special_model.rs
@@ -39,7 +39,7 @@ impl<T: MediaClockFrequencyOperation + Default> CtlModel<(SndUnit, FwNode)> for 
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/presonus/firebox_model.rs
+++ b/libs/bebob/runtime/src/presonus/firebox_model.rs
@@ -158,7 +158,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/presonus/fp10_model.rs
+++ b/libs/bebob/runtime/src/presonus/fp10_model.rs
@@ -56,7 +56,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/presonus/inspire1394_model.rs
+++ b/libs/bebob/runtime/src/presonus/inspire1394_model.rs
@@ -154,7 +154,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/roland.rs
+++ b/libs/bebob/runtime/src/roland.rs
@@ -98,7 +98,7 @@ impl CtlModel<(SndUnit, FwNode)> for FaModel<Fa66MixerAnalogSourceProtocol> {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl.load_freq(card_cntr)?;
         self.analog_in_ctl.load_level(card_cntr)?;
@@ -171,7 +171,7 @@ impl CtlModel<(SndUnit, FwNode)> for FaModel<Fa101MixerAnalogSourceProtocol> {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl.load_freq(card_cntr)?;
         self.analog_in_ctl.load_level(card_cntr)?;

--- a/libs/bebob/runtime/src/stanton.rs
+++ b/libs/bebob/runtime/src/stanton.rs
@@ -52,7 +52,7 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/terratec/aureon_model.rs
+++ b/libs/bebob/runtime/src/terratec/aureon_model.rs
@@ -94,7 +94,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/terratec/phase88_model.rs
+++ b/libs/bebob/runtime/src/terratec/phase88_model.rs
@@ -114,7 +114,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/bebob/runtime/src/yamaha_terratec.rs
+++ b/libs/bebob/runtime/src/yamaha_terratec.rs
@@ -165,7 +165,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)
@@ -334,7 +334,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.clk_ctl
             .load_freq(card_cntr)

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -1155,7 +1155,7 @@ impl AvcControl for ApogeeCmd {
         AvcControl::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)
     }
 }
@@ -1170,10 +1170,11 @@ impl AvcStatus for ApogeeCmd {
         AvcStatus::build_operands(&mut self.op, addr, operands)
     }
 
-    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcStatus::parse_operands(&mut self.op, addr, operands)?;
         self.cmd
             .parse_variable(&self.op.data)
+            .map_err(|_| AvcRespParseError::UnexpectedOperands(4))
     }
 }
 

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -1144,7 +1144,11 @@ impl AvcOp for ApogeeCmd {
 }
 
 impl AvcControl for ApogeeCmd {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         let mut data = self.cmd.build_args();
         self.cmd.append_variable(&mut data);
         self.op.data = data;
@@ -1157,7 +1161,11 @@ impl AvcControl for ApogeeCmd {
 }
 
 impl AvcStatus for ApogeeCmd {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.data = self.cmd.build_args();
         AvcStatus::build_operands(&mut self.op, addr, operands)
     }

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -1172,7 +1172,8 @@ impl AvcStatus for ApogeeCmd {
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
         AvcStatus::parse_operands(&mut self.op, addr, operands)?;
-        self.cmd.parse_variable(&self.op.data)
+        self.cmd
+            .parse_variable(&self.op.data)
     }
 }
 

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -505,23 +505,22 @@ impl DuetFwInputProtocol {
                 };
 
                 let mut op = ApogeeCmd::new(VendorCmd::XlrIsConsumerLevel(i, Default::default()));
-                avc.status(&AvcAddr::Unit, &mut op, timeout_ms)
-                    .map(|_| {
-                        let is_consumer_level = match &op.cmd {
-                            VendorCmd::XlrIsConsumerLevel(_, enabled) => *enabled,
-                            _ => unreachable!(),
-                        };
+                avc.status(&AvcAddr::Unit, &mut op, timeout_ms).map(|_| {
+                    let is_consumer_level = match &op.cmd {
+                        VendorCmd::XlrIsConsumerLevel(_, enabled) => *enabled,
+                        _ => unreachable!(),
+                    };
 
-                        *level = if is_mic_level {
-                            DuetFwInputXlrNominalLevel::Microphone
+                    *level = if is_mic_level {
+                        DuetFwInputXlrNominalLevel::Microphone
+                    } else {
+                        if is_consumer_level {
+                            DuetFwInputXlrNominalLevel::Consumer
                         } else {
-                            if is_consumer_level {
-                                DuetFwInputXlrNominalLevel::Consumer
-                            } else {
-                                DuetFwInputXlrNominalLevel::Professional
-                            }
-                        };
-                    })
+                            DuetFwInputXlrNominalLevel::Professional
+                        }
+                    };
+                })
             })?;
 
         params

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -161,7 +161,7 @@ impl DuetFwKnobProtocol {
 
 impl DuetFwKnobProtocol {
     pub fn read_state(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         state: &mut DuetFwKnobState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -233,7 +233,7 @@ impl DuetFwOutputProtocol {
     pub const VOLUME_MAX: u8 = 64;
     pub const VOLUME_STEP: u8 = 1;
 
-    pub fn read_mute(avc: &mut FwFcp, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn read_mute(avc: &mut OxfwAvc, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = ApogeeCmd::new(VendorCmd::OutMute(Default::default()));
         avc.status(&AvcAddr::Unit, &mut op, timeout_ms).map(|_| {
             if let VendorCmd::OutMute(e) = &op.cmd {
@@ -242,12 +242,12 @@ impl DuetFwOutputProtocol {
         })
     }
 
-    pub fn write_mute(avc: &mut FwFcp, mute: bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn write_mute(avc: &mut OxfwAvc, mute: bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = ApogeeCmd::new(VendorCmd::OutMute(mute));
         avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
     }
 
-    pub fn read_volume(avc: &mut FwFcp, volume: &mut u8, timeout_ms: u32) -> Result<(), Error> {
+    pub fn read_volume(avc: &mut OxfwAvc, volume: &mut u8, timeout_ms: u32) -> Result<(), Error> {
         let mut op = ApogeeCmd::new(VendorCmd::OutVolume(Default::default()));
         avc.status(&AvcAddr::Unit, &mut op, timeout_ms).map(|_| {
             if let VendorCmd::OutVolume(v) = &op.cmd {
@@ -256,13 +256,13 @@ impl DuetFwOutputProtocol {
         })
     }
 
-    pub fn write_volume(avc: &mut FwFcp, volume: u8, timeout_ms: u32) -> Result<(), Error> {
+    pub fn write_volume(avc: &mut OxfwAvc, volume: u8, timeout_ms: u32) -> Result<(), Error> {
         let mut op = ApogeeCmd::new(VendorCmd::OutVolume(Self::VOLUME_MAX - volume));
         avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
     }
 
     pub fn read_src(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         src: &mut DuetFwOutputSource,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -279,7 +279,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn write_src(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         src: DuetFwOutputSource,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -289,7 +289,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn read_nominal_level(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         level: &mut DuetFwOutputNominalLevel,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -306,7 +306,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn write_nominal_level(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         level: DuetFwOutputNominalLevel,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -333,7 +333,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn read_mute_mode_for_analog_output(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: &mut DuetFwOutputMuteMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -357,7 +357,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn write_mute_mode_for_analog_output(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: DuetFwOutputMuteMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -371,7 +371,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn read_mute_mode_for_hp(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: &mut DuetFwOutputMuteMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -395,7 +395,7 @@ impl DuetFwOutputProtocol {
     }
 
     pub fn write_mute_mode_for_hp(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: DuetFwOutputMuteMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -462,7 +462,7 @@ impl DuetFwInputProtocol {
     pub const GAIN_STEP: u8 = 1;
 
     pub fn read_parameters(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         params: &mut DuetFwInputParameters,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -565,7 +565,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_gain(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         gain: u8,
         params: &mut DuetFwInputParameters,
@@ -584,7 +584,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_polarity(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         polarity: bool,
         params: &mut DuetFwInputParameters,
@@ -596,7 +596,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_xlr_nominal_level(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         level: DuetFwInputXlrNominalLevel,
         params: &mut DuetFwInputParameters,
@@ -617,7 +617,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_phantom_powering(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         enable: bool,
         params: &mut DuetFwInputParameters,
@@ -634,7 +634,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_src(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         src: DuetFwInputSource,
         params: &mut DuetFwInputParameters,
@@ -647,7 +647,7 @@ impl DuetFwInputProtocol {
     }
 
     pub fn write_clickless(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         enable: bool,
         params: &mut DuetFwInputParameters,
         timeout_ms: u32,
@@ -668,7 +668,7 @@ impl DuetFwMixerProtocol {
     pub const GAIN_STEP: u16 = 0x80;
 
     pub fn read_source_gain(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         dst: usize,
         src: usize,
         gain: &mut u16,
@@ -683,7 +683,7 @@ impl DuetFwMixerProtocol {
     }
 
     pub fn write_source_gain(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         dst: usize,
         src: usize,
         gain: u16,
@@ -739,7 +739,7 @@ pub struct DuetFwDisplayProtocol;
 
 impl DuetFwDisplayProtocol {
     pub fn read_target(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         target: &mut DuetFwDisplayTarget,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -756,7 +756,7 @@ impl DuetFwDisplayProtocol {
     }
 
     pub fn write_target(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         target: DuetFwDisplayTarget,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -766,7 +766,7 @@ impl DuetFwDisplayProtocol {
     }
 
     pub fn read_mode(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: &mut DuetFwDisplayMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -783,7 +783,7 @@ impl DuetFwDisplayProtocol {
     }
 
     pub fn write_mode(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: DuetFwDisplayMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -793,7 +793,7 @@ impl DuetFwDisplayProtocol {
     }
 
     pub fn read_overhold(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: &mut DuetFwDisplayOverhold,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -810,7 +810,7 @@ impl DuetFwDisplayProtocol {
     }
 
     pub fn write_overhold(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         mode: DuetFwDisplayOverhold,
         timeout_ms: u32,
     ) -> Result<(), Error> {

--- a/libs/oxfw/protocols/src/griffin.rs
+++ b/libs/oxfw/protocols/src/griffin.rs
@@ -23,7 +23,7 @@ impl FirewaveProtocol {
     const MUTE_FB_ID: u8 = 0x01;
 
     pub fn read_volume(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         volume: &mut i16,
         timeout_ms: u32,
@@ -48,7 +48,7 @@ impl FirewaveProtocol {
     }
 
     pub fn write_volume(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         idx: usize,
         volume: i16,
         timeout_ms: u32,
@@ -67,7 +67,7 @@ impl FirewaveProtocol {
         }
     }
 
-    pub fn read_mute(avc: &mut FwFcp, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn read_mute(avc: &mut OxfwAvc, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::MUTE_FB_ID,
             CtlAttr::Current,
@@ -82,7 +82,7 @@ impl FirewaveProtocol {
             })
     }
 
-    pub fn write_mute(avc: &mut FwFcp, mute: bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn write_mute(avc: &mut OxfwAvc, mute: bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::MUTE_FB_ID,
             CtlAttr::Current,

--- a/libs/oxfw/protocols/src/lacie.rs
+++ b/libs/oxfw/protocols/src/lacie.rs
@@ -18,7 +18,7 @@ impl FwSpeakersProtocol {
 
     const FB_ID: u8 = 0x01;
 
-    pub fn read_volume(avc: &mut FwFcp, volume: &mut i16, timeout_ms: u32) -> Result<(), Error> {
+    pub fn read_volume(avc: &mut OxfwAvc, volume: &mut i16, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
@@ -33,7 +33,7 @@ impl FwSpeakersProtocol {
             })
     }
 
-    pub fn write_volume(avc: &mut FwFcp, volume: i16, timeout_ms: u32) -> Result<(), Error> {
+    pub fn write_volume(avc: &mut OxfwAvc, volume: i16, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
@@ -43,7 +43,7 @@ impl FwSpeakersProtocol {
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }
 
-    pub fn read_mute(avc: &mut FwFcp, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn read_mute(avc: &mut OxfwAvc, mute: &mut bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
@@ -58,7 +58,7 @@ impl FwSpeakersProtocol {
             })
     }
 
-    pub fn write_mute(avc: &mut FwFcp, mute: bool, timeout_ms: u32) -> Result<(), Error> {
+    pub fn write_mute(avc: &mut OxfwAvc, mute: bool, timeout_ms: u32) -> Result<(), Error> {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -14,9 +14,9 @@ pub mod oxford;
 pub mod tascam;
 
 use {
-    glib::{Error, FileError},
+    glib::{Error, FileError, IsA},
     hinawa::{
-        prelude::{FwFcpExtManual, FwReqExtManual},
+        prelude::{FwFcpExtManual, FwFcpExt, FwReqExtManual},
         FwFcp, FwNode, FwReq, FwTcode,
     },
     ta1394::{audio::*, ccm::*, general::*, *},
@@ -25,12 +25,6 @@ use {
 /// The structure to implement AV/C transaction.
 #[derive(Default, Debug)]
 pub struct OxfwAvc(FwFcp);
-
-impl AsRef<FwFcp> for OxfwAvc {
-    fn as_ref(&self) -> &FwFcp {
-        &self.0
-    }
-}
 
 impl Ta1394Avc for OxfwAvc {
     fn transaction(
@@ -67,5 +61,11 @@ impl Ta1394Avc for OxfwAvc {
                     Ok((rcode, operands))
                 }
             })
+    }
+}
+
+impl OxfwAvc {
+    pub fn bind(&self, node: &impl IsA<FwNode>) -> Result<(), Error> {
+        self.0.bind(node)
     }
 }

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -15,6 +15,57 @@ pub mod tascam;
 
 use {
     glib::{Error, FileError},
-    hinawa::{prelude::FwReqExtManual, FwFcp, FwNode, FwReq, FwTcode},
+    hinawa::{
+        prelude::{FwFcpExtManual, FwReqExtManual},
+        FwFcp, FwNode, FwReq, FwTcode,
+    },
     ta1394::{audio::*, ccm::*, general::*, *},
 };
+
+/// The structure to implement AV/C transaction.
+#[derive(Default, Debug)]
+pub struct OxfwAvc(FwFcp);
+
+impl AsRef<FwFcp> for OxfwAvc {
+    fn as_ref(&self) -> &FwFcp {
+        &self.0
+    }
+}
+
+impl Ta1394Avc for OxfwAvc {
+    fn transaction(
+        &self,
+        ctype: AvcCmdType,
+        addr: &AvcAddr,
+        opcode: u8,
+        operands: &[u8],
+        timeout_ms: u32,
+    ) -> Result<(AvcRespCode, Vec<u8>), Error> {
+        let mut cmd = Vec::new();
+        cmd.push(ctype.into());
+        cmd.push(addr.into());
+        cmd.push(opcode);
+        cmd.extend_from_slice(operands);
+
+        let mut resp = vec![0; Self::FRAME_SIZE];
+        self.0
+            .avc_transaction(&cmd, &mut resp, timeout_ms)
+            .and_then(|len| {
+                if resp[1] != addr.into() {
+                    let label = format!("Unexpected address in response: {}", resp[1]);
+                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                } else if resp[2] != opcode {
+                    let label =
+                        format!("Unexpected opcode in response: {} but {}", opcode, resp[2]);
+                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                } else {
+                    let rcode = AvcRespCode::from(resp[0] & Self::RESP_CODE_MASK);
+
+                    resp.truncate(len);
+                    let operands = resp.split_off(3);
+
+                    Ok((rcode, operands))
+                }
+            })
+    }
+}

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -47,11 +47,11 @@ impl Ta1394Avc for OxfwAvc {
             .and_then(|len| {
                 if resp[1] != addr.into() {
                     let label = format!("Unexpected address in response: {}", resp[1]);
-                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
                 } else if resp[2] != opcode {
                     let label =
                         format!("Unexpected opcode in response: {} but {}", opcode, resp[2]);
-                    Err(Error::new(Ta1394AvcError::UnexpectedRespCode, &label))
+                    Err(Error::new(Ta1394AvcError::RespParse(AvcRespParseError::UnexpectedStatus), &label))
                 } else {
                     let rcode = AvcRespCode::from(resp[0] & Self::RESP_CODE_MASK);
 

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -27,23 +27,10 @@ use {
 pub struct OxfwAvc(FwFcp);
 
 impl Ta1394Avc for OxfwAvc {
-    fn transaction(
-        &self,
-        ctype: AvcCmdType,
-        addr: &AvcAddr,
-        opcode: u8,
-        operands: &[u8],
-        timeout_ms: u32,
-    ) -> Result<Vec<u8>, Error> {
-        let mut cmd = Vec::new();
-        cmd.push(ctype.into());
-        cmd.push(addr.into());
-        cmd.push(opcode);
-        cmd.extend_from_slice(operands);
-
+    fn transaction(&self, command_frame: &[u8], timeout_ms: u32) -> Result<Vec<u8>, Error> {
         let mut resp = vec![0; Self::FRAME_SIZE];
         self.0
-            .avc_transaction(&cmd, &mut resp, timeout_ms)
+            .avc_transaction(&command_frame, &mut resp, timeout_ms)
             .map(|len| {
                 resp.truncate(len);
                 resp

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -16,7 +16,7 @@ pub mod tascam;
 use {
     glib::{Error, FileError, IsA},
     hinawa::{
-        prelude::{FwFcpExtManual, FwFcpExt, FwReqExtManual},
+        prelude::{FwFcpExt, FwFcpExtManual, FwReqExtManual},
         FwFcp, FwNode, FwReq, FwTcode,
     },
     ta1394::{audio::*, ccm::*, general::*, *},
@@ -26,7 +26,7 @@ use {
 #[derive(Default, Debug)]
 pub struct OxfwAvc(FwFcp);
 
-impl Ta1394Avc for OxfwAvc {
+impl Ta1394Avc<Error> for OxfwAvc {
     fn transaction(&self, command_frame: &[u8], timeout_ms: u32) -> Result<Vec<u8>, Error> {
         let mut resp = vec![0; Self::FRAME_SIZE];
         self.0
@@ -41,5 +41,31 @@ impl Ta1394Avc for OxfwAvc {
 impl OxfwAvc {
     pub fn bind(&self, node: &impl IsA<FwNode>) -> Result<(), Error> {
         self.0.bind(node)
+    }
+
+    pub fn control<O: AvcOp + AvcControl>(
+        &self,
+        addr: &AvcAddr,
+        op: &mut O,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Ta1394Avc::<Error>::control(self, addr, op, timeout_ms).map_err(|err| from_avc_err(err))
+    }
+
+    pub fn status<O: AvcOp + AvcStatus>(
+        &self,
+        addr: &AvcAddr,
+        op: &mut O,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Ta1394Avc::<Error>::status(self, addr, op, timeout_ms).map_err(|err| from_avc_err(err))
+    }
+}
+
+fn from_avc_err(err: Ta1394AvcError<Error>) -> Error {
+    match err {
+        Ta1394AvcError::CmdBuild(cause) => Error::new(FileError::Inval, &cause.to_string()),
+        Ta1394AvcError::CommunicationFailure(cause) => cause,
+        Ta1394AvcError::RespParse(cause) => Error::new(FileError::Io, &cause.to_string()),
     }
 }

--- a/libs/oxfw/protocols/src/loud.rs
+++ b/libs/oxfw/protocols/src/loud.rs
@@ -40,7 +40,7 @@ impl LinkFwProtocol {
     ];
 
     pub fn read_input_source(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         src: &mut LinkFwInputSource,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -59,7 +59,7 @@ impl LinkFwProtocol {
     }
 
     pub fn write_input_source(
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         src: LinkFwInputSource,
         timeout_ms: u32,
     ) -> Result<(), Error> {

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -290,7 +290,11 @@ impl AvcOp for TascamProto {
 }
 
 impl AvcControl for TascamProto {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         let mut data = self.cmd.build_data();
         self.cmd.append_variable(&mut data);
         self.op.data = data;
@@ -303,7 +307,11 @@ impl AvcControl for TascamProto {
 }
 
 impl AvcStatus for TascamProto {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.data = self.cmd.build_data();
         AvcStatus::build_operands(&mut self.op, addr, operands)
     }
@@ -338,7 +346,8 @@ impl Ta1394Avc for TascamAvc {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let mut operands = Vec::new();
-        AvcControl::build_operands(op, addr, &mut operands)?;
+        AvcControl::build_operands(op, addr, &mut operands)
+            .map_err(|err| Error::new(Ta1394AvcError::CmdBuild(err), ""))?;
         self.transaction(AvcCmdType::Control, addr, O::OPCODE, &operands, timeout_ms)
             .and_then(|(rcode, operands)| {
                 let expected = if O::OPCODE != VendorDependent::OPCODE {

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -318,12 +318,6 @@ impl AvcStatus for TascamProto {
 #[derive(Default, Debug)]
 pub struct TascamAvc(OxfwAvc);
 
-impl AsRef<FwFcp> for TascamAvc {
-    fn as_ref(&self) -> &FwFcp {
-        self.0.as_ref()
-    }
-}
-
 impl Ta1394Avc for TascamAvc {
     fn transaction(
         &self,
@@ -363,6 +357,12 @@ impl Ta1394Avc for TascamAvc {
                     AvcControl::parse_operands(op, addr, &operands)
                 }
             })
+    }
+}
+
+impl TascamAvc {
+    pub fn bind(&self, node: &impl IsA<FwNode>) -> Result<(), Error> {
+        self.0.bind(node)
     }
 }
 

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -316,15 +316,27 @@ impl AvcStatus for TascamProto {
 
 /// The structure to represent AV/C protocol for TASCAM FireOne.
 #[derive(Default, Debug)]
-pub struct TascamAvc(pub FwFcp);
+pub struct TascamAvc(OxfwAvc);
 
 impl AsRef<FwFcp> for TascamAvc {
     fn as_ref(&self) -> &FwFcp {
-        &self.0
+        self.0.as_ref()
     }
 }
 
 impl Ta1394Avc for TascamAvc {
+    fn transaction(
+        &self,
+        ctype: AvcCmdType,
+        addr: &AvcAddr,
+        opcode: u8,
+        operands: &[u8],
+        timeout_ms: u32,
+    ) -> Result<(AvcRespCode, Vec<u8>), Error> {
+        self.0
+            .transaction(ctype, addr, opcode, operands, timeout_ms)
+    }
+
     fn control<O: AvcOp + AvcControl>(
         &self,
         addr: &AvcAddr,

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -31,7 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl
             .load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -9,7 +9,7 @@ use {
 #[derive(Default, Debug)]
 pub struct ApogeeModel {
     req: FwReq,
-    avc: FwFcp,
+    avc: OxfwAvc,
     common_ctl: CommonCtl,
     meter_ctl: MeterCtl,
     knob_ctl: KnobCtl,
@@ -31,7 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl
             .load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;
@@ -317,7 +317,7 @@ impl KnobCtl {
     fn load_state(
         &mut self,
         card_cntr: &mut CardCntr,
-        fcp: &mut FwFcp,
+        fcp: &mut OxfwAvc,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let labels: Vec<&str> = Self::KNOB_TARGETS
@@ -332,7 +332,7 @@ impl KnobCtl {
         self.measure_state(fcp, timeout_ms)
     }
 
-    fn measure_state(&mut self, fcp: &mut FwFcp, timeout_ms: u32) -> Result<(), Error> {
+    fn measure_state(&mut self, fcp: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
         DuetFwKnobProtocol::read_state(fcp, &mut self.0, timeout_ms)
     }
 
@@ -403,7 +403,7 @@ impl OutputCtl {
     fn load_params(
         &mut self,
         card_cntr: &mut CardCntr,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUTPUT_MUTE_NAME, 0);
@@ -457,7 +457,7 @@ impl OutputCtl {
 
     fn read_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
         timeout_ms: u32,
@@ -518,7 +518,7 @@ impl OutputCtl {
 
     fn write_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -612,7 +612,7 @@ impl InputCtl {
     fn load_params(
         &mut self,
         card_cntr: &mut CardCntr,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_GAIN_NAME, 0);
@@ -710,7 +710,7 @@ impl InputCtl {
 
     fn write_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,
@@ -798,7 +798,7 @@ impl MixerCtl {
 
     fn read_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
         timeout_ms: u32,
@@ -819,7 +819,7 @@ impl MixerCtl {
 
     fn write_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,
@@ -904,7 +904,7 @@ impl DisplayCtl {
 
     fn read_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
         timeout_ms: u32,
@@ -934,7 +934,7 @@ impl DisplayCtl {
 
     fn write_params(
         &mut self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,

--- a/libs/oxfw/runtime/src/common_model.rs
+++ b/libs/oxfw/runtime/src/common_model.rs
@@ -19,7 +19,7 @@ impl CtlModel<(SndUnit, FwNode)> for CommonModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl
             .load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;

--- a/libs/oxfw/runtime/src/common_model.rs
+++ b/libs/oxfw/runtime/src/common_model.rs
@@ -5,7 +5,7 @@ use super::{common_ctl::*, *};
 
 #[derive(Default, Debug)]
 pub struct CommonModel {
-    avc: hinawa::FwFcp,
+    avc: OxfwAvc,
     common_ctl: CommonCtl,
 }
 
@@ -19,7 +19,7 @@ impl CtlModel<(SndUnit, FwNode)> for CommonModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl
             .load(&self.avc, card_cntr, Self::FCP_TIMEOUT_MS)?;

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -24,7 +24,7 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -8,7 +8,7 @@ use {
 
 #[derive(Default, Debug)]
 pub struct GriffinModel {
-    avc: hinawa::FwFcp,
+    avc: OxfwAvc,
     common_ctl: CommonCtl,
     voluntary: bool,
 }
@@ -24,7 +24,7 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -8,7 +8,7 @@ use {
 
 #[derive(Default, Debug)]
 pub struct LacieModel {
-    avc: hinawa::FwFcp,
+    avc: OxfwAvc,
     common_ctl: CommonCtl,
     voluntary: bool,
 }
@@ -24,7 +24,7 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -24,7 +24,7 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -15,7 +15,7 @@ use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
-    hinawa::{prelude::{FwFcpExt, FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     nix::sys::signal,

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -15,10 +15,11 @@ use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
-    hinawa::{prelude::{FwFcpExt, FwNodeExt, FwNodeExtManual}, FwFcp, FwNode, FwReq},
+    hinawa::{prelude::{FwFcpExt, FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     nix::sys::signal,
+    oxfw_protocols::*,
     std::{convert::TryFrom, sync::mpsc},
     ta1394::config_rom::*,
 };

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -5,7 +5,7 @@ use {super::common_ctl::CommonCtl, super::*, oxfw_protocols::loud::*};
 
 #[derive(Default, Debug)]
 pub struct LinkFwModel {
-    avc: FwFcp,
+    avc: OxfwAvc,
     common_ctl: CommonCtl,
     specific_ctl: SpecificCtl,
 }
@@ -18,7 +18,7 @@ impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
         self.specific_ctl.load(card_cntr)?;
@@ -115,7 +115,7 @@ impl SpecificCtl {
 
     fn read(
         &self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
         timeout_ms: u32,
@@ -134,7 +134,7 @@ impl SpecificCtl {
 
     fn write(
         &self,
-        avc: &mut FwFcp,
+        avc: &mut OxfwAvc,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -18,7 +18,7 @@ impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
         self.specific_ctl.load(card_cntr)?;

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -71,7 +71,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.0.bind(&unit.1)?;
+        self.avc.as_ref().bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -71,7 +71,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.avc.as_ref().bind(&unit.1)?;
+        self.avc.bind(&unit.1)?;
 
         self.common_ctl.load(&self.avc, card_cntr, FCP_TIMEOUT_MS)?;
 

--- a/libs/ta1394/Cargo.toml
+++ b/libs/ta1394/Cargo.toml
@@ -13,5 +13,4 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
 glib = "0.15"
-hinawa = "0.7"
 ieee1212-config-rom = "0.1"

--- a/libs/ta1394/Cargo.toml
+++ b/libs/ta1394/Cargo.toml
@@ -12,5 +12,4 @@ license = "GPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]
-glib = "0.15"
 ieee1212-config-rom = "0.1"

--- a/libs/ta1394/src/amdtp.rs
+++ b/libs/ta1394/src/amdtp.rs
@@ -4,7 +4,7 @@
 pub const FMT_IS_AMDTP: u8 = 0x90;
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum AmdtpEventType{
+pub enum AmdtpEventType {
     Am824,
     AudioPack,
     FloatingPoint,
@@ -12,7 +12,7 @@ pub enum AmdtpEventType{
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct AmdtpFdf{
+pub struct AmdtpFdf {
     pub ev_type: AmdtpEventType,
     pub cmd_rate_ctl: bool,
     pub freq: u32,
@@ -42,7 +42,7 @@ impl AmdtpFdf {
     const SFC_RESERVED: u8 = 0x07;
 
     pub fn new(ev_type: AmdtpEventType, cmd_rate_ctl: bool, freq: u32) -> Self {
-        AmdtpFdf{
+        AmdtpFdf {
             ev_type,
             cmd_rate_ctl,
             freq,
@@ -74,7 +74,7 @@ impl From<&[u8]> for AmdtpFdf {
             _ => 0,
         };
 
-        AmdtpFdf{
+        AmdtpFdf {
             ev_type,
             cmd_rate_ctl: nflag > 0,
             freq,
@@ -82,9 +82,9 @@ impl From<&[u8]> for AmdtpFdf {
     }
 }
 
-impl From<AmdtpFdf> for [u8;3] {
+impl From<AmdtpFdf> for [u8; 3] {
     fn from(fdf: AmdtpFdf) -> Self {
-        let mut data = [0xff;3];
+        let mut data = [0xff; 3];
 
         let ev_type = match fdf.ev_type {
             AmdtpEventType::Am824 => AmdtpFdf::AM824,
@@ -106,9 +106,9 @@ impl From<AmdtpFdf> for [u8;3] {
             _ => AmdtpFdf::SFC_RESERVED,
         };
 
-        data[0] = ((ev_type & AmdtpFdf::EVT_MASK) << AmdtpFdf::EVT_SHIFT) |
-                  ((nflag as u8 & AmdtpFdf::NFLAG_MASK) << AmdtpFdf::NFLAG_SHIFT) |
-                  ((sfc & AmdtpFdf::SFC_MASK) << AmdtpFdf::SFC_SHIFT);
+        data[0] = ((ev_type & AmdtpFdf::EVT_MASK) << AmdtpFdf::EVT_SHIFT)
+            | ((nflag as u8 & AmdtpFdf::NFLAG_MASK) << AmdtpFdf::NFLAG_SHIFT)
+            | ((sfc & AmdtpFdf::SFC_MASK) << AmdtpFdf::SFC_SHIFT);
 
         data
     }

--- a/libs/ta1394/src/audio.rs
+++ b/libs/ta1394/src/audio.rs
@@ -151,12 +151,13 @@ impl AudioFuncBlk {
         }
     }
 
-    fn build_operands(&self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         match addr {
-            AvcAddr::Unit => {
-                let label = "Unit address is not supported by AudioFuncBlk";
-                Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
-            }
+            AvcAddr::Unit => Err(AvcCmdBuildError::InvalidAddress),
             AvcAddr::Subunit(s) => {
                 if s.subunit_type == AvcSubunitType::Audio {
                     operands.push(self.func_blk_type.into());
@@ -167,8 +168,7 @@ impl AudioFuncBlk {
                     self.ctl.build_raw(operands);
                     Ok(())
                 } else {
-                    let label = "SubUnit address except for audio is not supported by AudioFuncBlk";
-                    Err(Error::new(Ta1394AvcError::InvalidCmdOperands, &label))
+                    Err(AvcCmdBuildError::InvalidAddress)
                 }
             }
         }
@@ -221,7 +221,11 @@ impl AvcOp for AudioFuncBlk {
 }
 
 impl AvcStatus for AudioFuncBlk {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         AudioFuncBlk::build_operands(self, addr, operands)
     }
 
@@ -231,7 +235,11 @@ impl AvcStatus for AudioFuncBlk {
 }
 
 impl AvcControl for AudioFuncBlk {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         AudioFuncBlk::build_operands(self, addr, operands)
     }
 
@@ -258,7 +266,7 @@ impl AudioSelector {
         }
     }
 
-    fn build_func_blk(&mut self) -> Result<(), Error> {
+    fn build_func_blk(&mut self) -> Result<(), AvcCmdBuildError> {
         self.func_blk.audio_selector_data.clear();
         self.func_blk.audio_selector_data.push(self.input_plug_id);
         self.func_blk.ctl.selector = Self::SELECTOR_CONTROL;
@@ -287,7 +295,11 @@ impl AvcOp for AudioSelector {
 }
 
 impl AvcStatus for AudioSelector {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcStatus::build_operands(&mut self.func_blk, addr, operands)
     }
@@ -299,7 +311,11 @@ impl AvcStatus for AudioSelector {
 }
 
 impl AvcControl for AudioSelector {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcControl::build_operands(&mut self.func_blk, addr, operands)
     }
@@ -580,7 +596,7 @@ impl AudioFeature {
         }
     }
 
-    fn build_func_blk(&mut self) -> Result<(), Error> {
+    fn build_func_blk(&mut self) -> Result<(), AvcCmdBuildError> {
         self.func_blk.audio_selector_data.clear();
         self.func_blk.audio_selector_data.push(u8::from(self.audio_ch_num));
         self.func_blk.ctl = AudioFuncBlkCtl::from(&self.ctl);
@@ -605,7 +621,11 @@ impl AvcOp for AudioFeature {
 }
 
 impl AvcStatus for AudioFeature {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcStatus::build_operands(&mut self.func_blk, addr, operands)
     }
@@ -617,7 +637,11 @@ impl AvcStatus for AudioFeature {
 }
 
 impl AvcControl for AudioFeature {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcControl::build_operands(&mut self.func_blk, addr, operands)
     }
@@ -721,7 +745,7 @@ impl AudioProcessing {
         }
     }
 
-    fn build_func_blk(&mut self) -> Result<(), Error> {
+    fn build_func_blk(&mut self) -> Result<(), AvcCmdBuildError> {
         self.func_blk.audio_selector_data.clear();
         self.func_blk.audio_selector_data.push(self.input_plug_id);
         self.func_blk.audio_selector_data.push(u8::from(self.input_ch));
@@ -761,7 +785,11 @@ impl AvcOp for AudioProcessing {
 }
 
 impl AvcStatus for AudioProcessing {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcStatus::build_operands(&mut self.func_blk, addr, operands)
     }
@@ -773,7 +801,11 @@ impl AvcStatus for AudioProcessing {
 }
 
 impl AvcControl for AudioProcessing {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.build_func_blk()?;
         AvcControl::build_operands(&mut self.func_blk, addr, operands)
     }

--- a/libs/ta1394/src/audio.rs
+++ b/libs/ta1394/src/audio.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
 
-use super::{AvcSubunitType, AUDIO_SUBUNIT_0, AvcAddr, Ta1394AvcError};
-use super::{AvcOp, AvcStatus, AvcControl};
+use super::*;
 
 pub const AUDIO_SUBUNIT_0_ADDR: AvcAddr = AvcAddr::Subunit(AUDIO_SUBUNIT_0);
 
@@ -788,12 +786,7 @@ impl AvcControl for AudioProcessing {
 
 #[cfg(test)]
 mod test {
-    use super::super::AvcAddr;
-    use super::super::{AvcStatus, AvcControl};
-    use super::{AUDIO_SUBUNIT_0_ADDR, AudioFuncBlk, AudioFuncBlkType, AudioFuncBlkCtl, CtlAttr};
-    use super::AudioSelector;
-    use super::{AudioFeature, FeatureCtl, GraphicEqualizerData, AudioCh};
-    use super::{AudioProcessing, ProcessingCtl};
+    use crate::audio::*;
 
     #[test]
     fn func_blk_operands() {

--- a/libs/ta1394/src/audio.rs
+++ b/libs/ta1394/src/audio.rs
@@ -105,7 +105,7 @@ struct AudioFuncBlkCtl {
 
 impl AudioFuncBlkCtl {
     fn new() -> Self {
-        AudioFuncBlkCtl{
+        AudioFuncBlkCtl {
             selector: 0xff,
             data: Vec::new(),
         }
@@ -142,7 +142,7 @@ struct AudioFuncBlk {
 
 impl AudioFuncBlk {
     fn new(func_blk_type: AudioFuncBlkType, func_blk_id: u8, ctl_attr: CtlAttr) -> Self {
-        AudioFuncBlk{
+        AudioFuncBlk {
             func_blk_type,
             func_blk_id,
             ctl_attr,
@@ -187,21 +187,28 @@ impl AudioFuncBlk {
 
         let func_blk_id = operands[1];
         if func_blk_id != self.func_blk_id {
-            let label = format!("Unexpected function block ID: {} but {}",
-                                self.func_blk_id, func_blk_id);
+            let label = format!(
+                "Unexpected function block ID: {} but {}",
+                self.func_blk_id, func_blk_id
+            );
             return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
         }
 
         let ctl_attr = CtlAttr::from(operands[2]);
         if ctl_attr != self.ctl_attr {
-            let label = format!("Unexpected control attribute: {} but {}",
-                                self.ctl_attr, ctl_attr);
+            let label = format!(
+                "Unexpected control attribute: {} but {}",
+                self.ctl_attr, ctl_attr
+            );
             return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
         }
 
         let mut audio_selector_length = operands[3] as usize;
         if operands.len() < 3 + audio_selector_length {
-            let label = format!("Oprands too short for selector of AudioFuncBlk; {}", operands.len());
+            let label = format!(
+                "Oprands too short for selector of AudioFuncBlk; {}",
+                operands.len()
+            );
             return Err(Error::new(Ta1394AvcError::TooShortResp, &label));
         } else if audio_selector_length < 1 {
             let label = "The length of audio selector is less thant 1:";
@@ -260,7 +267,7 @@ impl AudioSelector {
     const SELECTOR_CONTROL: u8 = 0x01;
 
     pub fn new(func_blk_id: u8, ctl_attr: CtlAttr, input_plug_id: u8) -> Self {
-        AudioSelector{
+        AudioSelector {
             input_plug_id,
             func_blk: AudioFuncBlk::new(AudioFuncBlkType::Selector, func_blk_id, ctl_attr),
         }
@@ -276,12 +283,18 @@ impl AudioSelector {
 
     fn parse_func_blk(&mut self) -> Result<(), Error> {
         if self.func_blk.ctl.selector != Self::SELECTOR_CONTROL {
-            let label = format!("Unexpected control selector: {} but {}",
-                                Self::SELECTOR_CONTROL, self.func_blk.ctl.selector);
+            let label = format!(
+                "Unexpected control selector: {} but {}",
+                Self::SELECTOR_CONTROL,
+                self.func_blk.ctl.selector
+            );
             Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
         } else if self.func_blk.ctl.data.len() > 0 {
-            let label = format!("Unexpected length of control data: {} but {}",
-                                0, self.func_blk.ctl.data.len());
+            let label = format!(
+                "Unexpected length of control data: {} but {}",
+                0,
+                self.func_blk.ctl.data.len()
+            );
             Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
         } else {
             self.input_plug_id = self.func_blk.audio_selector_data[0];
@@ -331,16 +344,16 @@ impl AvcControl for AudioSelector {
 //
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GraphicEqualizerData {
-    pub bands_present: [u8;4],
-    pub ex_bands_present: [u8;4],
+    pub bands_present: [u8; 4],
+    pub ex_bands_present: [u8; 4],
     pub gain: Vec<i8>,
 }
 
 impl From<&[u8]> for GraphicEqualizerData {
     fn from(raw: &[u8]) -> Self {
-        let mut data = GraphicEqualizerData{
-            bands_present: [0;4],
-            ex_bands_present: [0;4],
+        let mut data = GraphicEqualizerData {
+            bands_present: [0; 4],
+            ex_bands_present: [0; 4],
             gain: Vec::new(),
         };
         data.bands_present.copy_from_slice(&raw[0..4]);
@@ -361,15 +374,29 @@ impl From<&GraphicEqualizerData> for Vec<u8> {
 }
 
 fn i16_vector_to_raw(data: &[i16]) -> Vec<u8> {
-    data.iter().fold(Vec::new(), |mut raw, d| { raw.extend_from_slice(&d.to_be_bytes()); raw})
+    data.iter().fold(Vec::new(), |mut raw, d| {
+        raw.extend_from_slice(&d.to_be_bytes());
+        raw
+    })
 }
 
 fn u16_vector_to_raw(data: &[u16]) -> Vec<u8> {
-    data.iter().fold(Vec::new(), |mut raw, d| { raw.extend_from_slice(&d.to_be_bytes()); raw})
+    data.iter().fold(Vec::new(), |mut raw, d| {
+        raw.extend_from_slice(&d.to_be_bytes());
+        raw
+    })
 }
 
 fn bool_vector_to_raw(data: &[bool]) -> Vec<u8> {
-    data.iter().map(|&d| if d { FeatureCtl::TRUE } else { FeatureCtl::FALSE }).collect()
+    data.iter()
+        .map(|&d| {
+            if d {
+                FeatureCtl::TRUE
+            } else {
+                FeatureCtl::FALSE
+            }
+        })
+        .collect()
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -413,102 +440,80 @@ impl FeatureCtl {
 impl From<&FeatureCtl> for AudioFuncBlkCtl {
     fn from(ctl: &FeatureCtl) -> Self {
         match &ctl {
-            FeatureCtl::Mute(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::MUTE,
-                    data: bool_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::Volume(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::VOLUME,
-                    data: i16_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::LrBalance(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::LR_BALANCE,
-                    data: data.to_be_bytes().to_vec(),
-                }
-            }
-            FeatureCtl::FrBalance(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::FR_BALANCE,
-                    data: data.to_be_bytes().to_vec(),
-                }
-            }
-            FeatureCtl::Bass(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::BASS,
-                    data: data.iter().map(|v| *v as u8).collect(),
-                }
-            }
-            FeatureCtl::Mid(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::MID,
-                    data: data.iter().map(|v| *v as u8).collect(),
-                }
-            }
-            FeatureCtl::Treble(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::TREBLE,
-                    data: data.iter().map(|v| *v as u8).collect(),
-                }
-            }
-            FeatureCtl::GraphicEqualizer(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::GRAPHIC_EQUALIZER,
-                    data: data.into(),
-                }
-            }
-            FeatureCtl::AutomaticGain(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::AUTOMATIC_GAIN,
-                    data: bool_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::Delay(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::DELAY,
-                    data: u16_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::BassBoost(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::BASS_BOOST,
-                    data: bool_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::Loudness(data) => {
-                AudioFuncBlkCtl{
-                    selector: FeatureCtl::LOUDNESS,
-                    data: bool_vector_to_raw(data),
-                }
-            }
-            FeatureCtl::Reserved(data) => {
-                AudioFuncBlkCtl{
-                    selector: data[0],
-                    data: data[2..].to_vec(),
-                }
-            }
+            FeatureCtl::Mute(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::MUTE,
+                data: bool_vector_to_raw(data),
+            },
+            FeatureCtl::Volume(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::VOLUME,
+                data: i16_vector_to_raw(data),
+            },
+            FeatureCtl::LrBalance(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::LR_BALANCE,
+                data: data.to_be_bytes().to_vec(),
+            },
+            FeatureCtl::FrBalance(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::FR_BALANCE,
+                data: data.to_be_bytes().to_vec(),
+            },
+            FeatureCtl::Bass(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::BASS,
+                data: data.iter().map(|v| *v as u8).collect(),
+            },
+            FeatureCtl::Mid(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::MID,
+                data: data.iter().map(|v| *v as u8).collect(),
+            },
+            FeatureCtl::Treble(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::TREBLE,
+                data: data.iter().map(|v| *v as u8).collect(),
+            },
+            FeatureCtl::GraphicEqualizer(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::GRAPHIC_EQUALIZER,
+                data: data.into(),
+            },
+            FeatureCtl::AutomaticGain(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::AUTOMATIC_GAIN,
+                data: bool_vector_to_raw(data),
+            },
+            FeatureCtl::Delay(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::DELAY,
+                data: u16_vector_to_raw(data),
+            },
+            FeatureCtl::BassBoost(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::BASS_BOOST,
+                data: bool_vector_to_raw(data),
+            },
+            FeatureCtl::Loudness(data) => AudioFuncBlkCtl {
+                selector: FeatureCtl::LOUDNESS,
+                data: bool_vector_to_raw(data),
+            },
+            FeatureCtl::Reserved(data) => AudioFuncBlkCtl {
+                selector: data[0],
+                data: data[2..].to_vec(),
+            },
         }
     }
 }
 
 fn i16_vector_from_raw(raw: &[u8]) -> Vec<i16> {
-    (0..(raw.len() / 2)).map(|i| {
-        let mut doublet = [0;2];
-        doublet.copy_from_slice(&raw[(i * 2)..(i * 2 + 2)]);
-        i16::from_be_bytes(doublet)
-    }).collect()
+    (0..(raw.len() / 2))
+        .map(|i| {
+            let mut doublet = [0; 2];
+            doublet.copy_from_slice(&raw[(i * 2)..(i * 2 + 2)]);
+            i16::from_be_bytes(doublet)
+        })
+        .collect()
 }
 
 fn u16_vector_from_raw(raw: &[u8]) -> Vec<u16> {
-    (0..(raw.len() / 2)).map(|i| {
-        let mut doublet = [0;2];
-        doublet.copy_from_slice(&raw[(i * 2)..(i * 2 + 2)]);
-        u16::from_be_bytes(doublet)
-    }).collect()
+    (0..(raw.len() / 2))
+        .map(|i| {
+            let mut doublet = [0; 2];
+            doublet.copy_from_slice(&raw[(i * 2)..(i * 2 + 2)]);
+            u16::from_be_bytes(doublet)
+        })
+        .collect()
 }
 
 fn bool_vector_from_raw(raw: &[u8]) -> Vec<bool> {
@@ -520,7 +525,7 @@ fn i8_vector_from_raw(raw: &[u8]) -> Vec<i8> {
 }
 
 fn i16_from_raw(data: &[u8]) -> i16 {
-    let mut doublet = [0;2];
+    let mut doublet = [0; 2];
     doublet.copy_from_slice(&data);
     i16::from_be_bytes(doublet)
 }
@@ -589,7 +594,7 @@ pub struct AudioFeature {
 
 impl AudioFeature {
     pub fn new(func_blk_id: u8, ctl_attr: CtlAttr, audio_ch_num: AudioCh, ctl: FeatureCtl) -> Self {
-        AudioFeature{
+        AudioFeature {
             audio_ch_num,
             ctl,
             func_blk: AudioFuncBlk::new(AudioFuncBlkType::Feature, func_blk_id, ctl_attr),
@@ -598,7 +603,9 @@ impl AudioFeature {
 
     fn build_func_blk(&mut self) -> Result<(), AvcCmdBuildError> {
         self.func_blk.audio_selector_data.clear();
-        self.func_blk.audio_selector_data.push(u8::from(self.audio_ch_num));
+        self.func_blk
+            .audio_selector_data
+            .push(u8::from(self.audio_ch_num));
         self.func_blk.ctl = AudioFuncBlkCtl::from(&self.ctl);
         Ok(())
     }
@@ -606,8 +613,10 @@ impl AudioFeature {
     fn parse_func_blk(&mut self) -> Result<(), Error> {
         let audio_ch_num = AudioCh::from(self.func_blk.audio_selector_data[0]);
         if audio_ch_num != self.audio_ch_num {
-            let label = format!("Unexpected channel number for AudioFeature: {:?} but {:?}",
-                                self.audio_ch_num, audio_ch_num);
+            let label = format!(
+                "Unexpected channel number for AudioFeature: {:?} but {:?}",
+                self.audio_ch_num, audio_ch_num
+            );
             Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
         } else {
             self.ctl = FeatureCtl::from(&self.func_blk.ctl);
@@ -679,30 +688,26 @@ impl ProcessingCtl {
 impl From<&ProcessingCtl> for AudioFuncBlkCtl {
     fn from(ctl: &ProcessingCtl) -> Self {
         match ctl {
-            ProcessingCtl::Enable(data) => {
-                AudioFuncBlkCtl{
-                    selector: ProcessingCtl::ENABLE,
-                    data: vec![if *data { ProcessingCtl::TRUE } else { ProcessingCtl::FALSE }],
-                }
-            }
-            ProcessingCtl::Mode(data) => {
-                AudioFuncBlkCtl{
-                    selector: ProcessingCtl::MODE,
-                    data: data.to_vec(),
-                }
-            }
-            ProcessingCtl::Mixer(data) => {
-                AudioFuncBlkCtl{
-                    selector: ProcessingCtl::MIXER,
-                    data: i16_vector_to_raw(data),
-                }
-            }
-            ProcessingCtl::Reserved(data) => {
-                AudioFuncBlkCtl{
-                    selector: data[0],
-                    data: data[2..].to_vec(),
-                }
-            }
+            ProcessingCtl::Enable(data) => AudioFuncBlkCtl {
+                selector: ProcessingCtl::ENABLE,
+                data: vec![if *data {
+                    ProcessingCtl::TRUE
+                } else {
+                    ProcessingCtl::FALSE
+                }],
+            },
+            ProcessingCtl::Mode(data) => AudioFuncBlkCtl {
+                selector: ProcessingCtl::MODE,
+                data: data.to_vec(),
+            },
+            ProcessingCtl::Mixer(data) => AudioFuncBlkCtl {
+                selector: ProcessingCtl::MIXER,
+                data: i16_vector_to_raw(data),
+            },
+            ProcessingCtl::Reserved(data) => AudioFuncBlkCtl {
+                selector: data[0],
+                data: data[2..].to_vec(),
+            },
         }
     }
 }
@@ -734,9 +739,15 @@ pub struct AudioProcessing {
 }
 
 impl AudioProcessing {
-    pub fn new(func_blk_id: u8, ctl_attr: CtlAttr, input_plug_id: u8, input_ch: AudioCh,
-               output_ch: AudioCh, ctl: ProcessingCtl) -> Self {
-        AudioProcessing{
+    pub fn new(
+        func_blk_id: u8,
+        ctl_attr: CtlAttr,
+        input_plug_id: u8,
+        input_ch: AudioCh,
+        output_ch: AudioCh,
+        ctl: ProcessingCtl,
+    ) -> Self {
+        AudioProcessing {
             input_plug_id,
             input_ch,
             output_ch,
@@ -748,30 +759,40 @@ impl AudioProcessing {
     fn build_func_blk(&mut self) -> Result<(), AvcCmdBuildError> {
         self.func_blk.audio_selector_data.clear();
         self.func_blk.audio_selector_data.push(self.input_plug_id);
-        self.func_blk.audio_selector_data.push(u8::from(self.input_ch));
-        self.func_blk.audio_selector_data.push(u8::from(self.output_ch));
+        self.func_blk
+            .audio_selector_data
+            .push(u8::from(self.input_ch));
+        self.func_blk
+            .audio_selector_data
+            .push(u8::from(self.output_ch));
         self.func_blk.ctl = AudioFuncBlkCtl::from(&self.ctl);
         Ok(())
     }
 
     fn parse_func_blk(&mut self) -> Result<(), Error> {
         if self.func_blk.audio_selector_data[0] != self.input_plug_id {
-            let label = format!("Unexpected input plug ID for AudioProcessing: {} but {}",
-                                self.input_plug_id, self.func_blk.func_blk_id);
+            let label = format!(
+                "Unexpected input plug ID for AudioProcessing: {} but {}",
+                self.input_plug_id, self.func_blk.func_blk_id
+            );
             return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
         }
 
         let input_ch = AudioCh::from(self.func_blk.audio_selector_data[1]);
         if input_ch != self.input_ch {
-            let label = format!("Unexpected input audio channel number for AudioProcessing: {:?} but {:?}",
-                                self.input_ch, input_ch);
+            let label = format!(
+                "Unexpected input audio channel number for AudioProcessing: {:?} but {:?}",
+                self.input_ch, input_ch
+            );
             return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
         }
 
         let output_ch = AudioCh::from(self.func_blk.audio_selector_data[2]);
         if output_ch != self.output_ch {
-            let label = format!("Unexpected output audio channel number for AudioProcessing: {:?} but {:?}",
-                                self.output_ch, output_ch);
+            let label = format!(
+                "Unexpected output audio channel number for AudioProcessing: {:?} but {:?}",
+                self.output_ch, output_ch
+            );
             return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
         }
 
@@ -823,13 +844,17 @@ mod test {
     #[test]
     fn func_blk_operands() {
         let mut op = AudioFuncBlk::new(AudioFuncBlkType::Selector, 0xfe, CtlAttr::Resolution);
-        op.audio_selector_data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        op.audio_selector_data
+            .extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
         op.ctl.selector = 0x11;
         op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
 
         let mut operands = Vec::new();
         AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x80, 0xfe, 0x01, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x11, 0x02, 0xbe, 0xef]);
+        assert_eq!(
+            &operands,
+            &[0x80, 0xfe, 0x01, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x11, 0x02, 0xbe, 0xef]
+        );
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.func_blk_type, AudioFuncBlkType::Selector);
@@ -840,13 +865,17 @@ mod test {
         assert_eq!(&op.ctl.data, &[0xbe, 0xef]);
 
         let mut op = AudioFuncBlk::new(AudioFuncBlkType::Selector, 0xfd, CtlAttr::Minimum);
-        op.audio_selector_data.extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
+        op.audio_selector_data
+            .extend_from_slice(&[0xde, 0xad, 0xbe, 0xef]);
         op.ctl.selector = 0x12;
         op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
 
         let mut operands = Vec::new();
         AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x80, 0xfd, 0x02, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x12, 0x02, 0xbe, 0xef]);
+        assert_eq!(
+            &operands,
+            &[0x80, 0xfd, 0x02, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x12, 0x02, 0xbe, 0xef]
+        );
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.func_blk_type, AudioFuncBlkType::Selector);
@@ -863,7 +892,10 @@ mod test {
 
         let mut operands = Vec::new();
         AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x81, 0xfc, 0x03, 0x01, 0x13, 0x04, 0xfe, 0xeb, 0xda, 0xed]);
+        assert_eq!(
+            &operands,
+            &[0x81, 0xfc, 0x03, 0x01, 0x13, 0x04, 0xfe, 0xeb, 0xda, 0xed]
+        );
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.func_blk_type, AudioFuncBlkType::Feature);
@@ -879,7 +911,10 @@ mod test {
 
         let mut operands = Vec::new();
         AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x81, 0xfb, 0x04, 0x01, 0x14, 0x04, 0xfe, 0xeb, 0xda, 0xed]);
+        assert_eq!(
+            &operands,
+            &[0x81, 0xfb, 0x04, 0x01, 0x14, 0x04, 0xfe, 0xeb, 0xda, 0xed]
+        );
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.func_blk_type, AudioFuncBlkType::Feature);
@@ -962,10 +997,12 @@ mod test {
         let ctl = FeatureCtl::Mid(vec![30, -30, -40, 40]);
         assert_eq!(ctl, FeatureCtl::from(&AudioFuncBlkCtl::from(&ctl)));
 
-        let data = GraphicEqualizerData{
+        let data = GraphicEqualizerData {
             bands_present: [0x00, 0x01, 0x02, 0x03],
             ex_bands_present: [0x04, 0x05, 0x06, 0x07],
-            gain: vec![-1, -2, -3, 10, 14, -40, -100, 33, 87, 99, -123, 100, -76, -97, 18, 21],
+            gain: vec![
+                -1, -2, -3, 10, 14, -40, -100, 33, 87, 99, -123, 100, -76, -97, 18, 21,
+            ],
         };
         let ctl = FeatureCtl::GraphicEqualizer(data);
         assert_eq!(ctl, FeatureCtl::from(&AudioFuncBlkCtl::from(&ctl)));
@@ -995,7 +1032,10 @@ mod test {
         let mut op = AudioFeature::new(0x03, CtlAttr::Minimum, AudioCh::Each(0x1b), ctl.clone());
         let mut operands = Vec::new();
         AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x81, 0x03, 0x02, 0x02, 0x1c, 0x02, 0x06, 0xfb, 0x2e, 0x16, 0x2e, 0x0c, 0x8a]);
+        assert_eq!(
+            &operands,
+            &[0x81, 0x03, 0x02, 0x02, 0x1c, 0x02, 0x06, 0xfb, 0x2e, 0x16, 0x2e, 0x0c, 0x8a]
+        );
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(AudioCh::Each(0x1b), op.audio_ch_num);
@@ -1005,7 +1045,10 @@ mod test {
         let mut op = AudioFeature::new(0x33, CtlAttr::Resolution, AudioCh::Each(0xd8), ctl.clone());
         let mut operands = Vec::new();
         AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x81, 0x33, 0x01, 0x2, 0xd9, 0x07, 0x04, 0x28, 0xdf, 0x7b, 0xa0]);
+        assert_eq!(
+            &operands,
+            &[0x81, 0x33, 0x01, 0x2, 0xd9, 0x07, 0x04, 0x28, 0xdf, 0x7b, 0xa0]
+        );
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(AudioCh::Each(0xd8), op.audio_ch_num);
@@ -1027,11 +1070,20 @@ mod test {
     #[test]
     fn avcaudioprocessing_operands() {
         let ctl = ProcessingCtl::Enable(true);
-        let mut op = AudioProcessing::new(0xf5, CtlAttr::Default, 0x71, AudioCh::Each(0xa8),
-                                          AudioCh::Each(0x3e), ctl.clone());
+        let mut op = AudioProcessing::new(
+            0xf5,
+            CtlAttr::Default,
+            0x71,
+            AudioCh::Each(0xa8),
+            AudioCh::Each(0x3e),
+            ctl.clone(),
+        );
         let mut operands = Vec::new();
         AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x82, 0xf5, 0x04, 0x04, 0x71, 0xa9, 0x3f, 0x01, 0x01, 0x70]);
+        assert_eq!(
+            &operands,
+            &[0x82, 0xf5, 0x04, 0x04, 0x71, 0xa9, 0x3f, 0x01, 0x01, 0x70]
+        );
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(0x71, op.input_plug_id);
@@ -1040,11 +1092,20 @@ mod test {
         assert_eq!(ctl, op.ctl);
 
         let ctl = ProcessingCtl::Mixer(vec![10, -10]);
-        let mut op = AudioProcessing::new(0x11, CtlAttr::Minimum, 0x22, AudioCh::Each(0x32),
-                                          AudioCh::Each(0x43), ctl.clone());
+        let mut op = AudioProcessing::new(
+            0x11,
+            CtlAttr::Minimum,
+            0x22,
+            AudioCh::Each(0x32),
+            AudioCh::Each(0x43),
+            ctl.clone(),
+        );
         let mut operands = Vec::new();
         AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
-        assert_eq!(&operands, &[0x82, 0x11, 0x02, 0x04, 0x22, 0x33, 0x44, 0x03, 0x04, 0x00, 0x0a, 0xff, 0xf6]);
+        assert_eq!(
+            &operands,
+            &[0x82, 0x11, 0x02, 0x04, 0x22, 0x33, 0x44, 0x03, 0x04, 0x00, 0x0a, 0xff, 0xf6]
+        );
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(0x22, op.input_plug_id);

--- a/libs/ta1394/src/ccm.rs
+++ b/libs/ta1394/src/ccm.rs
@@ -14,8 +14,8 @@ impl SignalUnitAddr {
     const PLUG_ID_MASK: u8 = 0x7f;
 }
 
-impl From<&[u8;2]> for SignalUnitAddr {
-    fn from(data: &[u8;2]) -> Self {
+impl From<&[u8; 2]> for SignalUnitAddr {
+    fn from(data: &[u8; 2]) -> Self {
         let plug_id = data[1] & Self::PLUG_ID_MASK;
         if data[1] & Self::EXT_PLUG_FLAG > 0 {
             Self::Ext(plug_id)
@@ -25,9 +25,9 @@ impl From<&[u8;2]> for SignalUnitAddr {
     }
 }
 
-impl From<SignalUnitAddr> for [u8;2] {
+impl From<SignalUnitAddr> for [u8; 2] {
     fn from(addr: SignalUnitAddr) -> Self {
-        let mut data = [0;2];
+        let mut data = [0; 2];
         data[0] = AvcAddr::UNIT_ADDR;
         data[1] = match addr {
             SignalUnitAddr::Isoc(val) => val,
@@ -43,17 +43,17 @@ pub struct SignalSubunitAddr {
     pub plug_id: u8,
 }
 
-impl From<&[u8;2]> for SignalSubunitAddr {
-    fn from(data: &[u8;2]) -> Self {
+impl From<&[u8; 2]> for SignalSubunitAddr {
+    fn from(data: &[u8; 2]) -> Self {
         let subunit = AvcAddrSubunit::from(data[0]);
         let plug_id = data[1];
-        SignalSubunitAddr{subunit, plug_id}
+        SignalSubunitAddr { subunit, plug_id }
     }
 }
 
-impl From<SignalSubunitAddr> for [u8;2] {
+impl From<SignalSubunitAddr> for [u8; 2] {
     fn from(addr: SignalSubunitAddr) -> Self {
-        let mut data = [0;2];
+        let mut data = [0; 2];
         data[0] = u8::from(addr.subunit);
         data[1] = addr.plug_id;
         data
@@ -76,15 +76,18 @@ impl SignalAddr {
     }
 
     pub fn new_for_subunit(subunit_type: AvcSubunitType, subunit_id: u8, plug_id: u8) -> Self {
-        SignalAddr::Subunit(SignalSubunitAddr{
-            subunit: AvcAddrSubunit{subunit_type, subunit_id},
+        SignalAddr::Subunit(SignalSubunitAddr {
+            subunit: AvcAddrSubunit {
+                subunit_type,
+                subunit_id,
+            },
             plug_id,
         })
     }
 }
 
-impl From<&[u8;2]> for SignalAddr {
-    fn from(data: &[u8;2]) -> Self {
+impl From<&[u8; 2]> for SignalAddr {
+    fn from(data: &[u8; 2]) -> Self {
         if data[0] == AvcAddr::UNIT_ADDR {
             SignalAddr::Unit(data.into())
         } else {
@@ -93,7 +96,7 @@ impl From<&[u8;2]> for SignalAddr {
     }
 }
 
-impl From<SignalAddr> for [u8;2] {
+impl From<SignalAddr> for [u8; 2] {
     fn from(addr: SignalAddr) -> Self {
         match addr {
             SignalAddr::Unit(a) => a.into(),
@@ -110,7 +113,7 @@ pub struct SignalSource {
 
 impl SignalSource {
     pub fn new(dst: &SignalAddr) -> Self {
-        SignalSource{
+        SignalSource {
             src: SignalAddr::Unit(SignalUnitAddr::Isoc(SignalUnitAddr::PLUG_ID_MASK)),
             dst: *dst,
         }
@@ -118,7 +121,7 @@ impl SignalSource {
 
     fn parse_operands(&mut self, operands: &[u8]) -> Result<(), Error> {
         if operands.len() > 4 {
-            let mut doublet = [0;2];
+            let mut doublet = [0; 2];
             doublet.copy_from_slice(&operands[1..3]);
             self.src = SignalAddr::from(&doublet);
             doublet.copy_from_slice(&operands[3..5]);
@@ -175,19 +178,37 @@ mod test {
 
     #[test]
     fn signaladdr_from() {
-        assert_eq!([0xff, 0x00], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x00])));
-        assert_eq!([0xff, 0x27], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x27])));
-        assert_eq!([0xff, 0x87], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0x87])));
-        assert_eq!([0xff, 0xc7], Into::<[u8;2]>::into(SignalAddr::from(&[0xff, 0xc7])));
-        assert_eq!([0x63, 0x07], Into::<[u8;2]>::into(SignalAddr::from(&[0x63, 0x07])));
-        assert_eq!([0x09, 0x11], Into::<[u8;2]>::into(SignalAddr::from(&[0x09, 0x11])));
+        assert_eq!(
+            [0xff, 0x00],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0xff, 0x00]))
+        );
+        assert_eq!(
+            [0xff, 0x27],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0xff, 0x27]))
+        );
+        assert_eq!(
+            [0xff, 0x87],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0xff, 0x87]))
+        );
+        assert_eq!(
+            [0xff, 0xc7],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0xff, 0xc7]))
+        );
+        assert_eq!(
+            [0x63, 0x07],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0x63, 0x07]))
+        );
+        assert_eq!(
+            [0x09, 0x11],
+            Into::<[u8; 2]>::into(SignalAddr::from(&[0x09, 0x11]))
+        );
     }
 
     #[test]
     fn signalsource_operands() {
         let operands = [0x00, 0x2e, 0x1c, 0xff, 0x05];
         let dst = SignalAddr::Unit(SignalUnitAddr::Isoc(0x05));
-        let src = SignalAddr::Subunit(SignalSubunitAddr{
+        let src = SignalAddr::Subunit(SignalSubunitAddr {
             subunit: AvcAddrSubunit::new(AvcSubunitType::Tuner, 0x06),
             plug_id: 0x1c,
         });
@@ -201,16 +222,16 @@ mod test {
         assert_eq!(targets, [0xff, 0xff, 0xfe, 0xff, 0x05]);
 
         let mut targets = Vec::new();
-        let src = SignalAddr::Subunit(SignalSubunitAddr{
+        let src = SignalAddr::Subunit(SignalSubunitAddr {
             subunit: AvcAddrSubunit::new(AvcSubunitType::Extended, 0x05),
             plug_id: 0x07,
         });
         let dst = SignalAddr::Unit(SignalUnitAddr::Ext(0x03));
-        let mut op = SignalSource{src, dst};
+        let mut op = SignalSource { src, dst };
         AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut targets).unwrap();
         assert_eq!(targets, [0xff, 0xf5, 0x07, 0xff, 0x83]);
 
-        let mut op = SignalSource{
+        let mut op = SignalSource {
             src: SignalAddr::Unit(SignalUnitAddr::Isoc(0xf)),
             dst: SignalAddr::Unit(SignalUnitAddr::Isoc(0xf)),
         };

--- a/libs/ta1394/src/ccm.rs
+++ b/libs/ta1394/src/ccm.rs
@@ -136,10 +136,14 @@ impl AvcOp for SignalSource {
 }
 
 impl AvcControl for SignalSource {
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(0xff);
-        operands.extend_from_slice(&Into::<[u8;2]>::into(self.src));
-        operands.extend_from_slice(&Into::<[u8;2]>::into(self.dst));
+        operands.extend_from_slice(&Into::<[u8; 2]>::into(self.src));
+        operands.extend_from_slice(&Into::<[u8; 2]>::into(self.dst));
         Ok(())
     }
 
@@ -149,10 +153,14 @@ impl AvcControl for SignalSource {
 }
 
 impl AvcStatus for SignalSource {
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(0xff);
         operands.extend_from_slice(&[0xff, 0xfe]);
-        operands.extend_from_slice(&Into::<[u8;2]>::into(self.dst));
+        operands.extend_from_slice(&Into::<[u8; 2]>::into(self.dst));
         Ok(())
     }
 

--- a/libs/ta1394/src/ccm.rs
+++ b/libs/ta1394/src/ccm.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
 
-use super::{AvcSubunitType, AvcAddr, AvcAddrSubunit, Ta1394AvcError};
-use super::{AvcOp, AvcStatus, AvcControl};
+use super::*;
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum SignalUnitAddr {
@@ -165,9 +163,7 @@ impl AvcStatus for SignalSource {
 
 #[cfg(test)]
 mod test {
-    use super::{AvcSubunitType, AvcAddrSubunit, AvcAddr};
-    use super::{AvcStatus, AvcControl};
-    use super::{SignalAddr, SignalUnitAddr, SignalSubunitAddr, SignalSource};
+    use crate::ccm::*;
 
     #[test]
     fn signaladdr_from() {

--- a/libs/ta1394/src/ccm.rs
+++ b/libs/ta1394/src/ccm.rs
@@ -119,7 +119,7 @@ impl SignalSource {
         }
     }
 
-    fn parse_operands(&mut self, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, operands: &[u8]) -> Result<(), AvcRespParseError> {
         if operands.len() > 4 {
             let mut doublet = [0; 2];
             doublet.copy_from_slice(&operands[1..3]);
@@ -128,8 +128,7 @@ impl SignalSource {
             self.dst = SignalAddr::from(&doublet);
             Ok(())
         } else {
-            let label = format!("Oprands too short for VendorDependent; {}", operands.len());
-            Err(Error::new(Ta1394AvcError::TooShortResp, &label))
+            Err(AvcRespParseError::TooShortResp(4))
         }
     }
 }
@@ -150,7 +149,7 @@ impl AvcControl for SignalSource {
         Ok(())
     }
 
-    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         Self::parse_operands(self, operands)
     }
 }
@@ -167,7 +166,7 @@ impl AvcStatus for SignalSource {
         Ok(())
     }
 
-    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
+    fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         Self::parse_operands(self, operands)
     }
 }

--- a/libs/ta1394/src/config_rom.rs
+++ b/libs/ta1394/src/config_rom.rs
@@ -23,46 +23,48 @@ pub trait Ta1394ConfigRom<'a> {
 
 impl<'a> Ta1394ConfigRom<'a> for ConfigRom<'a> {
     fn get_vendor(&'a self) -> Option<VendorData<'a>> {
-        detect_desc_text(&self.root, KeyType::Vendor)
-            .map(|(vendor_id, vendor_name)| VendorData{vendor_id, vendor_name})
+        detect_desc_text(&self.root, KeyType::Vendor).map(|(vendor_id, vendor_name)| VendorData {
+            vendor_id,
+            vendor_name,
+        })
     }
 
     fn get_model(&'a self) -> Option<UnitData<'a>> {
-        self.root.iter().find_map(|entry| {
-            EntryDataAccess::<&[Entry]>::get(entry, KeyType::Unit)
-        })
-        .and_then(|entries| {
-            entries.iter().find_map(|entry| {
-                EntryDataAccess::<u32>::get(entry, KeyType::SpecifierId)
+        self.root
+            .iter()
+            .find_map(|entry| EntryDataAccess::<&[Entry]>::get(entry, KeyType::Unit))
+            .and_then(|entries| {
+                entries
+                    .iter()
+                    .find_map(|entry| EntryDataAccess::<u32>::get(entry, KeyType::SpecifierId))
+                    .and_then(|specifier_id| {
+                        entries
+                            .iter()
+                            .find_map(|entry| EntryDataAccess::<u32>::get(entry, KeyType::Version))
+                            .and_then(|version| {
+                                detect_desc_text(entries, KeyType::Model).map(
+                                    |(model_id, model_name)| UnitData {
+                                        model_id,
+                                        model_name,
+                                        specifier_id,
+                                        version,
+                                    },
+                                )
+                            })
+                    })
             })
-            .and_then(|specifier_id| {
-                entries.iter().find_map(|entry| {
-                    EntryDataAccess::<u32>::get(entry, KeyType::Version)
-                })
-                .and_then(|version| {
-                    detect_desc_text(entries, KeyType::Model)
-                        .map(|(model_id, model_name)| {
-                            UnitData{model_id, model_name, specifier_id, version}
-                        })
-                })
-            })
-        })
     }
 }
 
 fn detect_desc_text<'a>(entries: &'a [Entry], key_type: KeyType) -> Option<(u32, &'a str)> {
     let mut peekable = entries.iter().peekable();
 
-    while let Some(entry) = peekable.next()
-    {
-        let result = EntryDataAccess::<u32>::get(entry, key_type)
-            .and_then(|value| {
-                peekable.peek()
-                    .and_then(|&next| {
-                        EntryDataAccess::<&str>::get(next, KeyType::Descriptor)
-                            .map(|name| (value, name))
-                    })
-            });
+    while let Some(entry) = peekable.next() {
+        let result = EntryDataAccess::<u32>::get(entry, key_type).and_then(|value| {
+            peekable.peek().and_then(|&next| {
+                EntryDataAccess::<&str>::get(next, KeyType::Descriptor).map(|name| (value, name))
+            })
+        });
 
         if result.is_some() {
             return result;

--- a/libs/ta1394/src/general.rs
+++ b/libs/ta1394/src/general.rs
@@ -10,17 +10,17 @@ use super::*;
 pub struct UnitInfo {
     pub unit_type: AvcSubunitType,
     pub unit_id: u8,
-    pub company_id: [u8;3],
+    pub company_id: [u8; 3],
 }
 
 impl UnitInfo {
     const FIRST_OPERAND: u8 = 0x07;
 
     pub fn new() -> Self {
-        UnitInfo{
+        UnitInfo {
             unit_type: AvcSubunitType::Reserved(AvcAddrSubunit::SUBUNIT_TYPE_MASK),
             unit_id: AvcAddrSubunit::SUBUNIT_ID_MASK,
-            company_id: [0xff;3],
+            company_id: [0xff; 3],
         }
     }
 }
@@ -49,8 +49,10 @@ impl AvcStatus for UnitInfo {
             let label = format!("Oprands too short for UnitInfo; {}", operands.len());
             Err(Error::new(Ta1394AvcError::TooShortResp, &label))
         } else {
-            let unit_type = (operands[1] >> AvcAddrSubunit::SUBUNIT_TYPE_SHIFT) & AvcAddrSubunit::SUBUNIT_TYPE_MASK;
-            let unit_id = (operands[1] >> AvcAddrSubunit::SUBUNIT_ID_SHIFT) & AvcAddrSubunit::SUBUNIT_ID_MASK;
+            let unit_type = (operands[1] >> AvcAddrSubunit::SUBUNIT_TYPE_SHIFT)
+                & AvcAddrSubunit::SUBUNIT_TYPE_MASK;
+            let unit_id =
+                (operands[1] >> AvcAddrSubunit::SUBUNIT_ID_SHIFT) & AvcAddrSubunit::SUBUNIT_ID_MASK;
 
             self.unit_type = AvcSubunitType::from(unit_type);
             self.unit_id = unit_id;
@@ -64,19 +66,22 @@ impl AvcStatus for UnitInfo {
 // AV/C SUBUNIT INFO command.
 //
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub struct SubunitInfoEntry{
+pub struct SubunitInfoEntry {
     pub subunit_type: AvcSubunitType,
     pub maximum_id: u8,
 }
 
 impl SubunitInfoEntry {
     pub fn new(subunit_type: AvcSubunitType, maximum_id: u8) -> Self {
-        SubunitInfoEntry{subunit_type, maximum_id}
+        SubunitInfoEntry {
+            subunit_type,
+            maximum_id,
+        }
     }
 }
 
 #[derive(Debug)]
-pub struct SubunitInfo{
+pub struct SubunitInfo {
     pub page: u8,
     pub extension_code: u8,
     pub entries: Vec<SubunitInfoEntry>,
@@ -89,7 +94,7 @@ impl SubunitInfo {
     const EXTENSION_CODE_MASK: u8 = 0x07;
 
     pub fn new(page: u8, extension_code: u8) -> Self {
-        SubunitInfo{
+        SubunitInfo {
             page,
             extension_code,
             entries: Vec::new(),
@@ -126,18 +131,23 @@ impl AvcStatus for SubunitInfo {
             Err(Error::new(Ta1394AvcError::TooShortResp, &label))
         } else {
             self.page = (operands[0] >> Self::PAGE_SHIFT) & Self::PAGE_MASK;
-            self.extension_code = (operands[0] >> Self::EXTENSION_CODE_SHIFT) & Self::EXTENSION_CODE_MASK;
+            self.extension_code =
+                (operands[0] >> Self::EXTENSION_CODE_SHIFT) & Self::EXTENSION_CODE_MASK;
 
-            self.entries = operands[1..5].iter()
+            self.entries = operands[1..5]
+                .iter()
                 .filter(|&operand| *operand != 0xff)
                 .map(|operand| {
-                    let subunit_type = (operand >> AvcAddrSubunit::SUBUNIT_TYPE_SHIFT) & AvcAddrSubunit::SUBUNIT_TYPE_MASK;
-                    let maximum_id = (operand >> AvcAddrSubunit::SUBUNIT_ID_SHIFT) & AvcAddrSubunit::SUBUNIT_ID_MASK;
-                    SubunitInfoEntry{
+                    let subunit_type = (operand >> AvcAddrSubunit::SUBUNIT_TYPE_SHIFT)
+                        & AvcAddrSubunit::SUBUNIT_TYPE_MASK;
+                    let maximum_id = (operand >> AvcAddrSubunit::SUBUNIT_ID_SHIFT)
+                        & AvcAddrSubunit::SUBUNIT_ID_MASK;
+                    SubunitInfoEntry {
                         subunit_type: AvcSubunitType::from(subunit_type),
                         maximum_id,
                     }
-                }).collect();
+                })
+                .collect();
 
             Ok(())
         }
@@ -149,13 +159,13 @@ impl AvcStatus for SubunitInfo {
 //
 #[derive(Debug)]
 pub struct VendorDependent {
-    pub company_id: [u8;3],
+    pub company_id: [u8; 3],
     pub data: Vec<u8>,
 }
 
 impl VendorDependent {
-    pub fn new(company_id: &[u8;3]) -> Self {
-        VendorDependent{
+    pub fn new(company_id: &[u8; 3]) -> Self {
+        VendorDependent {
             company_id: *company_id,
             data: Vec::new(),
         }
@@ -266,7 +276,7 @@ impl PlugInfo {
     const SUBFUNC_SUBUNIT: u8 = 0x00;
 
     pub fn new_for_unit_isoc_ext_plugs() -> Self {
-        PlugInfo::Unit(PlugInfoUnitData::IsocExt(PlugInfoUnitIsocExtData{
+        PlugInfo::Unit(PlugInfoUnitData::IsocExt(PlugInfoUnitIsocExtData {
             isoc_input_plugs: 0xff,
             isoc_output_plugs: 0xff,
             external_input_plugs: 0xff,
@@ -275,14 +285,14 @@ impl PlugInfo {
     }
 
     pub fn new_for_unit_async_plugs() -> Self {
-        PlugInfo::Unit(PlugInfoUnitData::Async(PlugInfoUnitAsyncData{
+        PlugInfo::Unit(PlugInfoUnitData::Async(PlugInfoUnitAsyncData {
             async_input_plugs: 0xff,
             async_output_plugs: 0xff,
         }))
     }
 
     pub fn new_for_unit_other_plugs(subfunction: u8) -> Self {
-        PlugInfo::Unit(PlugInfoUnitData::Other(PlugInfoUnitOtherData{
+        PlugInfo::Unit(PlugInfoUnitData::Other(PlugInfoUnitOtherData {
             subfunction,
             first_input_plug: 0xff,
             input_plugs: 0xff,
@@ -292,7 +302,7 @@ impl PlugInfo {
     }
 
     pub fn new_for_subunit_plugs() -> Self {
-        PlugInfo::Subunit(PlugInfoSubunitData{
+        PlugInfo::Subunit(PlugInfoSubunitData {
             dst_plugs: 0xff,
             src_plugs: 0xff,
         })
@@ -328,7 +338,7 @@ impl AvcStatus for PlugInfo {
             }
         };
         operands.push(subfunction);
-        operands.extend_from_slice(&[0xff;4]);
+        operands.extend_from_slice(&[0xff; 4]);
         Ok(())
     }
 
@@ -340,41 +350,45 @@ impl AvcStatus for PlugInfo {
 
         let subfunction = operands[0];
         match self {
-            PlugInfo::Unit(u) => {
-                match u {
-                    PlugInfoUnitData::IsocExt(d) => {
-                        if subfunction != Self::SUBFUNC_UNIT_ISOC_EXT {
-                            let label = format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
-                            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
-                        }
-                        d.isoc_input_plugs = operands[1];
-                        d.isoc_output_plugs = operands[2];
-                        d.external_input_plugs = operands[3];
-                        d.external_output_plugs = operands[4];
+            PlugInfo::Unit(u) => match u {
+                PlugInfoUnitData::IsocExt(d) => {
+                    if subfunction != Self::SUBFUNC_UNIT_ISOC_EXT {
+                        let label =
+                            format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
+                        return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
                     }
-                    PlugInfoUnitData::Async(d) => {
-                        if subfunction != Self::SUBFUNC_UNIT_ASYNC {
-                            let label = format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
-                            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
-                        }
-                        d.async_input_plugs = operands[1];
-                        d.async_output_plugs = operands[2];
-                    }
-                    PlugInfoUnitData::Other(d) => {
-                        if subfunction != d.subfunction {
-                            let label = format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
-                            return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
-                        }
-                        d.first_input_plug = operands[1];
-                        d.input_plugs = operands[2];
-                        d.first_output_plug = operands[3];
-                        d.output_plugs = operands[4];
-                    }
+                    d.isoc_input_plugs = operands[1];
+                    d.isoc_output_plugs = operands[2];
+                    d.external_input_plugs = operands[3];
+                    d.external_output_plugs = operands[4];
                 }
-            }
+                PlugInfoUnitData::Async(d) => {
+                    if subfunction != Self::SUBFUNC_UNIT_ASYNC {
+                        let label =
+                            format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
+                        return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+                    }
+                    d.async_input_plugs = operands[1];
+                    d.async_output_plugs = operands[2];
+                }
+                PlugInfoUnitData::Other(d) => {
+                    if subfunction != d.subfunction {
+                        let label =
+                            format!("Invalid subfunction for unit by PlugInfo: {}", subfunction);
+                        return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
+                    }
+                    d.first_input_plug = operands[1];
+                    d.input_plugs = operands[2];
+                    d.first_output_plug = operands[3];
+                    d.output_plugs = operands[4];
+                }
+            },
             PlugInfo::Subunit(s) => {
                 if subfunction != Self::SUBFUNC_SUBUNIT {
-                    let label = format!("Invalid subfunction for subunit by PlugInfo: {}", subfunction);
+                    let label = format!(
+                        "Invalid subfunction for subunit by PlugInfo: {}",
+                        subfunction
+                    );
                     return Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label));
                 }
                 s.dst_plugs = operands[1];
@@ -393,15 +407,15 @@ impl AvcStatus for PlugInfo {
 pub struct InputPlugSignalFormat {
     pub plug_id: u8,
     pub fmt: u8,
-    pub fdf: [u8;3],
+    pub fdf: [u8; 3],
 }
 
 impl InputPlugSignalFormat {
     pub fn new(plug_id: u8) -> Self {
-        InputPlugSignalFormat{
+        InputPlugSignalFormat {
             plug_id,
             fmt: 0xff,
-            fdf: [0xff;3],
+            fdf: [0xff; 3],
         }
     }
 
@@ -412,7 +426,10 @@ impl InputPlugSignalFormat {
             self.fdf.copy_from_slice(&operands[2..5]);
             Ok(())
         } else {
-            let label = format!("Oprands too short for InputPlugSignalFormat; {}", operands.len());
+            let label = format!(
+                "Oprands too short for InputPlugSignalFormat; {}",
+                operands.len()
+            );
             Err(Error::new(Ta1394AvcError::TooShortResp, &label))
         }
     }
@@ -470,15 +487,15 @@ impl AvcStatus for InputPlugSignalFormat {
 pub struct OutputPlugSignalFormat {
     pub plug_id: u8,
     pub fmt: u8,
-    pub fdf: [u8;3],
+    pub fdf: [u8; 3],
 }
 
 impl OutputPlugSignalFormat {
     pub fn new(plug_id: u8) -> Self {
-        OutputPlugSignalFormat{
+        OutputPlugSignalFormat {
             plug_id,
             fmt: 0xff,
-            fdf: [0xff;3],
+            fdf: [0xff; 3],
         }
     }
 
@@ -489,7 +506,10 @@ impl OutputPlugSignalFormat {
             self.fdf.copy_from_slice(&operands[2..5]);
             Ok(())
         } else {
-            let label = format!("Oprands too short for OutputPlugSignalFormat; {}", operands.len());
+            let label = format!(
+                "Oprands too short for OutputPlugSignalFormat; {}",
+                operands.len()
+            );
             Err(Error::new(Ta1394AvcError::TooShortResp, &label))
         }
     }
@@ -565,10 +585,22 @@ mod test {
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.page, 0x05);
         assert_eq!(op.extension_code, 0x06);
-        assert_eq!(op.entries[0], SubunitInfoEntry::new(AvcSubunitType::Reserved(0x15), 0x05));
-        assert_eq!(op.entries[1], SubunitInfoEntry::new(AvcSubunitType::Reserved(0x17), 0x06));
-        assert_eq!(op.entries[2], SubunitInfoEntry::new(AvcSubunitType::Reserved(0x1d), 0x07));
-        assert_eq!(op.entries[3], SubunitInfoEntry::new(AvcSubunitType::Camera, 0x02));
+        assert_eq!(
+            op.entries[0],
+            SubunitInfoEntry::new(AvcSubunitType::Reserved(0x15), 0x05)
+        );
+        assert_eq!(
+            op.entries[1],
+            SubunitInfoEntry::new(AvcSubunitType::Reserved(0x17), 0x06)
+        );
+        assert_eq!(
+            op.entries[2],
+            SubunitInfoEntry::new(AvcSubunitType::Reserved(0x1d), 0x07)
+        );
+        assert_eq!(
+            op.entries[3],
+            SubunitInfoEntry::new(AvcSubunitType::Camera, 0x02)
+        );
     }
 
     #[test]
@@ -605,9 +637,9 @@ mod test {
                     assert_eq!(d.isoc_output_plugs, 0xad);
                     assert_eq!(d.external_input_plugs, 0xbe);
                     assert_eq!(d.external_output_plugs, 0xef);
-                },
+                }
                 _ => unreachable!(),
-            }
+            },
             _ => unreachable!(),
         }
 
@@ -625,7 +657,7 @@ mod test {
                     assert_eq!(d.async_output_plugs, 0xad);
                 }
                 _ => unreachable!(),
-            }
+            },
             _ => unreachable!(),
         }
 
@@ -646,7 +678,7 @@ mod test {
                     assert_eq!(d.output_plugs, 0xef);
                 }
                 _ => unreachable!(),
-            }
+            },
             _ => unreachable!(),
         }
 
@@ -666,7 +698,7 @@ mod test {
         }
 
         let mut target = Vec::new();
-        let addr = AvcAddr::Subunit(AvcAddrSubunit{
+        let addr = AvcAddr::Subunit(AvcAddrSubunit {
             subunit_type: AvcSubunitType::Audio,
             subunit_id: 0x4,
         });

--- a/libs/ta1394/src/general.rs
+++ b/libs/ta1394/src/general.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::Error;
 
-use super::{AvcAddr, AvcAddrSubunit, AvcSubunitType, Ta1394AvcError};
-use super::{AvcOp, AvcStatus, AvcControl};
+use super::*;
 
 //
 // AV/C UNIT INFO command.
@@ -514,11 +512,7 @@ impl AvcStatus for OutputPlugSignalFormat {
 
 #[cfg(test)]
 mod test {
-    use super::{AvcSubunitType, AvcAddr, AvcAddrSubunit};
-    use super::{AvcStatus, AvcControl};
-    use super::{UnitInfo, SubunitInfo, SubunitInfoEntry, VendorDependent};
-    use super::{PlugInfo, PlugInfoUnitData};
-    use super::{InputPlugSignalFormat, OutputPlugSignalFormat};
+    use crate::general::*;
 
     #[test]
     fn unitinfo_operands() {

--- a/libs/ta1394/src/lib.rs
+++ b/libs/ta1394/src/lib.rs
@@ -552,12 +552,18 @@ mod test {
     #[test]
     fn avcaddr_from() {
         assert_eq!(AvcAddr::from(0xff), AvcAddr::Unit);
-        assert_eq!(AvcAddr::from(0x09),
-                   AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Audio, 0x01)));
-        assert_eq!(AvcAddr::from(0x63),
-                   AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Music, 0x03)));
-        assert_eq!(AvcAddr::from(0x87),
-                   AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Reserved(0x10), 0x07)));
+        assert_eq!(
+            AvcAddr::from(0x09),
+            AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Audio, 0x01))
+        );
+        assert_eq!(
+            AvcAddr::from(0x63),
+            AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Music, 0x03))
+        );
+        assert_eq!(
+            AvcAddr::from(0x87),
+            AvcAddr::Subunit(AvcAddrSubunit::new(AvcSubunitType::Reserved(0x10), 0x07))
+        );
     }
 
     #[test]

--- a/libs/ta1394/src/lib.rs
+++ b/libs/ta1394/src/lib.rs
@@ -196,12 +196,18 @@ impl From<AvcAddr> for u8 {
     }
 }
 
+/// The type of command in AV/C transaction.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AvcCmdType {
+    /// Perform an operation to the addressed target.
     Control,
+    /// Check current status of the addressed target.
     Status,
+    /// Check whether the addressed target supports a particular Control command including operands.
     SpecificInquiry,
+    /// Schedule notification of a change in the addressed target.
     Notify,
+    /// Check whether the addressed target supports a particular Control command just with opcode.
     GeneralInquiry,
     Reserved(u8),
 }
@@ -240,14 +246,23 @@ impl From<AvcCmdType> for u8 {
     }
 }
 
+/// The status of response in AV/C transaction.
 #[derive(Debug, Eq, PartialEq)]
 pub enum AvcRespCode {
+    /// The target does not implement the requested command or the addressed subunit.
     NotImplemented,
+    /// The requested CONTROL command has been processed or is scheduled to process.
     Accepted,
+    /// The target refused to process the requested command due to some reasons.
     Rejected,
+    /// The target is under transition state and can not process the requested STATUS command.
     InTransition,
+    /// The target implements the inquired command or returns current status against the requested
+    /// STATUS command.
     ImplementedStable,
+    /// The actual notification scheduled by the NOTIFY command.
     Changed,
+    /// The intermediate response during AV/C deferred transaction.
     Interim,
     Reserved(u8),
 }
@@ -278,7 +293,7 @@ impl From<u8> for AvcRespCode {
 }
 
 impl From<AvcRespCode> for u8 {
-    fn from(resp: AvcRespCode) -> u8 {
+    fn from(resp: AvcRespCode) -> Self {
         match resp {
             AvcRespCode::NotImplemented => AvcRespCode::NOT_IMPLEMENTED,
             AvcRespCode::Accepted => AvcRespCode::ACCEPTED,
@@ -292,20 +307,25 @@ impl From<AvcRespCode> for u8 {
     }
 }
 
+/// For AV/C operation with opcode.
 pub trait AvcOp {
+    /// The code to specify operation.
     const OPCODE: u8;
 }
 
+/// The AV/C operation supporting control and inquiry command.
 pub trait AvcControl {
     fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;
 }
 
+/// The AV/C operation supporting status command.
 pub trait AvcStatus {
     fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;
 }
 
+/// The AV/C operation supporting notify command.
 pub trait AvcNotify {
     fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error>;
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), Error>;

--- a/libs/ta1394/src/lib.rs
+++ b/libs/ta1394/src/lib.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
+pub mod amdtp;
+pub mod audio;
+pub mod ccm;
 pub mod config_rom;
 pub mod general;
-pub mod amdtp;
-pub mod ccm;
-pub mod audio;
 pub mod stream_format;
 
-use glib::{Error, error::ErrorDomain, Quark};
-
-use hinawa::{prelude::FwFcpExtManual, FwFcp};
+use {
+    glib::{error::ErrorDomain, Error, FileError, Quark},
+    hinawa::{prelude::FwFcpExtManual, FwFcp},
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AvcSubunitType {
@@ -418,8 +419,7 @@ impl Ta1394Avc for FwFcp {}
 
 #[cfg(test)]
 mod test {
-    use super::{AvcSubunitType, AvcAddrSubunit, AvcAddr};
-    use super::{AvcCmdType, AvcRespCode, Ta1394AvcError, ErrorDomain};
+    use crate::*;
 
     #[test]
     fn avcsubunittype_from() {

--- a/libs/ta1394/src/stream_format.rs
+++ b/libs/ta1394/src/stream_format.rs
@@ -650,30 +650,27 @@ pub enum StreamFormat {
 impl StreamFormat {
     pub const HIER_ROOT_AM: u8 = 0x90;
 
-    fn as_am_stream(&self) -> Result<&AmStream, Error> {
+    fn as_am_stream(&self) -> Option<&AmStream> {
         if let StreamFormat::Am(i) = self {
-            Ok(i)
+            Some(i)
         } else {
-            let label = "Audio & Music format is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 
-    pub fn as_am824_stream(&self) -> Result<&Am824Stream, Error> {
+    pub fn as_am824_stream(&self) -> Option<&Am824Stream> {
         if let AmStream::Am824(s) = self.as_am_stream()? {
-            Ok(s)
+            Some(s)
         } else {
-            let label = "AM824 format is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 
-    pub fn as_compound_am824_stream(&self) -> Result<&CompoundAm824Stream, Error> {
+    pub fn as_compound_am824_stream(&self) -> Option<&CompoundAm824Stream> {
         if let AmStream::CompoundAm824(s) = self.as_am_stream()? {
-            Ok(s)
+            Some(s)
         } else {
-            let label = "Compound AM824 stream is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 }

--- a/libs/ta1394/src/stream_format.rs
+++ b/libs/ta1394/src/stream_format.rs
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::{Error, FileError};
 
-use super::{AvcAddr, Ta1394AvcError};
-use super::{AvcOp, AvcStatus, AvcControl};
+use super::*;
 
 //
 // AV/C STREAM FORMAT INFORMATION
@@ -1068,15 +1066,7 @@ impl AvcStatus for ExtendedStreamFormatList {
 
 #[cfg(test)]
 mod tests {
-    use super::{Am824MultiBitAudioAttr, Am824OneBitAudioAttr, Am824Stream};
-    use super::{CompoundAm824Stream, CompoundAm824StreamEntry, CompoundAm824StreamFormat, RateCtl};
-    use super::{AmStream, StreamFormat};
-
-    use super::{UnitPlugType, UnitPlugData, SubunitPlugData, FunctionBlockPlugData, PlugAddrMode, PlugDirection, PlugAddr};
-
-    use super::AvcAddr;
-    use super::{AvcStatus, AvcControl};
-    use super::{SupportStatus, ExtendedStreamFormatSingle, ExtendedStreamFormatList};
+    use crate::stream_format::*;
 
     #[test]
     fn am824multibitaudioattr_from() {

--- a/libs/ta1394/src/stream_format.rs
+++ b/libs/ta1394/src/stream_format.rs
@@ -32,10 +32,10 @@ impl Am824MultiBitAudioAttr {
     const RATE_CTL_SHIFT: usize = 0;
 }
 
-impl From<&[u8;2]> for Am824MultiBitAudioAttr {
-    fn from(raw: &[u8;2]) -> Self {
-        let freq_code =
-            (raw[0] >> Am824MultiBitAudioAttr::FREQ_CODE_SHIFT) & Am824MultiBitAudioAttr::FREQ_CODE_MASK;
+impl From<&[u8; 2]> for Am824MultiBitAudioAttr {
+    fn from(raw: &[u8; 2]) -> Self {
+        let freq_code = (raw[0] >> Am824MultiBitAudioAttr::FREQ_CODE_SHIFT)
+            & Am824MultiBitAudioAttr::FREQ_CODE_MASK;
         let freq = match freq_code {
             Am824MultiBitAudioAttr::FREQ_CODE_22050 => 22050,
             Am824MultiBitAudioAttr::FREQ_CODE_24000 => 24000,
@@ -48,18 +48,15 @@ impl From<&[u8;2]> for Am824MultiBitAudioAttr {
             _ => 0xffffffff,
         };
 
-        let rate_ctl_code =
-            (raw[0] >> Am824MultiBitAudioAttr::RATE_CTL_SHIFT) & Am824MultiBitAudioAttr::RATE_CTL_MASK;
+        let rate_ctl_code = (raw[0] >> Am824MultiBitAudioAttr::RATE_CTL_SHIFT)
+            & Am824MultiBitAudioAttr::RATE_CTL_MASK;
         let rate_ctl = rate_ctl_code == Am824MultiBitAudioAttr::RATE_CTL_SUPPORTED;
 
-        Am824MultiBitAudioAttr{
-            freq,
-            rate_ctl,
-        }
+        Am824MultiBitAudioAttr { freq, rate_ctl }
     }
 }
 
-impl From<&Am824MultiBitAudioAttr> for [u8;2] {
+impl From<&Am824MultiBitAudioAttr> for [u8; 2] {
     fn from(data: &Am824MultiBitAudioAttr) -> Self {
         let freq_code = match data.freq {
             22050 => Am824MultiBitAudioAttr::FREQ_CODE_22050,
@@ -79,10 +76,11 @@ impl From<&Am824MultiBitAudioAttr> for [u8;2] {
             Am824MultiBitAudioAttr::RATE_CTL_DONT_CARE
         };
 
-        let mut raw = [0xff;2];
-        raw[0] =
-            ((freq_code & Am824MultiBitAudioAttr::FREQ_CODE_MASK) << Am824MultiBitAudioAttr::FREQ_CODE_SHIFT) |
-            ((rate_ctl_code & Am824MultiBitAudioAttr::RATE_CTL_MASK) << Am824MultiBitAudioAttr::RATE_CTL_SHIFT);
+        let mut raw = [0xff; 2];
+        raw[0] = ((freq_code & Am824MultiBitAudioAttr::FREQ_CODE_MASK)
+            << Am824MultiBitAudioAttr::FREQ_CODE_SHIFT)
+            | ((rate_ctl_code & Am824MultiBitAudioAttr::RATE_CTL_MASK)
+                << Am824MultiBitAudioAttr::RATE_CTL_SHIFT);
         raw
     }
 }
@@ -112,10 +110,10 @@ impl Am824OneBitAudioAttr {
     const RATE_CTL_SHIFT: usize = 0;
 }
 
-impl From<&[u8;2]> for Am824OneBitAudioAttr {
-    fn from(raw: &[u8;2]) -> Self {
-        let freq_code =
-            (raw[0] >> Am824OneBitAudioAttr::FREQ_CODE_SHIFT) & Am824OneBitAudioAttr::FREQ_CODE_MASK;
+impl From<&[u8; 2]> for Am824OneBitAudioAttr {
+    fn from(raw: &[u8; 2]) -> Self {
+        let freq_code = (raw[0] >> Am824OneBitAudioAttr::FREQ_CODE_SHIFT)
+            & Am824OneBitAudioAttr::FREQ_CODE_MASK;
         let freq = match freq_code {
             Am824OneBitAudioAttr::FREQ_CODE_2048000 => 2048000,
             Am824OneBitAudioAttr::FREQ_CODE_2822400 => 2822400,
@@ -131,23 +129,20 @@ impl From<&[u8;2]> for Am824OneBitAudioAttr {
             (raw[0] >> Am824OneBitAudioAttr::RATE_CTL_SHIFT) & Am824OneBitAudioAttr::RATE_CTL_MASK;
         let rate_ctl = rate_ctl_code == Am824OneBitAudioAttr::RATE_CTL_SUPPORTED;
 
-        Am824OneBitAudioAttr{
-            freq,
-            rate_ctl,
-        }
+        Am824OneBitAudioAttr { freq, rate_ctl }
     }
 }
 
-impl From<&Am824OneBitAudioAttr> for [u8;2] {
+impl From<&Am824OneBitAudioAttr> for [u8; 2] {
     fn from(data: &Am824OneBitAudioAttr) -> Self {
         let freq_code = match data.freq {
-             2048000 => Am824OneBitAudioAttr::FREQ_CODE_2048000,
-             2822400 => Am824OneBitAudioAttr::FREQ_CODE_2822400,
-             3072000 => Am824OneBitAudioAttr::FREQ_CODE_3072000,
-             5644800 => Am824OneBitAudioAttr::FREQ_CODE_5644800,
-             6144000 => Am824OneBitAudioAttr::FREQ_CODE_6144000,
-             11289600 => Am824OneBitAudioAttr::FREQ_CODE_11289600,
-             12288000 => Am824OneBitAudioAttr::FREQ_CODE_12288000,
+            2048000 => Am824OneBitAudioAttr::FREQ_CODE_2048000,
+            2822400 => Am824OneBitAudioAttr::FREQ_CODE_2822400,
+            3072000 => Am824OneBitAudioAttr::FREQ_CODE_3072000,
+            5644800 => Am824OneBitAudioAttr::FREQ_CODE_5644800,
+            6144000 => Am824OneBitAudioAttr::FREQ_CODE_6144000,
+            11289600 => Am824OneBitAudioAttr::FREQ_CODE_11289600,
+            12288000 => Am824OneBitAudioAttr::FREQ_CODE_12288000,
             _ => 0x0f,
         };
 
@@ -157,10 +152,11 @@ impl From<&Am824OneBitAudioAttr> for [u8;2] {
             Am824OneBitAudioAttr::RATE_CTL_DONT_CARE
         };
 
-        let mut raw = [0xff;2];
-        raw[0] =
-            ((freq_code & Am824OneBitAudioAttr::FREQ_CODE_MASK) << Am824OneBitAudioAttr::FREQ_CODE_SHIFT) |
-            ((rate_ctl_code & Am824OneBitAudioAttr::RATE_CTL_MASK) << Am824OneBitAudioAttr::RATE_CTL_SHIFT);
+        let mut raw = [0xff; 2];
+        raw[0] = ((freq_code & Am824OneBitAudioAttr::FREQ_CODE_MASK)
+            << Am824OneBitAudioAttr::FREQ_CODE_SHIFT)
+            | ((rate_ctl_code & Am824OneBitAudioAttr::RATE_CTL_MASK)
+                << Am824OneBitAudioAttr::RATE_CTL_SHIFT);
         raw
     }
 }
@@ -180,8 +176,8 @@ pub enum Am824Stream {
     OneBitAudioEncodedRaw(Am824OneBitAudioAttr),
     OneBitAudioEncodedSacd(Am824OneBitAudioAttr),
     HighPrecisionMultiBitLinearAudio(Am824MultiBitAudioAttr),
-    MidiConformant([u8;2]),
-    Reserved([u8;4]),
+    MidiConformant([u8; 2]),
+    Reserved([u8; 4]),
 }
 
 impl Am824Stream {
@@ -201,19 +197,19 @@ impl Am824Stream {
     const MIDI_CONFORMANT: u8 = 0x0d;
 }
 
-impl From<&[u8;4]> for Am824Stream {
-    fn from(raw: &[u8;4]) -> Self {
+impl From<&[u8; 4]> for Am824Stream {
+    fn from(raw: &[u8; 4]) -> Self {
         match raw[0] {
-            Am824Stream::IEC60958_3 |
-            Am824Stream::IEC61937_3 |
-            Am824Stream::IEC61937_4 |
-            Am824Stream::IEC61937_5 |
-            Am824Stream::IEC61937_6 |
-            Am824Stream::IEC61937_7 |
-            Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW |
-            Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD |
-            Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
-                let mut r = [0;2];
+            Am824Stream::IEC60958_3
+            | Am824Stream::IEC61937_3
+            | Am824Stream::IEC61937_4
+            | Am824Stream::IEC61937_5
+            | Am824Stream::IEC61937_6
+            | Am824Stream::IEC61937_7
+            | Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW
+            | Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD
+            | Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                let mut r = [0; 2];
                 r.copy_from_slice(&raw[2..4]);
                 let attrs = Am824MultiBitAudioAttr::from(&r);
                 match raw[0] {
@@ -223,36 +219,41 @@ impl From<&[u8;4]> for Am824Stream {
                     Am824Stream::IEC61937_5 => Am824Stream::Iec61937_5(attrs),
                     Am824Stream::IEC61937_6 => Am824Stream::Iec61937_6(attrs),
                     Am824Stream::IEC61937_7 => Am824Stream::Iec61937_7(attrs),
-                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW =>
-                        Am824Stream::MultiBitLinearAudioRaw(attrs),
-                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD =>
-                        Am824Stream::MultiBitLinearAudioDvd(attrs),
-                    Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO =>
-                        Am824Stream::HighPrecisionMultiBitLinearAudio(attrs),
+                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW => {
+                        Am824Stream::MultiBitLinearAudioRaw(attrs)
+                    }
+                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD => {
+                        Am824Stream::MultiBitLinearAudioDvd(attrs)
+                    }
+                    Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                        Am824Stream::HighPrecisionMultiBitLinearAudio(attrs)
+                    }
                     _ => unreachable!(),
                 }
             }
-            Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW |
-            Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD |
-            Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW |
-            Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
-                let mut r = [0;2];
+            Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW
+            | Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD
+            | Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW
+            | Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
+                let mut r = [0; 2];
                 r.copy_from_slice(&raw[2..4]);
                 let attrs = Am824OneBitAudioAttr::from(&r);
                 match raw[0] {
-                    Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW =>
-                        Am824Stream::OneBitAudioPlainRaw(attrs),
-                    Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD =>
-                        Am824Stream::OneBitAudioPlainSacd(attrs),
-                    Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW =>
-                        Am824Stream::OneBitAudioEncodedRaw(attrs),
-                    Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD =>
-                        Am824Stream::OneBitAudioEncodedSacd(attrs),
+                    Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW => Am824Stream::OneBitAudioPlainRaw(attrs),
+                    Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD => {
+                        Am824Stream::OneBitAudioPlainSacd(attrs)
+                    }
+                    Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW => {
+                        Am824Stream::OneBitAudioEncodedRaw(attrs)
+                    }
+                    Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
+                        Am824Stream::OneBitAudioEncodedSacd(attrs)
+                    }
                     _ => unreachable!(),
                 }
             }
             Am824Stream::MIDI_CONFORMANT => {
-                let mut r = [0;2];
+                let mut r = [0; 2];
                 r.copy_from_slice(&raw[2..4]);
                 Am824Stream::MidiConformant(r)
             }
@@ -261,19 +262,19 @@ impl From<&[u8;4]> for Am824Stream {
     }
 }
 
-impl From<&Am824Stream> for [u8;4] {
+impl From<&Am824Stream> for [u8; 4] {
     fn from(format: &Am824Stream) -> Self {
-        let mut raw = [0xff;4];
+        let mut raw = [0xff; 4];
         match format {
-            Am824Stream::Iec60958_3(attrs) |
-            Am824Stream::Iec61937_3(attrs) |
-            Am824Stream::Iec61937_4(attrs) |
-            Am824Stream::Iec61937_5(attrs) |
-            Am824Stream::Iec61937_6(attrs) |
-            Am824Stream::Iec61937_7(attrs) |
-            Am824Stream::MultiBitLinearAudioRaw(attrs) |
-            Am824Stream::MultiBitLinearAudioDvd(attrs) |
-            Am824Stream::HighPrecisionMultiBitLinearAudio(attrs) => {
+            Am824Stream::Iec60958_3(attrs)
+            | Am824Stream::Iec61937_3(attrs)
+            | Am824Stream::Iec61937_4(attrs)
+            | Am824Stream::Iec61937_5(attrs)
+            | Am824Stream::Iec61937_6(attrs)
+            | Am824Stream::Iec61937_7(attrs)
+            | Am824Stream::MultiBitLinearAudioRaw(attrs)
+            | Am824Stream::MultiBitLinearAudioDvd(attrs)
+            | Am824Stream::HighPrecisionMultiBitLinearAudio(attrs) => {
                 raw[0] = match format {
                     Am824Stream::Iec60958_3(_) => Am824Stream::IEC60958_3,
                     Am824Stream::Iec61937_3(_) => Am824Stream::IEC61937_3,
@@ -281,35 +282,40 @@ impl From<&Am824Stream> for [u8;4] {
                     Am824Stream::Iec61937_5(_) => Am824Stream::IEC61937_5,
                     Am824Stream::Iec61937_6(_) => Am824Stream::IEC61937_6,
                     Am824Stream::Iec61937_7(_) => Am824Stream::IEC61937_7,
-                    Am824Stream::MultiBitLinearAudioRaw(_) =>
-                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW,
-                    Am824Stream::MultiBitLinearAudioDvd(_) =>
-                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD,
-                    Am824Stream::HighPrecisionMultiBitLinearAudio(_) =>
-                        Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+                    Am824Stream::MultiBitLinearAudioRaw(_) => {
+                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW
+                    }
+                    Am824Stream::MultiBitLinearAudioDvd(_) => {
+                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD
+                    }
+                    Am824Stream::HighPrecisionMultiBitLinearAudio(_) => {
+                        Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
+                    }
                     _ => unreachable!(),
                 };
-                let a = Into::<[u8;2]>::into(attrs);
+                let a = Into::<[u8; 2]>::into(attrs);
                 raw[2..4].copy_from_slice(&a);
                 raw
             }
-            Am824Stream::OneBitAudioPlainRaw(attrs) |
-            Am824Stream::OneBitAudioPlainSacd(attrs) |
-            Am824Stream::OneBitAudioEncodedRaw(attrs) |
-            Am824Stream::OneBitAudioEncodedSacd(attrs) => {
+            Am824Stream::OneBitAudioPlainRaw(attrs)
+            | Am824Stream::OneBitAudioPlainSacd(attrs)
+            | Am824Stream::OneBitAudioEncodedRaw(attrs)
+            | Am824Stream::OneBitAudioEncodedSacd(attrs) => {
                 raw[0] = match format {
                     Am824Stream::OneBitAudioPlainRaw(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW,
                     Am824Stream::OneBitAudioPlainSacd(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD,
                     Am824Stream::OneBitAudioEncodedRaw(_) => Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW,
-                    Am824Stream::OneBitAudioEncodedSacd(_) => Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD,
+                    Am824Stream::OneBitAudioEncodedSacd(_) => {
+                        Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD
+                    }
                     _ => unreachable!(),
                 };
-                let a = Into::<[u8;2]>::into(attrs);
+                let a = Into::<[u8; 2]>::into(attrs);
                 raw[2..4].copy_from_slice(&a);
                 raw
             }
             Am824Stream::MidiConformant(d) => {
-                let mut raw = [0xff;4];
+                let mut raw = [0xff; 4];
                 raw[0] = Am824Stream::MIDI_CONFORMANT;
                 raw[2..4].copy_from_slice(d);
                 raw
@@ -320,7 +326,7 @@ impl From<&Am824Stream> for [u8;4] {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum CompoundAm824StreamFormat{
+pub enum CompoundAm824StreamFormat {
     Iec60958_3,
     Iec61937_3,
     Iec61937_4,
@@ -364,11 +370,19 @@ impl From<u8> for CompoundAm824StreamFormat {
             CompoundAm824StreamFormat::IEC61937_5 => CompoundAm824StreamFormat::Iec61937_5,
             CompoundAm824StreamFormat::IEC61937_6 => CompoundAm824StreamFormat::Iec61937_6,
             CompoundAm824StreamFormat::IEC61937_7 => CompoundAm824StreamFormat::Iec61937_7,
-            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW => CompoundAm824StreamFormat::MultiBitLinearAudioRaw,
-            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD => CompoundAm824StreamFormat::MultiBitLinearAudioDvd,
-            CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio,
+            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW => {
+                CompoundAm824StreamFormat::MultiBitLinearAudioRaw
+            }
+            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD => {
+                CompoundAm824StreamFormat::MultiBitLinearAudioDvd
+            }
+            CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio
+            }
             CompoundAm824StreamFormat::MIDI_CONFORMANT => CompoundAm824StreamFormat::MidiConformant,
-            CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT => CompoundAm824StreamFormat::SmpteTimeCodeConformant,
+            CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT => {
+                CompoundAm824StreamFormat::SmpteTimeCodeConformant
+            }
             CompoundAm824StreamFormat::SAMPLE_COUNT => CompoundAm824StreamFormat::SampleCount,
             CompoundAm824StreamFormat::ANCILLARY_DATA => CompoundAm824StreamFormat::AncillaryData,
             CompoundAm824StreamFormat::SYNC_STREAM => CompoundAm824StreamFormat::SyncStream,
@@ -386,11 +400,19 @@ impl From<CompoundAm824StreamFormat> for u8 {
             CompoundAm824StreamFormat::Iec61937_5 => CompoundAm824StreamFormat::IEC61937_5,
             CompoundAm824StreamFormat::Iec61937_6 => CompoundAm824StreamFormat::IEC61937_6,
             CompoundAm824StreamFormat::Iec61937_7 => CompoundAm824StreamFormat::IEC61937_7,
-            CompoundAm824StreamFormat::MultiBitLinearAudioRaw => CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW,
-            CompoundAm824StreamFormat::MultiBitLinearAudioDvd => CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD,
-            CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio => CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+            CompoundAm824StreamFormat::MultiBitLinearAudioRaw => {
+                CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW
+            }
+            CompoundAm824StreamFormat::MultiBitLinearAudioDvd => {
+                CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD
+            }
+            CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio => {
+                CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
+            }
             CompoundAm824StreamFormat::MidiConformant => CompoundAm824StreamFormat::MIDI_CONFORMANT,
-            CompoundAm824StreamFormat::SmpteTimeCodeConformant => CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT,
+            CompoundAm824StreamFormat::SmpteTimeCodeConformant => {
+                CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT
+            }
             CompoundAm824StreamFormat::SampleCount => CompoundAm824StreamFormat::SAMPLE_COUNT,
             CompoundAm824StreamFormat::AncillaryData => CompoundAm824StreamFormat::ANCILLARY_DATA,
             CompoundAm824StreamFormat::SyncStream => CompoundAm824StreamFormat::SYNC_STREAM,
@@ -400,21 +422,21 @@ impl From<CompoundAm824StreamFormat> for u8 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CompoundAm824StreamEntry{
+pub struct CompoundAm824StreamEntry {
     pub count: u8,
     pub format: CompoundAm824StreamFormat,
 }
 
-impl From<&[u8;2]> for CompoundAm824StreamEntry {
-    fn from(raw: &[u8;2]) -> Self {
-        CompoundAm824StreamEntry{
+impl From<&[u8; 2]> for CompoundAm824StreamEntry {
+    fn from(raw: &[u8; 2]) -> Self {
+        CompoundAm824StreamEntry {
             count: raw[0],
             format: CompoundAm824StreamFormat::from(raw[1]),
         }
     }
 }
 
-impl From<&CompoundAm824StreamEntry> for [u8;2] {
+impl From<&CompoundAm824StreamEntry> for [u8; 2] {
     fn from(data: &CompoundAm824StreamEntry) -> Self {
         [data.count, data.format.into()]
     }
@@ -457,7 +479,7 @@ impl From<u8> for RateCtl {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CompoundAm824Stream{
+pub struct CompoundAm824Stream {
     pub freq: u32,
     pub sync_src: bool,
     pub rate_ctl: RateCtl,
@@ -503,16 +525,23 @@ impl From<&[u8]> for CompoundAm824Stream {
             (raw[1] >> CompoundAm824Stream::RATE_CTL_SHIFT) & CompoundAm824Stream::RATE_CTL_MASK;
         let rate_ctl = RateCtl::from(rate_ctl_code);
         let entry_count = raw[2] as usize;
-        let entries = (0..entry_count).filter_map(|i| {
-            if 3 + i * 2 + 2 > raw.len() {
-                None
-            } else {
-                let mut doublet = [0;2];
-                doublet.copy_from_slice(&raw[(3 + i * 2)..(3 + i * 2 + 2)]);
-                Some(CompoundAm824StreamEntry::from(&doublet))
-            }
-        }).collect();
-        CompoundAm824Stream{freq, sync_src, rate_ctl, entries}
+        let entries = (0..entry_count)
+            .filter_map(|i| {
+                if 3 + i * 2 + 2 > raw.len() {
+                    None
+                } else {
+                    let mut doublet = [0; 2];
+                    doublet.copy_from_slice(&raw[(3 + i * 2)..(3 + i * 2 + 2)]);
+                    Some(CompoundAm824StreamEntry::from(&doublet))
+                }
+            })
+            .collect();
+        CompoundAm824Stream {
+            freq,
+            sync_src,
+            rate_ctl,
+            entries,
+        }
     }
 }
 
@@ -533,22 +562,22 @@ impl From<&CompoundAm824Stream> for Vec<u8> {
         };
         raw.push(freq_code);
 
-        let sync_src_code = ((data.sync_src as u8) & CompoundAm824Stream::SYNC_SRC_MASK) <<
-                            CompoundAm824Stream::SYNC_SRC_SHIFT;
-        let rate_ctl_code = (u8::from(data.rate_ctl) & CompoundAm824Stream::RATE_CTL_MASK) <<
-                            CompoundAm824Stream::RATE_CTL_SHIFT;
+        let sync_src_code = ((data.sync_src as u8) & CompoundAm824Stream::SYNC_SRC_MASK)
+            << CompoundAm824Stream::SYNC_SRC_SHIFT;
+        let rate_ctl_code = (u8::from(data.rate_ctl) & CompoundAm824Stream::RATE_CTL_MASK)
+            << CompoundAm824Stream::RATE_CTL_SHIFT;
         raw.push(sync_src_code | rate_ctl_code);
 
         raw.push(data.entries.len() as u8);
-        data.entries.iter().for_each(|entry|{
-            raw.extend_from_slice(&Into::<[u8;2]>::into(entry));
+        data.entries.iter().for_each(|entry| {
+            raw.extend_from_slice(&Into::<[u8; 2]>::into(entry));
         });
         raw
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum AmStream{
+pub enum AmStream {
     Am824(Am824Stream),
     AudioPack,
     Fp32,
@@ -567,7 +596,7 @@ impl From<&[u8]> for AmStream {
     fn from(raw: &[u8]) -> Self {
         match raw[0] {
             AmStream::HIER_LEVEL_1_AM824 => {
-                let mut r = [0xff;4];
+                let mut r = [0xff; 4];
                 r.copy_from_slice(&raw[1..5]);
                 let format = Am824Stream::from(&r);
                 AmStream::Am824(format)
@@ -589,7 +618,7 @@ impl From<&AmStream> for Vec<u8> {
         match data {
             AmStream::Am824(d) => {
                 raw.push(AmStream::HIER_LEVEL_1_AM824);
-                raw.extend_from_slice(&Into::<[u8;4]>::into(d));
+                raw.extend_from_slice(&Into::<[u8; 4]>::into(d));
             }
             AmStream::AudioPack => {
                 raw.push(AmStream::HIER_LEVEL_1_AUDIO_PACK);
@@ -612,7 +641,7 @@ impl From<&AmStream> for Vec<u8> {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum StreamFormat{
+pub enum StreamFormat {
     // Dvcr is not supported currently.
     Am(AmStream),
     Reserved(Vec<u8>),
@@ -706,47 +735,45 @@ impl From<UnitPlugType> for u8 {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct UnitPlugData{
+pub struct UnitPlugData {
     pub unit_type: UnitPlugType,
     pub plug_id: u8,
 }
 
 impl From<&[u8]> for UnitPlugData {
     fn from(raw: &[u8]) -> Self {
-        UnitPlugData{
+        UnitPlugData {
             unit_type: raw[0].into(),
             plug_id: raw[1],
         }
     }
 }
 
-impl From<UnitPlugData> for [u8;3] {
+impl From<UnitPlugData> for [u8; 3] {
     fn from(data: UnitPlugData) -> Self {
         [u8::from(data.unit_type), data.plug_id, 0xff]
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct SubunitPlugData{
+pub struct SubunitPlugData {
     pub plug_id: u8,
 }
 
 impl From<&[u8]> for SubunitPlugData {
     fn from(raw: &[u8]) -> Self {
-        SubunitPlugData{
-            plug_id: raw[0],
-        }
+        SubunitPlugData { plug_id: raw[0] }
     }
 }
 
-impl From<SubunitPlugData> for [u8;3] {
+impl From<SubunitPlugData> for [u8; 3] {
     fn from(data: SubunitPlugData) -> Self {
         [data.plug_id, 0xff, 0xff]
     }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct FunctionBlockPlugData{
+pub struct FunctionBlockPlugData {
     pub fb_type: u8,
     pub fb_id: u8,
     pub plug_id: u8,
@@ -754,7 +781,7 @@ pub struct FunctionBlockPlugData{
 
 impl From<&[u8]> for FunctionBlockPlugData {
     fn from(raw: &[u8]) -> Self {
-        FunctionBlockPlugData{
+        FunctionBlockPlugData {
             fb_type: raw[0],
             fb_id: raw[1],
             plug_id: raw[2],
@@ -762,7 +789,7 @@ impl From<&[u8]> for FunctionBlockPlugData {
     }
 }
 
-impl From<FunctionBlockPlugData> for [u8;3] {
+impl From<FunctionBlockPlugData> for [u8; 3] {
     fn from(data: FunctionBlockPlugData) -> Self {
         [data.fb_type, data.fb_id, data.plug_id]
     }
@@ -787,23 +814,23 @@ impl From<&[u8]> for PlugAddrMode {
     }
 }
 
-impl From<PlugAddrMode> for [u8;4] {
+impl From<PlugAddrMode> for [u8; 4] {
     fn from(mode: PlugAddrMode) -> Self {
-        let mut raw: [u8;4] = [0xff;4];
+        let mut raw: [u8; 4] = [0xff; 4];
         match mode {
             PlugAddrMode::Unit(data) => {
                 raw[0] = 0;
-                let d: [u8;3] = data.into();
+                let d: [u8; 3] = data.into();
                 raw[1..4].copy_from_slice(&d);
             }
             PlugAddrMode::Subunit(data) => {
                 raw[0] = 1;
-                let d: [u8;3] = data.into();
+                let d: [u8; 3] = data.into();
                 raw[1..4].copy_from_slice(&d);
             }
             PlugAddrMode::FunctionBlock(data) => {
                 raw[0] = 2;
-                let d: [u8;3] = data.into();
+                let d: [u8; 3] = data.into();
                 raw[1..4].copy_from_slice(&d);
             }
             _ => (),
@@ -845,7 +872,7 @@ impl From<PlugDirection> for u8 {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct PlugAddr{
+pub struct PlugAddr {
     pub direction: PlugDirection,
     pub mode: PlugAddrMode,
 }
@@ -859,11 +886,11 @@ impl From<&[u8]> for PlugAddr {
     }
 }
 
-impl From<PlugAddr> for [u8;5] {
-    fn from(addr: PlugAddr) -> [u8;5] {
-        let mut raw = [0xff;5];
+impl From<PlugAddr> for [u8; 5] {
+    fn from(addr: PlugAddr) -> [u8; 5] {
+        let mut raw = [0xff; 5];
         raw[0] = u8::from(addr.direction);
-        let m: [u8;4] = addr.mode.into();
+        let m: [u8; 4] = addr.mode.into();
         raw[1..5].copy_from_slice(&m);
         raw
     }
@@ -910,7 +937,7 @@ impl From<SupportStatus> for u8 {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-struct ExtendedStreamFormat{
+struct ExtendedStreamFormat {
     subfunc: u8,
     plug_addr: PlugAddr,
     support_status: SupportStatus,
@@ -918,9 +945,9 @@ struct ExtendedStreamFormat{
 
 impl ExtendedStreamFormat {
     const OPCODE: u8 = 0xbf;
-    
+
     fn new(subfunc: u8, plug_addr: &PlugAddr) -> Self {
-        ExtendedStreamFormat{
+        ExtendedStreamFormat {
             subfunc,
             plug_addr: *plug_addr,
             support_status: SupportStatus::Reserved(0xff),
@@ -929,25 +956,31 @@ impl ExtendedStreamFormat {
 
     fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
         operands.push(self.subfunc);
-        operands.extend_from_slice(&Into::<[u8;5]>::into(self.plug_addr));
+        operands.extend_from_slice(&Into::<[u8; 5]>::into(self.plug_addr));
         operands.push(self.support_status.into());
         Ok(())
     }
 
     fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), Error> {
         if operands.len() < 7 {
-            let label = format!("Unexpected length of data for ExtendedStreamFormat: {}",
-                                operands.len());
+            let label = format!(
+                "Unexpected length of data for ExtendedStreamFormat: {}",
+                operands.len()
+            );
             Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
         } else if operands[0] != self.subfunc {
-            let label = format!("Unexpected subfunction for ExtendedStreamFormat: {} but {}",
-                                self.subfunc, operands[0]);
+            let label = format!(
+                "Unexpected subfunction for ExtendedStreamFormat: {} but {}",
+                self.subfunc, operands[0]
+            );
             Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
         } else {
             let plug_addr = PlugAddr::from(&operands[1..6]);
             if plug_addr != self.plug_addr {
-                let label = format!("Unexpected address to plug for ExtendedStreamFormat: {:?} but {:?}",
-                                    plug_addr, self.plug_addr);
+                let label = format!(
+                    "Unexpected address to plug for ExtendedStreamFormat: {:?} but {:?}",
+                    plug_addr, self.plug_addr
+                );
                 Err(Error::new(Ta1394AvcError::UnexpectedRespOperands, &label))
             } else {
                 self.support_status = SupportStatus::from(operands[6]);
@@ -958,7 +991,7 @@ impl ExtendedStreamFormat {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ExtendedStreamFormatSingle{
+pub struct ExtendedStreamFormatSingle {
     pub support_status: SupportStatus,
     pub stream_format: StreamFormat,
     op: ExtendedStreamFormat,
@@ -968,7 +1001,7 @@ impl ExtendedStreamFormatSingle {
     const SUBFUNC: u8 = 0xc0;
 
     pub fn new(plug_addr: &PlugAddr) -> Self {
-        ExtendedStreamFormatSingle{
+        ExtendedStreamFormatSingle {
             support_status: SupportStatus::NoInfo,
             stream_format: StreamFormat::Reserved(Vec::new()),
             op: ExtendedStreamFormat::new(Self::SUBFUNC, plug_addr),
@@ -1016,7 +1049,7 @@ impl AvcControl for ExtendedStreamFormatSingle {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct ExtendedStreamFormatList{
+pub struct ExtendedStreamFormatList {
     pub support_status: SupportStatus,
     pub index: u8,
     pub stream_format: StreamFormat,
@@ -1027,7 +1060,7 @@ impl ExtendedStreamFormatList {
     const SUBFUNC: u8 = 0xc1;
 
     pub fn new(plug_addr: &PlugAddr, index: u8) -> Self {
-        ExtendedStreamFormatList{
+        ExtendedStreamFormatList {
             support_status: SupportStatus::Reserved(0xff),
             index,
             stream_format: StreamFormat::Reserved(Vec::new()),
@@ -1074,7 +1107,7 @@ mod tests {
         let attr = Am824MultiBitAudioAttr::from(&raw);
         assert_eq!(44100, attr.freq);
         assert_eq!(false, attr.rate_ctl);
-        assert_eq!(raw, Into::<[u8;2]>::into(&attr));
+        assert_eq!(raw, Into::<[u8; 2]>::into(&attr));
     }
 
     #[test]
@@ -1083,30 +1116,33 @@ mod tests {
         let attr = Am824OneBitAudioAttr::from(&raw);
         assert_eq!(6144000, attr.freq);
         assert_eq!(true, attr.rate_ctl);
-        assert_eq!(raw, Into::<[u8;2]>::into(&attr));
+        assert_eq!(raw, Into::<[u8; 2]>::into(&attr));
     }
 
     #[test]
     fn am824stream_from() {
         let raw = [0x06, 0xff, 0x20, 0xff];
         let format = Am824Stream::from(&raw);
-        let attr = Am824MultiBitAudioAttr{
+        let attr = Am824MultiBitAudioAttr {
             freq: 32000,
             rate_ctl: true,
         };
         assert_eq!(format, Am824Stream::MultiBitLinearAudioRaw(attr));
-        assert_eq!(raw, Into::<[u8;4]>::into(&format));
+        assert_eq!(raw, Into::<[u8; 4]>::into(&format));
     }
 
     #[test]
     fn amstream_from() {
         let raw: &[u8] = &[0x00, 0x08, 0xff, 0x40, 0xff];
-        let attr = Am824OneBitAudioAttr{
+        let attr = Am824OneBitAudioAttr {
             freq: 6144000,
             rate_ctl: true,
         };
         let format = AmStream::from(raw);
-        assert_eq!(AmStream::Am824(Am824Stream::OneBitAudioPlainRaw(attr)), format);
+        assert_eq!(
+            AmStream::Am824(Am824Stream::OneBitAudioPlainRaw(attr)),
+            format
+        );
         assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
 
         let raw: &[u8] = &[0x01, 0xff, 0xff, 0xff, 0xff];
@@ -1181,9 +1217,18 @@ mod tests {
 
     #[test]
     fn compoundam824streamentry_from() {
-        assert_eq!([0x02, 0x04], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x02, 0x04])));
-        assert_eq!([0x19, 0x03], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x19, 0x03])));
-        assert_eq!([0x37, 0x00], Into::<[u8;2]>::into(&CompoundAm824StreamEntry::from(&[0x37, 0x00])));
+        assert_eq!(
+            [0x02, 0x04],
+            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x02, 0x04]))
+        );
+        assert_eq!(
+            [0x19, 0x03],
+            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x19, 0x03]))
+        );
+        assert_eq!(
+            [0x37, 0x00],
+            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x37, 0x00]))
+        );
     }
 
     #[test]
@@ -1206,8 +1251,14 @@ mod tests {
         assert_eq!(0xee, s.entries[0].count);
         assert_eq!(CompoundAm824StreamFormat::Iec61937_5, s.entries[0].format);
         assert_eq!(0x37, s.entries[1].count);
-        assert_eq!(CompoundAm824StreamFormat::MidiConformant, s.entries[1].format);
-        assert_eq!(raw, Into::<Vec<u8>>::into(&CompoundAm824Stream::from(raw.as_slice())));
+        assert_eq!(
+            CompoundAm824StreamFormat::MidiConformant,
+            s.entries[1].format
+        );
+        assert_eq!(
+            raw,
+            Into::<Vec<u8>>::into(&CompoundAm824Stream::from(raw.as_slice()))
+        );
     }
 
     #[test]
@@ -1219,7 +1270,7 @@ mod tests {
                 plug_id: 0x2,
             }),
         };
-        let raw: [u8;5] = unit_pcr.into();
+        let raw: [u8; 5] = unit_pcr.into();
         assert_eq!(unit_pcr, raw[..].into());
 
         let unit_ext = PlugAddr {
@@ -1229,7 +1280,7 @@ mod tests {
                 plug_id: 0x3,
             }),
         };
-        let raw: [u8;5] = unit_ext.into();
+        let raw: [u8; 5] = unit_ext.into();
         assert_eq!(unit_ext, raw[..].into());
 
         let unit_async = PlugAddr {
@@ -1239,14 +1290,14 @@ mod tests {
                 plug_id: 0x4,
             }),
         };
-        let raw: [u8;5] = unit_async.into();
+        let raw: [u8; 5] = unit_async.into();
         assert_eq!(unit_async, raw[..].into());
 
         let subunit = PlugAddr {
             direction: PlugDirection::Output,
             mode: PlugAddrMode::Subunit(SubunitPlugData { plug_id: 0x8 }),
         };
-        let raw: [u8;5] = subunit.into();
+        let raw: [u8; 5] = subunit.into();
         assert_eq!(subunit, raw[..].into());
 
         let fb = PlugAddr {
@@ -1257,15 +1308,15 @@ mod tests {
                 plug_id: 0x29,
             }),
         };
-        let raw: [u8;5] = fb.into();
+        let raw: [u8; 5] = fb.into();
         assert_eq!(fb, raw[..].into());
     }
 
     #[test]
     fn single_operands() {
-        let plug_addr = PlugAddr{
+        let plug_addr = PlugAddr {
             direction: PlugDirection::Output,
-            mode: PlugAddrMode::Unit(UnitPlugData{
+            mode: PlugAddrMode::Unit(UnitPlugData {
                 unit_type: UnitPlugType::Pcr,
                 plug_id: 0x03,
             }),
@@ -1275,8 +1326,10 @@ mod tests {
         AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut operands).unwrap();
         assert_eq!(&operands, &[0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0xff]);
 
-        let operands = [0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01,
-                        0x90, 0x40, 0x04, 0x00, 0x02, 0x02, 0x06, 0x02, 0x00];
+        let operands = [
+            0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01, 0x90, 0x40, 0x04, 0x00, 0x02, 0x02, 0x06,
+            0x02, 0x00,
+        ];
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.op.plug_addr, plug_addr);
         assert_eq!(op.op.support_status, SupportStatus::Inactive);
@@ -1287,8 +1340,20 @@ mod tests {
                 assert_eq!(s.sync_src, false);
                 assert_eq!(s.rate_ctl, RateCtl::Supported);
                 assert_eq!(s.entries.len(), 2);
-                assert_eq!(s.entries[0], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw});
-                assert_eq!(s.entries[1], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::Iec60958_3});
+                assert_eq!(
+                    s.entries[0],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw
+                    }
+                );
+                assert_eq!(
+                    s.entries[1],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::Iec60958_3
+                    }
+                );
             } else {
                 unreachable!();
             }
@@ -1298,12 +1363,19 @@ mod tests {
 
         let mut operands = Vec::new();
         AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut operands).unwrap();
-        assert_eq!(&operands, &[0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01,
-                                0x90, 0x40, 0x04, 0x00, 0x02, 0x02, 0x06, 0x02, 0x00]);
+        assert_eq!(
+            &operands,
+            &[
+                0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01, 0x90, 0x40, 0x04, 0x00, 0x02, 0x02, 0x06,
+                0x02, 0x00
+            ]
+        );
 
         let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
-        let operands = [0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0xff,
-                        0x90, 0x40, 0x05, 0x04, 0x02, 0x02, 0x06, 0x02, 0x00];
+        let operands = [
+            0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0xff, 0x90, 0x40, 0x05, 0x04, 0x02, 0x02, 0x06,
+            0x02, 0x00,
+        ];
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.op.plug_addr, plug_addr);
         assert_eq!(op.op.support_status, SupportStatus::NoInfo);
@@ -1313,8 +1385,20 @@ mod tests {
                 assert_eq!(s.sync_src, true);
                 assert_eq!(s.rate_ctl, RateCtl::Supported);
                 assert_eq!(s.entries.len(), 2);
-                assert_eq!(s.entries[0], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw});
-                assert_eq!(s.entries[1], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::Iec60958_3});
+                assert_eq!(
+                    s.entries[0],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw
+                    }
+                );
+                assert_eq!(
+                    s.entries[1],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::Iec60958_3
+                    }
+                );
             } else {
                 unreachable!();
             }
@@ -1325,9 +1409,9 @@ mod tests {
 
     #[test]
     fn list_operands() {
-        let plug_addr = PlugAddr{
+        let plug_addr = PlugAddr {
             direction: PlugDirection::Output,
-            mode: PlugAddrMode::Unit(UnitPlugData{
+            mode: PlugAddrMode::Unit(UnitPlugData {
                 unit_type: UnitPlugType::Pcr,
                 plug_id: 0x03,
             }),
@@ -1337,8 +1421,10 @@ mod tests {
         AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut operands).unwrap();
         assert_eq!(&operands, &[0xc1, 0x01, 0x00, 0x00, 0x03, 0xff, 0xff, 0x31]);
 
-        let operands = [0xc1, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01, 0x31,
-                        0x90, 0x40, 0x04, 0x00, 0x02, 0x02, 0x06, 0x02, 0x00];
+        let operands = [
+            0xc1, 0x01, 0x00, 0x00, 0x03, 0xff, 0x01, 0x31, 0x90, 0x40, 0x04, 0x00, 0x02, 0x02,
+            0x06, 0x02, 0x00,
+        ];
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.op.plug_addr, plug_addr);
         assert_eq!(op.op.support_status, SupportStatus::Inactive);
@@ -1349,8 +1435,20 @@ mod tests {
                 assert_eq!(s.sync_src, false);
                 assert_eq!(s.rate_ctl, RateCtl::Supported);
                 assert_eq!(s.entries.len(), 2);
-                assert_eq!(s.entries[0], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw});
-                assert_eq!(s.entries[1], CompoundAm824StreamEntry{count: 2, format: CompoundAm824StreamFormat::Iec60958_3});
+                assert_eq!(
+                    s.entries[0],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::MultiBitLinearAudioRaw
+                    }
+                );
+                assert_eq!(
+                    s.entries[1],
+                    CompoundAm824StreamEntry {
+                        count: 2,
+                        format: CompoundAm824StreamFormat::Iec60958_3
+                    }
+                );
             } else {
                 unreachable!();
             }

--- a/libs/ta1394/src/stream_format.rs
+++ b/libs/ta1394/src/stream_format.rs
@@ -951,7 +951,11 @@ impl ExtendedStreamFormat {
         }
     }
 
-    fn build_operands(&mut self, _: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        _: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         operands.push(self.subfunc);
         operands.extend_from_slice(&Into::<[u8; 5]>::into(self.plug_addr));
         operands.push(self.support_status.into());
@@ -1011,7 +1015,11 @@ impl AvcOp for ExtendedStreamFormatSingle {
 }
 
 impl AvcStatus for ExtendedStreamFormatSingle {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.support_status = SupportStatus::Reserved(0xff);
         self.op.build_operands(addr, operands)
     }
@@ -1028,7 +1036,11 @@ impl AvcStatus for ExtendedStreamFormatSingle {
 }
 
 impl AvcControl for ExtendedStreamFormatSingle {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.build_operands(addr, operands)?;
         operands.append(&mut Into::<Vec<u8>>::into(&self.stream_format));
         Ok(())
@@ -1071,7 +1083,11 @@ impl AvcOp for ExtendedStreamFormatList {
 }
 
 impl AvcStatus for ExtendedStreamFormatList {
-    fn build_operands(&mut self, addr: &AvcAddr, operands: &mut Vec<u8>) -> Result<(), Error> {
+    fn build_operands(
+        &mut self,
+        addr: &AvcAddr,
+        operands: &mut Vec<u8>,
+    ) -> Result<(), AvcCmdBuildError> {
         self.op.support_status = SupportStatus::Reserved(0xff);
         self.op.build_operands(addr, operands)?;
         operands.push(self.index);


### PR DESCRIPTION
Current implementation of `Ta1394Avc` trait depends on hinawa and glib crates,
while the dependencies are necessarily needed.

This patchset removes the dependencies by reworking for the trait. The default
implementation of `Ta1394Avc::trx()` is deleted and delegate the implementation
to protocol crates. `Ta1394AvcError` enumeration is redesigned to be generic so
that the implementator can decide the type of error returned from the method.

```
Takashi Sakamoto (15):
  ta1394: code refactoring for use statements
  ta1394: code cleanup for stream_format module by standard format
  ta1394: remove dependency on glib crate from stream_format module
  ta1394: code refactoring for AV/C address
  ta1394: code cleanup for AV/C operation
  ta1394: code refactoring for AV/C operations
  bebob-protocols: localize implementation of AV/C transaction
  oxfw-protocols: localize implementation of AV/C transaction
  ta1394: remove hinawa dependency
  ta1394: split error enumeration for command building from operation error
  ta1394: code cleanup by stardard format
  ta1394: split error enumeration for response parsing from operation error
  ta1394: add helper function to detect operands in response frame
  ta1394: add helper function to compose command frame
  ta1394: use parameterized enumeration to report communication error

 libs/bebob/protocols/src/apogee/ensemble.rs   |  12 +-
 libs/bebob/protocols/src/bridgeco.rs          | 131 ++--
 libs/bebob/protocols/src/focusrite.rs         |  16 +-
 libs/bebob/protocols/src/lib.rs               | 110 ++--
 libs/bebob/protocols/src/maudio/normal.rs     |   8 +-
 libs/bebob/protocols/src/maudio/special.rs    |   8 +-
 .../protocols/src/presonus/inspire1394.rs     |  16 +-
 .../runtime/src/apogee/ensemble_model.rs      |   2 +-
 libs/bebob/runtime/src/behringer.rs           |   2 +-
 libs/bebob/runtime/src/digidesign.rs          |   2 +-
 libs/bebob/runtime/src/esi.rs                 |   2 +-
 .../runtime/src/focusrite/saffire_model.rs    |   2 +-
 .../runtime/src/focusrite/saffirele_model.rs  |   2 +-
 .../src/focusrite/saffirepro10io_model.rs     |   2 +-
 .../src/focusrite/saffirepro26io_model.rs     |   2 +-
 libs/bebob/runtime/src/icon.rs                |   2 +-
 libs/bebob/runtime/src/lib.rs                 |   2 +-
 .../runtime/src/maudio/audiophile_model.rs    |   2 +-
 libs/bebob/runtime/src/maudio/fw410_model.rs  |   2 +-
 libs/bebob/runtime/src/maudio/ozonic_model.rs |   2 +-
 .../src/maudio/profirelightbridge_model.rs    |   2 +-
 libs/bebob/runtime/src/maudio/solo_model.rs   |   2 +-
 .../bebob/runtime/src/maudio/special_model.rs |   2 +-
 .../runtime/src/presonus/firebox_model.rs     |   2 +-
 libs/bebob/runtime/src/presonus/fp10_model.rs |   2 +-
 .../runtime/src/presonus/inspire1394_model.rs |   2 +-
 libs/bebob/runtime/src/roland.rs              |   4 +-
 libs/bebob/runtime/src/stanton.rs             |   2 +-
 .../runtime/src/terratec/aureon_model.rs      |   2 +-
 .../runtime/src/terratec/phase88_model.rs     |   2 +-
 libs/bebob/runtime/src/yamaha_terratec.rs     |   4 +-
 libs/oxfw/protocols/src/apogee.rs             | 105 ++--
 libs/oxfw/protocols/src/griffin.rs            |   8 +-
 libs/oxfw/protocols/src/lacie.rs              |   8 +-
 libs/oxfw/protocols/src/lib.rs                |  55 +-
 libs/oxfw/protocols/src/loud.rs               |   4 +-
 libs/oxfw/protocols/src/tascam.rs             | 110 ++--
 libs/oxfw/runtime/src/apogee_model.rs         |  24 +-
 libs/oxfw/runtime/src/common_ctl.rs           |  90 ++-
 libs/oxfw/runtime/src/common_model.rs         |   2 +-
 libs/oxfw/runtime/src/griffin_model.rs        |   2 +-
 libs/oxfw/runtime/src/lacie_model.rs          |   2 +-
 libs/oxfw/runtime/src/lib.rs                  |   3 +-
 libs/oxfw/runtime/src/loud_model.rs           |   6 +-
 libs/oxfw/runtime/src/tascam_model.rs         |   2 +-
 libs/ta1394/Cargo.toml                        |   2 -
 libs/ta1394/src/amdtp.rs                      |  18 +-
 libs/ta1394/src/audio.rs                      | 481 ++++++++-------
 libs/ta1394/src/ccm.rs                        | 108 ++--
 libs/ta1394/src/config_rom.rs                 |  62 +-
 libs/ta1394/src/general.rs                    | 302 +++++-----
 libs/ta1394/src/lib.rs                        | 403 ++++++++-----
 libs/ta1394/src/stream_format.rs              | 558 ++++++++++--------
 53 files changed, 1602 insertions(+), 1106 deletions(-)
```