### PR TITLE
[PATCH 00/19] ta1394/audio: fix audio channel and rewrite feature data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ members = [
 #    "libs/tascam/protocols",
 #    "libs/efw/protocols",
 #    "libs/motu/protocols",
-#    "libs/oxfw/protocols",
+    "libs/oxfw/protocols",
     "libs/bebob/protocols",
 #    "libs/dice/protocols",
 #    "libs/ff/protocols",
@@ -68,5 +68,5 @@ firewire-bebob-protocols = { path = "libs/bebob/protocols" }
 #firewire-fireworks-protocols = { path = "libs/efw/protocols" }
 #firewire-fireface-protocols = { path = "libs/ff/protocols" }
 #firewire-motu-protocols = { path = "libs/motu/protocols" }
-#firewire-oxfw-protocols = { path = "libs/oxfw/protocols" }
+firewire-oxfw-protocols = { path = "libs/oxfw/protocols" }
 #firewire-tascam-protocols = { path = "libs/tascam/protocols" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ members = [
 #    "libs/alsa-ctl-tlv-codec",
 #    "libs/ieee1212-config-rom",
     "libs/ta1394/general",
-#    "libs/ta1394/audio",
+    "libs/ta1394/audio",
     "libs/ta1394/stream-format",
     "libs/ta1394/ccm",
 #    "libs/dg00x/protocols",
@@ -59,7 +59,7 @@ members = [
 #alsa-ctl-tlv-codec = { path = "libs/alsa-ctl-tlv-codec" }
 #ieee1212-config-rom = { path = "libs/ieee1212-config-rom" }
 ta1394-avc-general = { path = "libs/ta1394/general" }
-#ta1394-avc-audio = { path = "libs/ta1394/audio" }
+ta1394-avc-audio = { path = "libs/ta1394/audio" }
 ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
 ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
 firewire-bebob-protocols = { path = "libs/bebob/protocols" }

--- a/libs/bebob/protocols/src/icon.rs
+++ b/libs/bebob/protocols/src/icon.rs
@@ -108,7 +108,7 @@ pub struct FirexonMixerSourceProtocol;
 
 impl AvcLevelOperation for FirexonMixerSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
-        (0x04, AudioCh::All), // stream-input-1/2
-        (0x05, AudioCh::All), // monitor-output-1/2
+        (0x04, AudioCh::Master), // stream-input-1/2
+        (0x05, AudioCh::Master), // monitor-output-1/2
     ];
 }

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -264,8 +264,8 @@ pub trait AvcLevelOperation {
 
 /// The trait of LR balance operation for audio function blocks.
 pub trait AvcLrBalanceOperation: AvcLevelOperation {
-    const BALANCE_MIN: i16 = FeatureCtl::NEG_INFINITY;
-    const BALANCE_MAX: i16 = FeatureCtl::INFINITY;
+    const BALANCE_MIN: i16 = LrBalanceData::VALUE_LEFT_NEG_INFINITY;
+    const BALANCE_MAX: i16 = LrBalanceData::VALUE_LEFT_MAX;
     const BALANCE_STEP: i16 = 0x80;
 
     fn read_lr_balance(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<i16, Error> {
@@ -278,12 +278,12 @@ pub trait AvcLrBalanceOperation: AvcLevelOperation {
             func_block_id,
             CtlAttr::Current,
             audio_ch,
-            FeatureCtl::LrBalance(-1),
+            FeatureCtl::LrBalance(Default::default()),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
 
         if let FeatureCtl::LrBalance(balance) = op.ctl {
-            Ok(balance)
+            Ok(balance.0)
         } else {
             unreachable!();
         }
@@ -304,7 +304,7 @@ pub trait AvcLrBalanceOperation: AvcLevelOperation {
             func_block_id,
             CtlAttr::Current,
             audio_ch,
-            FeatureCtl::LrBalance(balance),
+            FeatureCtl::LrBalance(LrBalanceData(balance)),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -221,8 +221,8 @@ pub trait SamplingClockSourceOperation {
 pub trait AvcLevelOperation {
     const ENTRIES: &'static [(u8, AudioCh)];
 
-    const LEVEL_MIN: i16 = FeatureCtl::NEG_INFINITY;
-    const LEVEL_MAX: i16 = 0;
+    const LEVEL_MIN: i16 = VolumeData::VALUE_NEG_INFINITY;
+    const LEVEL_MAX: i16 = VolumeData::VALUE_ZERO;
     const LEVEL_STEP: i16 = 0x100;
 
     fn read_level(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<i16, Error> {
@@ -235,12 +235,12 @@ pub trait AvcLevelOperation {
             func_block_id,
             CtlAttr::Current,
             audio_ch,
-            FeatureCtl::Volume(vec![-1]),
+            FeatureCtl::Volume(VolumeData::new(1)),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
 
         if let FeatureCtl::Volume(data) = op.ctl {
-            Ok(data[0])
+            Ok(data.0[0])
         } else {
             unreachable!();
         }
@@ -256,7 +256,7 @@ pub trait AvcLevelOperation {
             func_block_id,
             CtlAttr::Current,
             audio_ch,
-            FeatureCtl::Volume(vec![vol]),
+            FeatureCtl::Volume(VolumeData(vec![vol])),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/bebob/protocols/src/presonus/firebox.rs
+++ b/libs/bebob/protocols/src/presonus/firebox.rs
@@ -146,8 +146,10 @@ impl AvcMuteOperation for FireboxMixerOutputProtocol {}
 /// The protocol implementation of analog input.
 pub struct FireboxAnalogInputProtocol;
 
-const BOOST_OFF: i16 = 0x7ffe;
-const BOOST_ON: i16 = 0x0000;
+impl FireboxAnalogInputProtocol {
+    const BOOST_OFF: i16 = VolumeData::VALUE_MIN;
+    const BOOST_ON: i16 = VolumeData::VALUE_ZERO;
+}
 
 impl AvcSelectorOperation for FireboxAnalogInputProtocol {
     // NOTE: "analog-input-1", "analog-input-2", "analog-input-3", "analog-input-4"
@@ -170,12 +172,12 @@ impl AvcSelectorOperation for FireboxAnalogInputProtocol {
             func_block_id,
             CtlAttr::Current,
             AudioCh::Each(ch_id as u8),
-            FeatureCtl::Volume(vec![-1]),
+            FeatureCtl::Volume(VolumeData::new(1)),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
 
         if let FeatureCtl::Volume(data) = op.ctl {
-            let val = if data[0] == BOOST_OFF { 0 } else { 1 };
+            let val = if data.0[0] == Self::BOOST_OFF { 0 } else { 1 };
             Ok(val)
         } else {
             unreachable!();
@@ -202,7 +204,7 @@ impl AvcSelectorOperation for FireboxAnalogInputProtocol {
             func_block_id,
             CtlAttr::Current,
             AudioCh::Each(ch_id as u8),
-            FeatureCtl::Volume(vec![if val == 0 { BOOST_OFF } else { BOOST_ON }]),
+            FeatureCtl::Volume(VolumeData(vec![if val == 0 { Self::BOOST_OFF } else { Self::BOOST_ON }])),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/bebob/protocols/src/presonus/inspire1394.rs
+++ b/libs/bebob/protocols/src/presonus/inspire1394.rs
@@ -140,7 +140,7 @@ impl AvcMuteOperation for Inspire1394MixerAnalogSourceProtocol {}
 pub struct Inspire1394MixerStreamSourceProtocol;
 
 impl AvcLevelOperation for Inspire1394MixerStreamSourceProtocol {
-    const ENTRIES: &'static [(u8, AudioCh)] = &[(0x05, AudioCh::All)];
+    const ENTRIES: &'static [(u8, AudioCh)] = &[(0x05, AudioCh::Master)];
 }
 
 impl AvcMuteOperation for Inspire1394MixerStreamSourceProtocol {}

--- a/libs/bebob/protocols/src/terratec/aureon.rs
+++ b/libs/bebob/protocols/src/terratec/aureon.rs
@@ -77,8 +77,8 @@ pub struct AureonPhysInputProtocol;
 
 impl AvcLevelOperation for AureonPhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
-        (0x02, AudioCh::All), // analog-input-1/2
-        (0x03, AudioCh::All), // analog-input-3/4
+        (0x02, AudioCh::Master), // analog-input-1/2
+        (0x03, AudioCh::Master), // analog-input-3/4
     ];
 }
 
@@ -98,7 +98,7 @@ pub struct AureonMonitorOutputProtocol;
 
 impl AvcLevelOperation for AureonMonitorOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
-        (0x04, AudioCh::All), // monitor-output-1/2
+        (0x04, AudioCh::Master), // monitor-output-1/2
     ];
 }
 

--- a/libs/bebob/protocols/src/yamaha_terratec.rs
+++ b/libs/bebob/protocols/src/yamaha_terratec.rs
@@ -171,17 +171,17 @@ impl AvcSelectorOperation for GoPhase24CoaxPhysInputProtocol {
             INPUT_NOMINAL_LEVEL_FB_ID,
             CtlAttr::Current,
             AudioCh::Master,
-            FeatureCtl::Volume(vec![0xff]),
+            FeatureCtl::Volume(VolumeData::new(1)),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
         if let FeatureCtl::Volume(data) = op.ctl {
             INPUT_NOMINAL_LEVELS
                 .iter()
-                .position(|l| *l == data[0])
+                .position(|l| *l == data.0[0])
                 .ok_or_else(|| {
                     let msg = format!(
                         "Unexpected value for value of nominal level: 0x{:04x}",
-                        data[0]
+                        data.0[0]
                     );
                     Error::new(FileError::Io, &msg)
                 })
@@ -212,7 +212,7 @@ impl AvcSelectorOperation for GoPhase24CoaxPhysInputProtocol {
             INPUT_NOMINAL_LEVEL_FB_ID,
             CtlAttr::Current,
             AudioCh::Master,
-            FeatureCtl::Volume(vec![v]),
+            FeatureCtl::Volume(VolumeData(vec![v])),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/bebob/protocols/src/yamaha_terratec.rs
+++ b/libs/bebob/protocols/src/yamaha_terratec.rs
@@ -170,7 +170,7 @@ impl AvcSelectorOperation for GoPhase24CoaxPhysInputProtocol {
         let mut op = AudioFeature::new(
             INPUT_NOMINAL_LEVEL_FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Volume(vec![0xff]),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
@@ -211,7 +211,7 @@ impl AvcSelectorOperation for GoPhase24CoaxPhysInputProtocol {
         let mut op = AudioFeature::new(
             INPUT_NOMINAL_LEVEL_FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Volume(vec![v]),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)

--- a/libs/oxfw/protocols/src/griffin.rs
+++ b/libs/oxfw/protocols/src/griffin.rs
@@ -12,8 +12,8 @@ use super::*;
 pub struct FirewaveProtocol;
 
 impl FirewaveProtocol {
-    pub const VOLUME_MIN: i16 = i16::MIN;
-    pub const VOLUME_MAX: i16 = 0;
+    pub const VOLUME_MIN: i16 = VolumeData::VALUE_NEG_INFINITY;
+    pub const VOLUME_MAX: i16 = VolumeData::VALUE_ZERO;
     pub const VOLUME_STEP: i16 = 1;
 
     pub const PLAYBACK_COUNT: usize = Self::CHANNEL_MAP.len();
@@ -36,12 +36,12 @@ impl FirewaveProtocol {
                 Self::VOL_FB_ID,
                 CtlAttr::Current,
                 AudioCh::Each(Self::CHANNEL_MAP[idx]),
-                FeatureCtl::Volume(vec![-1]),
+                FeatureCtl::Volume(VolumeData::new(1)),
             );
             avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
                 .map(|_| {
                     if let FeatureCtl::Volume(data) = op.ctl {
-                        *volume = data[0]
+                        *volume = data.0[0]
                     }
                 })
         }
@@ -61,7 +61,7 @@ impl FirewaveProtocol {
                 Self::VOL_FB_ID,
                 CtlAttr::Current,
                 AudioCh::Each(Self::CHANNEL_MAP[idx]),
-                FeatureCtl::Volume(vec![volume]),
+                FeatureCtl::Volume(VolumeData(vec![volume])),
             );
             avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
         }

--- a/libs/oxfw/protocols/src/griffin.rs
+++ b/libs/oxfw/protocols/src/griffin.rs
@@ -71,7 +71,7 @@ impl FirewaveProtocol {
         let mut op = AudioFeature::new(
             Self::MUTE_FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Mute(vec![false]),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
@@ -86,7 +86,7 @@ impl FirewaveProtocol {
         let mut op = AudioFeature::new(
             Self::MUTE_FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Mute(vec![mute]),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)

--- a/libs/oxfw/protocols/src/lacie.rs
+++ b/libs/oxfw/protocols/src/lacie.rs
@@ -12,8 +12,8 @@ use super::*;
 pub struct FwSpeakersProtocol;
 
 impl FwSpeakersProtocol {
-    pub const VOLUME_MIN: i16 = i16::MIN;
-    pub const VOLUME_MAX: i16 = 0;
+    pub const VOLUME_MIN: i16 = VolumeData::VALUE_NEG_INFINITY;
+    pub const VOLUME_MAX: i16 = VolumeData::VALUE_ZERO;
     pub const VOLUME_STEP: i16 = 1;
 
     const FB_ID: u8 = 0x01;
@@ -23,12 +23,12 @@ impl FwSpeakersProtocol {
             Self::FB_ID,
             CtlAttr::Current,
             AudioCh::Master,
-            FeatureCtl::Volume(vec![-1]),
+            FeatureCtl::Volume(VolumeData::new(1)),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
             .map(|_| {
                 if let FeatureCtl::Volume(data) = op.ctl {
-                    *volume = data[0]
+                    *volume = data.0[0]
                 }
             })
     }
@@ -38,7 +38,7 @@ impl FwSpeakersProtocol {
             Self::FB_ID,
             CtlAttr::Current,
             AudioCh::Master,
-            FeatureCtl::Volume(vec![volume]),
+            FeatureCtl::Volume(VolumeData(vec![volume])),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/oxfw/protocols/src/lacie.rs
+++ b/libs/oxfw/protocols/src/lacie.rs
@@ -22,7 +22,7 @@ impl FwSpeakersProtocol {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Volume(vec![-1]),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
@@ -37,7 +37,7 @@ impl FwSpeakersProtocol {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Volume(vec![volume]),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
@@ -47,7 +47,7 @@ impl FwSpeakersProtocol {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Mute(vec![false]),
         );
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
@@ -62,7 +62,7 @@ impl FwSpeakersProtocol {
         let mut op = AudioFeature::new(
             Self::FB_ID,
             CtlAttr::Current,
-            AudioCh::All,
+            AudioCh::Master,
             FeatureCtl::Mute(vec![mute]),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)

--- a/libs/ta1394/audio/src/lib.rs
+++ b/libs/ta1394/audio/src/lib.rs
@@ -337,13 +337,13 @@ impl AvcStatus for AudioSelector {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcStatus::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 
@@ -353,13 +353,13 @@ impl AvcControl for AudioSelector {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcControl::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcControl::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcControl::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 
@@ -698,13 +698,13 @@ impl AvcStatus for AudioFeature {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcStatus::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 
@@ -714,13 +714,13 @@ impl AvcControl for AudioFeature {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcControl::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcControl::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcControl::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 
@@ -866,13 +866,13 @@ impl AvcStatus for AudioProcessing {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcStatus::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcStatus::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 
@@ -882,13 +882,13 @@ impl AvcControl for AudioProcessing {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.build_func_blk()?;
-        AvcControl::build_operands(&mut self.func_blk, addr, operands)
+        self.build_func_blk()
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
-        AvcControl::parse_operands(&mut self.func_blk, addr, operands)?;
-        self.parse_func_blk()
+        AvcControl::parse_operands(&mut self.func_blk, addr, operands)
+            .and_then(|_| self.parse_func_blk())
     }
 }
 

--- a/libs/ta1394/audio/src/lib.rs
+++ b/libs/ta1394/audio/src/lib.rs
@@ -190,21 +190,20 @@ impl AudioFuncBlk {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        match addr {
-            AvcAddr::Unit => Err(AvcCmdBuildError::InvalidAddress),
-            AvcAddr::Subunit(s) => {
-                if s.subunit_type == AvcSubunitType::Audio {
-                    operands.push(self.func_blk_type.to_val());
-                    operands.push(self.func_blk_id);
-                    operands.push(self.ctl_attr.to_val());
-                    operands.push(1 + self.audio_selector_data.len() as u8);
-                    operands.extend_from_slice(&self.audio_selector_data);
-                    operands.append(&mut self.ctl.to_raw());
-                    Ok(())
-                } else {
-                    Err(AvcCmdBuildError::InvalidAddress)
-                }
-            }
+        if let AvcAddr::Subunit(AvcAddrSubunit {
+            subunit_type: AvcSubunitType::Audio,
+            subunit_id: _,
+        }) = addr
+        {
+            operands.push(self.func_blk_type.to_val());
+            operands.push(self.func_blk_id);
+            operands.push(self.ctl_attr.to_val());
+            operands.push(1 + self.audio_selector_data.len() as u8);
+            operands.extend_from_slice(&self.audio_selector_data);
+            operands.append(&mut self.ctl.to_raw());
+            Ok(())
+        } else {
+            Err(AvcCmdBuildError::InvalidAddress)
         }
     }
 

--- a/libs/ta1394/audio/src/lib.rs
+++ b/libs/ta1394/audio/src/lib.rs
@@ -23,24 +23,22 @@ enum AudioFuncBlkType {
     Reserved(u8),
 }
 
-impl From<u8> for AudioFuncBlkType {
-    fn from(val: u8) -> Self {
+impl AudioFuncBlkType {
+    fn from_val(val: u8) -> Self {
         match val {
-            0x80 => AudioFuncBlkType::Selector,
-            0x81 => AudioFuncBlkType::Feature,
-            0x82 => AudioFuncBlkType::Processing,
-            _ => AudioFuncBlkType::Reserved(val),
+            0x80 => Self::Selector,
+            0x81 => Self::Feature,
+            0x82 => Self::Processing,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<AudioFuncBlkType> for u8 {
-    fn from(func_blk_type: AudioFuncBlkType) -> Self {
-        match func_blk_type {
-            AudioFuncBlkType::Selector => 0x80,
-            AudioFuncBlkType::Feature => 0x81,
-            AudioFuncBlkType::Processing => 0x82,
-            AudioFuncBlkType::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Selector => 0x80,
+            Self::Feature => 0x81,
+            Self::Processing => 0x82,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -184,7 +182,7 @@ impl AudioFuncBlk {
             AvcAddr::Unit => Err(AvcCmdBuildError::InvalidAddress),
             AvcAddr::Subunit(s) => {
                 if s.subunit_type == AvcSubunitType::Audio {
-                    operands.push(self.func_blk_type.into());
+                    operands.push(self.func_blk_type.to_val());
                     operands.push(self.func_blk_id);
                     operands.push(self.ctl_attr.into());
                     operands.push(1 + self.audio_selector_data.len() as u8);
@@ -202,7 +200,7 @@ impl AudioFuncBlk {
         if operands.len() < 4 {
             Err(AvcRespParseError::TooShortResp(4))?;
         }
-        let func_blk_type = AudioFuncBlkType::from(operands[0]);
+        let func_blk_type = AudioFuncBlkType::from_val(operands[0]);
         if func_blk_type != self.func_blk_type {
             Err(AvcRespParseError::UnexpectedOperands(0))?;
         }


### PR DESCRIPTION
Current implementation includes wrong interpretation for audio channel in AV/C audio
subunit commands. This patchset includes fix as well as rewriting data of feature function block
command.

```
Takashi Sakamoto (19):
  ta1394/audio: start crate development for v0.2.0
  oxfw/protocols: start crate development for v0.2.0
  ta1394/audio: fix value for audio channel
  ta1394/audio: localize serializer/deserializer for AudioFuncBlkType
  ta1394/audio: localize serializer/deserializer for CtlAttr structure
  ta1394/audio: code refactoring for AudioFuncBlkCtl
  ta1394/audio: code refactoring for AudioFuncBlk
  ta1394/audio: localize serializer/deserializer for FeatureCtl
  ta1394/audio: localize serializer/deserializer for ProcessingCtl
  ta1394/audio: implement Default trait for Audio Function Block command
  ta1394/audio: code refactoring for each function block command
  ta1394/audio: rewrite data of graphic equalizer
  ta1394/audio: rewrite volume data
  ta1394/audio: rewrite L/R Balance data
  ta1394/audio: rewrite F/R Balance data
  ta1394/audio: rewrite bass data
  ta1394/audio: rewrite mid data
  ta1394/audio: rewrite treble data
  ta1394/audio: rewrite delay data

 Cargo.toml                                    |    8 +-
 libs/bebob/protocols/src/icon.rs              |    4 +-
 libs/bebob/protocols/src/lib.rs               |   20 +-
 libs/bebob/protocols/src/presonus/firebox.rs  |   12 +-
 .../protocols/src/presonus/inspire1394.rs     |    2 +-
 libs/bebob/protocols/src/terratec/aureon.rs   |    6 +-
 libs/bebob/protocols/src/yamaha_terratec.rs   |   12 +-
 libs/oxfw/protocols/src/griffin.rs            |   14 +-
 libs/oxfw/protocols/src/lacie.rs              |   18 +-
 libs/ta1394/audio/src/lib.rs                  | 1058 ++++++++++++-----
 10 files changed, 830 insertions(+), 324 deletions(-)
```