### PR TITLE
[PATCH 00/10] ta1394/general: delegate task of vector allocation to each AV/C command

### DIFF
--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -1224,11 +1224,7 @@ impl AvcOp for EnsembleOperation {
 }
 
 impl AvcControl for EnsembleOperation {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.op.data = Into::<Vec<u8>>::into(&self.cmd);
 
         // At least, 6 bytes should be required to align to 3 quadlets. Unless, the target unit is freezed.
@@ -1236,7 +1232,7 @@ impl AvcControl for EnsembleOperation {
             self.op.data.push(0xff);
         }
 
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1190,7 +1190,7 @@ impl From<&[u8]> for BcoAmStream {
                 let s = BcoCompoundAm824Stream::from(&raw[1..]);
                 BcoAmStream::BcoStream(s)
             }
-            _ => BcoAmStream::AmStream(AmStream::from(raw)),
+            _ => BcoAmStream::AmStream(AmStream::from_raw(raw)),
         }
     }
 }

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1190,7 +1190,7 @@ impl From<&[u8]> for BcoAmStream {
                 let s = BcoCompoundAm824Stream::from(&raw[1..]);
                 BcoAmStream::BcoStream(s)
             }
-            _ => BcoAmStream::AmStream(AmStream::from_raw(raw)),
+            _ => BcoAmStream::AmStream(AmStream::from_raw(raw).unwrap()),
         }
     }
 }

--- a/libs/bebob/protocols/src/focusrite.rs
+++ b/libs/bebob/protocols/src/focusrite.rs
@@ -399,11 +399,7 @@ const FOCUSRITE_CONTROL_ACTION: u8 = 0x01;
 const FOCUSRITE_STATUS_ACTION: u8 = 0x03;
 
 impl AvcControl for SaffireAvcOperation {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         assert!(self.offsets.len() <= MAXIMUM_OFFSET_COUNT);
         assert_eq!(self.offsets.len() * 4, self.buf.len());
 
@@ -418,7 +414,7 @@ impl AvcControl for SaffireAvcOperation {
             data.extend_from_slice(&idx.to_be_bytes());
             data.extend_from_slice(&buf[pos..(pos + 4)]);
         });
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -433,11 +429,7 @@ impl AvcControl for SaffireAvcOperation {
 }
 
 impl AvcStatus for SaffireAvcOperation {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         assert!(self.offsets.len() <= MAXIMUM_OFFSET_COUNT);
         assert_eq!(self.offsets.len() * 4, self.buf.len());
 
@@ -450,7 +442,7 @@ impl AvcStatus for SaffireAvcOperation {
             data.extend_from_slice(&idx.to_be_bytes());
             data.extend_from_slice(&[0xff; 4]);
         });
-        AvcStatus::build_operands(&mut self.op, addr, operands)
+        AvcStatus::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -662,8 +654,7 @@ mod test {
             buf: vec![0x01, 0x23, 0x45, 0x67, 0x76, 0x54, 0x32, 0x10],
             ..Default::default()
         };
-        let mut generated = Vec::new();
-        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut generated).unwrap();
+        let generated = AvcControl::build_operands(&mut op, &AvcAddr::Unit).unwrap();
 
         let expected = [
             0x00, 0x13, 0x0e, 0x01, 0x02, 0x00, 0x00, 0x00, 0x10, 0x01, 0x23, 0x45, 0x67, 0x00,
@@ -709,8 +700,7 @@ mod test {
             buf: vec![0; 8],
             ..Default::default()
         };
-        let mut generated = Vec::new();
-        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut generated).unwrap();
+        let generated = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
 
         let expected = [
             0x00, 0x13, 0x0e, 0x03, 0x02, 0x00, 0x00, 0x00, 0x10, 0xff, 0xff, 0xff, 0xff, 0x00,

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -65,7 +65,7 @@ impl Ta1394Avc<Error> for BebobAvc {
         let operands =
             AvcControl::build_operands(op, addr).map_err(|err| Ta1394AvcError::CmdBuild(err))?;
         let command_frame =
-            Self::compose_command_frame(AvcCmdType::Control, addr, O::OPCODE, &operands);
+            Self::compose_command_frame(AvcCmdType::Control, addr, O::OPCODE, &operands)?;
         let response_frame = self
             .transaction(&command_frame, timeout_ms)
             .map_err(|cause| Ta1394AvcError::CommunicationFailure(cause))?;

--- a/libs/bebob/protocols/src/maudio/normal.rs
+++ b/libs/bebob/protocols/src/maudio/normal.rs
@@ -730,13 +730,9 @@ impl AvcOp for AudiophileLedSwitch {
 }
 
 impl AvcControl for AudiophileLedSwitch {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.op.data[3] = self.state.into();
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {

--- a/libs/bebob/protocols/src/maudio/special.rs
+++ b/libs/bebob/protocols/src/maudio/special.rs
@@ -138,13 +138,9 @@ impl AvcOp for MaudioSpecialLedSwitch {
 }
 
 impl AvcControl for MaudioSpecialLedSwitch {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.op.data[0] = self.state.into();
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {

--- a/libs/bebob/protocols/src/presonus/firebox.rs
+++ b/libs/bebob/protocols/src/presonus/firebox.rs
@@ -204,7 +204,11 @@ impl AvcSelectorOperation for FireboxAnalogInputProtocol {
             func_block_id,
             CtlAttr::Current,
             AudioCh::Each(ch_id as u8),
-            FeatureCtl::Volume(VolumeData(vec![if val == 0 { Self::BOOST_OFF } else { Self::BOOST_ON }])),
+            FeatureCtl::Volume(VolumeData(vec![if val == 0 {
+                Self::BOOST_OFF
+            } else {
+                Self::BOOST_ON
+            }])),
         );
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
     }

--- a/libs/bebob/protocols/src/presonus/inspire1394.rs
+++ b/libs/bebob/protocols/src/presonus/inspire1394.rs
@@ -364,11 +364,7 @@ impl AvcOp for InputParameterOperation {
 }
 
 impl AvcControl for InputParameterOperation {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         match self.param {
             InputParameter::Analog34Phono(state) => {
                 self.op.data[0] = CMD_PHONO;
@@ -396,7 +392,7 @@ impl AvcControl for InputParameterOperation {
                 self.op.data[2] = state as u8;
             }
         }
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -405,11 +401,7 @@ impl AvcControl for InputParameterOperation {
 }
 
 impl AvcStatus for InputParameterOperation {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         match self.param {
             InputParameter::Analog34Phono(_) => {
                 self.op.data[0] = CMD_PHONO;
@@ -433,7 +425,7 @@ impl AvcStatus for InputParameterOperation {
             }
         }
         self.op.data[2] = 0xff;
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {

--- a/libs/oxfw/protocols/src/apogee.rs
+++ b/libs/oxfw/protocols/src/apogee.rs
@@ -1143,15 +1143,11 @@ impl AvcOp for ApogeeCmd {
 }
 
 impl AvcControl for ApogeeCmd {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         let mut data = self.cmd.build_args();
         self.cmd.append_variable(&mut data);
         self.op.data = data;
-        AvcControl::build_operands(&mut self.op, addr, operands)
+        AvcControl::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1160,13 +1156,9 @@ impl AvcControl for ApogeeCmd {
 }
 
 impl AvcStatus for ApogeeCmd {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.op.data = self.cmd.build_args();
-        AvcStatus::build_operands(&mut self.op, addr, operands)
+        AvcStatus::build_operands(&mut self.op, addr)
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1193,16 +1185,14 @@ mod test {
             unreachable!();
         }
 
-        let mut o = Vec::new();
-        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands[..9]);
 
         let mut op = ApogeeCmd::new(VendorCmd::OutSourceIsMixer(Default::default()));
         let operands = [0x00, 0x03, 0xdb, 0x50, 0x43, 0x4d, 0x11, 0xff, 0xff, 0x60];
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
 
-        let mut o = Vec::new();
-        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcControl::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands);
 
         // One argument command.
@@ -1216,8 +1206,7 @@ mod test {
             unreachable!();
         }
 
-        let mut o = Vec::new();
-        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands[..9]);
 
         let mut op = ApogeeCmd::new(VendorCmd::XlrIsConsumerLevel(1, true));
@@ -1230,8 +1219,7 @@ mod test {
             unreachable!();
         }
 
-        let mut o = Vec::new();
-        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcControl::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands);
 
         // Two arguments command.
@@ -1249,8 +1237,7 @@ mod test {
             unreachable!();
         }
 
-        let mut o = Vec::new();
-        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands[..9]);
 
         let mut op = ApogeeCmd::new(VendorCmd::MixerSrc(1, 0, 0xde00));
@@ -1260,8 +1247,7 @@ mod test {
         ];
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
 
-        let mut o = Vec::new();
-        AvcControl::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcControl::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands[..11]);
 
         // Command for block request.
@@ -1280,8 +1266,7 @@ mod test {
             unreachable!();
         }
 
-        let mut o = Vec::new();
-        AvcStatus::build_operands(&mut op, &AvcAddr::Unit, &mut o).unwrap();
+        let o = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
         assert_eq!(o, operands[..9]);
     }
 }

--- a/libs/oxfw/protocols/src/lib.rs
+++ b/libs/oxfw/protocols/src/lib.rs
@@ -17,8 +17,8 @@ use {
         FwFcp, FwNode, FwReq, FwTcode,
     },
     ta1394_avc_audio::*,
-    ta1394_avc_general::{general::*, *},
     ta1394_avc_ccm::*,
+    ta1394_avc_general::{general::*, *},
 };
 
 /// The implementation of AV/C transaction.

--- a/libs/oxfw/protocols/src/tascam.rs
+++ b/libs/oxfw/protocols/src/tascam.rs
@@ -330,7 +330,7 @@ impl Ta1394Avc<Error> for TascamAvc {
         let operands =
             AvcControl::build_operands(op, addr).map_err(|err| Ta1394AvcError::CmdBuild(err))?;
         let command_frame =
-            Self::compose_command_frame(AvcCmdType::Control, addr, O::OPCODE, &operands);
+            Self::compose_command_frame(AvcCmdType::Control, addr, O::OPCODE, &operands)?;
         let response_frame = self
             .transaction(&command_frame, timeout_ms)
             .map_err(|cause| Ta1394AvcError::CommunicationFailure(cause))?;

--- a/libs/ta1394/audio/src/lib.rs
+++ b/libs/ta1394/audio/src/lib.rs
@@ -198,23 +198,20 @@ impl Default for AudioFuncBlk {
 }
 
 impl AudioFuncBlk {
-    fn build_operands(
-        &self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         if let AvcAddr::Subunit(AvcAddrSubunit {
             subunit_type: AvcSubunitType::Audio,
             subunit_id: _,
         }) = addr
         {
+            let mut operands = Vec::new();
             operands.push(self.func_blk_type.to_val());
             operands.push(self.func_blk_id);
             operands.push(self.ctl_attr.to_val());
             operands.push(1 + self.audio_selector_data.len() as u8);
             operands.extend_from_slice(&self.audio_selector_data);
             operands.append(&mut self.ctl.to_raw());
-            Ok(())
+            Ok(operands)
         } else {
             Err(AvcCmdBuildError::InvalidAddress)
         }
@@ -260,12 +257,8 @@ impl AvcOp for AudioFuncBlk {
 }
 
 impl AvcStatus for AudioFuncBlk {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
-        AudioFuncBlk::build_operands(self, addr, operands)
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
+        AudioFuncBlk::build_operands(self, addr)
     }
 
     fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -274,12 +267,8 @@ impl AvcStatus for AudioFuncBlk {
 }
 
 impl AvcControl for AudioFuncBlk {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
-        AudioFuncBlk::build_operands(self, addr, operands)
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
+        AudioFuncBlk::build_operands(self, addr)
     }
 
     fn parse_operands(&mut self, _: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -336,13 +325,9 @@ impl AvcOp for AudioSelector {
 }
 
 impl AvcStatus for AudioSelector {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -352,13 +337,9 @@ impl AvcStatus for AudioSelector {
 }
 
 impl AvcControl for AudioSelector {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1057,13 +1038,9 @@ impl AvcOp for AudioFeature {
 }
 
 impl AvcStatus for AudioFeature {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1073,13 +1050,9 @@ impl AvcStatus for AudioFeature {
 }
 
 impl AvcControl for AudioFeature {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1225,13 +1198,9 @@ impl AvcOp for AudioProcessing {
 }
 
 impl AvcStatus for AudioProcessing {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcStatus::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1241,13 +1210,9 @@ impl AvcStatus for AudioProcessing {
 }
 
 impl AvcControl for AudioProcessing {
-    fn build_operands(
-        &mut self,
-        addr: &AvcAddr,
-        operands: &mut Vec<u8>,
-    ) -> Result<(), AvcCmdBuildError> {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         self.build_func_blk()
-            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr, operands))
+            .and_then(|_| AvcControl::build_operands(&mut self.func_blk, addr))
     }
 
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
@@ -1273,8 +1238,7 @@ mod test {
         op.ctl.selector = 0x11;
         op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
 
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x80, 0xfe, 0x01, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x11, 0x02, 0xbe, 0xef]
@@ -1299,8 +1263,7 @@ mod test {
         op.ctl.selector = 0x12;
         op.ctl.data.extend_from_slice(&[0xbe, 0xef]);
 
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x80, 0xfd, 0x02, 0x05, 0xde, 0xad, 0xbe, 0xef, 0x12, 0x02, 0xbe, 0xef]
@@ -1324,8 +1287,7 @@ mod test {
         op.ctl.selector = 0x13;
         op.ctl.data.extend_from_slice(&[0xfe, 0xeb, 0xda, 0xed]);
 
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x81, 0xfc, 0x03, 0x01, 0x13, 0x04, 0xfe, 0xeb, 0xda, 0xed]
@@ -1350,8 +1312,7 @@ mod test {
             ..Default::default()
         };
 
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x81, 0xfb, 0x04, 0x01, 0x14, 0x04, 0xfe, 0xeb, 0xda, 0xed]
@@ -1377,8 +1338,7 @@ mod test {
             },
         };
 
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(&operands, &[0x82, 0xfa, 0x08, 0x03, 0xda, 0xed, 0x15]);
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
@@ -1400,8 +1360,7 @@ mod test {
             },
         };
 
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(&operands, &[0x82, 0xf9, 0x10, 0x03, 0xda, 0xed, 0x16]);
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
@@ -1416,16 +1375,14 @@ mod test {
     #[test]
     fn avcaudioselector_operands() {
         let mut op = AudioSelector::new(0xe5, CtlAttr::Duration, 0x28);
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(&operands, &[0x80, 0xe5, 0x08, 0x02, 0x28, 0x01]);
 
         AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.input_plug_id, 0x28);
 
         let mut op = AudioSelector::new(0x1e, CtlAttr::Move, 0x96);
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(&operands, &[0x80, 0x1e, 0x18, 0x02, 0x96, 0x01]);
 
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
@@ -1548,8 +1505,7 @@ mod test {
         let data = VolumeData(vec![-1234, 5678, 3210]);
         let ctl = FeatureCtl::Volume(data);
         let mut op = AudioFeature::new(0x03, CtlAttr::Minimum, AudioCh::Each(0x1b), ctl.clone());
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x81, 0x03, 0x02, 0x02, 0x1c, 0x02, 0x06, 0xfb, 0x2e, 0x16, 0x2e, 0x0c, 0x8a]
@@ -1561,8 +1517,7 @@ mod test {
 
         let ctl = FeatureCtl::Treble(TrebleData(vec![40, -33, 123, -96]));
         let mut op = AudioFeature::new(0x33, CtlAttr::Resolution, AudioCh::Each(0xd8), ctl.clone());
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x81, 0x33, 0x01, 0x2, 0xd9, 0x07, 0x04, 0x28, 0xdf, 0x7b, 0xa0]
@@ -1596,8 +1551,7 @@ mod test {
             AudioCh::Each(0x3e),
             ctl.clone(),
         );
-        let mut operands = Vec::new();
-        AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcStatus::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x82, 0xf5, 0x04, 0x04, 0x71, 0xa9, 0x3f, 0x01, 0x01, 0x70]
@@ -1618,8 +1572,7 @@ mod test {
             AudioCh::Each(0x43),
             ctl.clone(),
         );
-        let mut operands = Vec::new();
-        AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR, &mut operands).unwrap();
+        let operands = AvcControl::build_operands(&mut op, &AUDIO_SUBUNIT_0_ADDR).unwrap();
         assert_eq!(
             &operands,
             &[0x82, 0x11, 0x02, 0x04, 0x22, 0x33, 0x44, 0x03, 0x04, 0x00, 0x0a, 0xff, 0xf6]

--- a/libs/ta1394/general/src/lib.rs
+++ b/libs/ta1394/general/src/lib.rs
@@ -365,6 +365,10 @@ pub enum AvcRespParseError {
     ),
     /// The status code in response frame is not expected.
     UnexpectedStatus,
+    /// The address in response frame is not expected.
+    UnexpectedAddr,
+    /// The operation code in response frame is not expected.
+    UnexpectedOpcode,
     /// Any of operand in response frame is not expected.
     UnexpectedOperands(
         /// The first offset for unexpected operand.
@@ -390,6 +394,8 @@ impl std::fmt::Display for AvcRespParseError {
         match self {
             Self::TooShortResp(expected) => write!(f, "response frame too short {}", expected),
             Self::UnexpectedStatus => write!(f, "unexpected response status"),
+            Self::UnexpectedAddr => write!(f, "unexpected response address"),
+            Self::UnexpectedOpcode => write!(f, "unexpected response operation code"),
             Self::UnexpectedOperands(offset) => {
                 write!(f, "unexpected response operands at {}", offset)
             }
@@ -486,9 +492,9 @@ pub trait Ta1394Avc<T: std::fmt::Display + Clone> {
         opcode: u8,
     ) -> Result<(AvcRespCode, &'a [u8]), AvcRespParseError> {
         if frame[1] != addr.into() {
-            Err(AvcRespParseError::UnexpectedStatus)
+            Err(AvcRespParseError::UnexpectedAddr)
         } else if frame[2] != opcode {
-            Err(AvcRespParseError::UnexpectedStatus)
+            Err(AvcRespParseError::UnexpectedOpcode)
         } else {
             let rcode = AvcRespCode::from(frame[0] & Self::RESP_CODE_MASK);
             let operands = &frame[3..];

--- a/libs/ta1394/general/src/lib.rs
+++ b/libs/ta1394/general/src/lib.rs
@@ -369,6 +369,19 @@ pub enum AvcRespParseError {
     ),
 }
 
+impl AvcRespParseError {
+    /// Add given offset to some enumerations.
+    pub fn add_offset(mut self, offset: usize) -> Self {
+        match &mut self {
+            AvcRespParseError::TooShortResp(pos) | AvcRespParseError::UnexpectedOperands(pos) => {
+                *pos += offset
+            }
+            _ => (),
+        }
+        self
+    }
+}
+
 impl std::fmt::Display for AvcRespParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/libs/ta1394/stream-format/src/lib.rs
+++ b/libs/ta1394/stream-format/src/lib.rs
@@ -1066,7 +1066,7 @@ pub enum SupportStatus {
     /// The format is not uset yet.
     NoStreamFormat,
     /// For response frame of specific inquiry operation.
-    NoInfo,
+    NotUsed,
     Reserved(u8),
 }
 
@@ -1080,14 +1080,14 @@ impl SupportStatus {
     const ACTIVE: u8 = 0x00;
     const INACTIVE: u8 = 0x01;
     const NO_STREAM_FORMAT: u8 = 0x02;
-    const NO_INFO: u8 = 0xff;
+    const NOT_USED: u8 = 0xff;
 
     fn from_val(val: u8) -> Self {
         match val {
             Self::ACTIVE => Self::Active,
             Self::INACTIVE => Self::Inactive,
             Self::NO_STREAM_FORMAT => Self::NoStreamFormat,
-            Self::NO_INFO => Self::NoInfo,
+            Self::NOT_USED => Self::NotUsed,
             _ => Self::Reserved(val),
         }
     }
@@ -1097,7 +1097,7 @@ impl SupportStatus {
             Self::Active => Self::ACTIVE,
             Self::Inactive => Self::INACTIVE,
             Self::NoStreamFormat => Self::NO_STREAM_FORMAT,
-            Self::NoInfo => Self::NO_INFO,
+            Self::NotUsed => Self::NOT_USED,
             Self::Reserved(val) => *val,
         }
     }
@@ -1181,7 +1181,7 @@ impl ExtendedStreamFormatSingle {
 
     pub fn new(plug_addr: &PlugAddr) -> Self {
         ExtendedStreamFormatSingle {
-            support_status: SupportStatus::NoInfo,
+            support_status: SupportStatus::NotUsed,
             stream_format: StreamFormat::Reserved(Vec::new()),
             op: ExtendedStreamFormat::new(Self::SUBFUNC, plug_addr),
         }
@@ -1262,7 +1262,7 @@ impl ExtendedStreamFormatList {
 
     pub fn new(plug_addr: &PlugAddr, index: u8) -> Self {
         ExtendedStreamFormatList {
-            support_status: SupportStatus::Reserved(0xff),
+            support_status: SupportStatus::NotUsed,
             index,
             stream_format: StreamFormat::Reserved(Vec::new()),
             op: ExtendedStreamFormat::new(Self::SUBFUNC, plug_addr),
@@ -1280,7 +1280,7 @@ impl AvcStatus for ExtendedStreamFormatList {
         addr: &AvcAddr,
         operands: &mut Vec<u8>,
     ) -> Result<(), AvcCmdBuildError> {
-        self.op.support_status = SupportStatus::Reserved(0xff);
+        self.op.support_status = SupportStatus::NotUsed;
         self.op
             .build_operands(addr, operands)
             .map(|_| operands.push(self.index))
@@ -1587,7 +1587,7 @@ mod tests {
         ];
         AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
         assert_eq!(op.op.plug_addr, plug_addr);
-        assert_eq!(op.op.support_status, SupportStatus::NoInfo);
+        assert_eq!(op.op.support_status, SupportStatus::NotUsed);
         if let StreamFormat::Am(stream_format) = &op.stream_format {
             if let AmStream::CompoundAm824(s) = stream_format {
                 assert_eq!(s.freq, 96000);


### PR DESCRIPTION
Current implementation of ta1394-avc-general takes ownership of vector for operands
to Ta139Avc trait implementation, while it's more natural to take it to command traits.

This patchset includes fix for it as well as some code refactoring.

```
Takashi Sakamoto (10):
  ta1394/stream-format: further localize serializer/deserializer for AmStream
  ta1394/stream-format: obsolete panic internally for format of stream
  ta1394/stream-format: obsolete panic internally for address of plug
  ta1394/stream-format: delete undefined values in stream format
  ta1394/stream-format: fix name of enumeration in support status
  ta1394/audio: obsolete panic internally for AudioFuncBlk
  ta1394/ccm: obsolete panic internally for address of signal
  ta1394/general: delegate task of vector allocation to each AV/C command
  ta1394/general: check length of command frame
  ta1394/general: correct errors in response frame

 libs/bebob/protocols/src/apogee/ensemble.rs   |   8 +-
 libs/bebob/protocols/src/bridgeco.rs          |  68 +--
 libs/bebob/protocols/src/focusrite.rs         |  22 +-
 libs/bebob/protocols/src/lib.rs               |  54 +-
 libs/bebob/protocols/src/maudio/normal.rs     |   8 +-
 libs/bebob/protocols/src/maudio/special.rs    |   8 +-
 libs/bebob/protocols/src/presonus/firebox.rs  |   6 +-
 .../protocols/src/presonus/inspire1394.rs     |  16 +-
 libs/oxfw/protocols/src/apogee.rs             |  37 +-
 libs/oxfw/protocols/src/lib.rs                |   2 +-
 libs/oxfw/protocols/src/tascam.rs             |  67 +--
 libs/ta1394/audio/src/lib.rs                  | 121 ++---
 libs/ta1394/ccm/src/lib.rs                    | 104 ++--
 libs/ta1394/general/src/general.rs            | 127 ++---
 libs/ta1394/general/src/lib.rs                | 161 +++---
 libs/ta1394/stream-format/src/lib.rs          | 502 ++++++++++--------
 16 files changed, 611 insertions(+), 700 deletions(-)
```