### PR TITLE
dice/audio: fix audio channels - spro40

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ members = [
 #    "libs/motu/protocols",
 #    "libs/oxfw/protocols",
     "libs/bebob/protocols",
-#    "libs/dice/protocols",
+    "libs/dice/protocols",
 #    "libs/ff/protocols",
 ]
 
@@ -64,7 +64,7 @@ ta1394-avc-stream-format = { path = "libs/ta1394/stream-format" }
 ta1394-avc-ccm = { path = "libs/ta1394/ccm" }
 firewire-bebob-protocols = { path = "libs/bebob/protocols" }
 #firewire-digi00x-protocols = { path = "libs/dg00x/protocols" }
-#firewire-dice-protocols = { path = "libs/dice/protocols" }
+firewire-dice-protocols = { path = "libs/dice/protocols" }
 #firewire-fireworks-protocols = { path = "libs/efw/protocols" }
 #firewire-fireface-protocols = { path = "libs/ff/protocols" }
 #firewire-motu-protocols = { path = "libs/motu/protocols" }

--- a/libs/dice/protocols/src/focusrite/spro40.rs
+++ b/libs/dice/protocols/src/focusrite/spro40.rs
@@ -20,7 +20,7 @@ impl Tcd22xxSpecOperation for SPro40Protocol {
         Input {
             id: SrcBlkId::Ins1,
             offset: 0,
-            count: 6,
+            count: 8,
             label: None,
         },
         Input {


### PR DESCRIPTION
Hi. Sorry it was easier to just make a new PR, fix is same as before. Hope it's closer to what you were asking there. All details are as in pr #104 

replaces:

* pr #104

fixes:

* issue #92
* Fixes: missing last 2 analog input channels `6+7` (from index starting `0`)
* Solution: fill complete `ins1` inputs from `6` --> `8` (i2c in direction, into the DICE chip)

closes:

* pr #104
* issue #92