### PR TITLE
[PATCH 00/12] ta1394: code refactoring for general and ccm crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
     "libs/ta1394/general",
 #    "libs/ta1394/audio",
 #    "libs/ta1394/stream-format",
-#    "libs/ta1394/ccm",
+    "libs/ta1394/ccm",
 #    "libs/dg00x/protocols",
 #    "libs/tascam/protocols",
 #    "libs/efw/protocols",
@@ -61,7 +61,7 @@ members = [
 ta1394-avc-general = { path = "libs/ta1394/general" }
 #ta1394-avc-audio = { path = "libs/ta1394/audio" }
 #ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
-#ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
+ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
 #firewire-bebob-protocols = { path = "libs/bebob/protocols" }
 #firewire-digi00x-protocols = { path = "libs/dg00x/protocols" }
 #firewire-dice-protocols = { path = "libs/dice/protocols" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 # They are now available in crates.io.
 #    "libs/alsa-ctl-tlv-codec",
 #    "libs/ieee1212-config-rom",
-#    "libs/ta1394/general",
+    "libs/ta1394/general",
 #    "libs/ta1394/audio",
 #    "libs/ta1394/stream-format",
 #    "libs/ta1394/ccm",
@@ -55,10 +55,10 @@ members = [
 ]
 
 # For development purpose.
-#[patch.crates-io]
+[patch.crates-io]
 #alsa-ctl-tlv-codec = { path = "libs/alsa-ctl-tlv-codec" }
 #ieee1212-config-rom = { path = "libs/ieee1212-config-rom" }
-#ta1394-avc-general = { path = "libs/ta1394/general" }
+ta1394-avc-general = { path = "libs/ta1394/general" }
 #ta1394-avc-audio = { path = "libs/ta1394/audio" }
 #ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
 #ta1394-avc-ccm = { path = "libs/ta1394/ccm" }

--- a/libs/ta1394/ccm/src/lib.rs
+++ b/libs/ta1394/ccm/src/lib.rs
@@ -20,6 +20,12 @@ pub enum SignalUnitAddr {
     ),
 }
 
+impl Default for SignalUnitAddr {
+    fn default() -> Self {
+        Self::Isoc(Self::PLUG_ID_MASK)
+    }
+}
+
 impl SignalUnitAddr {
     const EXT_PLUG_FLAG: u8 = 0x80;
     const PLUG_ID_MASK: u8 = 0x7f;
@@ -56,6 +62,15 @@ pub struct SignalSubunitAddr {
     pub plug_id: u8,
 }
 
+impl Default for SignalSubunitAddr {
+    fn default() -> Self {
+        Self {
+            subunit: Default::default(),
+            plug_id: 0xff,
+        }
+    }
+}
+
 impl SignalSubunitAddr {
     const LENGTH: usize = 2;
 
@@ -79,6 +94,12 @@ impl SignalSubunitAddr {
 pub enum SignalAddr {
     Unit(SignalUnitAddr),
     Subunit(SignalSubunitAddr),
+}
+
+impl Default for SignalAddr {
+    fn default() -> Self {
+        Self::Unit(Default::default())
+    }
 }
 
 impl SignalAddr {
@@ -133,8 +154,8 @@ pub struct SignalSource {
 impl SignalSource {
     pub fn new(dst: &SignalAddr) -> Self {
         SignalSource {
-            src: SignalAddr::Unit(SignalUnitAddr::Isoc(SignalUnitAddr::PLUG_ID_MASK)),
             dst: *dst,
+            ..Default::default()
         }
     }
 
@@ -145,6 +166,15 @@ impl SignalSource {
             Ok(())
         } else {
             Err(AvcRespParseError::TooShortResp(4))
+        }
+    }
+}
+
+impl Default for SignalSource {
+    fn default() -> Self {
+        Self {
+            src: Default::default(),
+            dst: Default::default(),
         }
     }
 }

--- a/libs/ta1394/general/src/general.rs
+++ b/libs/ta1394/general/src/general.rs
@@ -15,15 +15,21 @@ pub struct UnitInfo {
     pub company_id: [u8; 3],
 }
 
-impl UnitInfo {
-    const FIRST_OPERAND: u8 = 0x07;
-
-    pub fn new() -> Self {
-        UnitInfo {
+impl Default for UnitInfo {
+    fn default() -> Self {
+        Self {
             unit_type: AvcSubunitType::Reserved(AvcAddrSubunit::SUBUNIT_TYPE_MASK),
             unit_id: AvcAddrSubunit::SUBUNIT_ID_MASK,
             company_id: [0xff; 3],
         }
+    }
+}
+
+impl UnitInfo {
+    const FIRST_OPERAND: u8 = 0x07;
+
+    pub fn new() -> Self {
+        Default::default()
     }
 }
 

--- a/libs/ta1394/general/src/general.rs
+++ b/libs/ta1394/general/src/general.rs
@@ -189,11 +189,20 @@ pub struct VendorDependent {
     pub data: Vec<u8>,
 }
 
+impl Default for VendorDependent {
+    fn default() -> Self {
+        Self {
+            company_id: [0xff, 0xff, 0xff],
+            data: Default::default(),
+        }
+    }
+}
+
 impl VendorDependent {
     pub fn new(company_id: &[u8; 3]) -> Self {
-        VendorDependent {
+        Self {
             company_id: *company_id,
-            data: Vec::new(),
+            ..Default::default()
         }
     }
 

--- a/libs/ta1394/general/src/general.rs
+++ b/libs/ta1394/general/src/general.rs
@@ -268,11 +268,31 @@ pub struct PlugInfoUnitIsocExtData {
     pub external_output_plugs: u8,
 }
 
+impl Default for PlugInfoUnitIsocExtData {
+    fn default() -> Self {
+        Self {
+            isoc_input_plugs: 0xff,
+            isoc_output_plugs: 0xff,
+            external_input_plugs: 0xff,
+            external_output_plugs: 0xff,
+        }
+    }
+}
+
 /// The data of unit plugs for asynchronous inputs/outputs.
 #[derive(Debug)]
 pub struct PlugInfoUnitAsyncData {
     pub async_input_plugs: u8,
     pub async_output_plugs: u8,
+}
+
+impl Default for PlugInfoUnitAsyncData {
+    fn default() -> Self {
+        Self {
+            async_input_plugs: 0xff,
+            async_output_plugs: 0xff,
+        }
+    }
 }
 
 /// The data of the number of plugs for inputs/outputs.
@@ -285,6 +305,18 @@ pub struct PlugInfoUnitOtherData {
     pub output_plugs: u8,
 }
 
+impl Default for PlugInfoUnitOtherData {
+    fn default() -> Self {
+        Self {
+            subfunction: 0xff,
+            first_input_plug: 0xff,
+            input_plugs: 0xff,
+            first_output_plug: 0xff,
+            output_plugs: 0xff,
+        }
+    }
+}
+
 /// Plug information for unit.
 #[derive(Debug)]
 pub enum PlugInfoUnitData {
@@ -293,11 +325,26 @@ pub enum PlugInfoUnitData {
     Other(PlugInfoUnitOtherData),
 }
 
+impl Default for PlugInfoUnitData {
+    fn default() -> Self {
+        Self::IsocExt(Default::default())
+    }
+}
+
 /// Plug information for subunit.
 #[derive(Debug)]
 pub struct PlugInfoSubunitData {
     pub dst_plugs: u8,
     pub src_plugs: u8,
+}
+
+impl Default for PlugInfoSubunitData {
+    fn default() -> Self {
+        Self {
+            dst_plugs: 0xff,
+            src_plugs: 0xff,
+        }
+    }
 }
 
 /// AV/C PLUG INFO command.
@@ -309,42 +356,34 @@ pub enum PlugInfo {
     Subunit(PlugInfoSubunitData),
 }
 
+impl Default for PlugInfo {
+    fn default() -> Self {
+        Self::Unit(Default::default())
+    }
+}
+
 impl PlugInfo {
     const SUBFUNC_UNIT_ISOC_EXT: u8 = 0x00;
     const SUBFUNC_UNIT_ASYNC: u8 = 0x01;
     const SUBFUNC_SUBUNIT: u8 = 0x00;
 
     pub fn new_for_unit_isoc_ext_plugs() -> Self {
-        PlugInfo::Unit(PlugInfoUnitData::IsocExt(PlugInfoUnitIsocExtData {
-            isoc_input_plugs: 0xff,
-            isoc_output_plugs: 0xff,
-            external_input_plugs: 0xff,
-            external_output_plugs: 0xff,
-        }))
+        PlugInfo::Unit(PlugInfoUnitData::IsocExt(Default::default()))
     }
 
     pub fn new_for_unit_async_plugs() -> Self {
-        PlugInfo::Unit(PlugInfoUnitData::Async(PlugInfoUnitAsyncData {
-            async_input_plugs: 0xff,
-            async_output_plugs: 0xff,
-        }))
+        PlugInfo::Unit(PlugInfoUnitData::Async(Default::default()))
     }
 
     pub fn new_for_unit_other_plugs(subfunction: u8) -> Self {
         PlugInfo::Unit(PlugInfoUnitData::Other(PlugInfoUnitOtherData {
             subfunction,
-            first_input_plug: 0xff,
-            input_plugs: 0xff,
-            first_output_plug: 0xff,
-            output_plugs: 0xff,
+            ..Default::default()
         }))
     }
 
     pub fn new_for_subunit_plugs() -> Self {
-        PlugInfo::Subunit(PlugInfoSubunitData {
-            dst_plugs: 0xff,
-            src_plugs: 0xff,
-        })
+        PlugInfo::Subunit(Default::default())
     }
 }
 

--- a/libs/ta1394/general/src/general.rs
+++ b/libs/ta1394/general/src/general.rs
@@ -76,9 +76,18 @@ pub struct SubunitInfoEntry {
     pub maximum_id: u8,
 }
 
+impl Default for SubunitInfoEntry {
+    fn default() -> Self {
+        SubunitInfoEntry {
+            subunit_type: Default::default(),
+            maximum_id: AvcAddrSubunit::SUBUNIT_ID_MASK,
+        }
+    }
+}
+
 impl SubunitInfoEntry {
     pub fn new(subunit_type: AvcSubunitType, maximum_id: u8) -> Self {
-        SubunitInfoEntry {
+        Self {
             subunit_type,
             maximum_id,
         }
@@ -95,6 +104,16 @@ pub struct SubunitInfo {
     pub entries: Vec<SubunitInfoEntry>,
 }
 
+impl Default for SubunitInfo {
+    fn default() -> Self {
+        SubunitInfo {
+            page: Self::PAGE_MASK,
+            extension_code: Self::EXTENSION_CODE_MASK,
+            entries: Default::default(),
+        }
+    }
+}
+
 impl SubunitInfo {
     const PAGE_SHIFT: usize = 4;
     const PAGE_MASK: u8 = 0x07;
@@ -102,10 +121,10 @@ impl SubunitInfo {
     const EXTENSION_CODE_MASK: u8 = 0x07;
 
     pub fn new(page: u8, extension_code: u8) -> Self {
-        SubunitInfo {
+        Self {
             page,
             extension_code,
-            entries: Vec::new(),
+            ..Default::default()
         }
     }
 }

--- a/libs/ta1394/general/src/lib.rs
+++ b/libs/ta1394/general/src/lib.rs
@@ -298,6 +298,12 @@ impl AvcRespCode {
     const INTERIM: u8 = 0x0f;
 }
 
+impl Default for AvcRespCode {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
+}
+
 impl From<u8> for AvcRespCode {
     fn from(val: u8) -> Self {
         match val {

--- a/libs/ta1394/general/src/lib.rs
+++ b/libs/ta1394/general/src/lib.rs
@@ -26,6 +26,12 @@ pub enum AvcSubunitType {
     Reserved(u8),
 }
 
+impl Default for AvcSubunitType {
+    fn default() -> Self {
+        Self::Reserved(AvcAddrSubunit::SUBUNIT_TYPE_MASK)
+    }
+}
+
 impl AvcSubunitType {
     const MONITOR: u8 = 0x00;
     const AUDIO: u8 = 0x01;
@@ -112,6 +118,15 @@ pub struct AvcAddrSubunit {
     pub subunit_id: u8,
 }
 
+impl Default for AvcAddrSubunit {
+    fn default() -> Self {
+        Self {
+            subunit_type: Default::default(),
+            subunit_id: Self::SUBUNIT_ID_MASK,
+        }
+    }
+}
+
 impl AvcAddrSubunit {
     const SUBUNIT_TYPE_SHIFT: usize = 3;
     const SUBUNIT_TYPE_MASK: u8 = 0x1f;
@@ -160,6 +175,12 @@ impl From<AvcAddrSubunit> for u8 {
 pub enum AvcAddr {
     Unit,
     Subunit(AvcAddrSubunit),
+}
+
+impl Default for AvcAddr {
+    fn default() -> Self {
+        Self::Unit
+    }
 }
 
 impl AvcAddr {

--- a/libs/ta1394/general/src/lib.rs
+++ b/libs/ta1394/general/src/lib.rs
@@ -235,6 +235,12 @@ impl AvcCmdType {
     const GENERAL_INQUIRY: u8 = 0x04;
 }
 
+impl Default for AvcCmdType {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
+}
+
 impl From<u8> for AvcCmdType {
     fn from(val: u8) -> Self {
         match val {


### PR DESCRIPTION
Current implementation of general and ccm crates have lack of implementation of
Defailt trait for some public structures. It`s not necessarily convenient. Additionally,
it`s not convenient to implement serializer/deserializer by From trait for local usage.

This patchset refactors the crates.

```
Takashi Sakamoto (12):
  ta1394/general: start crate development for v0.2.0
  ta1394/general: implement Default trait for AvcAddr
  ta1394/general: implement Default trait for AvcCmdType
  ta1394/general: implement Default trait for AvcRespCode
  ta1394/general: implement Default trait for UnitInfo
  ta1394/general: implement Default trait for SubunitInfo
  ta1394/general: implement Default trait for VendorDependent
  ta1394/general: implement Default trait for PlugInfo
  ta1394/ccm: start crate development for v0.2.0
  ta1394/ccm: localize serializer/deserializer for SignalAddr
  ta1394/ccm: implement Default trait for SignalSource
  ta1394/ccm: code refactoring for SignalSource

 Cargo.toml                         |  10 +-
 libs/ta1394/ccm/src/lib.rs         | 179 ++++++++++++++++-------------
 libs/ta1394/general/src/general.rs | 129 ++++++++++++++++-----
 libs/ta1394/general/src/lib.rs     |  33 ++++++
 4 files changed, 239 insertions(+), 112 deletions(-)
```