### PR TITLE
fix: focusrite pro 40 - it was missing last 2 analog input channels

### DIFF
--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -20,7 +20,7 @@ impl Tcd22xxSpecOperation for SPro40Protocol {
         Input {
             id: SrcBlkId::Ins1,
             offset: 0,
-            count: 6,
+            count: 8,
             label: None,
         },
         Input {


### PR DESCRIPTION
Ok,
So after all my own investigations, and searching around on the PCB. To see where the traces goes to from the DICE chip. This matter was checked and re-checked.

However in my assumption of a shuffling, I mistook the `Ins0` for `Ins1` in your code.... it seems with blurry eyes. But there is no actual conflict or re-occupying there with other hardware IO device. Everything else remains the same (for example all of the spdif, the adat etc). Others are all on their own separate interfaces such as `aes` etc.. So nothing else to worry about here. Those others all seem correct.

* For the analog outputs (=10) it uses both `Ins0` and then also `Ins1` because there are 10 (more than 8) output channels there. The extra 2 must be spilled onto `Ins0`. Because each `Ins` only fits 8 channel.
* However (unlike the outs) the analog ins =8. Which fits exactly onto the complete `Ins1`. But nothing else. No more.

So this is where the code incorrectly state `6` inputs here, but it is actual `8`. And can use that entire block of `Ins1`.

This change was tested on my own device (a saffire pro 40). And it definitely works. It lets the analog input 7+8 working. Nothing else seems in error. All other looks fine to me. As far as I could know to see, and check myself / do those investigations on the circuitry.

* Sorry not to raise this PR earlier!
* Actually all of those necessary investigations were already completed several weeks ago...
* This change solves / closes the issue #92 

Many thanks again for these firewire drivers / software layers. Very helpful tools, just keeps on getting better.