### PR TITLE
[PATCH 00/37] re-license protocols crate by LGPL v3.0 or later

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ License
   * `dice-protocols`
   * `dg00x-protocols`
   * `tascam-protocols`
+  * `motu-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,7 @@ License
 
   * `bebob-protocols`
   * `efw-protocols`
+  * `oxfw-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,11 @@ License
   * `ta1394-avc-stream-format`
   * `ta1394-avc-ccm`
 
+* Some library crates for protocol implementation are released under GNU Lesser General
+  Public License v3.0 or later with respect to clause for reverse engineering.
+
+  * `bebob-protocols`
+
 * The other crates are released under GNU General Public License Version 3.
 
 Dependencies

--- a/README.rst
+++ b/README.rst
@@ -51,6 +51,7 @@ License
   * `efw-protocols`
   * `oxfw-protocols`
   * `dice-protocols`
+  * `dg00x-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,7 @@ License
   * `dg00x-protocols`
   * `tascam-protocols`
   * `motu-protocols`
+  * `ff-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,7 @@ License
   * `oxfw-protocols`
   * `dice-protocols`
   * `dg00x-protocols`
+  * `tascam-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ License
   * `bebob-protocols`
   * `efw-protocols`
   * `oxfw-protocols`
+  * `dice-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/README.rst
+++ b/README.rst
@@ -48,6 +48,7 @@ License
   Public License v3.0 or later with respect to clause for reverse engineering.
 
   * `bebob-protocols`
+  * `efw-protocols`
 
 * The other crates are released under GNU General Public License Version 3.
 

--- a/libs/bebob/protocols/Cargo.toml
+++ b/libs/bebob/protocols/Cargo.toml
@@ -19,3 +19,7 @@ ta1394-avc-general = "0.1"
 ta1394-avc-audio = "0.1"
 ta1394-avc-stream-format = "0.1"
 ta1394-avc-ccm = "0.1"
+
+[[bin]]
+name = "bco-bootloader-info"
+doc = false

--- a/libs/bebob/protocols/Cargo.toml
+++ b/libs/bebob/protocols/Cargo.toml
@@ -9,7 +9,7 @@ Implementation of protocols defined by BridgeCo. AG and application vendors for 
 DM1500 ASICs with its BridgeCo. Enhanced Break Out Box (BeBoB) solution.
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/bebob/protocols/src/apogee.rs
+++ b/libs/bebob/protocols/src/apogee.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Apogee Electronics FireWire models.

--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -111,7 +111,7 @@ impl SamplingClockSourceOperation for EnsembleClkProtocol {
     ];
 }
 
-/// The structure of sample format converter.
+/// Parameters of sample format converter.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleConvertParameters {
     pub format_target: FormatConvertTarget,
@@ -132,7 +132,7 @@ impl From<&EnsembleConvertParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleConvertParameters> for BebobAvc {}
 
-/// The structure for parameters of display meters.
+/// Parameters of display meters.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleDisplayParameters {
     pub enabled: bool,
@@ -154,7 +154,7 @@ impl From<&EnsembleDisplayParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleDisplayParameters> for BebobAvc {}
 
-/// The parameters of analog/digital inputs. The gains, phantoms, and polarities parameters
+/// Parameters of analog/digital inputs. The gains, phantoms, and polarities parameters
 /// are available when channel 0-3 levels are for mic.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleInputParameters {
@@ -214,7 +214,7 @@ impl From<&EnsembleInputParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleInputParameters> for BebobAvc {}
 
-/// The structure for parameters of analog/digital outputs.
+/// Parameters of analog/digital outputs.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleOutputParameters {
     pub vol: u8,
@@ -258,7 +258,7 @@ impl From<&EnsembleOutputParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleOutputParameters> for BebobAvc {}
 
-/// The structure for parameters of input/output source.
+/// Parameters of input/output source.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleSourceParameters {
     /// To (18):
@@ -364,7 +364,7 @@ impl From<&EnsembleSourceParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleSourceParameters> for BebobAvc {}
 
-/// The structure for mixer parameters.
+/// Parameters of signal multiplexer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleMixerParameters {
     /// To (4):
@@ -442,7 +442,7 @@ impl From<&EnsembleMixerParameters> for Vec<EnsembleCmd> {
 
 impl EnsembleParameterProtocol<EnsembleMixerParameters> for BebobAvc {}
 
-/// The structure for stream parameters.
+/// Parameters of stream mode.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleStreamParameters {
     pub mode: StreamMode,
@@ -540,7 +540,7 @@ impl Default for KnobOutputTarget {
     }
 }
 
-/// The structure for meter information.
+/// Information of hardware metering.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct EnsembleMeter {
     pub knob_input_target: KnobInputTarget,
@@ -769,7 +769,7 @@ const METER_SHORT_FRAME_SIZE: usize = 17;
 const METER_LONG_FRAME_SIZE: usize = 56;
 const MIXER_COEFFICIENT_COUNT: usize = 18;
 
-/// The enumeration of command specific to Apogee Ensemble.
+/// Command specific to Apogee Ensemble.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum EnsembleCmd {
     InputLimit(usize, bool), // index, state
@@ -1110,7 +1110,7 @@ impl Default for DisplayMeterTarget {
     }
 }
 
-/// The enumeration of command for hardware operation.
+/// Command for functions in hardware category specific to Apogee Ensemble.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum HwCmd {
     /// STREAM_MODE command generates bus reset to change available stream formats.

--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Apogee Electronics Ensemble FireWire.

--- a/libs/bebob/protocols/src/behringer.rs
+++ b/libs/bebob/protocols/src/behringer.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Behringer Firepower series.

--- a/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
+++ b/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {

--- a/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
+++ b/libs/bebob/protocols/src/bin/bco-bootloader-info.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use glib::{FileError, MainContext, MainLoop};
-
-use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq};
-
-use bebob_protocols::bridgeco::*;
-
-use std::sync::Arc;
-use std::thread;
+use {
+    bebob_protocols as protocols,
+    glib::{FileError, MainContext, MainLoop},
+    hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
+    protocols::bridgeco::*,
+    std::{sync::Arc, thread},
+};
 
 const TIMEOUT_MS: u32 = 20;
 

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-//! Protocols defined by BridgeCo. AG for its BridgeCo. Enhanced Break Out Box (BeBoB) solution.
+//! Protocol implementation defined by BridgeCo. AG for its BridgeCo. Enhanced Break Out Box
+//! (BeBoB) solution.
 //!
 //! The module includes structure, enumeration, trait and its implementation for AV/C command
 //! extensions defined by BridgeCo. AG for BeBoB solution.
@@ -12,7 +13,7 @@ use super::*;
 // Bco Extended Plug Info command
 //
 
-/// The enumeration to express type of address to plug for unit.
+/// Type of address to plug for unit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPlugAddrUnitType {
     Isoc,
@@ -49,7 +50,7 @@ impl From<BcoPlugAddrUnitType> for u8 {
     }
 }
 
-/// The structure to express address to plug for unit.
+/// Address to plug for unit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddrUnit {
     pub plug_type: BcoPlugAddrUnitType,
@@ -71,7 +72,7 @@ impl From<&BcoPlugAddrUnit> for [u8; 3] {
     }
 }
 
-/// The structure to express address to plug for subunit.
+/// Address to plug for subunit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddrSubunit {
     pub plug_id: u8,
@@ -89,7 +90,7 @@ impl From<&BcoPlugAddrSubunit> for [u8; 3] {
     }
 }
 
-/// The structure to express address to plug for function block.
+/// Address to plug for function block.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddrFuncBlk {
     pub func_blk_type: u8,
@@ -113,7 +114,7 @@ impl From<&BcoPlugAddrFuncBlk> for [u8; 3] {
     }
 }
 
-/// The enumeration to express mode of address to plug.
+/// Mode of address to plug.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPlugAddrMode {
     Unit(BcoPlugAddrUnit),
@@ -165,7 +166,7 @@ impl From<&BcoPlugAddrMode> for [u8; 4] {
     }
 }
 
-/// The enumeration to express direction of plug.
+/// Direction of plug.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPlugDirection {
     Input,
@@ -198,7 +199,7 @@ impl From<BcoPlugDirection> for u8 {
     }
 }
 
-/// The structure for plug address.
+/// Address of plug.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddr {
     pub direction: BcoPlugDirection,
@@ -264,7 +265,7 @@ impl From<&BcoPlugAddr> for [u8; 5] {
     }
 }
 
-/// The enumeration to express mode of address to plug for input and output direction.
+/// Mode to address to plug for input and output direction.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoIoPlugAddrMode {
     Unit(BcoPlugAddrUnit),
@@ -330,7 +331,7 @@ impl From<&BcoIoPlugAddrMode> for [u8; 6] {
     }
 }
 
-/// The enumeration to express address to plug for input and output direction.
+/// Address to plug for input and output direction.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoIoPlugAddr {
     pub direction: BcoPlugDirection,
@@ -357,7 +358,7 @@ impl From<&BcoIoPlugAddr> for [u8; 7] {
     }
 }
 
-/// The enumeration to express type of plug.
+/// The type of plug.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPlugType {
     Isoc,
@@ -406,7 +407,7 @@ impl From<BcoPlugType> for u8 {
     }
 }
 
-/// The enumeration to express physical location of data channel for multi bit linear audio.
+/// Physical location of data channel for multi bit linear audio.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoLocation {
     LeftFront,
@@ -491,7 +492,7 @@ impl From<BcoLocation> for u8 {
     }
 }
 
-/// The structure to express information of data channel for multi bit linear audio.
+/// Information about data channel for multi bit linear audio.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoChannelInfo {
     pos: u8,
@@ -516,7 +517,7 @@ impl From<&[u8; 2]> for BcoChannelInfo {
     }
 }
 
-/// The structure to express cluster of data channels.
+/// Cluster with single or multiple data channels.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BcoCluster {
     entries: Vec<BcoChannelInfo>,
@@ -549,14 +550,14 @@ impl From<&BcoCluster> for Vec<u8> {
     }
 }
 
-/// The structure to express name of data channel.
+/// Name of data channel.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BcoChannelName {
     pub ch: u8,
     pub name: String,
 }
 
-/// The enumeration to express type of physical port.
+/// Type of physical port.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPortType {
     Speaker,
@@ -625,7 +626,7 @@ impl From<u8> for BcoPortType {
     }
 }
 
-/// The structure to express cluster of data channels.
+/// Information about cluster of data channels.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BcoClusterInfo {
     pub index: u8,
@@ -660,7 +661,7 @@ impl From<&BcoClusterInfo> for Vec<u8> {
     }
 }
 
-/// The enumeration to express information of plug.
+/// Type of information about plug.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BcoPlugInfo {
     Type(BcoPlugType),
@@ -795,9 +796,11 @@ impl From<&[u8]> for BcoPlugInfo {
     }
 }
 
-/// The structure to express operation for extended plug information command.
+/// AV/C command for extend plug information.
 pub struct ExtendedPlugInfo {
+    /// The address of plug.
     pub addr: BcoPlugAddr,
+    /// The type of plug information
     pub info: BcoPlugInfo,
 }
 
@@ -875,7 +878,7 @@ impl AvcStatus for ExtendedPlugInfo {
 // Bco Extended Subunit Info command
 //
 
-/// The structure to express operation for extended subunit information.
+/// Entry for information about plugs in subunit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ExtendedSubunitInfoEntry {
     pub func_blk_type: u8,
@@ -909,7 +912,7 @@ impl From<&ExtendedSubunitInfoEntry> for [u8; 5] {
     }
 }
 
-/// The structure to express operation for extended subunit information.
+/// AV/C command for extended subunit information.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExtendedSubunitInfo {
     pub page: u8,
@@ -970,7 +973,7 @@ impl AvcStatus for ExtendedSubunitInfo {
 // Bco Extended Stream Format Info command
 //
 
-/// The enumeration to express format of compound AM824 stream.
+/// Format of compound AM824 stream.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoCompoundAm824StreamFormat {
     Iec60958_3,
@@ -1051,7 +1054,7 @@ impl From<BcoCompoundAm824StreamFormat> for u8 {
     }
 }
 
-/// The structure to express entry for compound AM824 stream.
+/// Entry for compound AM824 stream.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BcoCompoundAm824StreamEntry {
     pub count: u8,
@@ -1073,7 +1076,7 @@ impl From<&BcoCompoundAm824StreamEntry> for [u8; 2] {
     }
 }
 
-/// The structure to express parameters for compound AM824 stream.
+/// Parameters for compound AM824 stream.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BcoCompoundAm824Stream {
     pub freq: u32,
@@ -1173,7 +1176,7 @@ impl From<&BcoCompoundAm824Stream> for Vec<u8> {
     }
 }
 
-/// The enumeration to express format of isochronous packet stream for audio and music data transmission.
+/// Format of isochronous packet stream for Audio and Music data transmission.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BcoAmStream {
     AmStream(AmStream),
@@ -1206,7 +1209,7 @@ impl From<&BcoAmStream> for Vec<u8> {
     }
 }
 
-/// The enumeration to express format of isochronous packet stream.
+/// Format of isochronous packet stream.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum BcoStreamFormat {
     // Dvcr is not supported currently.
@@ -1266,7 +1269,7 @@ impl From<&BcoStreamFormat> for Vec<u8> {
     }
 }
 
-/// The structure to express extended format of stream.
+/// AV/C command for extension of stream format.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct BcoExtendedStreamFormat {
     subfunc: u8,
@@ -1320,7 +1323,7 @@ impl AvcStatus for BcoExtendedStreamFormat {
     }
 }
 
-/// The structure to express operation to configure extended format of isochronous packet stream.
+/// AV/C command for single subfunction of extension of stream format.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExtendedStreamFormatSingle {
     pub support_status: SupportStatus,
@@ -1386,8 +1389,7 @@ impl AvcControl for ExtendedStreamFormatSingle {
     }
 }
 
-/// The structure to express operation to retrieve list of extended format of isochronous packet
-/// stream.
+/// AV/C command for list subfunction of extension of stream format.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ExtendedStreamFormatList {
     pub support_status: SupportStatus,
@@ -1440,7 +1442,7 @@ impl AvcStatus for ExtendedStreamFormatList {
     }
 }
 
-/// The structure for image information.
+/// Information about firmware image.
 #[derive(Debug)]
 pub struct BcoImageInformation {
     pub timestamp: glib::DateTime,
@@ -1458,7 +1460,7 @@ impl Default for BcoImageInformation {
     }
 }
 
-/// The structure for boot loader information.
+/// Information about boot loader.
 #[derive(Debug)]
 pub struct BcoBootloaderInformation {
     pub protocol_version: u32,

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation defined by BridgeCo. AG for its BridgeCo. Enhanced Break Out Box

--- a/libs/bebob/protocols/src/digidesign.rs
+++ b/libs/bebob/protocols/src/digidesign.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Digidesign Mbox 2 Pro.

--- a/libs/bebob/protocols/src/esi.rs
+++ b/libs/bebob/protocols/src/esi.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for ESI Quatafire series.

--- a/libs/bebob/protocols/src/focusrite.rs
+++ b/libs/bebob/protocols/src/focusrite.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Focusrite Saffire series based on BeBoB solution.

--- a/libs/bebob/protocols/src/focusrite/saffire.rs
+++ b/libs/bebob/protocols/src/focusrite/saffire.rs
@@ -185,7 +185,7 @@ impl SamplingClockSourceOperation for SaffireClkProtocol {
     ];
 }
 
-/// The structure for meter in Saffire.
+/// Information of hardware metering in Saffire.
 #[derive(Debug, Default)]
 pub struct SaffireMeter {
     pub phys_inputs: [i32; 4],
@@ -286,7 +286,7 @@ impl SaffireOutputOperation for SaffireOutputProtocol {
     const PAD_COUNT: usize = 0;
 }
 
-/// The enumeration for source of input-2/3.
+/// The signal source of input 2/3.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SaffireInputPair1Source {
     AnalogInputPair0,
@@ -299,7 +299,7 @@ impl Default for SaffireInputPair1Source {
     }
 }
 
-/// The enumeration for mode of mixer.
+/// The mode of signal multiplexer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SaffireMixerMode {
     StereoPaired,
@@ -312,7 +312,7 @@ impl Default for SaffireMixerMode {
     }
 }
 
-/// The structure for parameters specific to Saffire.
+/// Parameters specific to Saffire.
 #[derive(Default)]
 pub struct SaffireSpecificParameters {
     pub mode_192khz: bool,
@@ -656,7 +656,7 @@ impl SaffireStoreConfigOperation for SaffireStoreConfigProtocol {
     const OFFSET: usize = 0x148;
 }
 
-/// The structure for meter information in Saffire LE.
+/// Information of hardware metering in Saffire LE.
 #[derive(Default)]
 pub struct SaffireLeMeter {
     pub phys_inputs: [i32; 6],
@@ -767,7 +767,7 @@ impl SaffireOutputOperation for SaffireLeOutputProtocol {
     const PAD_COUNT: usize = 0;
 }
 
-/// The structure for parameters specific to Saffire.
+/// The parameters specific to Saffire.
 #[derive(Default)]
 pub struct SaffireLeSpecificParameters {
     pub analog_input_2_3_high_gains: [bool; 2],
@@ -839,7 +839,7 @@ impl SaffireLeSpecificProtocol {
     }
 }
 
-/// The enumeration for source of S/PDIF output.
+/// Signal source of S/PDIF output.
 #[derive(Debug)]
 pub enum SaffireLeSpdifOutputSource {
     MixerOutputPair01,
@@ -852,7 +852,7 @@ impl Default for SaffireLeSpdifOutputSource {
     }
 }
 
-/// The structure for mixer state at 44.1/48.0 kHz in Saffire LE.
+/// State of signal multiplexer in Saffire LE at 44.1/48.0 kHz.
 #[derive(Default, Debug)]
 pub struct SaffireLeMixerLowRateState {
     pub phys_src_gains: [[i16; 6]; 4],
@@ -1060,7 +1060,7 @@ impl SaffireLeMixerLowRateProtocol {
     }
 }
 
-/// The structure for mixer state at 88.2/96.0 kHz in Saffire LE.
+/// State of signal multiplexer in Saffire LE at 88.2/96.0 kHz.
 #[derive(Default, Debug)]
 pub struct SaffireLeMixerMiddleRateState {
     pub monitor_src_phys_input_gains: [i16; 6],
@@ -1271,7 +1271,7 @@ impl SaffireStoreConfigOperation for SaffireLeStoreConfigProtocol {
     const OFFSET: usize = 0x1b8;
 }
 
-/// The structure of mixer coefficiencies in Saffire and Saffire LE.
+/// State of signal multiplexer in Saffire.
 #[derive(Default, Debug)]
 pub struct SaffireMixerState {
     pub phys_inputs: Vec<Vec<i16>>,
@@ -1515,7 +1515,7 @@ pub trait SaffireMixerOperation {
     }
 }
 
-/// The structure for state of stereo-separated reverb effect in Saffire.
+/// State of stereo-separated reverb effect in Saffire.
 #[derive(Default, Debug)]
 pub struct SaffireReverbParameters {
     pub amounts: [i32; 2],
@@ -1686,7 +1686,7 @@ impl SaffireReverbProtocol {
     }
 }
 
-/// The structure for compressor effect in Saffire.
+/// Parameters of compressor effect in Saffire.
 #[derive(Default, Debug)]
 pub struct SaffireCompressorParameters {
     pub input_gains: [i32; 2],
@@ -1694,7 +1694,7 @@ pub struct SaffireCompressorParameters {
     pub output_volumes: [i32; 2],
 }
 
-/// The structure for protocol implementation to operate compressor parameters.
+/// The protocol implementation to operate compressor parameters.
 ///
 /// parameters    | ch 0  | ch 1  | minimum    | maximum    | min val | max val
 /// ------------- | ----- | ----- | ---------- | ---------- | ------- | -------
@@ -1805,7 +1805,7 @@ impl SaffireCompressorProtocol {
     }
 }
 
-/// The structure for equalizer effect in Saffire.
+/// Parameters of equalizer effect in Saffire.
 #[derive(Default, Debug)]
 pub struct SaffireEqualizerParameters {
     pub enables: [bool; 2],
@@ -1813,7 +1813,7 @@ pub struct SaffireEqualizerParameters {
     pub output_volumes: [i32; 2],
 }
 
-/// The structure for protocol implementation to operate equalizer parameters.
+/// The protocol implementation to operate equalizer parameters.
 ///
 /// parameters    | ch0    | ch1    | minimum    | maximum    | min val | max val
 /// ------------- | ------ | ------ | ---------- | ---------- | ------- | -------
@@ -1949,7 +1949,7 @@ impl SaffireEqualizerProtocol {
     }
 }
 
-/// The structure for amplifier effect in Saffire.
+/// Parameters of amplifier effect in Saffire.
 #[derive(Default, Debug)]
 pub struct SaffireAmplifierParameters {
     pub enables: [bool; 2],
@@ -2028,7 +2028,7 @@ impl SaffireAmplifierProtocol {
     }
 }
 
-/// The enumeration for order of compressor effect against equalizer/amplifier effect.
+/// Order of compressor effect against equalizer/amplifier effect.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SaffireChStripCompOrder {
     Pre,
@@ -2041,7 +2041,7 @@ impl Default for SaffireChStripCompOrder {
     }
 }
 
-/// The structure for protocol implementation to operate channel strip effects.
+/// The protocol implementation to operate channel strip effects.
 #[derive(Default)]
 pub struct SaffireChStripProtocol;
 

--- a/libs/bebob/protocols/src/focusrite/saffire.rs
+++ b/libs/bebob/protocols/src/focusrite/saffire.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Focusrite Saffire and Saffire LE.

--- a/libs/bebob/protocols/src/focusrite/saffireproio.rs
+++ b/libs/bebob/protocols/src/focusrite/saffireproio.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Focusrite Saffire Pro 10 i/o and Pro 26 i/o.

--- a/libs/bebob/protocols/src/focusrite/saffireproio.rs
+++ b/libs/bebob/protocols/src/focusrite/saffireproio.rs
@@ -260,7 +260,7 @@ pub trait SaffireProioMediaClockFrequencyOperation {
     }
 }
 
-/// The enumeration for source of sampling clock in Saffire Pro series.
+/// Signal source of sampling clock in Saffire Pro series.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SaffireProioSamplingClockSource {
     Internal,
@@ -344,7 +344,7 @@ impl SaffireThroughOperation for SaffireProioThroughProtocol {
     const AC3_THROUGH_OFFSET: usize = 0x01a0;
 }
 
-/// The structure for meter information in Saffire Pro i/o.
+/// Information of hardware metering in Saffire Pro i/o.
 #[derive(Default, Debug)]
 pub struct SaffireProioMeterState {
     pub monitor_knob: u8,
@@ -653,7 +653,7 @@ where
         .map(|_| old_levels.as_mut().copy_from_slice(levels))
 }
 
-/// The structure for parameters of mixer in Saffire Pro i/o.
+/// The parameters of signal multiplexer in Saffire Pro i/o.
 #[derive(Default, Debug)]
 pub struct SaffireProioMixerParameters {
     pub monitor_sources: [i16; 10],
@@ -849,7 +849,7 @@ fn calc_stream_source_pos(i: usize) -> usize {
     }
 }
 
-/// The enumeration for mode of stand alone.
+/// Working mode at standalone mode.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SaffireProioStandaloneMode {
     Mix,
@@ -862,7 +862,7 @@ impl Default for SaffireProioStandaloneMode {
     }
 }
 
-/// The structure for parameters specific to Saffire Pro i/o series.
+/// Parameters specific to Saffire Pro i/o series.
 #[derive(Default, Debug)]
 pub struct SaffireProioSpecificParameters {
     pub head_room: bool,

--- a/libs/bebob/protocols/src/icon.rs
+++ b/libs/bebob/protocols/src/icon.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for models of Icon Digital International.

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-//! Protocols defined for BridgeCo. Enhanced Break Out Box (BeBoB) solution.
+//! Protocol implementation for BridgeCo. Enhanced Break Out Box (BeBoB) solution and application
+//! devices.
 //!
 //! The crate includes various kind of protocols defined by BridgeCo. AG and application vendors
 //! for DM1000, DM1100, and DM1500 ASICs with its BridgeCo. Enhanced Break Out Box (BeBoB) solution.
@@ -41,7 +42,10 @@ pub const DM_APPL_PARAM_OFFSET: u64 = DM_APPL_OFFSET + 0x00700000;
 pub const DM_BCO_OFFSET: u64 = 0xffffc8000000;
 pub const DM_BCO_BOOTLOADER_INFO_OFFSET: u64 = DM_BCO_OFFSET + 0x00020000;
 
-/// The structure for AV/C transaction helper with quirks specific to BeBoB solution.
+/// The implementation of AV/C transaction with quirks specific to BeBoB solution.
+///
+/// It seems a unique quirk that the status code in response frame for some AV/C commands is
+/// against AV/C general specification in control operation.
 #[derive(Default, Debug)]
 pub struct BebobAvc(FwFcp);
 

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for BridgeCo. Enhanced Break Out Box (BeBoB) solution and application

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -36,11 +36,11 @@ use {
 };
 
 /// The offset for specific purposes in DM1000/DM1100/DM1500 ASICs.
-pub const DM_APPL_OFFSET: u64 = 0xffc700000000;
-pub const DM_APPL_METER_OFFSET: u64 = DM_APPL_OFFSET + 0x00600000;
-pub const DM_APPL_PARAM_OFFSET: u64 = DM_APPL_OFFSET + 0x00700000;
-pub const DM_BCO_OFFSET: u64 = 0xffffc8000000;
-pub const DM_BCO_BOOTLOADER_INFO_OFFSET: u64 = DM_BCO_OFFSET + 0x00020000;
+const DM_APPL_OFFSET: u64 = 0xffc700000000;
+const DM_APPL_METER_OFFSET: u64 = DM_APPL_OFFSET + 0x00600000;
+const DM_APPL_PARAM_OFFSET: u64 = DM_APPL_OFFSET + 0x00700000;
+const DM_BCO_OFFSET: u64 = 0xffffc8000000;
+const DM_BCO_BOOTLOADER_INFO_OFFSET: u64 = DM_BCO_OFFSET + 0x00020000;
 
 /// The implementation of AV/C transaction with quirks specific to BeBoB solution.
 ///

--- a/libs/bebob/protocols/src/maudio.rs
+++ b/libs/bebob/protocols/src/maudio.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for M-Audio FireWire series.

--- a/libs/bebob/protocols/src/maudio/normal.rs
+++ b/libs/bebob/protocols/src/maudio/normal.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for M-Audio FireWire series.

--- a/libs/bebob/protocols/src/maudio/pfl.rs
+++ b/libs/bebob/protocols/src/maudio/pfl.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for M-Audio ProFire Lightbridge.

--- a/libs/bebob/protocols/src/maudio/pfl.rs
+++ b/libs/bebob/protocols/src/maudio/pfl.rs
@@ -119,7 +119,7 @@ const METER_SIZE: usize = 56;
 #[derive(Default)]
 pub struct PflInputParametersProtocol;
 
-/// The enumeration for detected frequency of any external input.
+/// Nominal frequency detected for any external input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum PflDetectedInputFreq {
     Unavailable,
@@ -135,7 +135,7 @@ impl Default for PflDetectedInputFreq {
     }
 }
 
-/// The structure for meter information.
+/// Information of hardware metering.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PflMeterState {
     pub detected_input_freq: PflDetectedInputFreq,
@@ -209,7 +209,7 @@ impl PflMeterProtocol {
 
 const CACHE_SIZE: usize = 24;
 
-/// The structure for input configuration.
+/// Parameters of input configuration.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct PflInputParameters {
     pub adat_mute: [bool; 4],

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for M-Audio FireWire 1814 and ProjectMix I/O.

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -102,7 +102,7 @@ fn read_clk_freq(avc: &BebobAvc, freq_list: &[u32], timeout_ms: u32) -> Result<u
         })
 }
 
-/// The structure of AV/C vendor-dependent command for specific LED switch.
+/// AV/C vendor-dependent command for specific LED switch.
 pub struct MaudioSpecialLedSwitch {
     state: bool,
     op: VendorDependent,
@@ -157,7 +157,7 @@ pub struct MaudioSpecialMeterProtocol;
 
 const METER_SIZE: usize = 84;
 
-/// The structure for meter information.
+/// Information of hardware metering.
 #[derive(Debug)]
 pub struct MaudioSpecialMeterState {
     pub analog_inputs: [i16; 8],
@@ -315,7 +315,7 @@ const MIXER_STREAM_SOURCE_POS: usize = 0x0094;
 const HEADPHONE_PAIR_SOURCE_POS: usize = 0x0098;
 const ANALOG_OUTPUT_PAIR_SOURCE_POS: usize = 0x009c;
 
-/// The structure for cache of state;
+/// Cache of state.
 #[derive(Debug)]
 pub struct MaudioSpecialStateCache(pub [u8; CACHE_SIZE]);
 
@@ -340,7 +340,7 @@ impl MaudioSpecialStateCache {
     }
 }
 
-/// The structure for input parameters.
+/// Parameters of input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct MaudioSpecialInputParameters {
     pub stream_gains: [i16; 4],
@@ -452,7 +452,7 @@ impl MaudioSpecialInputProtocol {
 
 impl MaudioSpecialParameterProtocol<MaudioSpecialInputParameters> for MaudioSpecialInputProtocol {}
 
-/// The enumeration for source of analog output.
+/// Source of analog output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum OutputSource {
     MixerOutputPair,
@@ -465,7 +465,7 @@ impl Default for OutputSource {
     }
 }
 
-/// The enumeration for source of headphone.
+/// Source of headphone.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum HeadphoneSource {
     MixerOutputPair0,
@@ -479,7 +479,7 @@ impl Default for HeadphoneSource {
     }
 }
 
-/// The structure for output parameters.
+/// Parameters of output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct MaudioSpecialOutputParameters {
     pub analog_volumes: [i16; 4],
@@ -577,7 +577,7 @@ impl MaudioSpecialOutputProtocol {
 
 impl MaudioSpecialParameterProtocol<MaudioSpecialOutputParameters> for MaudioSpecialOutputProtocol {}
 
-/// The structure for aux parameters.
+/// Parameters of aux signal multiplexer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct MaudioSpecialAuxParameters {
     pub output_volumes: [i16; 2],
@@ -655,7 +655,7 @@ impl MaudioSpecialAuxProtocol {
 
 impl MaudioSpecialParameterProtocol<MaudioSpecialAuxParameters> for MaudioSpecialAuxProtocol {}
 
-/// The structure for aux parameters.
+/// Parameters of signal multiplexer.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct MaudioSpecialMixerParameters {
     pub analog_pairs: [[bool; 4]; 2],

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -4,7 +4,8 @@
 //! Protocol implementation for M-Audio FireWire 1814 and ProjectMix I/O.
 //!
 //! The module includes structure, enumeration, and trait and its implementation for protocol
-//! defined by M-Audio FireWire 1814 and ProjectMix I/O.
+//! defined by M-Audio FireWire 1814 and ProjectMix I/O. The configuration for these models
+//! is write-only, thus the implementaion includes caching mechanism for the configuration.
 //!
 //! DM1000 is used for M-Audio FireWire 1814.
 //!
@@ -437,6 +438,7 @@ impl MaudioSpecialParameterOperation for MaudioSpecialInputParameters {
     }
 }
 
+/// The protocol implementation to operate analog inputs.
 #[derive(Default)]
 pub struct MaudioSpecialInputProtocol;
 
@@ -566,6 +568,7 @@ impl MaudioSpecialParameterOperation for MaudioSpecialOutputParameters {
     }
 }
 
+/// The protocol implementation for physical output.
 #[derive(Default)]
 pub struct MaudioSpecialOutputProtocol;
 
@@ -640,6 +643,7 @@ impl MaudioSpecialParameterOperation for MaudioSpecialAuxParameters {
     }
 }
 
+/// The protocol implementation to operate input and output of AUX mixer.
 #[derive(Default)]
 pub struct MaudioSpecialAuxProtocol;
 
@@ -735,6 +739,7 @@ impl MaudioSpecialParameterOperation for MaudioSpecialMixerParameters {
     }
 }
 
+/// The protocol implementation for input and output of mixer.
 #[derive(Default)]
 pub struct MaudioSpecialMixerProtocol;
 

--- a/libs/bebob/protocols/src/presonus.rs
+++ b/libs/bebob/protocols/src/presonus.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for some PreSonus models.

--- a/libs/bebob/protocols/src/presonus/firebox.rs
+++ b/libs/bebob/protocols/src/presonus/firebox.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Firebox.

--- a/libs/bebob/protocols/src/presonus/fp10.rs
+++ b/libs/bebob/protocols/src/presonus/fp10.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Firepod/FP10.

--- a/libs/bebob/protocols/src/presonus/inspire1394.rs
+++ b/libs/bebob/protocols/src/presonus/inspire1394.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Inspire 1394.

--- a/libs/bebob/protocols/src/roland.rs
+++ b/libs/bebob/protocols/src/roland.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Roland Edirol FA series.

--- a/libs/bebob/protocols/src/stanton.rs
+++ b/libs/bebob/protocols/src/stanton.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Stanton Magnetics Final Scratch 2 ScratchAmp.

--- a/libs/bebob/protocols/src/terratec.rs
+++ b/libs/bebob/protocols/src/terratec.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for some Terratec models.

--- a/libs/bebob/protocols/src/terratec/aureon.rs
+++ b/libs/bebob/protocols/src/terratec/aureon.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Terratec Aureon 7.1 FW.

--- a/libs/bebob/protocols/src/terratec/phase88.rs
+++ b/libs/bebob/protocols/src/terratec/phase88.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Terratec Phase 88 FW.

--- a/libs/bebob/protocols/src/yamaha_terratec.rs
+++ b/libs/bebob/protocols/src/yamaha_terratec.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for Yamaha Go and Terratec Phase 24 FW series.

--- a/libs/bebob/runtime/src/apogee/ensemble_model.rs
+++ b/libs/bebob/runtime/src/apogee/ensemble_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{apogee::ensemble::*, *},
+    protocols::{apogee::ensemble::*, *},
 };
 
 const FCP_TIMEOUT_MS: u32 = 100;

--- a/libs/bebob/runtime/src/behringer.rs
+++ b/libs/bebob/runtime/src/behringer.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{behringer::*, *},
+    protocols::{behringer::*, *},
 };
 
 const FCP_TIMEOUT_MS: u32 = 100;

--- a/libs/bebob/runtime/src/common_ctls.rs
+++ b/libs/bebob/runtime/src/common_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, bebob_protocols::*};
+use {super::*, protocols::*};
 
 pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
     fn load_freq(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {

--- a/libs/bebob/runtime/src/digidesign.rs
+++ b/libs/bebob/runtime/src/digidesign.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{digidesign::*, *},
+    protocols::{digidesign::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/esi.rs
+++ b/libs/bebob/runtime/src/esi.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{esi::*, *},
+    protocols::{esi::*, *},
 };
 
 const FCP_TIMEOUT_MS: u32 = 100;

--- a/libs/bebob/runtime/src/focusrite.rs
+++ b/libs/bebob/runtime/src/focusrite.rs
@@ -9,7 +9,7 @@ pub mod saffirele_model;
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{
+    protocols::{
         focusrite::{saffire::*, saffireproio::*, *},
         *,
     },

--- a/libs/bebob/runtime/src/icon.rs
+++ b/libs/bebob/runtime/src/icon.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{icon::*, *},
+    protocols::{icon::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/lib.rs
+++ b/libs/bebob/runtime/src/lib.rs
@@ -21,6 +21,7 @@ mod yamaha_terratec;
 use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
+    bebob_protocols as protocols,
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
     hinawa::{

--- a/libs/bebob/runtime/src/maudio.rs
+++ b/libs/bebob/runtime/src/maudio.rs
@@ -9,7 +9,7 @@ pub mod special_model;
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{maudio::normal::*, *},
+    protocols::{maudio::normal::*, *},
     ta1394_avc_general::*,
 };
 

--- a/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
+++ b/libs/bebob/runtime/src/maudio/profirelightbridge_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    bebob_protocols::{maudio::pfl::*, *},
+    protocols::{maudio::pfl::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/maudio/special_model.rs
+++ b/libs/bebob/runtime/src/maudio/special_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    bebob_protocols::{maudio::special::*, *},
+    protocols::{maudio::special::*, *},
 };
 
 pub type Fw1814Model = SpecialModel<Fw1814ClkProtocol>;

--- a/libs/bebob/runtime/src/presonus/firebox_model.rs
+++ b/libs/bebob/runtime/src/presonus/firebox_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    bebob_protocols::{presonus::firebox::*, *},
+    protocols::{presonus::firebox::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/presonus/fp10_model.rs
+++ b/libs/bebob/runtime/src/presonus/fp10_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    bebob_protocols::{presonus::fp10::*, *},
+    protocols::{presonus::fp10::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/presonus/inspire1394_model.rs
+++ b/libs/bebob/runtime/src/presonus/inspire1394_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    bebob_protocols::{presonus::inspire1394::*, *},
+    protocols::{presonus::inspire1394::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/roland.rs
+++ b/libs/bebob/runtime/src/roland.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{roland::*, *},
+    protocols::{roland::*, *},
 };
 
 pub type Fa66Model = FaModel<Fa66MixerAnalogSourceProtocol>;

--- a/libs/bebob/runtime/src/stanton.rs
+++ b/libs/bebob/runtime/src/stanton.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{stanton::*, *},
+    protocols::{stanton::*, *},
 };
 
 const FCP_TIMEOUT_MS: u32 = 100;

--- a/libs/bebob/runtime/src/terratec/aureon_model.rs
+++ b/libs/bebob/runtime/src/terratec/aureon_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{terratec::aureon::*, *},
+    protocols::{terratec::aureon::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/terratec/phase88_model.rs
+++ b/libs/bebob/runtime/src/terratec/phase88_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{terratec::phase88::*, *},
+    protocols::{terratec::phase88::*, *},
 };
 
 #[derive(Default)]

--- a/libs/bebob/runtime/src/yamaha_terratec.rs
+++ b/libs/bebob/runtime/src/yamaha_terratec.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctls::*, *},
-    bebob_protocols::{yamaha_terratec::*, *},
+    protocols::{yamaha_terratec::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dg00x/protocols/Cargo.toml
+++ b/libs/dg00x/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Implementation of protocol for Digi 00x family
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/dg00x/protocols/src/lib.rs
+++ b/libs/dg00x/protocols/src/lib.rs
@@ -74,7 +74,7 @@ fn write_quadlet(
     )
 }
 
-/// The enumeration for frequency of media clock.
+/// Nominal frequency of media clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockRate {
     R44100,
@@ -89,7 +89,7 @@ impl Default for ClockRate {
     }
 }
 
-/// The enumeration for source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockSource {
     Internal,
@@ -104,7 +104,7 @@ impl Default for ClockSource {
     }
 }
 
-/// The enumeration for mode of optical interface.
+/// Mode of optical interface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum OpticalInterfaceMode {
     Adat,
@@ -268,7 +268,7 @@ pub trait Dg00xCommonOperation {
 const MONITOR_DST_COUNT: usize = 2;
 const MONITOR_SRC_COUNT: usize = 18;
 
-/// The structure for state of monitor. The gain is between 0x00 and 0x80 for -48.0 and 0.0 dB.
+/// State of monitor. The gain is between 0x00 and 0x80 for -48.0 and 0.0 dB.
 #[derive(Default, Debug)]
 pub struct Dg00xMonitorState {
     pub enabled: bool,

--- a/libs/dg00x/protocols/src/lib.rs
+++ b/libs/dg00x/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocols defined by Digidesign for Digi 00x family

--- a/libs/dg00x/runtime/src/lib.rs
+++ b/libs/dg00x/runtime/src/lib.rs
@@ -5,6 +5,7 @@ mod model;
 use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    dg00x_protocols as protocols,
     glib::{
         source, {Error, FileError},
     },

--- a/libs/dg00x/runtime/src/model.rs
+++ b/libs/dg00x/runtime/src/model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, alsa_ctl_tlv_codec::DbInterval, dg00x_protocols::*, std::marker::PhantomData};
+use {super::*, alsa_ctl_tlv_codec::DbInterval, protocols::*, std::marker::PhantomData};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/libs/dice/protocols/Cargo.toml
+++ b/libs/dice/protocols/Cargo.toml
@@ -9,7 +9,7 @@ Implementation of protocols defined by TC Applied Technologies for ASICs of
 Digital Interface Communication Engine (DICE) as well as hardware vendors.
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/dice/protocols/src/alesis.rs
+++ b/libs/dice/protocols/src/alesis.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol specific to Alesis iO FireWire series.

--- a/libs/dice/protocols/src/alesis/meter.rs
+++ b/libs/dice/protocols/src/alesis/meter.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Meter protocol specific to Alesis iO FireWire series.

--- a/libs/dice/protocols/src/alesis/mixer.rs
+++ b/libs/dice/protocols/src/alesis/mixer.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Mixer protocol specific to Alesis iO FireWire series.

--- a/libs/dice/protocols/src/alesis/output.rs
+++ b/libs/dice/protocols/src/alesis/output.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Output protocol specific to Alesis iO FireWire series.

--- a/libs/dice/protocols/src/avid.rs
+++ b/libs/dice/protocols/src/avid.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Hardware specification and application protocol specific to Avid Mbox 3 Pro

--- a/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
@@ -1,14 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
-use glib::FileError;
 
-use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
-
-use dice_protocols::tcat::config_rom::*;
-use ieee1212_config_rom::*;
-
-use std::convert::TryFrom;
-use std::io::Read;
+use {
+    dice_protocols as protocols,
+    glib::FileError,
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwNodeError,
+    },
+    ieee1212_config_rom::*,
+    protocols::tcat::config_rom::*,
+    std::{convert::TryFrom, io::Read},
+};
 
 fn main() {
     let code = std::env::args()

--- a/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-config-rom-parser.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {

--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use glib::{Error, FileError, MainContext, MainLoop};
-
-use hinawa::FwReq;
-use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
-
-use dice_protocols::tcat::extension::current_config_section::*;
-use dice_protocols::tcat::extension::peak_section::*;
-use dice_protocols::tcat::extension::standalone_section::*;
-use dice_protocols::tcat::extension::{caps_section::*, cmd_section::*, mixer_section::*, *};
-
-use std::sync::Arc;
-use std::thread;
+use {
+    dice_protocols as protocols,
+    glib::{Error, FileError, MainContext, MainLoop},
+    hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
+    protocols::tcat::extension::{
+        caps_section::*, cmd_section::*, current_config_section::*, mixer_section::*,
+        peak_section::*, standalone_section::*, *,
+    },
+    std::{sync::Arc, thread},
+};
 
 const TIMEOUT_MS: u32 = 20;
 

--- a/libs/dice/protocols/src/bin/tcat-extension-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-extension-parser.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {

--- a/libs/dice/protocols/src/bin/tcat-general-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-general-parser.rs
@@ -1,18 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use glib::{Error, FileError, MainContext, MainLoop};
-
-use hinawa::FwReq;
-use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
-
-use dice_protocols::tcat::{
-    ext_sync_section::*, global_section::*, rx_stream_format_section::*,
-    tx_stream_format_section::*, *,
+use {
+    dice_protocols as protocols,
+    glib::{Error, FileError, MainContext, MainLoop},
+    hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
+    protocols::tcat::{
+        ext_sync_section::*, global_section::*, rx_stream_format_section::*,
+        tx_stream_format_section::*, *,
+    },
+    std::sync::Arc,
+    std::thread,
 };
-
-use std::sync::Arc;
-use std::thread;
 
 const TIMEOUT_MS: u32 = 20;
 

--- a/libs/dice/protocols/src/bin/tcat-general-parser.rs
+++ b/libs/dice/protocols/src/bin/tcat-general-parser.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {

--- a/libs/dice/protocols/src/focusrite.rs
+++ b/libs/dice/protocols/src/focusrite.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire series.

--- a/libs/dice/protocols/src/focusrite/liquids56.rs
+++ b/libs/dice/protocols/src/focusrite/liquids56.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Liquid Saffire 56.

--- a/libs/dice/protocols/src/focusrite/spro14.rs
+++ b/libs/dice/protocols/src/focusrite/spro14.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire Pro 14.

--- a/libs/dice/protocols/src/focusrite/spro24.rs
+++ b/libs/dice/protocols/src/focusrite/spro24.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire Pro 24.

--- a/libs/dice/protocols/src/focusrite/spro24dsp.rs
+++ b/libs/dice/protocols/src/focusrite/spro24dsp.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire Pro 24 DSP.

--- a/libs/dice/protocols/src/focusrite/spro26.rs
+++ b/libs/dice/protocols/src/focusrite/spro26.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire Pro 26.

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Focusrite Saffire Pro 40.

--- a/libs/dice/protocols/src/lexicon.rs
+++ b/libs/dice/protocols/src/lexicon.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol specific to Lexicon I-ONIX FW810s.

--- a/libs/dice/protocols/src/lib.rs
+++ b/libs/dice/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocols defined for ASICs of Digital Interface Communication Engine (DICE).

--- a/libs/dice/protocols/src/loud.rs
+++ b/libs/dice/protocols/src/loud.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Hardware specification and application protocol specific to Loud (Mackie) Onyx Blackbird.

--- a/libs/dice/protocols/src/maudio.rs
+++ b/libs/dice/protocols/src/maudio.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Hardware specification and application protocol specific to M-Audio ProFire series.

--- a/libs/dice/protocols/src/presonus.rs
+++ b/libs/dice/protocols/src/presonus.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation specific to PreSonus FireStudio series.

--- a/libs/dice/protocols/src/presonus/fstudio.rs
+++ b/libs/dice/protocols/src/presonus/fstudio.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for PreSonus FireStudio.

--- a/libs/dice/protocols/src/presonus/fstudiomobile.rs
+++ b/libs/dice/protocols/src/presonus/fstudiomobile.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for PreSonus FireStudio Mobile.

--- a/libs/dice/protocols/src/presonus/fstudioproject.rs
+++ b/libs/dice/protocols/src/presonus/fstudioproject.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for PreSonus FireStudio Project.

--- a/libs/dice/protocols/src/tcat.rs
+++ b/libs/dice/protocols/src/tcat.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/config_rom.rs
+++ b/libs/dice/protocols/src/tcat/config_rom.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Parser for Configuration ROM according to specification defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/ext_sync_section.rs
+++ b/libs/dice/protocols/src/tcat/ext_sync_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! External synchronization section in general protocol defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension.rs
+++ b/libs/dice/protocols/src/tcat/extension.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/appl_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/appl_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Application section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/caps_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/caps_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Capabilities section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/cmd_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/cmd_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Command section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/current_config_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/current_config_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Current configuration section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/mixer_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/mixer_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Mixer section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/peak_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/peak_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Peak section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/router_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_entry.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 use super::{caps_section::*, *};
 

--- a/libs/dice/protocols/src/tcat/extension/router_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/router_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Router section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/standalone_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/standalone_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Standalone section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_entry.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 use super::{caps_section::*, *};
 

--- a/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/extension/stream_format_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Stream format section in protocol extension defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/global_section.rs
+++ b/libs/dice/protocols/src/tcat/global_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Global section in general protocol defined by TCAT for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/rx_stream_format_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Rx Stream format section in general protocol for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
+++ b/libs/dice/protocols/src/tcat/tcd22xx_spec.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 use super::{

--- a/libs/dice/protocols/src/tcat/tx_stream_format_section.rs
+++ b/libs/dice/protocols/src/tcat/tx_stream_format_section.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Tx Stream format section in general protocol for ASICs of DICE.

--- a/libs/dice/protocols/src/tcat/utils.rs
+++ b/libs/dice/protocols/src/tcat/utils.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 use super::Iec60958Param;
 

--- a/libs/dice/protocols/src/tcelectronic.rs
+++ b/libs/dice/protocols/src/tcelectronic.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol specific to TC Electronic Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/ch_strip.rs
+++ b/libs/dice/protocols/src/tcelectronic/ch_strip.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Data of channel strip effect in protocol defined by TC Electronic for Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/desktop.rs
+++ b/libs/dice/protocols/src/tcelectronic/desktop.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Desktop Konnekt 6.

--- a/libs/dice/protocols/src/tcelectronic/fw_led.rs
+++ b/libs/dice/protocols/src/tcelectronic/fw_led.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Common structure for hardware state for TC Electronic Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/midi_send.rs
+++ b/libs/dice/protocols/src/tcelectronic/midi_send.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Data of MIDI sender in protocol defined by TC Electronic for Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/prog.rs
+++ b/libs/dice/protocols/src/tcelectronic/prog.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Loaded program protocol defined by TC Electronic for Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/reverb.rs
+++ b/libs/dice/protocols/src/tcelectronic/reverb.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Data of reverb effect in protocol defined by TC Electronic for Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/shell.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Konnekt 24d, Konnekt 8, Konnekt Live, and Impact Twin.

--- a/libs/dice/protocols/src/tcelectronic/shell/itwin.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/itwin.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Impact Twin.

--- a/libs/dice/protocols/src/tcelectronic/shell/k24d.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/k24d.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Konnekt 24d.

--- a/libs/dice/protocols/src/tcelectronic/shell/k8.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/k8.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Konnekt 8.

--- a/libs/dice/protocols/src/tcelectronic/shell/klive.rs
+++ b/libs/dice/protocols/src/tcelectronic/shell/klive.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Konnekt Live.

--- a/libs/dice/protocols/src/tcelectronic/standalone.rs
+++ b/libs/dice/protocols/src/tcelectronic/standalone.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Konnekt series.

--- a/libs/dice/protocols/src/tcelectronic/studio.rs
+++ b/libs/dice/protocols/src/tcelectronic/studio.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
 //! Protocol defined by TC Electronic for Studio Konnekt 48.

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 use {
-    super::{common_ctl::*, tcd22xx_ctl::*, *},
+    super::{tcd22xx_ctl::*, *},
     protocols::{loud::*, tcat::extension::*},
 };
 

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -2,10 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    protocols::{
-        loud::*,
-        tcat::{extension::*, global_section::*, *},
-    },
+    protocols::{loud::*, tcat::extension::*},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/blackbird_model.rs
+++ b/libs/dice/runtime/src/blackbird_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         loud::*,
         tcat::{extension::*, global_section::*, *},
     },

--- a/libs/dice/runtime/src/common_ctl.rs
+++ b/libs/dice/runtime/src/common_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    dice_protocols::tcat::{global_section::*, *},
+    protocols::tcat::{global_section::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/common_ctl.rs
+++ b/libs/dice/runtime/src/common_ctl.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::*,
-    protocols::tcat::{global_section::*, *},
-};
+use super::*;
 
 #[derive(Default)]
 pub struct CommonCtl {

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {
-    super::{common_ctl::*, tcd22xx_ctl::*, *},
+    super::{tcd22xx_ctl::*, *},
     protocols::tcat::{extension::*, tcd22xx_spec::*},
 };
 

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -3,11 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    protocols::tcat::{
-        extension::*,
-        tcd22xx_spec::*,
-        {global_section::*, *},
-    },
+    protocols::tcat::{extension::*, tcd22xx_spec::*},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/extension_model.rs
+++ b/libs/dice/runtime/src/extension_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    dice_protocols::tcat::{
+    protocols::tcat::{
         extension::*,
         tcd22xx_spec::*,
         {global_section::*, *},

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -10,7 +10,7 @@ pub mod spro40_model;
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         focusrite::*,
         tcat::{extension::*, global_section::*, *},
     },

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -10,10 +10,7 @@ pub mod spro40_model;
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    protocols::{
-        focusrite::*,
-        tcat::{extension::*, global_section::*, *},
-    },
+    protocols::{focusrite::*, tcat::extension::*},
 };
 
 const VOL_NAME: &str = "output-group-volume";

--- a/libs/dice/runtime/src/focusrite.rs
+++ b/libs/dice/runtime/src/focusrite.rs
@@ -9,7 +9,7 @@ pub mod spro26_model;
 pub mod spro40_model;
 
 use {
-    super::{common_ctl::*, tcd22xx_ctl::*, *},
+    super::{tcd22xx_ctl::*, *},
     protocols::{focusrite::*, tcat::extension::*},
 };
 

--- a/libs/dice/runtime/src/focusrite/liquids56_model.rs
+++ b/libs/dice/runtime/src/focusrite/liquids56_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::liquids56::*};
+use {super::*, protocols::focusrite::liquids56::*};
 
 #[derive(Default)]
 pub struct LiquidS56Model {

--- a/libs/dice/runtime/src/focusrite/spro14_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro14_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::spro14::*};
+use {super::*, protocols::focusrite::spro14::*};
 
 #[derive(Default)]
 pub struct SPro14Model {

--- a/libs/dice/runtime/src/focusrite/spro24_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::spro24::*};
+use {super::*, protocols::focusrite::spro24::*};
 
 #[derive(Default)]
 pub struct SPro24Model {

--- a/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro24dsp_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::spro24dsp::*};
+use {super::*, protocols::focusrite::spro24dsp::*};
 
 #[derive(Default)]
 pub struct SPro24DspModel {

--- a/libs/dice/runtime/src/focusrite/spro26_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro26_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::spro26::*};
+use {super::*, protocols::focusrite::spro26::*};
 
 #[derive(Default)]
 pub struct SPro26Model {

--- a/libs/dice/runtime/src/focusrite/spro40_model.rs
+++ b/libs/dice/runtime/src/focusrite/spro40_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::focusrite::spro40::*};
+use {super::*, protocols::focusrite::spro40::*};
 
 #[derive(Default)]
 pub struct SPro40Model {

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -5,7 +5,7 @@ use {
     super::{common_ctl::*, *},
     protocols::{
         alesis::{meter::*, mixer::*, output::*, *},
-        tcat::{global_section::*, tx_stream_format_section::*, *},
+        tcat::tx_stream_format_section::*,
     },
 };
 

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         alesis::{meter::*, mixer::*, output::*, *},
         tcat::{global_section::*, tx_stream_format_section::*, *},
     },

--- a/libs/dice/runtime/src/io_fw_model.rs
+++ b/libs/dice/runtime/src/io_fw_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {
-    super::{common_ctl::*, *},
+    super::*,
     protocols::{
         alesis::{meter::*, mixer::*, output::*, *},
         tcat::tx_stream_format_section::*,

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::lexicon::*,
-};
+use {super::*, protocols::lexicon::*};
 
 #[derive(Default)]
 pub struct IonixModel {

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -3,10 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    protocols::{
-        lexicon::*,
-        tcat::{global_section::*, *},
-    },
+    protocols::lexicon::*,
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/ionix_model.rs
+++ b/libs/dice/runtime/src/ionix_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         lexicon::*,
         tcat::{global_section::*, *},
     },

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -22,10 +22,14 @@ use {
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     dice_protocols as protocols,
     glib::{source, Error, FileError},
-    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwReq,
+    },
     hitaki::{prelude::*, *},
     model::*,
     nix::sys::signal,
+    protocols::tcat::{global_section::*, *},
     std::sync::mpsc,
 };
 

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -19,6 +19,7 @@ mod tcd22xx_ctl;
 use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
+    common_ctl::*,
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     dice_protocols as protocols,
     glib::{source, Error, FileError},

--- a/libs/dice/runtime/src/lib.rs
+++ b/libs/dice/runtime/src/lib.rs
@@ -20,6 +20,7 @@ use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    dice_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
     hitaki::{prelude::*, *},

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         avid::*,
         tcat::{extension::*, global_section::*, *},
     },

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -3,10 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    protocols::{
-        avid::*,
-        tcat::{extension::*, global_section::*, *},
-    },
+    protocols::{avid::*, tcat::extension::*},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/mbox3_model.rs
+++ b/libs/dice/runtime/src/mbox3_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {
-    super::{common_ctl::*, tcd22xx_ctl::*, *},
+    super::{tcd22xx_ctl::*, *},
     protocols::{avid::*, tcat::extension::*},
 };
 

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::tcat::{global_section::*, *},
-};
+use super::{common_ctl::*, *};
 
 #[derive(Default)]
 pub struct MinimalModel {

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    dice_protocols::tcat::{global_section::*, *},
+    protocols::tcat::{global_section::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/minimal_model.rs
+++ b/libs/dice/runtime/src/minimal_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::{common_ctl::*, *};
+use super::*;
 
 #[derive(Default)]
 pub struct MinimalModel {

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -12,8 +12,8 @@ use {
         tcelectronic::k24d_model::*, tcelectronic::k8_model::*, tcelectronic::klive_model::*,
         tcelectronic::studiok48_model::*, *,
     },
-    dice_protocols::tcat::{config_rom::*, extension::*, *},
     ieee1212_config_rom::*,
+    protocols::tcat::{config_rom::*, extension::*, *},
     std::convert::TryFrom,
 };
 

--- a/libs/dice/runtime/src/model.rs
+++ b/libs/dice/runtime/src/model.rs
@@ -13,7 +13,7 @@ use {
         tcelectronic::studiok48_model::*, *,
     },
     ieee1212_config_rom::*,
-    protocols::tcat::{config_rom::*, extension::*, *},
+    protocols::tcat::{config_rom::*, extension::*},
     std::convert::TryFrom,
 };
 

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -3,10 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    protocols::{
-        maudio::*,
-        tcat::{extension::*, global_section::*, *},
-    },
+    protocols::{maudio::*, tcat::extension::*},
 };
 
 const TIMEOUT_MS: u32 = 20;

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {
-    super::{common_ctl::*, tcd22xx_ctl::*, *},
+    super::{tcd22xx_ctl::*, *},
     protocols::{maudio::*, tcat::extension::*},
 };
 

--- a/libs/dice/runtime/src/pfire_model.rs
+++ b/libs/dice/runtime/src/pfire_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, tcd22xx_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         maudio::*,
         tcat::{extension::*, global_section::*, *},
     },

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -7,5 +7,5 @@ pub mod fstudioproject_model;
 
 use {
     super::{common_ctl::*, *},
-    dice_protocols::tcat::{global_section::*, *},
+    protocols::tcat::{global_section::*, *},
 };

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -5,7 +5,4 @@ pub mod fstudio_model;
 pub mod fstudiomobile_model;
 pub mod fstudioproject_model;
 
-use {
-    super::{common_ctl::*, *},
-    protocols::tcat::{global_section::*, *},
-};
+use super::{common_ctl::*, *};

--- a/libs/dice/runtime/src/presonus.rs
+++ b/libs/dice/runtime/src/presonus.rs
@@ -5,4 +5,4 @@ pub mod fstudio_model;
 pub mod fstudiomobile_model;
 pub mod fstudioproject_model;
 
-use super::{common_ctl::*, *};
+use super::*;

--- a/libs/dice/runtime/src/presonus/fstudio_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudio_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, dice_protocols::presonus::fstudio::*};
+use {super::*, protocols::presonus::fstudio::*};
 
 #[derive(Default)]
 pub struct FStudioModel {

--- a/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudiomobile_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{tcd22xx_ctl::*, *},
-    dice_protocols::{presonus::fstudiomobile::*, tcat::extension::*},
+    protocols::{presonus::fstudiomobile::*, tcat::extension::*},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/presonus/fstudioproject_model.rs
+++ b/libs/dice/runtime/src/presonus/fstudioproject_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{tcd22xx_ctl::*, *},
-    dice_protocols::{presonus::fstudioproject::*, tcat::extension::*},
+    protocols::{presonus::fstudioproject::*, tcat::extension::*},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -10,7 +10,6 @@ use {
             {current_config_section::*, standalone_section::*},
         },
         tcd22xx_spec::*,
-        {global_section::*, *},
     },
 };
 

--- a/libs/dice/runtime/src/tcd22xx_ctl.rs
+++ b/libs/dice/runtime/src/tcd22xx_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    dice_protocols::tcat::{
+    protocols::tcat::{
         extension::{
             peak_section::*,
             {caps_section::*, cmd_section::*, mixer_section::*, *},

--- a/libs/dice/runtime/src/tcelectronic.rs
+++ b/libs/dice/runtime/src/tcelectronic.rs
@@ -23,10 +23,7 @@ use {
     self::reverb_ctl::*,
     self::standalone_ctl::*,
     super::{common_ctl::*, *},
-    protocols::{
-        tcat::{global_section::*, *},
-        tcelectronic::{
-            ch_strip::*, fw_led::*, midi_send::*, prog::*, reverb::*, standalone::*, *,
-        },
+    protocols::tcelectronic::{
+        ch_strip::*, fw_led::*, midi_send::*, prog::*, reverb::*, standalone::*, *,
     },
 };

--- a/libs/dice/runtime/src/tcelectronic.rs
+++ b/libs/dice/runtime/src/tcelectronic.rs
@@ -22,7 +22,7 @@ use {
     self::prog_ctl::*,
     self::reverb_ctl::*,
     self::standalone_ctl::*,
-    super::{common_ctl::*, *},
+    super::*,
     protocols::tcelectronic::{
         ch_strip::*, fw_led::*, midi_send::*, prog::*, reverb::*, standalone::*, *,
     },

--- a/libs/dice/runtime/src/tcelectronic.rs
+++ b/libs/dice/runtime/src/tcelectronic.rs
@@ -23,7 +23,7 @@ use {
     self::reverb_ctl::*,
     self::standalone_ctl::*,
     super::{common_ctl::*, *},
-    dice_protocols::{
+    protocols::{
         tcat::{global_section::*, *},
         tcelectronic::{
             ch_strip::*, fw_led::*, midi_send::*, prog::*, reverb::*, standalone::*, *,

--- a/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/desktopk6_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, dice_protocols::tcelectronic::desktop::*};
+use {super::*, protocols::tcelectronic::desktop::*};
 
 #[derive(Default)]
 pub struct Desktopk6Model {

--- a/libs/dice/runtime/src/tcelectronic/itwin_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/itwin_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{shell_ctl::*, *},
-    dice_protocols::tcelectronic::shell::{itwin::*, *},
+    protocols::tcelectronic::shell::{itwin::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/tcelectronic/k24d_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k24d_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{shell_ctl::*, *},
-    dice_protocols::tcelectronic::shell::{k24d::*, *},
+    protocols::tcelectronic::shell::{k24d::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/tcelectronic/k8_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/k8_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{shell_ctl::*, *},
-    dice_protocols::tcelectronic::shell::{k8::*, *},
+    protocols::tcelectronic::shell::{k8::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/tcelectronic/klive_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/klive_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{shell_ctl::*, *},
-    dice_protocols::tcelectronic::shell::{klive::*, *},
+    protocols::tcelectronic::shell::{klive::*, *},
 };
 
 #[derive(Default)]

--- a/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
+++ b/libs/dice/runtime/src/tcelectronic/shell_ctl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, dice_protocols::tcelectronic::shell::*};
+use {super::*, protocols::tcelectronic::shell::*};
 
 fn analog_jack_state_to_str(state: &ShellAnalogJackState) -> &'static str {
     match state {

--- a/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
+++ b/libs/dice/runtime/src/tcelectronic/studiok48_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, dice_protocols::tcelectronic::studio::*};
+use {super::*, protocols::tcelectronic::studio::*};
 
 #[derive(Default)]
 pub struct Studiok48Model {

--- a/libs/efw/protocols/Cargo.toml
+++ b/libs/efw/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Implementation of protocols defined by Echo Digital Audio Corporation for Fireworks board module.
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/efw/protocols/src/flash.rs
+++ b/libs/efw/protocols/src/flash.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about operations for on-board flash memory.

--- a/libs/efw/protocols/src/hw_ctl.rs
+++ b/libs/efw/protocols/src/hw_ctl.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about hardware control.

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -36,7 +36,7 @@ const CMD_METER: u32 = 1;
 const CMD_CHANGE_RESP_ADDR: u32 = 2;
 const CMD_READ_SESSION_BLOCK: u32 = 3;
 
-/// The enumeration to express hardware capability.
+/// Hardware capability.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum HwCap {
     /// The address to which response of transaction is transmitted is configurable.
@@ -101,7 +101,7 @@ impl From<usize> for HwCap {
     }
 }
 
-/// The enumeration to express type of physical group.
+/// Type of physical group.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum PhysGroupType {
     Analog,
@@ -135,14 +135,14 @@ impl From<usize> for PhysGroupType {
     }
 }
 
-/// The structure to express entry of physical group.
+/// Entry of physical group.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct PhysGroupEntry {
     pub group_type: PhysGroupType,
     pub group_count: usize,
 }
 
-/// The structure to express hardware information.
+/// Information of hardware.
 #[derive(Debug)]
 pub struct HwInfo {
     pub caps: Vec<HwCap>,
@@ -293,7 +293,7 @@ impl HwInfo {
     }
 }
 
-/// The structure to express hardware meter.
+/// Hardware meter.
 #[derive(Debug)]
 pub struct HwMeter {
     pub detected_clk_srcs: Vec<(ClkSrc, bool)>,

--- a/libs/efw/protocols/src/hw_info.rs
+++ b/libs/efw/protocols/src/hw_info.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about hardware information.

--- a/libs/efw/protocols/src/lib.rs
+++ b/libs/efw/protocols/src/lib.rs
@@ -23,7 +23,7 @@ use {
     hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
 };
 
-/// The enumeration to express source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkSrc {
     Internal,
@@ -71,7 +71,7 @@ impl From<usize> for ClkSrc {
     }
 }
 
-/// The enumeration to express nominal level of audio signal.
+/// Nominal level of audio signal.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NominalSignalLevel {
     /// +4 dBu.

--- a/libs/efw/protocols/src/lib.rs
+++ b/libs/efw/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by Echo Audio Digital Corporation for Fireworks board module.

--- a/libs/efw/protocols/src/monitor.rs
+++ b/libs/efw/protocols/src/monitor.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about input monitor.

--- a/libs/efw/protocols/src/phys_input.rs
+++ b/libs/efw/protocols/src/phys_input.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about physical input.

--- a/libs/efw/protocols/src/phys_output.rs
+++ b/libs/efw/protocols/src/phys_output.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about physical output.

--- a/libs/efw/protocols/src/playback.rs
+++ b/libs/efw/protocols/src/playback.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about stream playback.

--- a/libs/efw/protocols/src/port_conf.rs
+++ b/libs/efw/protocols/src/port_conf.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about port configuration.

--- a/libs/efw/protocols/src/port_conf.rs
+++ b/libs/efw/protocols/src/port_conf.rs
@@ -19,7 +19,7 @@ const CMD_GET_PHANTOM: u32 = 5;
 const CMD_SET_STREAM_MAP: u32 = 6;
 const CMD_GET_STREAM_MAP: u32 = 7;
 
-/// The enumeration to express the type of audio signal for dignal input and output.
+/// Type of audio signal for dignal input and output.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DigitalMode {
     /// Coaxial interface for S/PDIF signal.

--- a/libs/efw/protocols/src/robot_guitar.rs
+++ b/libs/efw/protocols/src/robot_guitar.rs
@@ -13,7 +13,7 @@ const CATEGORY_ROBOT_GUITAR: u32 = 10;
 const CMD_SET_CHARGE_STATE: u32 = 7;
 const CMD_GET_CHARGE_STATE: u32 = 8;
 
-/// The enumeration to express state of charging for Robot Guitar.
+/// State of charging for Robot Guitar.
 #[derive(Debug)]
 pub struct GuitarChargeState {
     pub manual_charge: bool,

--- a/libs/efw/protocols/src/robot_guitar.rs
+++ b/libs/efw/protocols/src/robot_guitar.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about robot guitar.

--- a/libs/efw/protocols/src/transaction.rs
+++ b/libs/efw/protocols/src/transaction.rs
@@ -18,6 +18,8 @@ use {
 };
 
 glib::wrapper! {
+    /// The implementation of hitaki`::EfwProtocolExt` and `hitaki::EfwProtocolExtManual` traits
+    /// so that it can perform Echo Audio Fireworks transaction instead of ALSA Fireworks driver.
     pub struct EfwTransaction(ObjectSubclass<imp::EfwTransactionPrivate>)
         @extends FwResp, @implements EfwProtocol;
 }

--- a/libs/efw/protocols/src/transaction.rs
+++ b/libs/efw/protocols/src/transaction.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
 //! Transaction protocol implementation defined by Echo Audio Digital Corporation for Fireworks

--- a/libs/efw/protocols/src/transport.rs
+++ b/libs/efw/protocols/src/transport.rs
@@ -31,7 +31,7 @@ impl From<TxPacketFormat> for u32 {
 
 /// Protocol about transmission for Fireworks board module.
 pub trait TransportProtocol: EfwProtocolExtManual {
-    fn get_hw_info(&mut self, fmt: TxPacketFormat, timeout_ms: u32) -> Result<(), Error> {
+    fn get_packet_format(&mut self, fmt: TxPacketFormat, timeout_ms: u32) -> Result<(), Error> {
         let args = [u32::from(fmt)];
         self.transaction(
             CATEGORY_TRANSPORT,

--- a/libs/efw/protocols/src/transport.rs
+++ b/libs/efw/protocols/src/transport.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol about hardware information.

--- a/libs/efw/runtime/src/clk_ctl.rs
+++ b/libs/efw/runtime/src/clk_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    efw_protocols::{hw_ctl::*, hw_info::*, ClkSrc},
+    protocols::{hw_ctl::*, hw_info::*, ClkSrc},
 };
 
 fn clk_src_to_str(src: &ClkSrc) -> &'static str {

--- a/libs/efw/runtime/src/guitar_ctl.rs
+++ b/libs/efw/runtime/src/guitar_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    efw_protocols::{hw_info::*, robot_guitar::*},
+    protocols::{hw_info::*, robot_guitar::*},
 };
 
 #[derive(Default)]

--- a/libs/efw/runtime/src/iec60958_ctl.rs
+++ b/libs/efw/runtime/src/iec60958_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    efw_protocols::{hw_ctl::*, hw_info::*, *},
+    protocols::{hw_ctl::*, hw_info::*, *},
 };
 
 #[derive(Default)]

--- a/libs/efw/runtime/src/input_ctl.rs
+++ b/libs/efw/runtime/src/input_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    efw_protocols::{hw_info::*, phys_input::*, *},
+    protocols::{hw_info::*, phys_input::*, *},
 };
 
 #[derive(Default)]

--- a/libs/efw/runtime/src/lib.rs
+++ b/libs/efw/runtime/src/lib.rs
@@ -14,6 +14,7 @@ mod port_ctl;
 use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
+    efw_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{prelude::{FwNodeExtManual, FwNodeExt}, FwNode},
     hitaki::{prelude::*, SndEfw},

--- a/libs/efw/runtime/src/meter_ctl.rs
+++ b/libs/efw/runtime/src/meter_ctl.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, efw_protocols::hw_info::*};
+use {super::*, protocols::hw_info::*};
 
 #[derive(Default)]
 pub struct MeterCtl {

--- a/libs/efw/runtime/src/mixer_ctl.rs
+++ b/libs/efw/runtime/src/mixer_ctl.rs
@@ -4,7 +4,7 @@
 use {
     super::*,
     alsa_ctl_tlv_codec::DbInterval,
-    efw_protocols::{hw_ctl::*, hw_info::*, monitor::*, playback::*},
+    protocols::{hw_ctl::*, hw_info::*, monitor::*, playback::*},
 };
 
 #[derive(Default)]

--- a/libs/efw/runtime/src/model.rs
+++ b/libs/efw/runtime/src/model.rs
@@ -2,7 +2,7 @@
 // Copyright (c) 2020 Takashi Sakamoto
 
 use {
-    super::*, efw_protocols::hw_info::*, ieee1212_config_rom::ConfigRom, std::convert::TryFrom,
+    super::*, protocols::hw_info::*, ieee1212_config_rom::ConfigRom, std::convert::TryFrom,
     ta1394_avc_general::config_rom::Ta1394ConfigRom,
 };
 

--- a/libs/efw/runtime/src/output_ctl.rs
+++ b/libs/efw/runtime/src/output_ctl.rs
@@ -4,7 +4,7 @@
 use {
     super::*,
     alsa_ctl_tlv_codec::DbInterval,
-    efw_protocols::{hw_info::*, phys_output::*, *},
+    protocols::{hw_info::*, phys_output::*, *},
 };
 
 #[derive(Default)]

--- a/libs/efw/runtime/src/port_ctl.rs
+++ b/libs/efw/runtime/src/port_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    efw_protocols::{hw_info::*, port_conf::*},
+    protocols::{hw_info::*, port_conf::*},
 };
 
 fn phys_group_type_to_str(phys_group_type: &PhysGroupType) -> &'static str {

--- a/libs/ff/protocols/Cargo.toml
+++ b/libs/ff/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Implementation of protocols defined by RME GmbH for its Fireface series.
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
+++ b/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {

--- a/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
+++ b/libs/ff/protocols/src/bin/ff-config-rom-parser.rs
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
-use glib::FileError;
 
-use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
-
-use ff_protocols::*;
-use ieee1212_config_rom::*;
-
-use std::convert::TryFrom;
-use std::io::Read;
+use {
+    ff_protocols as protocols,
+    glib::FileError,
+    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError},
+    ieee1212_config_rom::*,
+    protocols::*,
+    std::{convert::TryFrom, io::Read},
+};
 
 fn main() {
     let code = std::env::args()

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for former models of Firewire series.

--- a/libs/ff/protocols/src/former.rs
+++ b/libs/ff/protocols/src/former.rs
@@ -12,7 +12,7 @@ use {
     super::*,
 };
 
-/// The structure to represent state of hardware meter.
+/// State of hardware meter.
 ///
 /// Each value of 32 bit integer is between 0x00000000 and 0x7fffff00 to represent -90.03 and
 /// 0.00 dB. When reaching saturation, 1 byte in LSB side represent ratio of overload.
@@ -110,7 +110,7 @@ pub trait RmeFfFormerMeterOperation {
     }
 }
 
-/// The structure for state of output volumes.
+/// State of output volumes.
 ///
 /// The value for volume is between 0x00000000 and 0x00010000 through 0x00000001 and 0x00080000 to
 /// represent the range from negative infinite to 6.00 dB through -90.30 dB and 0.00 dB.
@@ -175,7 +175,7 @@ pub trait RmeFormerOutputOperation {
     }
 }
 
-/// The structure to represent source of mixer specific to former models of RME Fireface.
+/// Sources of mixer specific to former models of RME Fireface.
 ///
 /// The value is between 0x00000000 and 0x00010000 through 0x00008000 to represent -90.30 and 6.02 dB
 /// through 0x00008000.
@@ -187,7 +187,7 @@ pub struct FormerMixerSrc {
     pub stream_gains: Vec<i32>,
 }
 
-/// The structure for state of mixer.
+/// State of mixer.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FormerMixerState(pub Vec<FormerMixerSrc>);
 
@@ -334,7 +334,7 @@ pub trait RmeFormerMixerOperation {
     }
 }
 
-/// The structure to represent configuration of S/PDIF output.
+/// Configuration of S/PDIF output.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FormerSpdifOutput {
     /// The format of S/PDIF signal.
@@ -345,7 +345,7 @@ pub struct FormerSpdifOutput {
     pub non_audio: bool,
 }
 
-/// The enumeration to represent nominal level of line inputs.
+/// Nominal level of line inputs.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FormerLineInNominalLevel {
     Low,

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface 400.

--- a/libs/ff/protocols/src/former/ff400.rs
+++ b/libs/ff/protocols/src/former/ff400.rs
@@ -9,7 +9,7 @@ use {
     super::*,
 };
 
-/// The structure to represent unique protocol for Fireface 400.
+/// The protocol implementation for Fireface 400.
 #[derive(Default)]
 pub struct Ff400Protocol;
 
@@ -72,7 +72,7 @@ impl Ff400Protocol {
     }
 }
 
-/// The structure to represent status of input gains of Fireface 400.
+/// Status of input gains of Fireface 400.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400InputGainStatus {
     /// The level of gain for input 1 and 2. The value is between 0 and 65 by step 1 to represent
@@ -210,7 +210,7 @@ impl RmeFormerMixerOperation for Ff400Protocol {
     const AVAIL_COUNT: usize = 18;
 }
 
-/// The enumeration to represent source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Ff400ClkSrc {
     Internal,
@@ -283,7 +283,7 @@ const Q1_CONF_CLK_RATE_48000_FLAG: u32 = 0x00000006;
 const Q1_CONF_CLK_RATE_44100_FLAG: u32 = 0x00000000;
 const Q1_CONF_CLK_RATE_32000_FLAG: u32 = 0x00000002;
 
-/// The structure to represent status of clock locking.
+/// Status of clock locking.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400ClkLockStatus {
     pub adat: bool,
@@ -299,7 +299,7 @@ impl Ff400ClkLockStatus {
     }
 }
 
-/// The structure to represent status of clock synchronization.
+/// Status of clock synchronization.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400ClkSyncStatus {
     pub adat: bool,
@@ -315,7 +315,7 @@ impl Ff400ClkSyncStatus {
     }
 }
 
-/// The structure to represent status of clock synchronization.
+/// Status of clock synchronization.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400Status {
     /// For S/PDIF input.
@@ -511,7 +511,7 @@ const Q2_CLK_AVAIL_RATE_DOUBLE_MASK: u32 = 0x00000008;
 const Q2_CLK_AVAIL_RATE_BASE_48000_MASK: u32 = 0x00000004;
 const Q2_CLK_AVAIL_RATE_BASE_44100_MASK: u32 = 0x00000002;
 
-/// The structure to represent configurations of sampling clock.
+/// Configurations of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400ClkConfig {
     pub primary_src: Ff400ClkSrc,
@@ -574,7 +574,7 @@ impl Ff400ClkConfig {
     }
 }
 
-/// The structure to represent configuration for analog inputs.
+/// Configuration for analog inputs.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400AnalogInConfig {
     /// The nominal level of audio signal for input 5, 6, 7 and 8.
@@ -653,7 +653,7 @@ impl Ff400AnalogInConfig {
     }
 }
 
-/// The enumeration to represent low offset of destination address for MIDI messages.
+/// Low offset of destination address for MIDI messages.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum Ff400MidiTxLowOffset {
     /// Between 0x0000 to 0x007c.
@@ -693,7 +693,7 @@ impl Ff400MidiTxLowOffset {
     }
 }
 
-/// The structure to represent configurations.
+/// Configurations for Fireface 400.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff400Config {
     /// The low offset of destination address for MIDI messages.

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -7,7 +7,7 @@ use hinawa::{FwNode, FwReq};
 use super::*;
 use crate::*;
 
-/// The structure to represent unique protocol for Fireface 800.
+/// Unique protocol for Fireface 800.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Ff800Protocol;
 
@@ -86,7 +86,7 @@ impl RmeFormerMixerOperation for Ff800Protocol {
     const AVAIL_COUNT: usize = 32;
 }
 
-/// The enumeration to represent source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Ff800ClkSrc {
     Internal,
@@ -166,7 +166,7 @@ const Q1_CONF_CLK_RATE_48000_FLAGS: u32 = 0x00000006;
 const Q1_CONF_CLK_RATE_44100_FLAGS: u32 = 0x00000000;
 const Q1_CONF_CLK_RATE_32000_FLAGS: u32 = 0x00000002;
 
-/// The structure to represent status of clock locking.
+/// Status of clock locking.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800ClkLockStatus {
     pub adat_a: bool,
@@ -186,7 +186,7 @@ impl Ff800ClkLockStatus {
     }
 }
 
-/// The structure to represent status of clock synchronization.
+/// Status of clock synchronization.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800ClkSyncStatus {
     pub adat_a: bool,
@@ -206,7 +206,7 @@ impl Ff800ClkSyncStatus {
     }
 }
 
-/// The structure to represent status of clock synchronization.
+/// Status of clock synchronization.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800Status {
     /// For S/PDIF input.
@@ -403,7 +403,7 @@ const Q2_CLK_AVAIL_RATE_BASE_48000_MASK: u32 = 0x00000004;
 const Q2_CLK_AVAIL_RATE_BASE_44100_MASK: u32 = 0x00000002;
 const Q2_CONTINUE_AT_ERRORS: u32 = 0x80000000;
 
-/// The structure to represent configurations of sampling clock.
+/// Configurations of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800ClkConfig {
     pub primary_src: Ff800ClkSrc,
@@ -468,7 +468,7 @@ impl Ff800ClkConfig {
     }
 }
 
-/// The structure to represent configurations for instrument.
+/// Configurations for instrument.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800InstConfig {
     /// Whether to add extra gain by 25 dB.
@@ -503,7 +503,7 @@ impl Ff800InstConfig {
     }
 }
 
-/// The enumeration to represent jack of analog inputs.
+/// Jack of analog inputs.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Ff800AnalogInputJack {
     Front,
@@ -517,7 +517,7 @@ impl Default for Ff800AnalogInputJack {
     }
 }
 
-/// The structure to represent configuration for analog inputs.
+/// Configuration for analog inputs.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800AnalogInConfig {
     /// Whether to use rear jack instead of front jack for input 1, 7, and 8.
@@ -620,7 +620,7 @@ impl Ff800AnalogInConfig {
     }
 }
 
-/// The structure to represent configurations.
+/// Configurations for Fireface 800.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct Ff800Config {
     /// For sampling clock.

--- a/libs/ff/protocols/src/former/ff800.rs
+++ b/libs/ff/protocols/src/former/ff800.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface 800.

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -23,7 +23,7 @@ const CFG_MIDI_TX_LOW_OFFSET_0100_FLAG: u32 = 0x00008000;
 const CFG_MIDI_TX_LOW_OFFSET_0080_FLAG: u32 = 0x00004000;
 const CFG_MIDI_TX_LOW_OFFSET_0000_FLAG: u32 = 0x00002000;
 
-/// The enumeration to represent low offset of destination address for MIDI messages.
+/// Low offset of destination address for MIDI messages.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 enum FfLatterMidiTxLowOffset {
     /// Between 0x0000 to 0x007c.
@@ -180,7 +180,7 @@ where
     }
 }
 
-/// The structure to represent state of meters.
+/// State of meters.
 ///
 /// Each value is between 0x'0000'0000'0000'0000 and 0x'3fff'ffff'ffff'ffff. 0x'0000'0000'0000'001f
 /// represents negative infinite.
@@ -332,7 +332,7 @@ pub trait RmeFfLatterMeterOperation {
     }
 }
 
-/// The structure to represent state of send effects (reverb and echo).
+/// State of send effects (reverb and echo).
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterDspState {
     pub input: FfLatterInputState,
@@ -602,7 +602,7 @@ const FX_ECHO_LPF_FREQ_CMD: u8 = 0x24;
 const FX_ECHO_VOLUME_CMD: u8 = 0x25;
 const FX_ECHO_STEREO_WIDTH_CMD: u8 = 0x26;
 
-/// The structure to represent nominal level of analog input.
+/// Nominal level of analog input.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum LatterInNominalLevel {
     Low,
@@ -625,7 +625,7 @@ impl From<LatterInNominalLevel> for i16 {
     }
 }
 
-/// The structure to represent state of inputs.
+/// State of inputs.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterInputState {
     /// Whether to link each pair of left and right ports.
@@ -748,7 +748,7 @@ impl From<LineOutNominalLevel> for i16 {
     }
 }
 
-/// The structure to represent state of inputs.
+/// State of outputs.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterOutputState {
     /// The level of volume. Each value is between -650 (0xfd76) and 60 (0x003c) to represent
@@ -868,7 +868,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
 
 impl<O: RmeFfLatterDspOperation> RmeFfLatterOutputOperation for O {}
 
-/// The structure to represent state of mixer.
+/// State of mixer.
 ///
 /// Each value is between 0x0000 and 0xa000 through 0x9000 to represent -65.00 dB and 6.00 dB
 /// through 0.00 dB.
@@ -974,7 +974,7 @@ impl From<FfLatterHpfRollOffLevel> for i16 {
     }
 }
 
-/// The structure to represent state of high pass filter in channel strip effect.
+/// State of high pass filter in channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterHpfState {
     /// Whether to activate high pass filter.
@@ -1037,7 +1037,7 @@ impl From<FfLatterChStripEqType> for i16 {
     }
 }
 
-/// The structure to represent state of equalizer in channel strip effect.
+/// State of equalizer in channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterEqState {
     /// Whether to activate equalizer.
@@ -1148,7 +1148,7 @@ fn eq_state_to_cmds(state: &FfLatterEqState, ch_offset: u8) -> Vec<u32> {
     cmds
 }
 
-/// The structure to represent state of dynamics in channel strip effect.
+/// State of dynamics in channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterDynState {
     /// Whether to activate dynamics.
@@ -1227,7 +1227,7 @@ fn dyn_state_to_cmds(state: &FfLatterDynState, ch_offset: u8) -> Vec<u32> {
     cmds
 }
 
-/// The structure to represent state of autolevel in channel strip effects.
+/// State of autolevel in channel strip effects.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterAutolevelState {
     /// Whether to activate auto level.
@@ -1274,7 +1274,7 @@ fn autolevel_state_to_cmds(state: &FfLatterAutolevelState, ch_offset: u8) -> Vec
     cmds
 }
 
-/// The structure to represent state of channel strip effect.
+/// State of channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterChStripState {
     pub hpf: FfLatterHpfState,
@@ -1427,7 +1427,7 @@ pub trait RmeFfLatterChStripOperation<T>: RmeFfLatterDspOperation {
     }
 }
 
-/// The structure to represent state of input channel strip effect.
+/// State of input channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterInputChStripState(pub FfLatterChStripState);
 
@@ -1444,7 +1444,7 @@ impl<O: RmeFfLatterDspOperation> RmeFfLatterChStripOperation<FfLatterInputChStri
     }
 }
 
-/// The structure to represent state of output channel strip effect.
+/// State of output channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterOutputChStripState(pub FfLatterChStripState);
 
@@ -1461,7 +1461,7 @@ impl<O: RmeFfLatterDspOperation> RmeFfLatterChStripOperation<FfLatterOutputChStr
     }
 }
 
-/// The enumeration to represent type of reverb effect.
+/// Type of reverb effect.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FfLatterFxReverbType {
     SmallRoom,
@@ -1509,7 +1509,7 @@ impl From<FfLatterFxReverbType> for i16 {
     }
 }
 
-/// The enumeration to represent type of echo effect.
+/// Type of echo effect.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FfLatterFxEchoType {
     StereoEcho,
@@ -1533,7 +1533,7 @@ impl From<FfLatterFxEchoType> for i16 {
     }
 }
 
-/// The enumeration to represent frequency of low pass filter for echo effect.
+/// Frequency of low pass filter for echo effect.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FfLatterFxEchoLpfFreq {
     Off,
@@ -1563,7 +1563,7 @@ impl From<FfLatterFxEchoLpfFreq> for i16 {
     }
 }
 
-/// The structure to represent state of reverb in send effect.
+/// State of reverb in send effect.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfLatterFxReverbState {
     /// Whether to activate reverb effect.
@@ -1675,7 +1675,7 @@ fn reverb_state_to_cmds(state: &FfLatterFxReverbState) -> Vec<u32> {
     cmds
 }
 
-/// The structure to represent state of echo in send effect.
+/// State of echo in send effect.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfLatterFxEchoState {
     /// Whether to activate echo effect.
@@ -1736,7 +1736,7 @@ fn echo_state_to_cmds(state: &FfLatterFxEchoState) -> Vec<u32> {
     cmds
 }
 
-/// The structure to represent state of send effects (reverb and echo).
+/// State of send effects (reverb and echo).
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterFxState {
     /// The gain of line inputs. Each value is between 0xfd76 (-65.0 dB) and 0x0000 (0.0 dB).

--- a/libs/ff/protocols/src/latter.rs
+++ b/libs/ff/protocols/src/latter.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for latter models of Fireface series.

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface 802.

--- a/libs/ff/protocols/src/latter/ff802.rs
+++ b/libs/ff/protocols/src/latter/ff802.rs
@@ -8,7 +8,7 @@ use {
     crate::*,
 };
 
-/// The structure to represent unique protocol for Fireface 802.
+/// Unique protocol for 802.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct Ff802Protocol;
 
@@ -25,7 +25,7 @@ const CFG_DSP_EFFECT_ON_INPUT_MASK: u32 = 0x00000040;
 const CFG_AESEBU_OUT_PRO_MASK: u32 = 0x00000020;
 const CFG_WORD_OUT_SINGLE_MASK: u32 = 0x00000010;
 
-/// The enumeration to represent source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum Ff802ClkSrc {
     Internal,
@@ -64,7 +64,7 @@ impl Ff802ClkSrc {
     }
 }
 
-/// The enumeration to represent interface of S/PDIF signal for Fireface 802.
+/// Digital interface of S/PDIF signal for 802.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum Ff802SpdifIface {
     Xlr,
@@ -77,7 +77,7 @@ impl Default for Ff802SpdifIface {
     }
 }
 
-/// The structure to represent unique protocol for Fireface 802.
+/// Unique protocol for 802.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Ff802Config {
     /// The low offset of destination address for MIDI messages.
@@ -176,7 +176,7 @@ const STATUS_LOCK_ADAT_A_MASK: u32 = 0x00000004;
 const STATUS_LOCK_SPDIF_MASK: u32 = 0x00000002;
 const STATUS_LOCK_WORD_CLK_MASK: u32 = 0x00000001;
 
-/// The structure to represent lock status of 802.
+/// Lock status of 802.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Ff802ExtLockStatus {
     pub word_clk: bool,
@@ -209,7 +209,7 @@ impl Ff802ExtLockStatus {
     }
 }
 
-/// The structure to represent sync status of 802.
+/// Sync status of 802.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Ff802ExtSyncStatus {
     pub word_clk: bool,
@@ -242,7 +242,7 @@ impl Ff802ExtSyncStatus {
     }
 }
 
-/// The structure to represent sync status of 802.
+/// Sync status of 802.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Ff802ExtRateStatus {
     pub word_clk: Option<ClkNominalRate>,
@@ -283,7 +283,7 @@ impl Ff802ExtRateStatus {
     }
 }
 
-/// The structure to represent status of 802.
+/// Status of 802.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct Ff802Status {
     pub ext_lock: Ff802ExtLockStatus,

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface UCX.

--- a/libs/ff/protocols/src/latter/ucx.rs
+++ b/libs/ff/protocols/src/latter/ucx.rs
@@ -8,7 +8,7 @@ use {
     crate::*,
 };
 
-/// The structure to represent unique protocol for Fireface UCX.
+/// Unique protocol for UCX.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfUcxProtocol;
 
@@ -24,7 +24,7 @@ const CFG_DSP_EFFECT_ON_INPUT_MASK: u32 = 0x00000040;
 const CFG_WORD_INPUT_TERMINATE_MASK: u32 = 0x00000008;
 const CFG_SPDIF_OUT_PRO_MASK: u32 = 0x00000020;
 
-/// The enumeration to represent source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FfUcxClkSrc {
     Internal,
@@ -60,7 +60,7 @@ impl FfUcxClkSrc {
     }
 }
 
-/// The structure to represent unique protocol for Fireface UCX.
+/// Configuration for UCX.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfUcxConfig {
     /// The low offset of destination address for MIDI messages.
@@ -150,7 +150,7 @@ const STATUS_LOCK_WORD_CLK_MASK: u32 = 0x00000004;
 const STATUS_LOCK_OPT_IFACE_MASK: u32 = 0x00000002;
 const STATUS_LOCK_COAX_IFACE_MASK: u32 = 0x00000001;
 
-/// The structure to represent lock status of UCX.
+/// Lock status of UCX.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfUcxExtLockStatus {
     pub word_clk: bool,
@@ -178,7 +178,7 @@ impl FfUcxExtLockStatus {
     }
 }
 
-/// The structure to represent sync status of UCX.
+/// Sync status of UCX.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfUcxExtSyncStatus {
     pub word_clk: bool,
@@ -206,7 +206,7 @@ impl FfUcxExtSyncStatus {
     }
 }
 
-/// The structure to represent sync status of UCX.
+/// Sync status of UCX.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfUcxExtRateStatus {
     pub word_clk: Option<ClkNominalRate>,
@@ -240,7 +240,7 @@ impl FfUcxExtRateStatus {
     }
 }
 
-/// The structure to represent status of UCX.
+/// Status of UCX.
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
 pub struct FfUcxStatus {
     pub ext_lock: FfUcxExtLockStatus,

--- a/libs/ff/protocols/src/lib.rs
+++ b/libs/ff/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface series.

--- a/libs/ff/protocols/src/lib.rs
+++ b/libs/ff/protocols/src/lib.rs
@@ -37,7 +37,7 @@ impl<'a> FfConfigRom for ConfigRom<'a> {
     }
 }
 
-/// The enumeration to represent nominal frequency of sampling clock.
+/// Nominal frequency of sampling clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClkNominalRate {
     R32000,
@@ -57,7 +57,7 @@ impl Default for ClkNominalRate {
     }
 }
 
-/// The enumeration to represent format of S/PDIF signal.
+/// Format of S/PDIF signal.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SpdifFormat {
     Consumer,
@@ -70,7 +70,7 @@ impl Default for SpdifFormat {
     }
 }
 
-/// The enumeration to represent interface of S/PDIF signal.
+/// Digital interface of S/PDIF signal.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SpdifIface {
     Coaxial,
@@ -83,7 +83,7 @@ impl Default for SpdifIface {
     }
 }
 
-/// The structure to represent configuration of S/PDIF input.
+/// Configuration of S/PDIF input.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct SpdifInput {
     /// The interface of S/PDIF signal.
@@ -92,7 +92,7 @@ pub struct SpdifInput {
     pub use_preemble: bool,
 }
 
-/// The enumeration to represent the type of signal to optical output interface.
+/// Type of signal to optical output interface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum OpticalOutputSignal {
     Adat,
@@ -105,7 +105,7 @@ impl Default for OpticalOutputSignal {
     }
 }
 
-/// The enumeration to represent nominal level of line outputs.
+/// Nominal level of line outputs.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LineOutNominalLevel {
     High,

--- a/libs/ff/runtime/src/ff400_model.rs
+++ b/libs/ff/runtime/src/ff400_model.rs
@@ -4,7 +4,7 @@
 use {
     super::{former_ctls::*, *},
     alsa_ctl_tlv_codec::DbInterval,
-    ff_protocols::{
+    protocols::{
         former::{ff400::*, *},
         *,
     },

--- a/libs/ff/runtime/src/ff800_model.rs
+++ b/libs/ff/runtime/src/ff800_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{former_ctls::*, *},
-    ff_protocols::{
+    protocols::{
         former::{ff800::*, *},
         *,
     },

--- a/libs/ff/runtime/src/ff802_model.rs
+++ b/libs/ff/runtime/src/ff802_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{latter_ctls::*, *},
-    ff_protocols::{
+    protocols::{
         latter::{ff802::*, *},
         *,
     },

--- a/libs/ff/runtime/src/former_ctls.rs
+++ b/libs/ff/runtime/src/former_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::*, alsa_ctl_tlv_codec::DbInterval, ff_protocols::former::*};
+use {super::*, alsa_ctl_tlv_codec::DbInterval, protocols::former::*};
 
 const VOL_NAME: &str = "output-volume";
 

--- a/libs/ff/runtime/src/latter_ctls.rs
+++ b/libs/ff/runtime/src/latter_ctls.rs
@@ -4,7 +4,7 @@
 use {
     super::*,
     alsa_ctl_tlv_codec::DbInterval,
-    ff_protocols::{latter::*, *},
+    protocols::{latter::*, *},
 };
 
 const LINE_INPUT_METER: &str = "meter:line-input";

--- a/libs/ff/runtime/src/lib.rs
+++ b/libs/ff/runtime/src/lib.rs
@@ -14,8 +14,12 @@ mod latter_ctls;
 use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    ff_protocols as protocols,
     glib::{source, Error, FileError},
-    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwReq,
+    },
     hitaki::{prelude::*, *},
     model::*,
     nix::sys::signal,

--- a/libs/ff/runtime/src/model.rs
+++ b/libs/ff/runtime/src/model.rs
@@ -3,8 +3,8 @@
 
 use {
     super::{ff400_model::*, ff800_model::*, ff802_model::*, ucx_model::*, *},
-    ff_protocols::{former::*, latter::*, *},
     ieee1212_config_rom::*,
+    protocols::{former::*, latter::*, *},
     std::convert::TryFrom,
 };
 

--- a/libs/ff/runtime/src/ucx_model.rs
+++ b/libs/ff/runtime/src/ucx_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{latter_ctls::*, *},
-    ff_protocols::{
+    protocols::{
         latter::{ucx::*, *},
         *,
     },

--- a/libs/motu/protocols/Cargo.toml
+++ b/libs/motu/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Implementation of protocols defined by Mark of the Unicorn for its FireWire series.
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/motu/protocols/src/command_dsp.rs
+++ b/libs/motu/protocols/src/command_dsp.rs
@@ -5,6 +5,10 @@
 //!
 //! The module includes structure, enumeration, and trait for hardware mixer function operated by
 //! command.
+//!
+//! The hardware transfers asynchronous packet to registered address when changing its state by
+//! user operation. The packet includes some command to express the change of status. The
+//! hardware also accepts the same command in asynchronous packet arrived at specific address.
 
 use {
     super::*,
@@ -404,7 +408,7 @@ fn append_data(raw: &mut Vec<u8>, identifier: &[u8], vals: &[u8]) {
     }
 }
 
-/// The enumeration for focus target.
+/// Target of focus.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FocusTarget {
     Output(usize),
@@ -1872,7 +1876,7 @@ pub trait CommandDspOperation {
     }
 }
 
-/// The structure for state of message parser.
+/// State of message parser.
 #[derive(Debug)]
 pub struct CommandDspMessageHandler {
     state: ParserState,
@@ -2002,7 +2006,7 @@ impl CommandDspMessageHandler {
     }
 }
 
-/// The structure for state of reverb function.
+/// State of reverb function.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct CommandDspReverbState {
     pub enable: bool,
@@ -2123,7 +2127,7 @@ pub trait CommandDspReverbOperation: CommandDspOperation {
     }
 }
 
-/// The structure for state of monitor function.
+/// State of monitor function.
 #[derive(Default, Debug, Copy, Clone, PartialEq)]
 pub struct CommandDspMonitorState {
     /// The volume adjusted by main (master) knob. -inf (mute), -80.0 dB to 0.0 dB.
@@ -2209,7 +2213,7 @@ pub trait CommandDspMonitorOperation: CommandDspOperation {
     }
 }
 
-/// The structure for state of entry of mixer function.
+/// State of entry of mixer function.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspMixerSourceState {
     pub mute: Vec<bool>,
@@ -2223,7 +2227,7 @@ pub struct CommandDspMixerSourceState {
 
 const MIXER_COUNT: usize = 8;
 
-/// The structure for state of mixer function.
+/// State of mixer function.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspMixerState {
     pub output_assign: [TargetPort; MIXER_COUNT],
@@ -2385,7 +2389,7 @@ pub trait CommandDspMixerOperation: CommandDspOperation {
     }
 }
 
-/// The structure for state of equalizer.
+/// State of equalizer.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspEqualizerState {
     pub enable: Vec<bool>,
@@ -2526,7 +2530,7 @@ fn parse_equalizer_parameter(
     }
 }
 
-/// The structure for state of dynamics.
+/// State of dynamics.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspDynamicsState {
     pub enable: Vec<bool>,
@@ -2594,7 +2598,7 @@ fn parse_dynamics_parameter(
     }
 }
 
-/// The structure for state of input function.
+/// State of input function.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspInputState {
     pub phase: Vec<bool>,
@@ -2824,7 +2828,7 @@ pub trait CommandDspInputOperation: CommandDspOperation {
     }
 }
 
-/// The structure for state of input function.
+/// State of input function.
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct CommandDspOutputState {
     pub equalizer: CommandDspEqualizerState,
@@ -2991,7 +2995,7 @@ pub trait CommandDspOutputOperation: CommandDspOperation {
     }
 }
 
-/// The structure for meter information.
+/// Information of Meter.
 #[derive(Default)]
 pub struct CommandDspMeterState {
     pub inputs: Vec<f32>,

--- a/libs/motu/protocols/src/command_dsp.rs
+++ b/libs/motu/protocols/src/command_dsp.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol for hardware mixer function operated by command.

--- a/libs/motu/protocols/src/config_rom.rs
+++ b/libs/motu/protocols/src/config_rom.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Parser for Configuration ROM.

--- a/libs/motu/protocols/src/config_rom.rs
+++ b/libs/motu/protocols/src/config_rom.rs
@@ -8,7 +8,7 @@
 
 use ieee1212_config_rom::*;
 
-/// The structure to represent data in unit directory of Configuration ROM.
+/// Data in unit directory of Configuration ROM.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct UnitData {
     pub model_id: u32,

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -117,7 +117,7 @@ fn set_idx_to_val(
     write_quad(req, node, offset, quad, timeout_ms)
 }
 
-/// The enumeration to express rate of sampling clock.
+/// Nominal rate of sampling clock.
 pub enum ClkRate {
     /// 44.1 kHx.
     R44100,
@@ -205,7 +205,7 @@ pub trait AssignOperation {
     }
 }
 
-/// The enumeration to express mode of speed for output signal of word clock on BNC interface.
+/// Mode of speed for output signal of word clock on BNC interface.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum WordClkSpeedMode {
     /// The speed is forced to be 44.1/48.0 kHz.
@@ -276,7 +276,7 @@ pub trait WordClkOperation {
     }
 }
 
-/// The enumeration to express the mode of rate convert for AES/EBU input/output signals.
+/// Mode of rate convert for AES/EBU input/output signals.
 pub enum AesebuRateConvertMode {
     /// Not available.
     None,
@@ -341,7 +341,7 @@ pub trait AesebuRateConvertOperation {
     }
 }
 
-/// The enumeration to express the mode of hold time for clip and peak LEDs.
+/// Mode of hold time for clip and peak LEDs.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LevelMetersHoldTimeMode {
     /// off.
@@ -368,7 +368,7 @@ impl Default for LevelMetersHoldTimeMode {
     }
 }
 
-/// The enumeration to express the mode of programmable meter display.
+/// Mode of programmable meter display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LevelMetersProgrammableMode {
     AnalogOutput,
@@ -382,7 +382,7 @@ impl Default for LevelMetersProgrammableMode {
     }
 }
 
-/// The enumeration to express the mode of AES/EBU meter display.
+/// Mode of AES/EBU meter display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LevelMetersAesebuMode {
     Input,
@@ -586,7 +586,7 @@ pub trait LevelMetersOperation {
     }
 }
 
-/// The enumeration for port to assign.
+/// Port to assign.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TargetPort {
     Disabled,
@@ -616,7 +616,7 @@ impl Default for TargetPort {
     }
 }
 
-/// The enumeration to express nominal level of audio signal.
+/// Nominal level of audio signal.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NominalSignalLevel {
     /// -10 dBV.

--- a/libs/motu/protocols/src/lib.rs
+++ b/libs/motu/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocols defined for Mark of the Unicorn FireWire series.

--- a/libs/motu/protocols/src/register_dsp.rs
+++ b/libs/motu/protocols/src/register_dsp.rs
@@ -5,6 +5,12 @@
 //!
 //! The module includes structure, enumeration, and trait for hardware mixer function expressed
 //! in registers.
+//!
+//! The hardware transfers isochronous packets in which its state, PCM frames, and MIDI messages
+//! are multiplexed. ALSA firewire-motu driver caches the state, and allow userspace application
+//! to read the cache from kernel space as `SndMotuRegisterDspParameter` structure. Additionally,
+//! when changing the cache, the driver generates notification to the application.
+//! `RegisterDspEvent` is available to parse the notification.
 
 use {super::*, hitaki::SndMotuRegisterDspParameter};
 
@@ -49,7 +55,7 @@ const MIXER_OUTPUT_MUTE_FLAG: u32 = 0x00001000;
 const MIXER_OUTPUT_DESTINATION_MASK: u32 = 0x00000f00;
 const MIXER_OUTPUT_VOLUME_MASK: u32 = 0x000000ff;
 
-/// The structure for state of mixer output.
+/// State of mixer output.
 #[derive(Default)]
 pub struct RegisterDspMixerOutputState {
     pub volume: [u8; MIXER_COUNT],
@@ -259,7 +265,7 @@ pub trait RegisterDspMixerReturnOperation {
     }
 }
 
-/// The structure for state of sources in mixer entiry.
+/// State of sources in mixer entiry.
 #[derive(Default, Clone)]
 pub struct RegisterDspMixerMonauralSourceEntry {
     pub gain: Vec<u8>,
@@ -268,7 +274,7 @@ pub struct RegisterDspMixerMonauralSourceEntry {
     pub solo: Vec<bool>,
 }
 
-/// The structure for state of mixer sources.
+/// State of mixer sources.
 #[derive(Default)]
 pub struct RegisterDspMixerMonauralSourceState(
     pub [RegisterDspMixerMonauralSourceEntry; MIXER_COUNT],
@@ -526,7 +532,7 @@ pub trait RegisterDspMixerMonauralSourceOperation {
 const MIXER_STEREO_SOURCE_COUNT: usize = 6;
 const MIXER_STEREO_SOURCE_PAIR_COUNT: usize = MIXER_STEREO_SOURCE_COUNT / 2;
 
-/// The structure for state of sources in mixer entiry.
+/// State of sources in mixer entiry.
 #[derive(Default, Clone)]
 pub struct RegisterDspMixerStereoSourceEntry {
     pub gain: [u8; MIXER_STEREO_SOURCE_COUNT],
@@ -537,7 +543,7 @@ pub struct RegisterDspMixerStereoSourceEntry {
     pub width: [u8; MIXER_STEREO_SOURCE_PAIR_COUNT],
 }
 
-/// The structure for state of mixer sources.
+/// State of mixer sources.
 #[derive(Default)]
 pub struct RegisterDspMixerStereoSourceState(pub [RegisterDspMixerStereoSourceEntry; MIXER_COUNT]);
 
@@ -888,7 +894,7 @@ pub trait RegisterDspMixerStereoSourceOperation {
 const MASTER_VOLUME_OFFSET: usize = 0x0c0c;
 const PHONE_VOLUME_OFFSET: usize = 0x0c10;
 
-/// The structure for state of output.
+/// State of output.
 #[derive(Default)]
 pub struct RegisterDspOutputState {
     pub master_volume: u8,
@@ -977,7 +983,7 @@ pub trait RegisterDspOutputOperation {
     }
 }
 
-/// The structure for state of inputs in 828mkII.
+/// State of inputs in 828mkII.
 #[derive(Default)]
 pub struct RegisterDspLineInputState {
     pub level: Vec<NominalSignalLevel>,
@@ -1122,7 +1128,7 @@ pub trait Traveler828mk2LineInputOperation {
 
 const MONAURAL_INPUT_COUNT: usize = 10;
 
-/// The structure for state of input in Ultralite.
+/// State of input in Ultralite.
 #[derive(Default)]
 pub struct RegisterDspMonauralInputState {
     pub gain: [u8; MONAURAL_INPUT_COUNT],
@@ -1131,7 +1137,7 @@ pub struct RegisterDspMonauralInputState {
 
 const STEREO_INPUT_COUNT: usize = 6;
 
-/// The structure for state of input in Audio Express, and 4 pre.
+/// State of input in Audio Express, and 4 pre.
 #[derive(Default)]
 pub struct RegisterDspStereoInputState {
     pub gain: [u8; STEREO_INPUT_COUNT],
@@ -1576,7 +1582,7 @@ pub trait RegisterDspStereoInputOperation {
     }
 }
 
-/// The structure for meter information.
+/// Information of meter.
 #[derive(Default)]
 pub struct RegisterDspMeterState {
     pub inputs: Vec<u8>,

--- a/libs/motu/protocols/src/register_dsp.rs
+++ b/libs/motu/protocols/src/register_dsp.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol for hardware mixer function expressed in registers.

--- a/libs/motu/protocols/src/version_1.rs
+++ b/libs/motu/protocols/src/version_1.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 
-/// The enumeration to express source of sampling clock.
+/// Signal source of sampling clock.
 pub enum V1ClkSrc {
     /// Internal.
     Internal,
@@ -24,7 +24,7 @@ pub enum V1ClkSrc {
     AesebuXlr,
 }
 
-/// The enumeration to express mode of optical interface.
+/// Mode of optical interface.
 pub enum V1OptIfaceMode {
     Adat,
     Spdif,

--- a/libs/motu/protocols/src/version_1.rs
+++ b/libs/motu/protocols/src/version_1.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol used in version 1 devices of MOTU FireWire series.

--- a/libs/motu/protocols/src/version_2.rs
+++ b/libs/motu/protocols/src/version_2.rs
@@ -8,7 +8,7 @@
 
 use super::{register_dsp::*, *};
 
-/// The enumeration to express source of sampling clock.
+/// Signal source of sampling clock.
 pub enum V2ClkSrc {
     /// Internal.
     Internal,
@@ -119,7 +119,7 @@ pub trait V2ClkOperation {
     }
 }
 
-/// The enumeration to express mode of optical interface.
+/// Mode of optical interface.
 pub enum V2OptIfaceMode {
     None,
     Adat,
@@ -597,7 +597,7 @@ impl RegisterDspMeterOperation for TravelerProtocol {
     ];
 }
 
-/// The structure for state of inputs in Traveler.
+/// State of inputs in Traveler.
 #[derive(Default)]
 pub struct TravelerMicInputState {
     pub gain: [u8; TravelerProtocol::MIC_INPUT_COUNT],

--- a/libs/motu/protocols/src/version_2.rs
+++ b/libs/motu/protocols/src/version_2.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol used in version 2 devices of MOTU FireWire series.

--- a/libs/motu/protocols/src/version_3.rs
+++ b/libs/motu/protocols/src/version_3.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol used in version 3 devices of MOTU FireWire series.

--- a/libs/motu/protocols/src/version_3.rs
+++ b/libs/motu/protocols/src/version_3.rs
@@ -8,7 +8,7 @@
 
 use super::{command_dsp::*, register_dsp::*, *};
 
-/// The enumeration to express source of sampling clock.
+/// Signal source of sampling clock.
 pub enum V3ClkSrc {
     /// Internal.
     Internal,
@@ -204,7 +204,7 @@ pub trait V3PortAssignOperation: AssignOperation {
     }
 }
 
-/// The enumeration for direction of optical interface.
+/// Direction of optical interface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum V3OptIfaceTarget {
     A,
@@ -217,7 +217,7 @@ impl Default for V3OptIfaceTarget {
     }
 }
 
-/// The enumeration for mode of optical interface.
+/// Mode of optical interface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum V3OptIfaceMode {
     Disabled,

--- a/libs/motu/runtime/src/command_dsp_runtime.rs
+++ b/libs/motu/runtime/src/command_dsp_runtime.rs
@@ -10,8 +10,8 @@ pub use {
     core::{card_cntr::*, dispatcher::*},
     glib::source,
     hinawa::{prelude::FwRespExtManual, FwRcode, FwResp, FwTcode},
-    motu_protocols::{command_dsp::*, version_3::*},
     nix::sys::signal::Signal,
+    protocols::{command_dsp::*, version_3::*},
     std::{
         sync::{mpsc, Arc, Mutex},
         thread,

--- a/libs/motu/runtime/src/lib.rs
+++ b/libs/motu/runtime/src/lib.rs
@@ -36,7 +36,8 @@ use {
     hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode},
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
-    motu_protocols::{config_rom::*, *},
+    motu_protocols as protocols,
+    protocols::{config_rom::*, *},
     std::convert::TryFrom,
 };
 

--- a/libs/motu/runtime/src/register_dsp_runtime.rs
+++ b/libs/motu/runtime/src/register_dsp_runtime.rs
@@ -11,8 +11,8 @@ pub use {
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*},
     glib::source,
     hinawa::FwReq,
-    motu_protocols::{register_dsp::*, version_2::*, version_3::*},
     nix::sys::signal::Signal,
+    protocols::{register_dsp::*, version_2::*, version_3::*},
     std::sync::mpsc,
 };
 

--- a/libs/motu/runtime/src/v1_runtime.rs
+++ b/libs/motu/runtime/src/v1_runtime.rs
@@ -6,8 +6,8 @@ pub use {
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*},
     glib::source,
-    motu_protocols::version_1::*,
     nix::sys::signal::Signal,
+    protocols::version_1::*,
     std::sync::mpsc,
 };
 

--- a/libs/oxfw/protocols/Cargo.toml
+++ b/libs/oxfw/protocols/Cargo.toml
@@ -17,3 +17,7 @@ hinawa = "0.7"
 ta1394-avc-general = "0.1"
 ta1394-avc-audio = "0.1"
 ta1394-avc-ccm = "0.1"
+
+[[bin]]
+name = "oxfw-info"
+doc = false

--- a/libs/oxfw/protocols/Cargo.toml
+++ b/libs/oxfw/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Implementation of protocol for Oxford Semiconductor FW970/971 chipset and vendor-specific models
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -823,7 +823,7 @@ impl DuetFwDisplayProtocol {
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 // Usually 5 params.
-pub enum VendorCmd {
+enum VendorCmd {
     MicPolarity(usize, bool),
     XlrIsMicLevel(usize, bool),
     XlrIsConsumerLevel(usize, bool),
@@ -1124,13 +1124,13 @@ impl VendorCmd {
 }
 
 /// AV/C vendor-dependent command specific to Apogee Duet FireWire.
-pub struct ApogeeCmd {
+struct ApogeeCmd {
     cmd: VendorCmd,
     op: VendorDependent,
 }
 
 impl ApogeeCmd {
-    pub fn new(cmd: VendorCmd) -> Self {
+    fn new(cmd: VendorCmd) -> Self {
         ApogeeCmd {
             cmd,
             op: VendorDependent::new(&APOGEE_OUI),

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by Apogee Electronics for Duet FireWire.

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -122,7 +122,7 @@ impl DuetFwMixerMeterProtocol {
     }
 }
 
-/// The enumeration for target of knob.
+/// Target of knob.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwKnobTarget {
     OutputPair0,
@@ -182,7 +182,7 @@ impl DuetFwKnobProtocol {
     }
 }
 
-/// The enumeration for source of output.
+/// Source of output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwOutputSource {
     StreamInputPair0,
@@ -195,7 +195,7 @@ impl Default for DuetFwOutputSource {
     }
 }
 
-/// The enumeration for level of output.
+/// Level of output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwOutputNominalLevel {
     /// Fixed level for external amplifier.
@@ -210,7 +210,7 @@ impl Default for DuetFwOutputNominalLevel {
     }
 }
 
-/// The enumeration for level of output.
+/// Level of output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwOutputMuteMode {
     Never,
@@ -409,7 +409,7 @@ impl DuetFwOutputProtocol {
     }
 }
 
-/// The enumeration for source of input.
+/// Source of input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwInputSource {
     /// From XLR plug.
@@ -424,7 +424,7 @@ impl Default for DuetFwInputSource {
     }
 }
 
-/// The enumeration for nominal level of input.
+/// Nominal level of input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwInputXlrNominalLevel {
     /// Adjustable between 10 and 75 dB.
@@ -441,7 +441,7 @@ impl Default for DuetFwInputXlrNominalLevel {
     }
 }
 
-/// The structure of input parameters.
+/// Input parameters.
 #[derive(Default, Debug)]
 pub struct DuetFwInputParameters {
     pub gains: [u8; 2],
@@ -693,7 +693,7 @@ impl DuetFwMixerProtocol {
     }
 }
 
-/// The enumeration for target of display.
+/// Target of display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwDisplayTarget {
     Output,
@@ -706,7 +706,7 @@ impl Default for DuetFwDisplayTarget {
     }
 }
 
-/// The enumeration for mode of display.
+/// Mode of display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwDisplayMode {
     Independent,
@@ -719,7 +719,7 @@ impl Default for DuetFwDisplayMode {
     }
 }
 
-/// The enumeration for overhold of display.
+/// Overhold of display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum DuetFwDisplayOverhold {
     Infinite,
@@ -819,7 +819,7 @@ impl DuetFwDisplayProtocol {
     }
 }
 
-/// The enumeration to represent type of command for Apogee Duet FireWire.
+/// Type of command for Apogee Duet FireWire.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 // Usually 5 params.
@@ -1123,7 +1123,7 @@ impl VendorCmd {
     }
 }
 
-/// The structure to represent protocol of Apogee Duet FireWire.
+/// AV/C vendor-dependent command specific to Apogee Duet FireWire.
 pub struct ApogeeCmd {
     cmd: VendorCmd,
     op: VendorDependent,

--- a/libs/oxfw/protocols/src/bin/oxfw-info.rs
+++ b/libs/oxfw/protocols/src/bin/oxfw-info.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {

--- a/libs/oxfw/protocols/src/bin/oxfw-info.rs
+++ b/libs/oxfw/protocols/src/bin/oxfw-info.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use glib::{FileError, MainContext, MainLoop};
-
-use hinawa::FwReq;
-use hinawa::{prelude::FwNodeExt, FwNode, FwNodeError};
-
-use oxfw_protocols::oxford::*;
-
-use std::sync::Arc;
-use std::thread;
+use {
+    glib::{FileError, MainContext, MainLoop},
+    hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
+    oxfw_protocols as protocols,
+    protocols::oxford::*,
+    std::{sync::Arc, thread},
+};
 
 const TIMEOUT_MS: u32 = 20;
 

--- a/libs/oxfw/protocols/src/griffin.rs
+++ b/libs/oxfw/protocols/src/griffin.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by Griffin for FireWave.

--- a/libs/oxfw/protocols/src/lacie.rs
+++ b/libs/oxfw/protocols/src/lacie.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by La Cie for FireWire Speakers.

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocols defined for Oxford Semiconductor FW970/971 chipset.

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -24,7 +24,7 @@ use {
     ta1394_avc_ccm::*,
 };
 
-/// The structure to implement AV/C transaction.
+/// The implementation of AV/C transaction.
 #[derive(Default, Debug)]
 pub struct OxfwAvc(FwFcp);
 

--- a/libs/oxfw/protocols/src/loud.rs
+++ b/libs/oxfw/protocols/src/loud.rs
@@ -8,7 +8,7 @@
 
 use super::*;
 
-/// The enumeration for source of capture.
+/// Source of capture.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LinkFwInputSource {
     Analog,

--- a/libs/oxfw/protocols/src/loud.rs
+++ b/libs/oxfw/protocols/src/loud.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by Loud Technologies for Tapco Link.FireWire 4x6.

--- a/libs/oxfw/protocols/src/oxford.rs
+++ b/libs/oxfw/protocols/src/oxford.rs
@@ -5,6 +5,7 @@
 
 use super::*;
 
+/// The implementation for protocol of FW970/971 ASICs.
 #[derive(Default, Debug)]
 pub struct OxfordProtocol;
 

--- a/libs/oxfw/protocols/src/oxford.rs
+++ b/libs/oxfw/protocols/src/oxford.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by Oxford Semiconductor, Inc for its FW970/971 ASICs.

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by TASCAM for FireOne.

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -9,7 +9,7 @@ use super::*;
 
 const TEAC_OUI: [u8; 3] = [0x00, 0x02, 0x2e];
 
-/// The enumeration for mode of display.
+/// Mode of display.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FireoneDisplayMode {
     Off,
@@ -28,7 +28,7 @@ impl Default for FireoneDisplayMode {
     }
 }
 
-/// The enumeration for mode of MIDI message.
+/// Mode of MIDI message.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FireoneMidiMessageMode {
     Native,
@@ -41,7 +41,7 @@ impl Default for FireoneMidiMessageMode {
     }
 }
 
-/// The enumeration for mode of input.
+/// Mode of input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum FireoneInputMode {
     Stereo,
@@ -174,7 +174,7 @@ impl FireoneProtocol {
     }
 }
 
-/// The enumeration to represent type of command for TASCAM FireOne.
+/// Type of command for TASCAM FireOne.
 pub enum VendorCmd {
     DisplayMode(u8),
     MessageMode(u8),
@@ -265,7 +265,7 @@ impl From<&VendorCmd> for u8 {
     }
 }
 
-/// The structure to represent protocol of TASCAM FireOne.
+/// AV/C vendor-dependent command specialized by TASCAM.
 pub struct TascamProto {
     cmd: VendorCmd,
     op: VendorDependent,
@@ -317,7 +317,10 @@ impl AvcStatus for TascamProto {
     }
 }
 
-/// The structure to represent AV/C protocol for TASCAM FireOne.
+/// The implementation of AV/C transaction with quirk specific to Tascam FireOne.
+///
+/// It seems a unique quirk that the status code in response frame for AV/C vendor-dependent
+/// command is against AV/C general specification in control operation.
 #[derive(Default, Debug)]
 pub struct TascamAvc(OxfwAvc);
 

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -175,7 +175,7 @@ impl FireoneProtocol {
 }
 
 /// Type of command for TASCAM FireOne.
-pub enum VendorCmd {
+enum VendorCmd {
     DisplayMode(u8),
     MessageMode(u8),
     InputMode(u8),
@@ -266,13 +266,13 @@ impl From<&VendorCmd> for u8 {
 }
 
 /// AV/C vendor-dependent command specialized by TASCAM.
-pub struct TascamProto {
+struct TascamProto {
     cmd: VendorCmd,
     op: VendorDependent,
 }
 
 impl TascamProto {
-    pub fn new(cmd: VendorCmd) -> Self {
+    fn new(cmd: VendorCmd) -> Self {
         TascamProto {
             cmd,
             op: VendorDependent::new(&TEAC_OUI),

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::apogee::*,
-};
+use {super::*, protocols::apogee::*};
 
 #[derive(Default, Debug)]
 pub struct ApogeeModel {

--- a/libs/oxfw/runtime/src/apogee_model.rs
+++ b/libs/oxfw/runtime/src/apogee_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    oxfw_protocols::apogee::*,
+    protocols::apogee::*,
 };
 
 #[derive(Default, Debug)]

--- a/libs/oxfw/runtime/src/common_model.rs
+++ b/libs/oxfw/runtime/src/common_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::{common_ctl::*, *};
+use super::*;
 
 #[derive(Default, Debug)]
 pub struct CommonModel {

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    oxfw_protocols::griffin::*,
+    protocols::griffin::*,
 };
 
 #[derive(Default, Debug)]

--- a/libs/oxfw/runtime/src/griffin_model.rs
+++ b/libs/oxfw/runtime/src/griffin_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::griffin::*,
-};
+use {super::*, protocols::griffin::*};
 
 #[derive(Default, Debug)]
 pub struct GriffinModel {

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::lacie::*,
-};
+use {super::*, protocols::lacie::*};
 
 #[derive(Default, Debug)]
 pub struct LacieModel {

--- a/libs/oxfw/runtime/src/lacie_model.rs
+++ b/libs/oxfw/runtime/src/lacie_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    oxfw_protocols::lacie::*,
+    protocols::lacie::*,
 };
 
 #[derive(Default, Debug)]

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -12,6 +12,7 @@ mod common_ctl;
 
 use {
     alsactl::{prelude::*, *},
+    common_ctl::*,
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
     hinawa::{

--- a/libs/oxfw/runtime/src/lib.rs
+++ b/libs/oxfw/runtime/src/lib.rs
@@ -11,7 +11,6 @@ mod tascam_model;
 mod common_ctl;
 
 use {
-    self::model::*,
     alsactl::{prelude::*, *},
     core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
     glib::{source, Error, FileError},
@@ -21,8 +20,10 @@ use {
     },
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
+    model::*,
     nix::sys::signal,
-    oxfw_protocols::*,
+    oxfw_protocols as protocols,
+    protocols::*,
     std::{convert::TryFrom, sync::mpsc},
     ta1394_avc_general::config_rom::*,
 };

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::common_ctl::CommonCtl, super::*, protocols::loud::*};
+use {super::*, protocols::loud::*};
 
 #[derive(Default, Debug)]
 pub struct LinkFwModel {

--- a/libs/oxfw/runtime/src/loud_model.rs
+++ b/libs/oxfw/runtime/src/loud_model.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {super::common_ctl::CommonCtl, super::*, oxfw_protocols::loud::*};
+use {super::common_ctl::CommonCtl, super::*, protocols::loud::*};
 
 #[derive(Default, Debug)]
 pub struct LinkFwModel {

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {
-    super::{common_ctl::*, *},
-    protocols::tascam::*,
-};
+use {super::*, protocols::tascam::*};
 
 #[derive(Default, Debug)]
 pub struct TascamModel {

--- a/libs/oxfw/runtime/src/tascam_model.rs
+++ b/libs/oxfw/runtime/src/tascam_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{common_ctl::*, *},
-    oxfw_protocols::tascam::*,
+    protocols::tascam::*,
 };
 
 #[derive(Default, Debug)]

--- a/libs/tascam/protocols/Cargo.toml
+++ b/libs/tascam/protocols/Cargo.toml
@@ -8,7 +8,7 @@ description = """
 Protocol implementation for TASCAM FireWire series
 """
 homepage = "https://alsa-project.github.io/gobject-introspection-docs/"
-license = "GPL-3.0-or-later"
+license = "LGPL-3.0-or-later"
 repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 
 [dependencies]

--- a/libs/tascam/protocols/src/asynch.rs
+++ b/libs/tascam/protocols/src/asynch.rs
@@ -20,6 +20,9 @@ use {
 };
 
 glib::wrapper! {
+    /// The implementation of `hitaki::TascamProtocol` so that it can cache status of hardware
+    /// from message in asynchronous packet from the hardware as ALSA firewire-tascam driver does
+    /// for message in isochronous packet.
     pub struct TascamExpander(ObjectSubclass<imp::TascamExpanderPrivate>)
         @extends FwResp, @implements TascamProtocol;
 }

--- a/libs/tascam/protocols/src/asynch.rs
+++ b/libs/tascam/protocols/src/asynch.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocols defined for Tascam for FireWire series only with asynchronous communication.

--- a/libs/tascam/protocols/src/asynch/fe8.rs
+++ b/libs/tascam/protocols/src/asynch/fe8.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for FE-8

--- a/libs/tascam/protocols/src/asynch/fe8.rs
+++ b/libs/tascam/protocols/src/asynch/fe8.rs
@@ -19,6 +19,7 @@
 
 use super::*;
 
+/// The protocol implementation of FE-8.
 #[derive(Default)]
 pub struct Fe8Protocol;
 
@@ -81,7 +82,7 @@ impl MachineStateOperation for Fe8Protocol {
     const HAS_BANK: bool = false;
 }
 
-/// The structure for state of control surface in FE-8.
+/// State of control surface in FE-8.
 #[derive(Default, Debug)]
 pub struct Fe8SurfaceState {
     common: SurfaceCommonState,

--- a/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
+++ b/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {

--- a/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
+++ b/libs/tascam/protocols/src/bin/tascam-config-rom-parser.rs
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use glib::{FileError, MainContext, MainLoop};
-
-use hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError};
-
-use ieee1212_config_rom::*;
-
-use tascam_protocols::config_rom::*;
-
-use std::convert::TryFrom;
-use std::sync::Arc;
-use std::thread;
+use {
+    glib::{FileError, MainContext, MainLoop},
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwNodeError,
+    },
+    ieee1212_config_rom::*,
+    protocols::config_rom::*,
+    std::{convert::TryFrom, sync::Arc, thread},
+    tascam_protocols as protocols,
+};
 
 fn main() {
     let result: Result<(), String> = (|| {

--- a/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
+++ b/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {

--- a/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
+++ b/libs/tascam/protocols/src/bin/tascam-hardware-info.rs
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use glib::{FileError, MainContext, MainLoop};
-
-use hinawa::{prelude::FwNodeExt, FwReq, FwNode, FwNodeError};
-
-use tascam_protocols::*;
-
-use std::sync::Arc;
-use std::thread;
+use {
+    glib::{FileError, MainContext, MainLoop},
+    hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
+    std::{sync::Arc, thread},
+    protocols::*,
+    tascam_protocols as protocols,
+};
 
 const TIMEOUT_MS: u32 = 50;
 

--- a/libs/tascam/protocols/src/config_rom.rs
+++ b/libs/tascam/protocols/src/config_rom.rs
@@ -9,7 +9,7 @@
 
 use {super::*, ieee1212_config_rom::*};
 
-/// The structure for data in unit directory of configuration ROM.
+/// Data in unit directory of configuration ROM.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct UnitData<'a> {
     pub specifier_id: u32,

--- a/libs/tascam/protocols/src/config_rom.rs
+++ b/libs/tascam/protocols/src/config_rom.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Parser of configuration ROM for Tascam FireWire series.

--- a/libs/tascam/protocols/src/isoch.rs
+++ b/libs/tascam/protocols/src/isoch.rs
@@ -12,7 +12,7 @@ pub mod fw1884;
 
 use super::*;
 
-/// The enumeration for source of sampling clock.
+/// Signal source of sampling clock.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ClkSrc {
     Internal,
@@ -27,7 +27,7 @@ impl Default for ClkSrc {
     }
 }
 
-/// The enumeration for frequency of media clock.
+/// Nominal frequency of media clock.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ClkRate {
     R44100,
@@ -42,7 +42,7 @@ impl Default for ClkRate {
     }
 }
 
-/// The enumeration for mode of monitor.
+/// Mode of monitor.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MonitorMode {
     Computer,
@@ -56,7 +56,7 @@ impl Default for MonitorMode {
     }
 }
 
-/// The structure for state of meter.
+/// State of meter.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct IsochMeterState {
     pub monitor: i16,
@@ -226,7 +226,7 @@ fn write_config_flag<T: Copy + Eq>(
     )
 }
 
-/// The enumeration for source of output coaxial interface.
+/// Source of output coaxial interface.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum CoaxialOutputSource {
     /// A pair in stream inputs.
@@ -471,7 +471,7 @@ pub trait IsochCommonOperation {
     }
 }
 
-/// The enumeration for source of S/PDIF input.
+/// Source of S/PDIF input.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum SpdifCaptureSource {
     Coaxial,
@@ -484,7 +484,7 @@ impl Default for SpdifCaptureSource {
     }
 }
 
-/// The enumeration for source of optical output.
+/// Source of optical output.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum OpticalOutputSource {
     /// 4 pairs in stream inputs.
@@ -547,7 +547,7 @@ pub trait IsochOpticalOperation {
     }
 }
 
-/// The structure for state of console.
+/// State of console.
 #[derive(Default, Debug)]
 pub struct IsochConsoleState {
     pub host_mode: bool,
@@ -585,7 +585,7 @@ pub trait IsochConsoleOperation {
 
 const RACK_STATE_SIZE: usize = 72;
 
-/// The structure for state of rack.
+/// State of rack.
 #[derive(Debug)]
 pub struct IsochRackState([u8; RACK_STATE_SIZE]);
 
@@ -707,7 +707,7 @@ pub trait IsochRackOperation {
     }
 }
 
-/// The structure for state of surface in isoch models.
+/// State of surface in isoch models.
 #[derive(Default, Debug)]
 struct SurfaceIsochState {
     shifted: bool,

--- a/libs/tascam/protocols/src/isoch.rs
+++ b/libs/tascam/protocols/src/isoch.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocols defined for Tascam for FireWire series with isochronous communication.

--- a/libs/tascam/protocols/src/isoch/fw1082.rs
+++ b/libs/tascam/protocols/src/isoch/fw1082.rs
@@ -134,7 +134,7 @@ impl MachineStateOperation for Fw1082Protocol {
     const HAS_BANK: bool = true;
 }
 
-/// The structure for state of control surface in FW-1082.
+/// State of control surface in FW-1082.
 #[derive(Default, Debug)]
 pub struct Fw1082SurfaceState {
     common: SurfaceCommonState,
@@ -414,7 +414,7 @@ impl Default for Fw1082EncoderMode {
     }
 }
 
-/// The structure for state of surface specific to FW-1082.
+/// State of surface specific to FW-1082.
 #[derive(Default, Debug)]
 struct SurfaceSpecificState {
     mode: Fw1082EncoderMode,

--- a/libs/tascam/protocols/src/isoch/fw1082.rs
+++ b/libs/tascam/protocols/src/isoch/fw1082.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for FW-1082.

--- a/libs/tascam/protocols/src/isoch/fw1804.rs
+++ b/libs/tascam/protocols/src/isoch/fw1804.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for FW-1804.

--- a/libs/tascam/protocols/src/isoch/fw1884.rs
+++ b/libs/tascam/protocols/src/isoch/fw1884.rs
@@ -243,7 +243,7 @@ impl MachineStateOperation for Fw1884Protocol {
     const HAS_BANK: bool = true;
 }
 
-/// The structure for state of control surface in FW-1884.
+/// State of control surface in FW-1884.
 #[derive(Default, Debug)]
 pub struct Fw1884SurfaceState {
     common: SurfaceCommonState,

--- a/libs/tascam/protocols/src/isoch/fw1884.rs
+++ b/libs/tascam/protocols/src/isoch/fw1884.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol implementation for FW-1884.

--- a/libs/tascam/protocols/src/lib.rs
+++ b/libs/tascam/protocols/src/lib.rs
@@ -112,7 +112,7 @@ fn write_quadlet(
     )
 }
 
-/// The structure of hardware information.
+/// Information of hardware.
 #[derive(Debug, Default, Copy, Clone)]
 pub struct HardwareInformation {
     pub register: u32,
@@ -121,7 +121,7 @@ pub struct HardwareInformation {
     pub hardware: u32,
 }
 
-/// The structure for protocol implementaion commonly available to Tascam FireWire models.
+/// The protocol implementaion commonly available to Tascam FireWire models.
 #[derive(Debug, Default)]
 pub struct HardwareInformationProtocol;
 
@@ -146,7 +146,7 @@ impl HardwareInformationProtocol {
     }
 }
 
-/// The enumeration for surface items.
+/// Items of surface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MachineItem {
     // Channel section.
@@ -487,17 +487,17 @@ pub trait SurfaceImageOperation<T> {
     ) -> Result<(), Error>;
 }
 
-/// The structure for common state of surface.
+/// Common state of surface.
 #[derive(Default, Debug)]
 struct SurfaceCommonState {
     stateful_items: Vec<bool>,
 }
 
-/// The structure of boolean value in surface image.
+/// Boolean value in surface image.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 struct SurfaceBoolValue(usize, u32); // index, mask.
 
-/// The structure of u16 value in surface image.
+/// U16 value in surface image.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 struct SurfaceU16Value(usize, u32, usize); // index, mask, shift
 

--- a/libs/tascam/protocols/src/lib.rs
+++ b/libs/tascam/protocols/src/lib.rs
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: LGPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! The implementation for protocol defined by Tascam specific to FireWire series.

--- a/libs/tascam/runtime/src/asynch_runtime.rs
+++ b/libs/tascam/runtime/src/asynch_runtime.rs
@@ -5,9 +5,9 @@ use {
     super::{fe8_model::*, seq_cntr::*, *},
     core::dispatcher::*,
     nix::sys::signal::Signal,
+    protocols::asynch::{fe8::*, *},
     std::marker::PhantomData,
     std::sync::mpsc,
-    tascam_protocols::asynch::{fe8::*, *},
 };
 
 pub type Fe8Runtime = AsynchRuntime<Fe8Model, Fe8Protocol, Fe8SurfaceState>;

--- a/libs/tascam/runtime/src/fe8_model.rs
+++ b/libs/tascam/runtime/src/fe8_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    tascam_protocols::asynch::{fe8::*, *},
+    protocols::asynch::{fe8::*, *},
 };
 
 pub struct Fe8Model {

--- a/libs/tascam/runtime/src/fw1082_model.rs
+++ b/libs/tascam/runtime/src/fw1082_model.rs
@@ -4,7 +4,7 @@
 use {
     super::{isoch_ctls::*, *},
     alsactl::*,
-    tascam_protocols::isoch::{fw1082::*, *},
+    protocols::isoch::{fw1082::*, *},
 };
 
 pub struct Fw1082Model {

--- a/libs/tascam/runtime/src/fw1804_model.rs
+++ b/libs/tascam/runtime/src/fw1804_model.rs
@@ -4,7 +4,7 @@
 use {
     super::{isoch_ctls::*, *},
     alsactl::*,
-    tascam_protocols::isoch::{fw1804::*, *},
+    protocols::isoch::{fw1804::*, *},
 };
 
 pub struct Fw1804Model {

--- a/libs/tascam/runtime/src/fw1884_model.rs
+++ b/libs/tascam/runtime/src/fw1884_model.rs
@@ -4,7 +4,7 @@
 use {
     super::{isoch_ctls::*, *},
     alsactl::{prelude::*, *},
-    tascam_protocols::isoch::{fw1884::*, *},
+    protocols::isoch::{fw1884::*, *},
 };
 
 pub struct Fw1884Model {

--- a/libs/tascam/runtime/src/isoch_console_runtime.rs
+++ b/libs/tascam/runtime/src/isoch_console_runtime.rs
@@ -7,8 +7,8 @@ use {
     alsaseq::{prelude::*, *},
     core::dispatcher::*,
     nix::sys::signal,
+    protocols::isoch::{fw1082::*, fw1884::*},
     std::{marker::PhantomData, sync::mpsc, time::Duration},
-    tascam_protocols::isoch::{fw1082::*, fw1884::*},
 };
 
 pub type Fw1884Runtime = IsochConsoleRuntime<Fw1884Model, Fw1884Protocol, Fw1884SurfaceState>;

--- a/libs/tascam/runtime/src/isoch_ctls.rs
+++ b/libs/tascam/runtime/src/isoch_ctls.rs
@@ -2,8 +2,11 @@
 // Copyright (c) 2021 Takashi Sakamoto
 
 use {
-    super::*, alsa_ctl_tlv_codec::DbInterval, alsactl::{prelude::*, *}, core::elem_value_accessor::*,
-    tascam_protocols::isoch::*,
+    super::*,
+    alsa_ctl_tlv_codec::DbInterval,
+    alsactl::{prelude::*, *},
+    core::elem_value_accessor::*,
+    protocols::isoch::*,
 };
 
 const MONITOR_ROTARY_NAME: &str = "monitor-rotary";

--- a/libs/tascam/runtime/src/lib.rs
+++ b/libs/tascam/runtime/src/lib.rs
@@ -18,14 +18,18 @@ use {
     asynch_runtime::*,
     core::{card_cntr::*, RuntimeOperation},
     glib::{source, Error, FileError, IsA},
-    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwReq},
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwReq,
+    },
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     isoch_console_runtime::*,
     isoch_rack_runtime::*,
+    protocols::{config_rom::*, *},
     seq_cntr::*,
     std::convert::TryFrom,
-    tascam_protocols::{config_rom::*, *},
+    tascam_protocols as protocols,
 };
 
 pub enum TascamRuntime {


### PR DESCRIPTION
This batch of patches is to change license of protocols crates from GPL v3.0 or later
to LGPL v3.0 or later. The protocols crates are designed to be used as library crate,
thus it's natural to use LGPL instead of GPL, The reason to select GPL is my respect
to clause for reverse engineering.

Additionally, the patchset includes documentation improvements and some code
refactoring for future publishing.

```
Takashi Sakamoto (37):
  bebob-protocols: hide utility executable from documentation
  oxfw-protocols: hide utility executable from documentation
  efw-protocols: fix suspicous copy-and-paste mistake
  bebob-protocols: improve comment documentation
  efw-protocols: improve comment documentation
  oxfw-protocols: improve comment documentation
  dg00x-protocols: improve comment documentation
  tascam-protocols: improve comment documentation
  motu-protocols: improve comment documentation
  ff-protocols: improve documentation
  bebob-protocols: code refactoring for use statement in binary executable
  bebob-runtime: use alias in use statement for bebob-protocols crate
  bebob-protocols: hide offset values
  efw-runtime: use alias in use statement for efw-protocols
  oxfw-protocols: code refactoring for use statement in binary executable
  oxfw-protocols: apogee: hide vendor dependent commands
  oxfw-protocols: tascam: hide vendor dependent command
  oxfw-runtime: use alias in use statement for oxfw-protocols
  oxfw-runtime: minor code refactoring for use statement with common controls
  dice-protocols: code refactoring for use statement in binary executable
  dice-runtime: use alias in use statement for dice-protocols
  dice-runtime: minor code refactoring for use statement with tcat module
  dice-runtime: minor code refactoring for use statement with common controls
  dg00x-runtime: use alias in use statement for dg00x-protocols
  tascam-protocols: code refactoring for use statement in binary executable
  tascam-runtime: use alias in use statement for tascam-protocols
  motu-runtime: use alias in use statement for motu-protocols
  ff-protocols: code refactoring for use statement in binary executable
  ff-runtime: use alias in use statement for ff-protocols
  bebob-protocols: change crate license to LGPL v3.0 or later
  efw-protocols: change crate license to LGPL v3.0 or later
  oxfw-protocols: change crate license to LGPL v3.0 or later
  dice-protocols: change crate license to LGPL v3.0 or later
  dg00x-protocols: change crate license to LGPL v3.0 or later
  tascam-protocols: change crate license to LGPL v3.0 or later
  motu-protocols: change crate license to LGPL v3.0 or later
  ff-protocols: change crate license to LGPL v3.0 or later

 README.rst                                    | 12 ++++
 libs/bebob/protocols/Cargo.toml               |  6 +-
 libs/bebob/protocols/src/apogee.rs            |  2 +-
 libs/bebob/protocols/src/apogee/ensemble.rs   | 22 +++---
 libs/bebob/protocols/src/behringer.rs         |  2 +-
 .../protocols/src/bin/bco-bootloader-info.rs  | 17 +++--
 libs/bebob/protocols/src/bridgeco.rs          | 68 ++++++++++---------
 libs/bebob/protocols/src/digidesign.rs        |  2 +-
 libs/bebob/protocols/src/esi.rs               |  2 +-
 libs/bebob/protocols/src/focusrite.rs         |  2 +-
 libs/bebob/protocols/src/focusrite/saffire.rs | 38 +++++------
 .../protocols/src/focusrite/saffireproio.rs   | 12 ++--
 libs/bebob/protocols/src/icon.rs              |  2 +-
 libs/bebob/protocols/src/lib.rs               | 22 +++---
 libs/bebob/protocols/src/maudio.rs            |  2 +-
 libs/bebob/protocols/src/maudio/normal.rs     |  2 +-
 libs/bebob/protocols/src/maudio/pfl.rs        |  8 +--
 libs/bebob/protocols/src/maudio/special.rs    | 27 +++++---
 libs/bebob/protocols/src/presonus.rs          |  2 +-
 libs/bebob/protocols/src/presonus/firebox.rs  |  2 +-
 libs/bebob/protocols/src/presonus/fp10.rs     |  2 +-
 .../protocols/src/presonus/inspire1394.rs     |  2 +-
 libs/bebob/protocols/src/roland.rs            |  2 +-
 libs/bebob/protocols/src/stanton.rs           |  2 +-
 libs/bebob/protocols/src/terratec.rs          |  2 +-
 libs/bebob/protocols/src/terratec/aureon.rs   |  2 +-
 libs/bebob/protocols/src/terratec/phase88.rs  |  2 +-
 libs/bebob/protocols/src/yamaha_terratec.rs   |  2 +-
 .../runtime/src/apogee/ensemble_model.rs      |  2 +-
 libs/bebob/runtime/src/behringer.rs           |  2 +-
 libs/bebob/runtime/src/common_ctls.rs         |  2 +-
 libs/bebob/runtime/src/digidesign.rs          |  2 +-
 libs/bebob/runtime/src/esi.rs                 |  2 +-
 libs/bebob/runtime/src/focusrite.rs           |  2 +-
 libs/bebob/runtime/src/icon.rs                |  2 +-
 libs/bebob/runtime/src/lib.rs                 |  1 +
 libs/bebob/runtime/src/maudio.rs              |  2 +-
 .../src/maudio/profirelightbridge_model.rs    |  2 +-
 .../bebob/runtime/src/maudio/special_model.rs |  2 +-
 .../runtime/src/presonus/firebox_model.rs     |  2 +-
 libs/bebob/runtime/src/presonus/fp10_model.rs |  2 +-
 .../runtime/src/presonus/inspire1394_model.rs |  2 +-
 libs/bebob/runtime/src/roland.rs              |  2 +-
 libs/bebob/runtime/src/stanton.rs             |  2 +-
 .../runtime/src/terratec/aureon_model.rs      |  2 +-
 .../runtime/src/terratec/phase88_model.rs     |  2 +-
 libs/bebob/runtime/src/yamaha_terratec.rs     |  2 +-
 libs/dg00x/protocols/Cargo.toml               |  2 +-
 libs/dg00x/protocols/src/lib.rs               | 10 +--
 libs/dg00x/runtime/src/lib.rs                 |  1 +
 libs/dg00x/runtime/src/model.rs               |  2 +-
 libs/dice/protocols/Cargo.toml                |  2 +-
 libs/dice/protocols/src/alesis.rs             |  2 +-
 libs/dice/protocols/src/alesis/meter.rs       |  2 +-
 libs/dice/protocols/src/alesis/mixer.rs       |  2 +-
 libs/dice/protocols/src/alesis/output.rs      |  2 +-
 libs/dice/protocols/src/avid.rs               |  2 +-
 .../src/bin/tcat-config-rom-parser.rs         | 21 +++---
 .../src/bin/tcat-extension-parser.rs          | 24 +++----
 .../protocols/src/bin/tcat-general-parser.rs  | 23 +++----
 libs/dice/protocols/src/focusrite.rs          |  2 +-
 .../dice/protocols/src/focusrite/liquids56.rs |  2 +-
 libs/dice/protocols/src/focusrite/spro14.rs   |  2 +-
 libs/dice/protocols/src/focusrite/spro24.rs   |  2 +-
 .../dice/protocols/src/focusrite/spro24dsp.rs |  2 +-
 libs/dice/protocols/src/focusrite/spro26.rs   |  2 +-
 libs/dice/protocols/src/focusrite/spro40.rs   |  2 +-
 libs/dice/protocols/src/lexicon.rs            |  2 +-
 libs/dice/protocols/src/lib.rs                |  2 +-
 libs/dice/protocols/src/loud.rs               |  2 +-
 libs/dice/protocols/src/maudio.rs             |  2 +-
 libs/dice/protocols/src/presonus.rs           |  2 +-
 libs/dice/protocols/src/presonus/fstudio.rs   |  2 +-
 .../protocols/src/presonus/fstudiomobile.rs   |  2 +-
 .../protocols/src/presonus/fstudioproject.rs  |  2 +-
 libs/dice/protocols/src/tcat.rs               |  2 +-
 libs/dice/protocols/src/tcat/config_rom.rs    |  2 +-
 .../protocols/src/tcat/ext_sync_section.rs    |  2 +-
 libs/dice/protocols/src/tcat/extension.rs     |  2 +-
 .../src/tcat/extension/appl_section.rs        |  2 +-
 .../src/tcat/extension/caps_section.rs        |  2 +-
 .../src/tcat/extension/cmd_section.rs         |  2 +-
 .../tcat/extension/current_config_section.rs  |  2 +-
 .../src/tcat/extension/mixer_section.rs       |  2 +-
 .../src/tcat/extension/peak_section.rs        |  2 +-
 .../src/tcat/extension/router_entry.rs        |  2 +-
 .../src/tcat/extension/router_section.rs      |  2 +-
 .../src/tcat/extension/standalone_section.rs  |  2 +-
 .../src/tcat/extension/stream_format_entry.rs |  2 +-
 .../tcat/extension/stream_format_section.rs   |  2 +-
 .../dice/protocols/src/tcat/global_section.rs |  2 +-
 .../src/tcat/rx_stream_format_section.rs      |  2 +-
 libs/dice/protocols/src/tcat/tcd22xx_spec.rs  |  2 +-
 .../src/tcat/tx_stream_format_section.rs      |  2 +-
 libs/dice/protocols/src/tcat/utils.rs         |  2 +-
 libs/dice/protocols/src/tcelectronic.rs       |  2 +-
 .../protocols/src/tcelectronic/ch_strip.rs    |  2 +-
 .../protocols/src/tcelectronic/desktop.rs     |  2 +-
 .../dice/protocols/src/tcelectronic/fw_led.rs |  2 +-
 .../protocols/src/tcelectronic/midi_send.rs   |  2 +-
 libs/dice/protocols/src/tcelectronic/prog.rs  |  2 +-
 .../dice/protocols/src/tcelectronic/reverb.rs |  2 +-
 libs/dice/protocols/src/tcelectronic/shell.rs |  2 +-
 .../protocols/src/tcelectronic/shell/itwin.rs |  2 +-
 .../protocols/src/tcelectronic/shell/k24d.rs  |  2 +-
 .../protocols/src/tcelectronic/shell/k8.rs    |  2 +-
 .../protocols/src/tcelectronic/shell/klive.rs |  2 +-
 .../protocols/src/tcelectronic/standalone.rs  |  2 +-
 .../dice/protocols/src/tcelectronic/studio.rs |  2 +-
 libs/dice/runtime/src/blackbird_model.rs      |  7 +-
 libs/dice/runtime/src/common_ctl.rs           |  5 +-
 libs/dice/runtime/src/extension_model.rs      |  8 +--
 libs/dice/runtime/src/focusrite.rs            |  7 +-
 .../runtime/src/focusrite/liquids56_model.rs  |  2 +-
 .../runtime/src/focusrite/spro14_model.rs     |  2 +-
 .../runtime/src/focusrite/spro24_model.rs     |  2 +-
 .../runtime/src/focusrite/spro24dsp_model.rs  |  2 +-
 .../runtime/src/focusrite/spro26_model.rs     |  2 +-
 .../runtime/src/focusrite/spro40_model.rs     |  2 +-
 libs/dice/runtime/src/io_fw_model.rs          |  6 +-
 libs/dice/runtime/src/ionix_model.rs          |  8 +--
 libs/dice/runtime/src/lib.rs                  |  8 ++-
 libs/dice/runtime/src/mbox3_model.rs          |  7 +-
 libs/dice/runtime/src/minimal_model.rs        |  5 +-
 libs/dice/runtime/src/model.rs                |  2 +-
 libs/dice/runtime/src/pfire_model.rs          |  7 +-
 libs/dice/runtime/src/presonus.rs             |  5 +-
 .../runtime/src/presonus/fstudio_model.rs     |  2 +-
 .../src/presonus/fstudiomobile_model.rs       |  2 +-
 .../src/presonus/fstudioproject_model.rs      |  2 +-
 libs/dice/runtime/src/tcd22xx_ctl.rs          |  3 +-
 libs/dice/runtime/src/tcelectronic.rs         |  9 +--
 .../src/tcelectronic/desktopk6_model.rs       |  2 +-
 .../runtime/src/tcelectronic/itwin_model.rs   |  2 +-
 .../runtime/src/tcelectronic/k24d_model.rs    |  2 +-
 .../dice/runtime/src/tcelectronic/k8_model.rs |  2 +-
 .../runtime/src/tcelectronic/klive_model.rs   |  2 +-
 .../runtime/src/tcelectronic/shell_ctl.rs     |  2 +-
 .../src/tcelectronic/studiok48_model.rs       |  2 +-
 libs/efw/protocols/Cargo.toml                 |  2 +-
 libs/efw/protocols/src/flash.rs               |  2 +-
 libs/efw/protocols/src/hw_ctl.rs              |  2 +-
 libs/efw/protocols/src/hw_info.rs             | 12 ++--
 libs/efw/protocols/src/lib.rs                 |  6 +-
 libs/efw/protocols/src/monitor.rs             |  2 +-
 libs/efw/protocols/src/phys_input.rs          |  2 +-
 libs/efw/protocols/src/phys_output.rs         |  2 +-
 libs/efw/protocols/src/playback.rs            |  2 +-
 libs/efw/protocols/src/port_conf.rs           |  4 +-
 libs/efw/protocols/src/robot_guitar.rs        |  4 +-
 libs/efw/protocols/src/transaction.rs         |  4 +-
 libs/efw/protocols/src/transport.rs           |  4 +-
 libs/efw/runtime/src/clk_ctl.rs               |  2 +-
 libs/efw/runtime/src/guitar_ctl.rs            |  2 +-
 libs/efw/runtime/src/iec60958_ctl.rs          |  2 +-
 libs/efw/runtime/src/input_ctl.rs             |  2 +-
 libs/efw/runtime/src/lib.rs                   |  1 +
 libs/efw/runtime/src/meter_ctl.rs             |  2 +-
 libs/efw/runtime/src/mixer_ctl.rs             |  2 +-
 libs/efw/runtime/src/model.rs                 |  2 +-
 libs/efw/runtime/src/output_ctl.rs            |  2 +-
 libs/efw/runtime/src/port_ctl.rs              |  2 +-
 libs/ff/protocols/Cargo.toml                  |  2 +-
 .../protocols/src/bin/ff-config-rom-parser.rs | 18 ++---
 libs/ff/protocols/src/former.rs               | 14 ++--
 libs/ff/protocols/src/former/ff400.rs         | 22 +++---
 libs/ff/protocols/src/former/ff800.rs         | 22 +++---
 libs/ff/protocols/src/latter.rs               | 42 ++++++------
 libs/ff/protocols/src/latter/ff802.rs         | 18 ++---
 libs/ff/protocols/src/latter/ucx.rs           | 16 ++---
 libs/ff/protocols/src/lib.rs                  | 14 ++--
 libs/ff/runtime/src/ff400_model.rs            |  2 +-
 libs/ff/runtime/src/ff800_model.rs            |  2 +-
 libs/ff/runtime/src/ff802_model.rs            |  2 +-
 libs/ff/runtime/src/former_ctls.rs            |  2 +-
 libs/ff/runtime/src/latter_ctls.rs            |  2 +-
 libs/ff/runtime/src/lib.rs                    |  6 +-
 libs/ff/runtime/src/model.rs                  |  2 +-
 libs/ff/runtime/src/ucx_model.rs              |  2 +-
 libs/motu/protocols/Cargo.toml                |  2 +-
 libs/motu/protocols/src/command_dsp.rs        | 28 ++++----
 libs/motu/protocols/src/config_rom.rs         |  4 +-
 libs/motu/protocols/src/lib.rs                | 18 ++---
 libs/motu/protocols/src/register_dsp.rs       | 28 +++++---
 libs/motu/protocols/src/version_1.rs          |  6 +-
 libs/motu/protocols/src/version_2.rs          |  8 +--
 libs/motu/protocols/src/version_3.rs          |  8 +--
 libs/motu/runtime/src/command_dsp_runtime.rs  |  2 +-
 libs/motu/runtime/src/lib.rs                  |  3 +-
 libs/motu/runtime/src/register_dsp_runtime.rs |  2 +-
 libs/motu/runtime/src/v1_runtime.rs           |  2 +-
 libs/oxfw/protocols/Cargo.toml                |  6 +-
 libs/oxfw/protocols/src/apogee.rs             | 32 ++++-----
 libs/oxfw/protocols/src/bin/oxfw-info.rs      | 18 +++--
 libs/oxfw/protocols/src/griffin.rs            |  2 +-
 libs/oxfw/protocols/src/lacie.rs              |  2 +-
 libs/oxfw/protocols/src/lib.rs                |  4 +-
 libs/oxfw/protocols/src/loud.rs               |  4 +-
 libs/oxfw/protocols/src/oxford.rs             |  3 +-
 libs/oxfw/protocols/src/tascam.rs             | 23 ++++---
 libs/oxfw/runtime/src/apogee_model.rs         |  5 +-
 libs/oxfw/runtime/src/common_model.rs         |  2 +-
 libs/oxfw/runtime/src/griffin_model.rs        |  5 +-
 libs/oxfw/runtime/src/lacie_model.rs          |  5 +-
 libs/oxfw/runtime/src/lib.rs                  |  6 +-
 libs/oxfw/runtime/src/loud_model.rs           |  2 +-
 libs/oxfw/runtime/src/tascam_model.rs         |  5 +-
 libs/tascam/protocols/Cargo.toml              |  2 +-
 libs/tascam/protocols/src/asynch.rs           |  5 +-
 libs/tascam/protocols/src/asynch/fe8.rs       |  5 +-
 .../src/bin/tascam-config-rom-parser.rs       | 24 +++----
 .../protocols/src/bin/tascam-hardware-info.rs | 17 +++--
 libs/tascam/protocols/src/config_rom.rs       |  4 +-
 libs/tascam/protocols/src/isoch.rs            | 22 +++---
 libs/tascam/protocols/src/isoch/fw1082.rs     |  6 +-
 libs/tascam/protocols/src/isoch/fw1804.rs     |  2 +-
 libs/tascam/protocols/src/isoch/fw1884.rs     |  4 +-
 libs/tascam/protocols/src/lib.rs              | 14 ++--
 libs/tascam/runtime/src/asynch_runtime.rs     |  2 +-
 libs/tascam/runtime/src/fe8_model.rs          |  2 +-
 libs/tascam/runtime/src/fw1082_model.rs       |  2 +-
 libs/tascam/runtime/src/fw1804_model.rs       |  2 +-
 libs/tascam/runtime/src/fw1884_model.rs       |  2 +-
 .../runtime/src/isoch_console_runtime.rs      |  2 +-
 libs/tascam/runtime/src/isoch_ctls.rs         |  7 +-
 libs/tascam/runtime/src/lib.rs                |  8 ++-
 226 files changed, 631 insertions(+), 608 deletions(-)
```