### PR TITLE
[PATCH 00/11] ta1394/stream-format: code refactoring for stream format commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
 #    "libs/efw/protocols",
 #    "libs/motu/protocols",
 #    "libs/oxfw/protocols",
-#    "libs/bebob/protocols",
+    "libs/bebob/protocols",
 #    "libs/dice/protocols",
 #    "libs/ff/protocols",
 ]
@@ -62,7 +62,7 @@ ta1394-avc-general = { path = "libs/ta1394/general" }
 #ta1394-avc-audio = { path = "libs/ta1394/audio" }
 #ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
 ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
-#firewire-bebob-protocols = { path = "libs/bebob/protocols" }
+firewire-bebob-protocols = { path = "libs/bebob/protocols" }
 #firewire-digi00x-protocols = { path = "libs/dg00x/protocols" }
 #firewire-dice-protocols = { path = "libs/dice/protocols" }
 #firewire-fireworks-protocols = { path = "libs/efw/protocols" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ members = [
 #    "libs/ieee1212-config-rom",
     "libs/ta1394/general",
 #    "libs/ta1394/audio",
-#    "libs/ta1394/stream-format",
+    "libs/ta1394/stream-format",
     "libs/ta1394/ccm",
 #    "libs/dg00x/protocols",
 #    "libs/tascam/protocols",
@@ -60,7 +60,7 @@ members = [
 #ieee1212-config-rom = { path = "libs/ieee1212-config-rom" }
 ta1394-avc-general = { path = "libs/ta1394/general" }
 #ta1394-avc-audio = { path = "libs/ta1394/audio" }
-#ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
+ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
 ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
 firewire-bebob-protocols = { path = "libs/bebob/protocols" }
 #firewire-digi00x-protocols = { path = "libs/dg00x/protocols" }

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -750,6 +750,12 @@ pub enum UnitPlugType {
     Invalid(u8),
 }
 
+impl Default for UnitPlugType {
+    fn default() -> Self {
+        Self::Invalid(0xff)
+    }
+}
+
 impl UnitPlugType {
     fn from_val(val: u8) -> Self {
         match val {
@@ -779,6 +785,15 @@ pub struct UnitPlugData {
     pub plug_id: u8,
 }
 
+impl Default for UnitPlugData {
+    fn default() -> Self {
+        Self {
+            unit_type: Default::default(),
+            plug_id: 0xff,
+        }
+    }
+}
+
 impl UnitPlugData {
     const LENGTH: usize = 3;
 
@@ -799,6 +814,12 @@ impl UnitPlugData {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SubunitPlugData {
     pub plug_id: u8,
+}
+
+impl Default for SubunitPlugData {
+    fn default() -> Self {
+        Self { plug_id: 0xff }
+    }
 }
 
 impl SubunitPlugData {
@@ -825,6 +846,16 @@ pub struct FunctionBlockPlugData {
     pub plug_id: u8,
 }
 
+impl Default for FunctionBlockPlugData {
+    fn default() -> Self {
+        Self {
+            fb_type: 0xff,
+            fb_id: 0xff,
+            plug_id: 0xff,
+        }
+    }
+}
+
 impl FunctionBlockPlugData {
     const LENGTH: usize = 3;
 
@@ -849,6 +880,12 @@ pub enum PlugAddrMode {
     Subunit(SubunitPlugData),
     FunctionBlock(FunctionBlockPlugData),
     Invalid([u8; 4]),
+}
+
+impl Default for PlugAddrMode {
+    fn default() -> Self {
+        Self::Invalid([0xff; Self::LENGTH])
+    }
 }
 
 impl PlugAddrMode {
@@ -897,6 +934,12 @@ pub enum PlugDirection {
     Invalid(u8),
 }
 
+impl Default for PlugDirection {
+    fn default() -> Self {
+        Self::Invalid(0xff)
+    }
+}
+
 impl PlugDirection {
     const INPUT: u8 = 0;
     const OUTPUT: u8 = 1;
@@ -925,6 +968,15 @@ pub struct PlugAddr {
     pub direction: PlugDirection,
     /// The mode of addressing.
     pub mode: PlugAddrMode,
+}
+
+impl Default for PlugAddr {
+    fn default() -> Self {
+        Self {
+            direction: Default::default(),
+            mode: Default::default(),
+        }
+    }
 }
 
 impl PlugAddr {

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -1052,6 +1052,16 @@ struct ExtendedStreamFormat {
     support_status: SupportStatus,
 }
 
+impl Default for ExtendedStreamFormat {
+    fn default() -> Self {
+        Self {
+            subfunc: 0xff,
+            plug_addr: Default::default(),
+            support_status: Default::default(),
+        }
+    }
+}
+
 impl ExtendedStreamFormat {
     const OPCODE: u8 = 0xbf;
 
@@ -1059,7 +1069,7 @@ impl ExtendedStreamFormat {
         ExtendedStreamFormat {
             subfunc,
             plug_addr: *plug_addr,
-            support_status: SupportStatus::Reserved(0xff),
+            ..Default::default()
         }
     }
 

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -1012,6 +1012,12 @@ pub enum SupportStatus {
     Reserved(u8),
 }
 
+impl Default for SupportStatus {
+    fn default() -> Self {
+        SupportStatus::Reserved(0xff)
+    }
+}
+
 impl SupportStatus {
     const ACTIVE: u8 = 0x00;
     const INACTIVE: u8 = 0x01;

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -30,57 +30,52 @@ impl Am824MultiBitAudioAttr {
 
     const RATE_CTL_MASK: u8 = 0x01;
     const RATE_CTL_SHIFT: usize = 0;
-}
 
-impl From<&[u8; 2]> for Am824MultiBitAudioAttr {
-    fn from(raw: &[u8; 2]) -> Self {
-        let freq_code = (raw[0] >> Am824MultiBitAudioAttr::FREQ_CODE_SHIFT)
-            & Am824MultiBitAudioAttr::FREQ_CODE_MASK;
+    const LENGTH: usize = 2;
+
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH);
+        let freq_code = (raw[0] >> Self::FREQ_CODE_SHIFT) & Self::FREQ_CODE_MASK;
         let freq = match freq_code {
-            Am824MultiBitAudioAttr::FREQ_CODE_22050 => 22050,
-            Am824MultiBitAudioAttr::FREQ_CODE_24000 => 24000,
-            Am824MultiBitAudioAttr::FREQ_CODE_32000 => 32000,
-            Am824MultiBitAudioAttr::FREQ_CODE_44100 => 44100,
-            Am824MultiBitAudioAttr::FREQ_CODE_48000 => 48000,
-            Am824MultiBitAudioAttr::FREQ_CODE_96000 => 96000,
-            Am824MultiBitAudioAttr::FREQ_CODE_176400 => 176400,
-            Am824MultiBitAudioAttr::FREQ_CODE_192000 => 192000,
+            Self::FREQ_CODE_22050 => 22050,
+            Self::FREQ_CODE_24000 => 24000,
+            Self::FREQ_CODE_32000 => 32000,
+            Self::FREQ_CODE_44100 => 44100,
+            Self::FREQ_CODE_48000 => 48000,
+            Self::FREQ_CODE_96000 => 96000,
+            Self::FREQ_CODE_176400 => 176400,
+            Self::FREQ_CODE_192000 => 192000,
             _ => 0xffffffff,
         };
 
-        let rate_ctl_code = (raw[0] >> Am824MultiBitAudioAttr::RATE_CTL_SHIFT)
-            & Am824MultiBitAudioAttr::RATE_CTL_MASK;
-        let rate_ctl = rate_ctl_code == Am824MultiBitAudioAttr::RATE_CTL_SUPPORTED;
+        let rate_ctl_code = (raw[0] >> Self::RATE_CTL_SHIFT) & Self::RATE_CTL_MASK;
+        let rate_ctl = rate_ctl_code == Self::RATE_CTL_SUPPORTED;
 
         Am824MultiBitAudioAttr { freq, rate_ctl }
     }
-}
 
-impl From<&Am824MultiBitAudioAttr> for [u8; 2] {
-    fn from(data: &Am824MultiBitAudioAttr) -> Self {
-        let freq_code = match data.freq {
-            22050 => Am824MultiBitAudioAttr::FREQ_CODE_22050,
-            24000 => Am824MultiBitAudioAttr::FREQ_CODE_24000,
-            32000 => Am824MultiBitAudioAttr::FREQ_CODE_32000,
-            44100 => Am824MultiBitAudioAttr::FREQ_CODE_44100,
-            48000 => Am824MultiBitAudioAttr::FREQ_CODE_48000,
-            96000 => Am824MultiBitAudioAttr::FREQ_CODE_96000,
-            176400 => Am824MultiBitAudioAttr::FREQ_CODE_176400,
-            192000 => Am824MultiBitAudioAttr::FREQ_CODE_192000,
+    fn to_raw(&self) -> [u8; Self::LENGTH] {
+        let freq_code = match self.freq {
+            22050 => Self::FREQ_CODE_22050,
+            24000 => Self::FREQ_CODE_24000,
+            32000 => Self::FREQ_CODE_32000,
+            44100 => Self::FREQ_CODE_44100,
+            48000 => Self::FREQ_CODE_48000,
+            96000 => Self::FREQ_CODE_96000,
+            176400 => Self::FREQ_CODE_176400,
+            192000 => Self::FREQ_CODE_192000,
             _ => 0x0f,
         };
 
-        let rate_ctl_code = if data.rate_ctl {
-            Am824MultiBitAudioAttr::RATE_CTL_SUPPORTED
+        let rate_ctl_code = if self.rate_ctl {
+            Self::RATE_CTL_SUPPORTED
         } else {
-            Am824MultiBitAudioAttr::RATE_CTL_DONT_CARE
+            Self::RATE_CTL_DONT_CARE
         };
 
-        let mut raw = [0xff; 2];
-        raw[0] = ((freq_code & Am824MultiBitAudioAttr::FREQ_CODE_MASK)
-            << Am824MultiBitAudioAttr::FREQ_CODE_SHIFT)
-            | ((rate_ctl_code & Am824MultiBitAudioAttr::RATE_CTL_MASK)
-                << Am824MultiBitAudioAttr::RATE_CTL_SHIFT);
+        let mut raw = [0xff; Self::LENGTH];
+        raw[0] = ((freq_code & Self::FREQ_CODE_MASK) << Self::FREQ_CODE_SHIFT)
+            | ((rate_ctl_code & Self::RATE_CTL_MASK) << Self::RATE_CTL_SHIFT);
         raw
     }
 }
@@ -109,55 +104,50 @@ impl Am824OneBitAudioAttr {
 
     const RATE_CTL_MASK: u8 = 0x01;
     const RATE_CTL_SHIFT: usize = 0;
-}
 
-impl From<&[u8; 2]> for Am824OneBitAudioAttr {
-    fn from(raw: &[u8; 2]) -> Self {
-        let freq_code = (raw[0] >> Am824OneBitAudioAttr::FREQ_CODE_SHIFT)
-            & Am824OneBitAudioAttr::FREQ_CODE_MASK;
+    const LENGTH: usize = 2;
+
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH);
+        let freq_code = (raw[0] >> Self::FREQ_CODE_SHIFT) & Self::FREQ_CODE_MASK;
         let freq = match freq_code {
-            Am824OneBitAudioAttr::FREQ_CODE_2048000 => 2048000,
-            Am824OneBitAudioAttr::FREQ_CODE_2822400 => 2822400,
-            Am824OneBitAudioAttr::FREQ_CODE_3072000 => 3072000,
-            Am824OneBitAudioAttr::FREQ_CODE_5644800 => 5644800,
-            Am824OneBitAudioAttr::FREQ_CODE_6144000 => 6144000,
-            Am824OneBitAudioAttr::FREQ_CODE_11289600 => 11289600,
-            Am824OneBitAudioAttr::FREQ_CODE_12288000 => 12288000,
+            Self::FREQ_CODE_2048000 => 2048000,
+            Self::FREQ_CODE_2822400 => 2822400,
+            Self::FREQ_CODE_3072000 => 3072000,
+            Self::FREQ_CODE_5644800 => 5644800,
+            Self::FREQ_CODE_6144000 => 6144000,
+            Self::FREQ_CODE_11289600 => 11289600,
+            Self::FREQ_CODE_12288000 => 12288000,
             _ => 0xffffffff,
         };
 
-        let rate_ctl_code =
-            (raw[0] >> Am824OneBitAudioAttr::RATE_CTL_SHIFT) & Am824OneBitAudioAttr::RATE_CTL_MASK;
-        let rate_ctl = rate_ctl_code == Am824OneBitAudioAttr::RATE_CTL_SUPPORTED;
+        let rate_ctl_code = (raw[0] >> Self::RATE_CTL_SHIFT) & Self::RATE_CTL_MASK;
+        let rate_ctl = rate_ctl_code == Self::RATE_CTL_SUPPORTED;
 
         Am824OneBitAudioAttr { freq, rate_ctl }
     }
-}
 
-impl From<&Am824OneBitAudioAttr> for [u8; 2] {
-    fn from(data: &Am824OneBitAudioAttr) -> Self {
-        let freq_code = match data.freq {
-            2048000 => Am824OneBitAudioAttr::FREQ_CODE_2048000,
-            2822400 => Am824OneBitAudioAttr::FREQ_CODE_2822400,
-            3072000 => Am824OneBitAudioAttr::FREQ_CODE_3072000,
-            5644800 => Am824OneBitAudioAttr::FREQ_CODE_5644800,
-            6144000 => Am824OneBitAudioAttr::FREQ_CODE_6144000,
-            11289600 => Am824OneBitAudioAttr::FREQ_CODE_11289600,
-            12288000 => Am824OneBitAudioAttr::FREQ_CODE_12288000,
+    fn to_raw(&self) -> [u8; Self::LENGTH] {
+        let freq_code = match self.freq {
+            2048000 => Self::FREQ_CODE_2048000,
+            2822400 => Self::FREQ_CODE_2822400,
+            3072000 => Self::FREQ_CODE_3072000,
+            5644800 => Self::FREQ_CODE_5644800,
+            6144000 => Self::FREQ_CODE_6144000,
+            11289600 => Self::FREQ_CODE_11289600,
+            12288000 => Self::FREQ_CODE_12288000,
             _ => 0x0f,
         };
 
-        let rate_ctl_code = if data.rate_ctl {
-            Am824OneBitAudioAttr::RATE_CTL_SUPPORTED
+        let rate_ctl_code = if self.rate_ctl {
+            Self::RATE_CTL_SUPPORTED
         } else {
-            Am824OneBitAudioAttr::RATE_CTL_DONT_CARE
+            Self::RATE_CTL_DONT_CARE
         };
 
-        let mut raw = [0xff; 2];
-        raw[0] = ((freq_code & Am824OneBitAudioAttr::FREQ_CODE_MASK)
-            << Am824OneBitAudioAttr::FREQ_CODE_SHIFT)
-            | ((rate_ctl_code & Am824OneBitAudioAttr::RATE_CTL_MASK)
-                << Am824OneBitAudioAttr::RATE_CTL_SHIFT);
+        let mut raw = [0xff; Self::LENGTH];
+        raw[0] = ((freq_code & Self::FREQ_CODE_MASK) << Self::FREQ_CODE_SHIFT)
+            | ((rate_ctl_code & Self::RATE_CTL_MASK) << Self::RATE_CTL_SHIFT);
         raw
     }
 }
@@ -197,132 +187,112 @@ impl Am824Stream {
     const ONE_BIT_AUDIO_ENCODED_SACD: u8 = 0x0b;
     const HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO: u8 = 0x0c;
     const MIDI_CONFORMANT: u8 = 0x0d;
-}
 
-impl From<&[u8; 4]> for Am824Stream {
-    fn from(raw: &[u8; 4]) -> Self {
+    const LENGTH: usize = 4;
+
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH);
         match raw[0] {
-            Am824Stream::IEC60958_3
-            | Am824Stream::IEC61937_3
-            | Am824Stream::IEC61937_4
-            | Am824Stream::IEC61937_5
-            | Am824Stream::IEC61937_6
-            | Am824Stream::IEC61937_7
-            | Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW
-            | Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD
-            | Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
-                let mut r = [0; 2];
-                r.copy_from_slice(&raw[2..4]);
-                let attrs = Am824MultiBitAudioAttr::from(&r);
+            Self::IEC60958_3
+            | Self::IEC61937_3
+            | Self::IEC61937_4
+            | Self::IEC61937_5
+            | Self::IEC61937_6
+            | Self::IEC61937_7
+            | Self::MULTI_BIT_LINEAR_AUDIO_RAW
+            | Self::MULTI_BIT_LINEAR_AUDIO_DVD
+            | Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                let attrs = Am824MultiBitAudioAttr::from_raw(&raw[2..]);
                 match raw[0] {
-                    Am824Stream::IEC60958_3 => Am824Stream::Iec60958_3(attrs),
-                    Am824Stream::IEC61937_3 => Am824Stream::Iec61937_3(attrs),
-                    Am824Stream::IEC61937_4 => Am824Stream::Iec61937_4(attrs),
-                    Am824Stream::IEC61937_5 => Am824Stream::Iec61937_5(attrs),
-                    Am824Stream::IEC61937_6 => Am824Stream::Iec61937_6(attrs),
-                    Am824Stream::IEC61937_7 => Am824Stream::Iec61937_7(attrs),
-                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW => {
-                        Am824Stream::MultiBitLinearAudioRaw(attrs)
-                    }
-                    Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD => {
-                        Am824Stream::MultiBitLinearAudioDvd(attrs)
-                    }
-                    Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
-                        Am824Stream::HighPrecisionMultiBitLinearAudio(attrs)
+                    Self::IEC60958_3 => Self::Iec60958_3(attrs),
+                    Self::IEC61937_3 => Self::Iec61937_3(attrs),
+                    Self::IEC61937_4 => Self::Iec61937_4(attrs),
+                    Self::IEC61937_5 => Self::Iec61937_5(attrs),
+                    Self::IEC61937_6 => Self::Iec61937_6(attrs),
+                    Self::IEC61937_7 => Self::Iec61937_7(attrs),
+                    Self::MULTI_BIT_LINEAR_AUDIO_RAW => Self::MultiBitLinearAudioRaw(attrs),
+                    Self::MULTI_BIT_LINEAR_AUDIO_DVD => Self::MultiBitLinearAudioDvd(attrs),
+                    Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
+                        Self::HighPrecisionMultiBitLinearAudio(attrs)
                     }
                     _ => unreachable!(),
                 }
             }
-            Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW
-            | Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD
-            | Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW
-            | Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
-                let mut r = [0; 2];
-                r.copy_from_slice(&raw[2..4]);
-                let attrs = Am824OneBitAudioAttr::from(&r);
+            Self::ONE_BIT_AUDIO_PLAIN_RAW
+            | Self::ONE_BIT_AUDIO_PLAIN_SACD
+            | Self::ONE_BIT_AUDIO_ENCODED_RAW
+            | Self::ONE_BIT_AUDIO_ENCODED_SACD => {
+                let attrs = Am824OneBitAudioAttr::from_raw(&raw[2..]);
                 match raw[0] {
-                    Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW => Am824Stream::OneBitAudioPlainRaw(attrs),
-                    Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD => {
-                        Am824Stream::OneBitAudioPlainSacd(attrs)
-                    }
-                    Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW => {
-                        Am824Stream::OneBitAudioEncodedRaw(attrs)
-                    }
-                    Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD => {
-                        Am824Stream::OneBitAudioEncodedSacd(attrs)
-                    }
+                    Self::ONE_BIT_AUDIO_PLAIN_RAW => Self::OneBitAudioPlainRaw(attrs),
+                    Self::ONE_BIT_AUDIO_PLAIN_SACD => Self::OneBitAudioPlainSacd(attrs),
+                    Self::ONE_BIT_AUDIO_ENCODED_RAW => Self::OneBitAudioEncodedRaw(attrs),
+                    Self::ONE_BIT_AUDIO_ENCODED_SACD => Self::OneBitAudioEncodedSacd(attrs),
                     _ => unreachable!(),
                 }
             }
-            Am824Stream::MIDI_CONFORMANT => {
+            Self::MIDI_CONFORMANT => {
                 let mut r = [0; 2];
                 r.copy_from_slice(&raw[2..4]);
-                Am824Stream::MidiConformant(r)
+                Self::MidiConformant(r)
             }
-            _ => Am824Stream::Reserved(*raw),
+            _ => {
+                let mut r = [0xff; 4];
+                r.copy_from_slice(&raw);
+                Self::Reserved(r)
+            }
         }
     }
-}
 
-impl From<&Am824Stream> for [u8; 4] {
-    fn from(format: &Am824Stream) -> Self {
-        let mut raw = [0xff; 4];
-        match format {
-            Am824Stream::Iec60958_3(attrs)
-            | Am824Stream::Iec61937_3(attrs)
-            | Am824Stream::Iec61937_4(attrs)
-            | Am824Stream::Iec61937_5(attrs)
-            | Am824Stream::Iec61937_6(attrs)
-            | Am824Stream::Iec61937_7(attrs)
-            | Am824Stream::MultiBitLinearAudioRaw(attrs)
-            | Am824Stream::MultiBitLinearAudioDvd(attrs)
-            | Am824Stream::HighPrecisionMultiBitLinearAudio(attrs) => {
-                raw[0] = match format {
-                    Am824Stream::Iec60958_3(_) => Am824Stream::IEC60958_3,
-                    Am824Stream::Iec61937_3(_) => Am824Stream::IEC61937_3,
-                    Am824Stream::Iec61937_4(_) => Am824Stream::IEC61937_4,
-                    Am824Stream::Iec61937_5(_) => Am824Stream::IEC61937_5,
-                    Am824Stream::Iec61937_6(_) => Am824Stream::IEC61937_6,
-                    Am824Stream::Iec61937_7(_) => Am824Stream::IEC61937_7,
-                    Am824Stream::MultiBitLinearAudioRaw(_) => {
-                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_RAW
-                    }
-                    Am824Stream::MultiBitLinearAudioDvd(_) => {
-                        Am824Stream::MULTI_BIT_LINEAR_AUDIO_DVD
-                    }
-                    Am824Stream::HighPrecisionMultiBitLinearAudio(_) => {
-                        Am824Stream::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
+    fn to_raw(&self) -> [u8; Self::LENGTH] {
+        let mut raw = [0xff; Self::LENGTH];
+        match self {
+            Self::Iec60958_3(attrs)
+            | Self::Iec61937_3(attrs)
+            | Self::Iec61937_4(attrs)
+            | Self::Iec61937_5(attrs)
+            | Self::Iec61937_6(attrs)
+            | Self::Iec61937_7(attrs)
+            | Self::MultiBitLinearAudioRaw(attrs)
+            | Self::MultiBitLinearAudioDvd(attrs)
+            | Self::HighPrecisionMultiBitLinearAudio(attrs) => {
+                raw[0] = match self {
+                    Self::Iec60958_3(_) => Self::IEC60958_3,
+                    Self::Iec61937_3(_) => Self::IEC61937_3,
+                    Self::Iec61937_4(_) => Self::IEC61937_4,
+                    Self::Iec61937_5(_) => Self::IEC61937_5,
+                    Self::Iec61937_6(_) => Self::IEC61937_6,
+                    Self::Iec61937_7(_) => Self::IEC61937_7,
+                    Self::MultiBitLinearAudioRaw(_) => Self::MULTI_BIT_LINEAR_AUDIO_RAW,
+                    Self::MultiBitLinearAudioDvd(_) => Self::MULTI_BIT_LINEAR_AUDIO_DVD,
+                    Self::HighPrecisionMultiBitLinearAudio(_) => {
+                        Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
                     }
                     _ => unreachable!(),
                 };
-                let a = Into::<[u8; 2]>::into(attrs);
-                raw[2..4].copy_from_slice(&a);
+                raw[2..4].copy_from_slice(&attrs.to_raw());
                 raw
             }
-            Am824Stream::OneBitAudioPlainRaw(attrs)
-            | Am824Stream::OneBitAudioPlainSacd(attrs)
-            | Am824Stream::OneBitAudioEncodedRaw(attrs)
-            | Am824Stream::OneBitAudioEncodedSacd(attrs) => {
-                raw[0] = match format {
-                    Am824Stream::OneBitAudioPlainRaw(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_RAW,
-                    Am824Stream::OneBitAudioPlainSacd(_) => Am824Stream::ONE_BIT_AUDIO_PLAIN_SACD,
-                    Am824Stream::OneBitAudioEncodedRaw(_) => Am824Stream::ONE_BIT_AUDIO_ENCODED_RAW,
-                    Am824Stream::OneBitAudioEncodedSacd(_) => {
-                        Am824Stream::ONE_BIT_AUDIO_ENCODED_SACD
-                    }
+            Self::OneBitAudioPlainRaw(attrs)
+            | Self::OneBitAudioPlainSacd(attrs)
+            | Self::OneBitAudioEncodedRaw(attrs)
+            | Self::OneBitAudioEncodedSacd(attrs) => {
+                raw[0] = match self {
+                    Self::OneBitAudioPlainRaw(_) => Self::ONE_BIT_AUDIO_PLAIN_RAW,
+                    Self::OneBitAudioPlainSacd(_) => Self::ONE_BIT_AUDIO_PLAIN_SACD,
+                    Self::OneBitAudioEncodedRaw(_) => Self::ONE_BIT_AUDIO_ENCODED_RAW,
+                    Self::OneBitAudioEncodedSacd(_) => Self::ONE_BIT_AUDIO_ENCODED_SACD,
                     _ => unreachable!(),
                 };
-                let a = Into::<[u8; 2]>::into(attrs);
-                raw[2..4].copy_from_slice(&a);
+                raw[2..4].copy_from_slice(&attrs.to_raw());
                 raw
             }
-            Am824Stream::MidiConformant(d) => {
-                let mut raw = [0xff; 4];
-                raw[0] = Am824Stream::MIDI_CONFORMANT;
+            Self::MidiConformant(d) => {
+                raw[0] = Self::MIDI_CONFORMANT;
                 raw[2..4].copy_from_slice(d);
                 raw
             }
-            Am824Stream::Reserved(raw) => *raw,
+            Self::Reserved(r) => *r,
         }
     }
 }
@@ -374,64 +344,44 @@ impl CompoundAm824StreamFormat {
     const SAMPLE_COUNT: u8 = 0x0f;
     const ANCILLARY_DATA: u8 = 0x10;
     const SYNC_STREAM: u8 = 0x40;
-}
 
-impl From<u8> for CompoundAm824StreamFormat {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
-            CompoundAm824StreamFormat::IEC60958_3 => CompoundAm824StreamFormat::Iec60958_3,
-            CompoundAm824StreamFormat::IEC61937_3 => CompoundAm824StreamFormat::Iec61937_3,
-            CompoundAm824StreamFormat::IEC61937_4 => CompoundAm824StreamFormat::Iec61937_4,
-            CompoundAm824StreamFormat::IEC61937_5 => CompoundAm824StreamFormat::Iec61937_5,
-            CompoundAm824StreamFormat::IEC61937_6 => CompoundAm824StreamFormat::Iec61937_6,
-            CompoundAm824StreamFormat::IEC61937_7 => CompoundAm824StreamFormat::Iec61937_7,
-            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW => {
-                CompoundAm824StreamFormat::MultiBitLinearAudioRaw
-            }
-            CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD => {
-                CompoundAm824StreamFormat::MultiBitLinearAudioDvd
-            }
-            CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
-                CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio
-            }
-            CompoundAm824StreamFormat::MIDI_CONFORMANT => CompoundAm824StreamFormat::MidiConformant,
-            CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT => {
-                CompoundAm824StreamFormat::SmpteTimeCodeConformant
-            }
-            CompoundAm824StreamFormat::SAMPLE_COUNT => CompoundAm824StreamFormat::SampleCount,
-            CompoundAm824StreamFormat::ANCILLARY_DATA => CompoundAm824StreamFormat::AncillaryData,
-            CompoundAm824StreamFormat::SYNC_STREAM => CompoundAm824StreamFormat::SyncStream,
-            _ => CompoundAm824StreamFormat::Reserved(val),
+            Self::IEC60958_3 => Self::Iec60958_3,
+            Self::IEC61937_3 => Self::Iec61937_3,
+            Self::IEC61937_4 => Self::Iec61937_4,
+            Self::IEC61937_5 => Self::Iec61937_5,
+            Self::IEC61937_6 => Self::Iec61937_6,
+            Self::IEC61937_7 => Self::Iec61937_7,
+            Self::MULTI_BIT_LINEAR_AUDIO_RAW => Self::MultiBitLinearAudioRaw,
+            Self::MULTI_BIT_LINEAR_AUDIO_DVD => Self::MultiBitLinearAudioDvd,
+            Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => Self::HighPrecisionMultiBitLinearAudio,
+            Self::MIDI_CONFORMANT => Self::MidiConformant,
+            Self::SMPTE_TIME_CODE_CONFORMANT => Self::SmpteTimeCodeConformant,
+            Self::SAMPLE_COUNT => Self::SampleCount,
+            Self::ANCILLARY_DATA => Self::AncillaryData,
+            Self::SYNC_STREAM => Self::SyncStream,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<CompoundAm824StreamFormat> for u8 {
-    fn from(fmt: CompoundAm824StreamFormat) -> Self {
-        match fmt {
-            CompoundAm824StreamFormat::Iec60958_3 => CompoundAm824StreamFormat::IEC60958_3,
-            CompoundAm824StreamFormat::Iec61937_3 => CompoundAm824StreamFormat::IEC61937_3,
-            CompoundAm824StreamFormat::Iec61937_4 => CompoundAm824StreamFormat::IEC61937_4,
-            CompoundAm824StreamFormat::Iec61937_5 => CompoundAm824StreamFormat::IEC61937_5,
-            CompoundAm824StreamFormat::Iec61937_6 => CompoundAm824StreamFormat::IEC61937_6,
-            CompoundAm824StreamFormat::Iec61937_7 => CompoundAm824StreamFormat::IEC61937_7,
-            CompoundAm824StreamFormat::MultiBitLinearAudioRaw => {
-                CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW
-            }
-            CompoundAm824StreamFormat::MultiBitLinearAudioDvd => {
-                CompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD
-            }
-            CompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio => {
-                CompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
-            }
-            CompoundAm824StreamFormat::MidiConformant => CompoundAm824StreamFormat::MIDI_CONFORMANT,
-            CompoundAm824StreamFormat::SmpteTimeCodeConformant => {
-                CompoundAm824StreamFormat::SMPTE_TIME_CODE_CONFORMANT
-            }
-            CompoundAm824StreamFormat::SampleCount => CompoundAm824StreamFormat::SAMPLE_COUNT,
-            CompoundAm824StreamFormat::AncillaryData => CompoundAm824StreamFormat::ANCILLARY_DATA,
-            CompoundAm824StreamFormat::SyncStream => CompoundAm824StreamFormat::SYNC_STREAM,
-            CompoundAm824StreamFormat::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Iec60958_3 => Self::IEC60958_3,
+            Self::Iec61937_3 => Self::IEC61937_3,
+            Self::Iec61937_4 => Self::IEC61937_4,
+            Self::Iec61937_5 => Self::IEC61937_5,
+            Self::Iec61937_6 => Self::IEC61937_6,
+            Self::Iec61937_7 => Self::IEC61937_7,
+            Self::MultiBitLinearAudioRaw => Self::MULTI_BIT_LINEAR_AUDIO_RAW,
+            Self::MultiBitLinearAudioDvd => Self::MULTI_BIT_LINEAR_AUDIO_DVD,
+            Self::HighPrecisionMultiBitLinearAudio => Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+            Self::MidiConformant => Self::MIDI_CONFORMANT,
+            Self::SmpteTimeCodeConformant => Self::SMPTE_TIME_CODE_CONFORMANT,
+            Self::SampleCount => Self::SAMPLE_COUNT,
+            Self::AncillaryData => Self::ANCILLARY_DATA,
+            Self::SyncStream => Self::SYNC_STREAM,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -445,18 +395,19 @@ pub struct CompoundAm824StreamEntry {
     pub format: CompoundAm824StreamFormat,
 }
 
-impl From<&[u8; 2]> for CompoundAm824StreamEntry {
-    fn from(raw: &[u8; 2]) -> Self {
-        CompoundAm824StreamEntry {
+impl CompoundAm824StreamEntry {
+    const LENGTH: usize = 2;
+
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH);
+        Self {
             count: raw[0],
-            format: CompoundAm824StreamFormat::from(raw[1]),
+            format: CompoundAm824StreamFormat::from_val(raw[1]),
         }
     }
-}
 
-impl From<&CompoundAm824StreamEntry> for [u8; 2] {
-    fn from(data: &CompoundAm824StreamEntry) -> Self {
-        [data.count, data.format.into()]
+    fn to_raw(&self) -> [u8; Self::LENGTH] {
+        [self.count, self.format.to_val()]
     }
 }
 
@@ -473,26 +424,22 @@ impl RateCtl {
     const SUPPORTED: u8 = 0x00;
     const DONT_CARE: u8 = 0x01;
     const NOT_SUPPORTED: u8 = 0x02;
-}
 
-impl From<RateCtl> for u8 {
-    fn from(rate_ctl: RateCtl) -> Self {
-        match rate_ctl {
-            RateCtl::Supported => RateCtl::SUPPORTED,
-            RateCtl::DontCare => RateCtl::DONT_CARE,
-            RateCtl::NotSupported => RateCtl::NOT_SUPPORTED,
-            RateCtl::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Supported => Self::SUPPORTED,
+            Self::DontCare => Self::DONT_CARE,
+            Self::NotSupported => Self::NOT_SUPPORTED,
+            Self::Reserved(val) => *val,
         }
     }
-}
 
-impl From<u8> for RateCtl {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
             Self::SUPPORTED => Self::Supported,
             Self::DONT_CARE => Self::DontCare,
             Self::NOT_SUPPORTED => Self::NotSupported,
-            _ => RateCtl::Reserved(val),
+            _ => Self::Reserved(val),
         }
     }
 }
@@ -526,75 +473,69 @@ impl CompoundAm824Stream {
 
     const RATE_CTL_MASK: u8 = 0x03;
     const RATE_CTL_SHIFT: usize = 0;
-}
 
-impl From<&[u8]> for CompoundAm824Stream {
-    fn from(raw: &[u8]) -> Self {
+    const LENGTH_MIN: usize = 3;
+
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH_MIN);
         let freq = match raw[0] {
-            CompoundAm824Stream::FREQ_CODE_22050 => 22050,
-            CompoundAm824Stream::FREQ_CODE_24000 => 24000,
-            CompoundAm824Stream::FREQ_CODE_32000 => 32000,
-            CompoundAm824Stream::FREQ_CODE_44100 => 44100,
-            CompoundAm824Stream::FREQ_CODE_48000 => 48000,
-            CompoundAm824Stream::FREQ_CODE_96000 => 96000,
-            CompoundAm824Stream::FREQ_CODE_176400 => 176400,
-            CompoundAm824Stream::FREQ_CODE_192000 => 192000,
-            CompoundAm824Stream::FREQ_CODE_88200 => 88200,
+            Self::FREQ_CODE_22050 => 22050,
+            Self::FREQ_CODE_24000 => 24000,
+            Self::FREQ_CODE_32000 => 32000,
+            Self::FREQ_CODE_44100 => 44100,
+            Self::FREQ_CODE_48000 => 48000,
+            Self::FREQ_CODE_96000 => 96000,
+            Self::FREQ_CODE_176400 => 176400,
+            Self::FREQ_CODE_192000 => 192000,
+            Self::FREQ_CODE_88200 => 88200,
             _ => u32::MAX,
         };
-        let sync_src_code =
-            (raw[1] >> CompoundAm824Stream::SYNC_SRC_SHIFT) & CompoundAm824Stream::SYNC_SRC_MASK;
+        let sync_src_code = (raw[1] >> Self::SYNC_SRC_SHIFT) & Self::SYNC_SRC_MASK;
         let sync_src = sync_src_code > 0;
-        let rate_ctl_code =
-            (raw[1] >> CompoundAm824Stream::RATE_CTL_SHIFT) & CompoundAm824Stream::RATE_CTL_MASK;
-        let rate_ctl = RateCtl::from(rate_ctl_code);
+        let rate_ctl_code = (raw[1] >> Self::RATE_CTL_SHIFT) & Self::RATE_CTL_MASK;
+        let rate_ctl = RateCtl::from_val(rate_ctl_code);
         let entry_count = raw[2] as usize;
         let entries = (0..entry_count)
             .filter_map(|i| {
-                if 3 + i * 2 + 2 > raw.len() {
+                let pos = 3 + i * 2;
+                if pos + CompoundAm824StreamEntry::LENGTH > raw.len() {
                     None
                 } else {
-                    let mut doublet = [0; 2];
-                    doublet.copy_from_slice(&raw[(3 + i * 2)..(3 + i * 2 + 2)]);
-                    Some(CompoundAm824StreamEntry::from(&doublet))
+                    Some(CompoundAm824StreamEntry::from_raw(&raw[pos..]))
                 }
             })
             .collect();
-        CompoundAm824Stream {
+        Self {
             freq,
             sync_src,
             rate_ctl,
             entries,
         }
     }
-}
 
-impl From<&CompoundAm824Stream> for Vec<u8> {
-    fn from(data: &CompoundAm824Stream) -> Self {
-        let mut raw = Vec::new();
-        let freq_code = match data.freq {
-            22050 => CompoundAm824Stream::FREQ_CODE_22050,
-            24000 => CompoundAm824Stream::FREQ_CODE_24000,
-            32000 => CompoundAm824Stream::FREQ_CODE_32000,
-            44100 => CompoundAm824Stream::FREQ_CODE_44100,
-            48000 => CompoundAm824Stream::FREQ_CODE_48000,
-            96000 => CompoundAm824Stream::FREQ_CODE_96000,
-            176400 => CompoundAm824Stream::FREQ_CODE_176400,
-            192000 => CompoundAm824Stream::FREQ_CODE_192000,
-            88200 => CompoundAm824Stream::FREQ_CODE_88200,
+    fn to_raw(&self) -> Vec<u8> {
+        let mut raw = Vec::with_capacity(Self::LENGTH_MIN);
+        let freq_code = match self.freq {
+            22050 => Self::FREQ_CODE_22050,
+            24000 => Self::FREQ_CODE_24000,
+            32000 => Self::FREQ_CODE_32000,
+            44100 => Self::FREQ_CODE_44100,
+            48000 => Self::FREQ_CODE_48000,
+            96000 => Self::FREQ_CODE_96000,
+            176400 => Self::FREQ_CODE_176400,
+            192000 => Self::FREQ_CODE_192000,
+            88200 => Self::FREQ_CODE_88200,
             _ => u8::MAX,
         };
         raw.push(freq_code);
 
-        let sync_src_code = ((data.sync_src as u8) & CompoundAm824Stream::SYNC_SRC_MASK)
-            << CompoundAm824Stream::SYNC_SRC_SHIFT;
-        let rate_ctl_code = (u8::from(data.rate_ctl) & CompoundAm824Stream::RATE_CTL_MASK)
-            << CompoundAm824Stream::RATE_CTL_SHIFT;
+        let sync_src_code = ((self.sync_src as u8) & Self::SYNC_SRC_MASK) << Self::SYNC_SRC_SHIFT;
+        let rate_ctl_code = (self.rate_ctl.to_val() & Self::RATE_CTL_MASK) << Self::RATE_CTL_SHIFT;
         raw.push(sync_src_code | rate_ctl_code);
 
-        raw.push(data.entries.len() as u8);
-        data.entries.iter().for_each(|entry| {
-            raw.extend_from_slice(&Into::<[u8; 2]>::into(entry));
+        raw.push(self.entries.len() as u8);
+        self.entries.iter().for_each(|entry| {
+            raw.extend_from_slice(&entry.to_raw());
         });
         raw
     }
@@ -619,35 +560,36 @@ impl AmStream {
     const HIER_LEVEL_1_AUDIO_PACK: u8 = 0x01;
     const HIER_LEVEL_1_FP32: u8 = 0x02;
     pub const HIER_LEVEL_1_COMPOUND_AM824: u8 = 0x40;
+
+    const LENGTH_MIN: usize = 4;
 }
 
 impl From<&[u8]> for AmStream {
     fn from(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH_MIN);
         match raw[0] {
-            AmStream::HIER_LEVEL_1_AM824 => {
-                let mut r = [0xff; 4];
-                r.copy_from_slice(&raw[1..5]);
-                let format = Am824Stream::from(&r);
-                AmStream::Am824(format)
+            Self::HIER_LEVEL_1_AM824 => {
+                let format = Am824Stream::from_raw(&raw[1..]);
+                Self::Am824(format)
             }
-            AmStream::HIER_LEVEL_1_AUDIO_PACK => AmStream::AudioPack,
-            AmStream::HIER_LEVEL_1_FP32 => AmStream::Fp32,
-            AmStream::HIER_LEVEL_1_COMPOUND_AM824 => {
-                let s = CompoundAm824Stream::from(&raw[1..]);
-                AmStream::CompoundAm824(s)
+            Self::HIER_LEVEL_1_AUDIO_PACK => Self::AudioPack,
+            Self::HIER_LEVEL_1_FP32 => Self::Fp32,
+            Self::HIER_LEVEL_1_COMPOUND_AM824 => {
+                let s = CompoundAm824Stream::from_raw(&raw[1..]);
+                Self::CompoundAm824(s)
             }
-            _ => AmStream::Reserved((*raw).to_vec()),
+            _ => Self::Reserved(raw.to_vec()),
         }
     }
 }
 
 impl From<&AmStream> for Vec<u8> {
     fn from(data: &AmStream) -> Self {
-        let mut raw = Vec::new();
+        let mut raw = Vec::with_capacity(AmStream::LENGTH_MIN);
         match data {
-            AmStream::Am824(d) => {
+            AmStream::Am824(format) => {
                 raw.push(AmStream::HIER_LEVEL_1_AM824);
-                raw.extend_from_slice(&Into::<[u8; 4]>::into(d));
+                raw.extend_from_slice(&format.to_raw());
             }
             AmStream::AudioPack => {
                 raw.push(AmStream::HIER_LEVEL_1_AUDIO_PACK);
@@ -659,7 +601,7 @@ impl From<&AmStream> for Vec<u8> {
             }
             AmStream::CompoundAm824(s) => {
                 raw.push(AmStream::HIER_LEVEL_1_COMPOUND_AM824);
-                raw.append(&mut Into::<Vec<u8>>::into(s));
+                raw.append(&mut s.to_raw());
             }
             AmStream::Reserved(d) => {
                 raw.copy_from_slice(d);
@@ -681,6 +623,8 @@ pub enum StreamFormat {
 impl StreamFormat {
     /// The value in `format_hierarchy_root` field for Audio and Music.
     pub const HIER_ROOT_AM: u8 = 0x90;
+
+    const LENGTH_MIN: usize = 1;
 
     fn as_am_stream(&self) -> Option<&AmStream> {
         if let StreamFormat::Am(i) = self {
@@ -707,21 +651,18 @@ impl StreamFormat {
             None
         }
     }
-}
 
-impl From<&[u8]> for StreamFormat {
-    fn from(raw: &[u8]) -> Self {
+    fn from_raw(raw: &[u8]) -> Self {
+        assert!(raw.len() >= Self::LENGTH_MIN);
         match raw[0] {
             Self::HIER_ROOT_AM => StreamFormat::Am(AmStream::from(&raw[1..])),
             _ => StreamFormat::Reserved(raw.to_vec()),
         }
     }
-}
 
-impl From<&StreamFormat> for Vec<u8> {
-    fn from(data: &StreamFormat) -> Self {
-        let mut raw = Vec::new();
-        match data {
+    fn to_raw(&self) -> Vec<u8> {
+        let mut raw = Vec::with_capacity(Self::LENGTH_MIN);
+        match self {
             StreamFormat::Am(i) => {
                 raw.push(StreamFormat::HIER_ROOT_AM);
                 raw.append(&mut i.into());
@@ -1071,7 +1012,7 @@ impl AvcStatus for ExtendedStreamFormatSingle {
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         self.op.parse_operands(addr, operands)?;
 
-        self.stream_format = StreamFormat::from(&operands[7..]);
+        self.stream_format = StreamFormat::from_raw(&operands[7..]);
 
         self.support_status = self.op.support_status;
 
@@ -1086,14 +1027,14 @@ impl AvcControl for ExtendedStreamFormatSingle {
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
         self.op.build_operands(addr, operands)?;
-        operands.append(&mut Into::<Vec<u8>>::into(&self.stream_format));
+        operands.append(&mut self.stream_format.to_raw());
         Ok(())
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         self.op.parse_operands(addr, operands)?;
 
-        self.stream_format = StreamFormat::from(&operands[7..]);
+        self.stream_format = StreamFormat::from_raw(&operands[7..]);
 
         self.support_status = self.op.support_status;
 
@@ -1152,7 +1093,7 @@ impl AvcStatus for ExtendedStreamFormatList {
             Err(AvcRespParseError::UnexpectedOperands(7))?;
         }
 
-        self.stream_format = StreamFormat::from(&operands[8..]);
+        self.stream_format = StreamFormat::from_raw(&operands[8..]);
 
         self.support_status = self.op.support_status;
 
@@ -1167,31 +1108,31 @@ mod tests {
     #[test]
     fn am824multibitaudioattr_from() {
         let raw = [0x31, 0xff];
-        let attr = Am824MultiBitAudioAttr::from(&raw);
+        let attr = Am824MultiBitAudioAttr::from_raw(&raw);
         assert_eq!(44100, attr.freq);
         assert_eq!(false, attr.rate_ctl);
-        assert_eq!(raw, Into::<[u8; 2]>::into(&attr));
+        assert_eq!(raw, attr.to_raw());
     }
 
     #[test]
     fn am824onebitaudioattr_from() {
         let raw = [0x40, 0xff];
-        let attr = Am824OneBitAudioAttr::from(&raw);
+        let attr = Am824OneBitAudioAttr::from_raw(&raw);
         assert_eq!(6144000, attr.freq);
         assert_eq!(true, attr.rate_ctl);
-        assert_eq!(raw, Into::<[u8; 2]>::into(&attr));
+        assert_eq!(raw, attr.to_raw());
     }
 
     #[test]
     fn am824stream_from() {
         let raw = [0x06, 0xff, 0x20, 0xff];
-        let format = Am824Stream::from(&raw);
+        let format = Am824Stream::from_raw(&raw);
         let attr = Am824MultiBitAudioAttr {
             freq: 32000,
             rate_ctl: true,
         };
         assert_eq!(format, Am824Stream::MultiBitLinearAudioRaw(attr));
-        assert_eq!(raw, Into::<[u8; 4]>::into(&format));
+        assert_eq!(raw, format.to_raw());
     }
 
     #[test]
@@ -1206,23 +1147,23 @@ mod tests {
             AmStream::Am824(Am824Stream::OneBitAudioPlainRaw(attr)),
             format
         );
-        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+        assert_eq!(raw, Vec::<u8>::from(&format));
 
         let raw: &[u8] = &[0x01, 0xff, 0xff, 0xff, 0xff];
         let format = AmStream::from(raw);
         assert_eq!(AmStream::AudioPack, format);
-        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+        assert_eq!(raw, Vec::<u8>::from(&format));
 
         let raw: &[u8] = &[0x02, 0xff, 0xff, 0xff, 0xff];
         let format = AmStream::from(raw);
         assert_eq!(AmStream::Fp32, format);
-        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+        assert_eq!(raw, Vec::<u8>::from(&format));
     }
 
     #[test]
     fn streamformat_from() {
         let raw: &[u8] = &[0x90, 0x00, 0x08, 0xff, 0x40, 0xff];
-        let format = StreamFormat::from(raw);
+        let format = StreamFormat::from_raw(raw);
         if let StreamFormat::Am(i) = &format {
             if let AmStream::Am824(s) = i {
                 if let Am824Stream::OneBitAudioPlainRaw(attr) = s {
@@ -1237,11 +1178,11 @@ mod tests {
         } else {
             unreachable!();
         }
-        assert_eq!(raw, Into::<Vec<u8>>::into(&format).as_slice());
+        assert_eq!(raw, format.to_raw());
 
         let mut raw = Vec::<u8>::new();
         raw.extend_from_slice(&[0x90, 0x40, 0x04, 0x02, 0x01, 0x1c, 0x02]);
-        let stream_format = StreamFormat::from(raw.as_slice());
+        let stream_format = StreamFormat::from_raw(&raw);
         if let StreamFormat::Am(i) = &stream_format {
             if let AmStream::CompoundAm824(s) = i {
                 assert_eq!(48000, s.freq);
@@ -1256,57 +1197,57 @@ mod tests {
         } else {
             unreachable!();
         }
-        assert_eq!(raw, Into::<Vec<u8>>::into(&stream_format));
+        assert_eq!(raw, stream_format.to_raw());
     }
 
     #[test]
     fn compoundam824streamformat_from() {
-        assert_eq!(0x00, u8::from(CompoundAm824StreamFormat::from(0x00)));
-        assert_eq!(0x01, u8::from(CompoundAm824StreamFormat::from(0x01)));
-        assert_eq!(0x02, u8::from(CompoundAm824StreamFormat::from(0x02)));
-        assert_eq!(0x03, u8::from(CompoundAm824StreamFormat::from(0x03)));
-        assert_eq!(0x04, u8::from(CompoundAm824StreamFormat::from(0x04)));
-        assert_eq!(0x05, u8::from(CompoundAm824StreamFormat::from(0x05)));
-        assert_eq!(0x06, u8::from(CompoundAm824StreamFormat::from(0x06)));
-        assert_eq!(0x07, u8::from(CompoundAm824StreamFormat::from(0x07)));
-        assert_eq!(0x0c, u8::from(CompoundAm824StreamFormat::from(0x0c)));
-        assert_eq!(0x0d, u8::from(CompoundAm824StreamFormat::from(0x0d)));
-        assert_eq!(0x0e, u8::from(CompoundAm824StreamFormat::from(0x0e)));
-        assert_eq!(0x0f, u8::from(CompoundAm824StreamFormat::from(0x0f)));
-        assert_eq!(0x10, u8::from(CompoundAm824StreamFormat::from(0x10)));
-        assert_eq!(0x40, u8::from(CompoundAm824StreamFormat::from(0x40)));
-        assert_eq!(0xff, u8::from(CompoundAm824StreamFormat::from(0xff)));
+        assert_eq!(0x00, CompoundAm824StreamFormat::from_val(0x00).to_val());
+        assert_eq!(0x01, CompoundAm824StreamFormat::from_val(0x01).to_val());
+        assert_eq!(0x02, CompoundAm824StreamFormat::from_val(0x02).to_val());
+        assert_eq!(0x03, CompoundAm824StreamFormat::from_val(0x03).to_val());
+        assert_eq!(0x04, CompoundAm824StreamFormat::from_val(0x04).to_val());
+        assert_eq!(0x05, CompoundAm824StreamFormat::from_val(0x05).to_val());
+        assert_eq!(0x06, CompoundAm824StreamFormat::from_val(0x06).to_val());
+        assert_eq!(0x07, CompoundAm824StreamFormat::from_val(0x07).to_val());
+        assert_eq!(0x0c, CompoundAm824StreamFormat::from_val(0x0c).to_val());
+        assert_eq!(0x0d, CompoundAm824StreamFormat::from_val(0x0d).to_val());
+        assert_eq!(0x0e, CompoundAm824StreamFormat::from_val(0x0e).to_val());
+        assert_eq!(0x0f, CompoundAm824StreamFormat::from_val(0x0f).to_val());
+        assert_eq!(0x10, CompoundAm824StreamFormat::from_val(0x10).to_val());
+        assert_eq!(0x40, CompoundAm824StreamFormat::from_val(0x40).to_val());
+        assert_eq!(0xff, CompoundAm824StreamFormat::from_val(0xff).to_val());
     }
 
     #[test]
     fn compoundam824streamentry_from() {
         assert_eq!(
             [0x02, 0x04],
-            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x02, 0x04]))
+            CompoundAm824StreamEntry::from_raw(&[0x02, 0x04]).to_raw()
         );
         assert_eq!(
             [0x19, 0x03],
-            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x19, 0x03]))
+            CompoundAm824StreamEntry::from_raw(&[0x19, 0x03]).to_raw()
         );
         assert_eq!(
             [0x37, 0x00],
-            Into::<[u8; 2]>::into(&CompoundAm824StreamEntry::from(&[0x37, 0x00]))
+            CompoundAm824StreamEntry::from_raw(&[0x37, 0x00]).to_raw()
         );
     }
 
     #[test]
     fn ratectl_from() {
-        assert_eq!(0x00, u8::from(RateCtl::from(0x00)));
-        assert_eq!(0x01, u8::from(RateCtl::from(0x01)));
-        assert_eq!(0x02, u8::from(RateCtl::from(0x02)));
-        assert_eq!(0xff, u8::from(RateCtl::from(0xff)));
+        assert_eq!(0x00, RateCtl::from_val(0x00).to_val());
+        assert_eq!(0x01, RateCtl::from_val(0x01).to_val());
+        assert_eq!(0x02, RateCtl::from_val(0x02).to_val());
+        assert_eq!(0xff, RateCtl::from_val(0xff).to_val());
     }
 
     #[test]
     fn compoundam824stream_from() {
         let mut raw = Vec::<u8>::new();
         raw.extend_from_slice(&[0x03, 0x02, 0x02, 0xee, 0x03, 0x37, 0x0d]);
-        let s = CompoundAm824Stream::from(raw.as_slice());
+        let s = CompoundAm824Stream::from_raw(&raw);
         assert_eq!(44100, s.freq);
         assert_eq!(false, s.sync_src);
         assert_eq!(RateCtl::NotSupported, s.rate_ctl);
@@ -1318,10 +1259,7 @@ mod tests {
             CompoundAm824StreamFormat::MidiConformant,
             s.entries[1].format
         );
-        assert_eq!(
-            raw,
-            Into::<Vec<u8>>::into(&CompoundAm824Stream::from(raw.as_slice()))
-        );
+        assert_eq!(raw, CompoundAm824Stream::from_raw(&raw).to_raw());
     }
 
     #[test]

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -12,6 +12,15 @@ pub struct Am824MultiBitAudioAttr {
     pub rate_ctl: bool,
 }
 
+impl Default for Am824MultiBitAudioAttr {
+    fn default() -> Self {
+        Self {
+            freq: 22050,
+            rate_ctl: Default::default(),
+        }
+    }
+}
+
 impl Am824MultiBitAudioAttr {
     const FREQ_CODE_22050: u8 = 0x00;
     const FREQ_CODE_24000: u8 = 0x01;
@@ -85,6 +94,15 @@ impl Am824MultiBitAudioAttr {
 pub struct Am824OneBitAudioAttr {
     pub freq: u32,
     pub rate_ctl: bool,
+}
+
+impl Default for Am824OneBitAudioAttr {
+    fn default() -> Self {
+        Self {
+            freq: 2048000,
+            rate_ctl: Default::default(),
+        }
+    }
 }
 
 impl Am824OneBitAudioAttr {
@@ -170,6 +188,12 @@ pub enum Am824Stream {
     HighPrecisionMultiBitLinearAudio(Am824MultiBitAudioAttr),
     MidiConformant([u8; 2]),
     Reserved([u8; 4]),
+}
+
+impl Default for Am824Stream {
+    fn default() -> Self {
+        Self::Reserved([0xff; 4])
+    }
 }
 
 impl Am824Stream {
@@ -329,6 +353,12 @@ pub enum CompoundAm824StreamFormat {
     Reserved(u8),
 }
 
+impl Default for CompoundAm824StreamFormat {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
+}
+
 impl CompoundAm824StreamFormat {
     const IEC60958_3: u8 = 0x00;
     const IEC61937_3: u8 = 0x01;
@@ -395,6 +425,15 @@ pub struct CompoundAm824StreamEntry {
     pub format: CompoundAm824StreamFormat,
 }
 
+impl Default for CompoundAm824StreamEntry {
+    fn default() -> Self {
+        Self {
+            count: 0,
+            format: Default::default(),
+        }
+    }
+}
+
 impl CompoundAm824StreamEntry {
     const LENGTH: usize = 2;
 
@@ -418,6 +457,12 @@ pub enum RateCtl {
     DontCare,
     NotSupported,
     Reserved(u8),
+}
+
+impl Default for RateCtl {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
 }
 
 impl RateCtl {
@@ -455,6 +500,17 @@ pub struct CompoundAm824Stream {
     pub rate_ctl: RateCtl,
     /// The entries of available stream format.
     pub entries: Vec<CompoundAm824StreamEntry>,
+}
+
+impl Default for CompoundAm824Stream {
+    fn default() -> Self {
+        Self {
+            freq: 22050,
+            sync_src: Default::default(),
+            rate_ctl: Default::default(),
+            entries: Default::default(),
+        }
+    }
 }
 
 impl CompoundAm824Stream {
@@ -555,6 +611,12 @@ pub enum AmStream {
     Reserved(Vec<u8>),
 }
 
+impl Default for AmStream {
+    fn default() -> Self {
+        Self::Reserved(vec![0xff; Self::LENGTH_MIN])
+    }
+}
+
 impl AmStream {
     const HIER_LEVEL_1_AM824: u8 = 0x00;
     const HIER_LEVEL_1_AUDIO_PACK: u8 = 0x01;
@@ -618,6 +680,12 @@ pub enum StreamFormat {
     /// Defined in Audio and Music Data Transmission Protocol.
     Am(AmStream),
     Reserved(Vec<u8>),
+}
+
+impl Default for StreamFormat {
+    fn default() -> Self {
+        Self::Reserved(vec![0xff; Self::LENGTH_MIN])
+    }
 }
 
 impl StreamFormat {

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -897,10 +897,8 @@ impl SupportStatus {
     const INACTIVE: u8 = 0x01;
     const NO_STREAM_FORMAT: u8 = 0x02;
     const NO_INFO: u8 = 0xff;
-}
 
-impl From<u8> for SupportStatus {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
             Self::ACTIVE => Self::Active,
             Self::INACTIVE => Self::Inactive,
@@ -909,16 +907,14 @@ impl From<u8> for SupportStatus {
             _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<SupportStatus> for u8 {
-    fn from(status: SupportStatus) -> Self {
-        match status {
-            SupportStatus::Active => SupportStatus::ACTIVE,
-            SupportStatus::Inactive => SupportStatus::INACTIVE,
-            SupportStatus::NoStreamFormat => SupportStatus::NO_STREAM_FORMAT,
-            SupportStatus::NoInfo => SupportStatus::NO_INFO,
-            SupportStatus::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Active => Self::ACTIVE,
+            Self::Inactive => Self::INACTIVE,
+            Self::NoStreamFormat => Self::NO_STREAM_FORMAT,
+            Self::NoInfo => Self::NO_INFO,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -948,7 +944,7 @@ impl ExtendedStreamFormat {
     ) -> Result<(), AvcCmdBuildError> {
         operands.push(self.subfunc);
         operands.extend_from_slice(&self.plug_addr.to_raw());
-        operands.push(self.support_status.into());
+        operands.push(self.support_status.to_val());
         Ok(())
     }
 
@@ -962,7 +958,7 @@ impl ExtendedStreamFormat {
             if plug_addr != self.plug_addr {
                 Err(AvcRespParseError::UnexpectedOperands(1))
             } else {
-                self.support_status = SupportStatus::from(operands[6]);
+                self.support_status = SupportStatus::from_val(operands[6]);
                 Ok(())
             }
         }


### PR DESCRIPTION
This patchset includes code refactoring for stream format commands.

```
Takashi Sakamoto (11):
  bebob/protocols: start crate development for v0.2.0
  bebob/protocols: implement unique support status
  ta1394/stream-format: start crate development for v0.2.0
  ta1394/stream-format: localize serializer/deserializer for StreamFormat
  ta1394/stream-format: localize serializer/deserializer for PlugAddr
  ta1394/stream-format: localize serializer/deserializer for SupportStatus
  ta1394/stream-format: implement Default trait for StreamFormat
  ta1394/stream-format: implement Default trait for PlugAddr
  ta1394/stream-format: implement Default trait for SupportStatus
  ta1394/stream-format: implement Default trait for ExtendedStreamFormat
  ta1394/stream-format: code refactoring for ExtendedStreamFormatSingle
    and ExtendedStreamFormatList

 Cargo.toml                           |    8 +-
 libs/bebob/protocols/src/bridgeco.rs |   65 +-
 libs/ta1394/stream-format/src/lib.rs | 1039 ++++++++++++++------------
 3 files changed, 617 insertions(+), 495 deletions(-)
```