### PR TITLE
[PATCH 00/27] bebob/protocols: code cleanup

### DIFF
--- a/libs/bebob/protocols/src/apogee/ensemble.rs
+++ b/libs/bebob/protocols/src/apogee/ensemble.rs
@@ -465,7 +465,13 @@ impl EnsembleParameterProtocol<EnsembleStreamParameters> for BebobAvc {
         let mut op = ExtendedStreamFormatSingle::new(&plug_addr);
         self.status(&AvcAddr::Unit, &mut op, timeout_ms)?;
 
-        let info = op.stream_format.as_bco_compound_am824_stream()?;
+        let info = op
+            .stream_format
+            .as_bco_compound_am824_stream()
+            .ok_or_else(|| {
+                let label = "Bco Compound AM824 stream is not available for the unit";
+                Error::new(FileError::Nxio, &label)
+            })?;
         let count = info
             .entries
             .iter()

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -550,42 +550,38 @@ impl BcoPortType {
     const ANALOG: u8 = 0x08;
     const DIGITAL: u8 = 0x09;
     const MIDI: u8 = 0x0a;
-}
 
-impl From<BcoPortType> for u8 {
-    fn from(port_type: BcoPortType) -> Self {
-        match port_type {
-            BcoPortType::Speaker => BcoPortType::SPEAKER,
-            BcoPortType::Headphone => BcoPortType::HEADPHONE,
-            BcoPortType::Microphone => BcoPortType::MICROPHONE,
-            BcoPortType::Line => BcoPortType::LINE,
-            BcoPortType::Spdif => BcoPortType::SPDIF,
-            BcoPortType::Adat => BcoPortType::ADAT,
-            BcoPortType::Tdif => BcoPortType::TDIF,
-            BcoPortType::Madi => BcoPortType::MADI,
-            BcoPortType::Analog => BcoPortType::ANALOG,
-            BcoPortType::Digital => BcoPortType::DIGITAL,
-            BcoPortType::Midi => BcoPortType::MIDI,
-            BcoPortType::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Speaker => Self::SPEAKER,
+            Self::Headphone => Self::HEADPHONE,
+            Self::Microphone => Self::MICROPHONE,
+            Self::Line => Self::LINE,
+            Self::Spdif => Self::SPDIF,
+            Self::Adat => Self::ADAT,
+            Self::Tdif => Self::TDIF,
+            Self::Madi => Self::MADI,
+            Self::Analog => Self::ANALOG,
+            Self::Digital => Self::DIGITAL,
+            Self::Midi => Self::MIDI,
+            Self::Reserved(val) => *val,
         }
     }
-}
 
-impl From<u8> for BcoPortType {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
-            BcoPortType::SPEAKER => BcoPortType::Speaker,
-            BcoPortType::HEADPHONE => BcoPortType::Headphone,
-            BcoPortType::MICROPHONE => BcoPortType::Microphone,
-            BcoPortType::LINE => BcoPortType::Line,
-            BcoPortType::SPDIF => BcoPortType::Spdif,
-            BcoPortType::ADAT => BcoPortType::Adat,
-            BcoPortType::TDIF => BcoPortType::Tdif,
-            BcoPortType::MADI => BcoPortType::Madi,
-            BcoPortType::ANALOG => BcoPortType::Analog,
-            BcoPortType::DIGITAL => BcoPortType::Digital,
-            BcoPortType::MIDI => BcoPortType::Midi,
-            _ => BcoPortType::Reserved(val),
+            Self::SPEAKER => Self::Speaker,
+            Self::HEADPHONE => Self::Headphone,
+            Self::MICROPHONE => Self::Microphone,
+            Self::LINE => Self::Line,
+            Self::SPDIF => Self::Spdif,
+            Self::ADAT => Self::Adat,
+            Self::TDIF => Self::Tdif,
+            Self::MADI => Self::Madi,
+            Self::ANALOG => Self::Analog,
+            Self::DIGITAL => Self::Digital,
+            Self::MIDI => Self::Midi,
+            _ => Self::Reserved(val),
         }
     }
 }
@@ -608,7 +604,7 @@ impl BcoClusterInfo {
         };
         Self {
             index: raw[0],
-            port_type: BcoPortType::from(raw[1]),
+            port_type: BcoPortType::from_val(raw[1]),
             name,
         }
     }
@@ -616,7 +612,7 @@ impl BcoClusterInfo {
     fn to_raw(&self) -> Vec<u8> {
         let mut raw = Vec::new();
         raw.push(self.index);
-        raw.push(self.port_type.into());
+        raw.push(self.port_type.to_val());
         raw.push(self.name.len() as u8);
         raw.append(&mut self.name.clone().into_bytes());
         raw

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -946,56 +946,36 @@ impl BcoCompoundAm824StreamFormat {
     const MULTI_BIT_LINEAR_AUDIO_DVD: u8 = 0x07;
     const HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO: u8 = 0x0c;
     const MIDI_CONFORMANT: u8 = 0x0d;
-}
 
-impl From<u8> for BcoCompoundAm824StreamFormat {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
-            BcoCompoundAm824StreamFormat::IEC60958_3 => BcoCompoundAm824StreamFormat::Iec60958_3,
-            BcoCompoundAm824StreamFormat::IEC61937_3 => BcoCompoundAm824StreamFormat::Iec61937_3,
-            BcoCompoundAm824StreamFormat::IEC61937_4 => BcoCompoundAm824StreamFormat::Iec61937_4,
-            BcoCompoundAm824StreamFormat::IEC61937_5 => BcoCompoundAm824StreamFormat::Iec61937_5,
-            BcoCompoundAm824StreamFormat::IEC61937_6 => BcoCompoundAm824StreamFormat::Iec61937_6,
-            BcoCompoundAm824StreamFormat::IEC61937_7 => BcoCompoundAm824StreamFormat::Iec61937_7,
-            BcoCompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW => {
-                BcoCompoundAm824StreamFormat::MultiBitLinearAudioRaw
-            }
-            BcoCompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD => {
-                BcoCompoundAm824StreamFormat::MultiBitLinearAudioDvd
-            }
-            BcoCompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => {
-                BcoCompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio
-            }
-            BcoCompoundAm824StreamFormat::MIDI_CONFORMANT => {
-                BcoCompoundAm824StreamFormat::MidiConformant
-            }
-            _ => BcoCompoundAm824StreamFormat::Reserved(val),
+            Self::IEC60958_3 => Self::Iec60958_3,
+            Self::IEC61937_3 => Self::Iec61937_3,
+            Self::IEC61937_4 => Self::Iec61937_4,
+            Self::IEC61937_5 => Self::Iec61937_5,
+            Self::IEC61937_6 => Self::Iec61937_6,
+            Self::IEC61937_7 => Self::Iec61937_7,
+            Self::MULTI_BIT_LINEAR_AUDIO_RAW => Self::MultiBitLinearAudioRaw,
+            Self::MULTI_BIT_LINEAR_AUDIO_DVD => Self::MultiBitLinearAudioDvd,
+            Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO => Self::HighPrecisionMultiBitLinearAudio,
+            Self::MIDI_CONFORMANT => Self::MidiConformant,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<BcoCompoundAm824StreamFormat> for u8 {
-    fn from(fmt: BcoCompoundAm824StreamFormat) -> u8 {
-        match fmt {
-            BcoCompoundAm824StreamFormat::Iec60958_3 => BcoCompoundAm824StreamFormat::IEC60958_3,
-            BcoCompoundAm824StreamFormat::Iec61937_3 => BcoCompoundAm824StreamFormat::IEC61937_3,
-            BcoCompoundAm824StreamFormat::Iec61937_4 => BcoCompoundAm824StreamFormat::IEC61937_4,
-            BcoCompoundAm824StreamFormat::Iec61937_5 => BcoCompoundAm824StreamFormat::IEC61937_5,
-            BcoCompoundAm824StreamFormat::Iec61937_6 => BcoCompoundAm824StreamFormat::IEC61937_6,
-            BcoCompoundAm824StreamFormat::Iec61937_7 => BcoCompoundAm824StreamFormat::IEC61937_7,
-            BcoCompoundAm824StreamFormat::MultiBitLinearAudioRaw => {
-                BcoCompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_RAW
-            }
-            BcoCompoundAm824StreamFormat::MultiBitLinearAudioDvd => {
-                BcoCompoundAm824StreamFormat::MULTI_BIT_LINEAR_AUDIO_DVD
-            }
-            BcoCompoundAm824StreamFormat::HighPrecisionMultiBitLinearAudio => {
-                BcoCompoundAm824StreamFormat::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO
-            }
-            BcoCompoundAm824StreamFormat::MidiConformant => {
-                BcoCompoundAm824StreamFormat::MIDI_CONFORMANT
-            }
-            BcoCompoundAm824StreamFormat::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Iec60958_3 => Self::IEC60958_3,
+            Self::Iec61937_3 => Self::IEC61937_3,
+            Self::Iec61937_4 => Self::IEC61937_4,
+            Self::Iec61937_5 => Self::IEC61937_5,
+            Self::Iec61937_6 => Self::IEC61937_6,
+            Self::Iec61937_7 => Self::IEC61937_7,
+            Self::MultiBitLinearAudioRaw => Self::MULTI_BIT_LINEAR_AUDIO_RAW,
+            Self::MultiBitLinearAudioDvd => Self::MULTI_BIT_LINEAR_AUDIO_DVD,
+            Self::HighPrecisionMultiBitLinearAudio => Self::HIGH_PRECISION_MULTI_BIT_LINEAR_AUDIO,
+            Self::MidiConformant => Self::MIDI_CONFORMANT,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -1007,18 +987,16 @@ pub struct BcoCompoundAm824StreamEntry {
     pub format: BcoCompoundAm824StreamFormat,
 }
 
-impl From<&[u8; 2]> for BcoCompoundAm824StreamEntry {
-    fn from(raw: &[u8; 2]) -> Self {
+impl BcoCompoundAm824StreamEntry {
+    fn from_raw(raw: &[u8; 2]) -> Self {
         BcoCompoundAm824StreamEntry {
             count: raw[0],
-            format: BcoCompoundAm824StreamFormat::from(raw[1]),
+            format: BcoCompoundAm824StreamFormat::from_val(raw[1]),
         }
     }
-}
 
-impl From<&BcoCompoundAm824StreamEntry> for [u8; 2] {
-    fn from(data: &BcoCompoundAm824StreamEntry) -> Self {
-        [data.count, data.format.into()]
+    fn to_raw(&self) -> [u8; 2] {
+        [self.count, self.format.to_val()]
     }
 }
 
@@ -1047,27 +1025,23 @@ impl BcoCompoundAm824Stream {
 
     const RATE_CTL_MASK: u8 = 0x03;
     const RATE_CTL_SHIFT: usize = 0;
-}
 
-impl From<&[u8]> for BcoCompoundAm824Stream {
-    fn from(raw: &[u8]) -> Self {
+    fn from_raw(raw: &[u8]) -> Self {
         let freq = match raw[0] {
-            BcoCompoundAm824Stream::FREQ_CODE_22050 => 22050,
-            BcoCompoundAm824Stream::FREQ_CODE_24000 => 24000,
-            BcoCompoundAm824Stream::FREQ_CODE_32000 => 32000,
-            BcoCompoundAm824Stream::FREQ_CODE_44100 => 44100,
-            BcoCompoundAm824Stream::FREQ_CODE_48000 => 48000,
-            BcoCompoundAm824Stream::FREQ_CODE_96000 => 96000,
-            BcoCompoundAm824Stream::FREQ_CODE_176400 => 176400,
-            BcoCompoundAm824Stream::FREQ_CODE_192000 => 192000,
-            BcoCompoundAm824Stream::FREQ_CODE_88200 => 88200,
+            Self::FREQ_CODE_22050 => 22050,
+            Self::FREQ_CODE_24000 => 24000,
+            Self::FREQ_CODE_32000 => 32000,
+            Self::FREQ_CODE_44100 => 44100,
+            Self::FREQ_CODE_48000 => 48000,
+            Self::FREQ_CODE_96000 => 96000,
+            Self::FREQ_CODE_176400 => 176400,
+            Self::FREQ_CODE_192000 => 192000,
+            Self::FREQ_CODE_88200 => 88200,
             _ => u32::MAX,
         };
-        let sync_src_code = (raw[1] >> BcoCompoundAm824Stream::SYNC_SRC_SHIFT)
-            & BcoCompoundAm824Stream::SYNC_SRC_MASK;
+        let sync_src_code = (raw[1] >> Self::SYNC_SRC_SHIFT) & Self::SYNC_SRC_MASK;
         let sync_src = sync_src_code > 0;
-        let rate_ctl_code = (raw[1] >> BcoCompoundAm824Stream::RATE_CTL_SHIFT)
-            & BcoCompoundAm824Stream::RATE_CTL_MASK;
+        let rate_ctl_code = (raw[1] >> Self::RATE_CTL_SHIFT) & Self::RATE_CTL_MASK;
         let rate_ctl = rate_ctl_code == 0;
         let entry_count = raw[2] as usize;
         let entries = (0..entry_count)
@@ -1077,45 +1051,41 @@ impl From<&[u8]> for BcoCompoundAm824Stream {
                 } else {
                     let mut doublet = [0; 2];
                     doublet.copy_from_slice(&raw[(3 + i * 2)..(3 + i * 2 + 2)]);
-                    Some(BcoCompoundAm824StreamEntry::from(&doublet))
+                    Some(BcoCompoundAm824StreamEntry::from_raw(&doublet))
                 }
             })
             .collect();
-        BcoCompoundAm824Stream {
+        Self {
             freq,
             sync_src,
             rate_ctl,
             entries,
         }
     }
-}
 
-impl From<&BcoCompoundAm824Stream> for Vec<u8> {
-    fn from(data: &BcoCompoundAm824Stream) -> Self {
+    fn to_raw(&self) -> Vec<u8> {
         let mut raw = Vec::new();
-        let freq_code = match data.freq {
-            22050 => BcoCompoundAm824Stream::FREQ_CODE_22050,
-            24000 => BcoCompoundAm824Stream::FREQ_CODE_24000,
-            32000 => BcoCompoundAm824Stream::FREQ_CODE_32000,
-            44100 => BcoCompoundAm824Stream::FREQ_CODE_44100,
-            48000 => BcoCompoundAm824Stream::FREQ_CODE_48000,
-            96000 => BcoCompoundAm824Stream::FREQ_CODE_96000,
-            176400 => BcoCompoundAm824Stream::FREQ_CODE_176400,
-            192000 => BcoCompoundAm824Stream::FREQ_CODE_192000,
-            88200 => BcoCompoundAm824Stream::FREQ_CODE_88200,
+        let freq_code = match self.freq {
+            22050 => Self::FREQ_CODE_22050,
+            24000 => Self::FREQ_CODE_24000,
+            32000 => Self::FREQ_CODE_32000,
+            44100 => Self::FREQ_CODE_44100,
+            48000 => Self::FREQ_CODE_48000,
+            96000 => Self::FREQ_CODE_96000,
+            176400 => Self::FREQ_CODE_176400,
+            192000 => Self::FREQ_CODE_192000,
+            88200 => Self::FREQ_CODE_88200,
             _ => u8::MAX,
         };
         raw.push(freq_code);
 
-        let sync_src_code = ((data.sync_src as u8) & BcoCompoundAm824Stream::SYNC_SRC_MASK)
-            << BcoCompoundAm824Stream::SYNC_SRC_SHIFT;
-        let rate_ctl_code = ((data.rate_ctl as u8) & BcoCompoundAm824Stream::RATE_CTL_MASK)
-            << BcoCompoundAm824Stream::RATE_CTL_SHIFT;
+        let sync_src_code = ((self.sync_src as u8) & Self::SYNC_SRC_MASK) << Self::SYNC_SRC_SHIFT;
+        let rate_ctl_code = ((self.rate_ctl as u8) & Self::RATE_CTL_MASK) << Self::RATE_CTL_SHIFT;
         raw.push(sync_src_code | rate_ctl_code);
 
-        raw.push(data.entries.len() as u8);
-        data.entries.iter().for_each(|entry| {
-            raw.extend_from_slice(&Into::<[u8; 2]>::into(entry));
+        raw.push(self.entries.len() as u8);
+        self.entries.iter().for_each(|entry| {
+            raw.extend_from_slice(&entry.to_raw());
         });
 
         raw
@@ -1133,7 +1103,7 @@ impl From<&[u8]> for BcoAmStream {
     fn from(raw: &[u8]) -> Self {
         match raw[0] {
             AmStream::HIER_LEVEL_1_COMPOUND_AM824 => {
-                let s = BcoCompoundAm824Stream::from(&raw[1..]);
+                let s = BcoCompoundAm824Stream::from_raw(&raw[1..]);
                 BcoAmStream::BcoStream(s)
             }
             _ => BcoAmStream::AmStream(AmStream::from_raw(raw).unwrap()),
@@ -1147,7 +1117,7 @@ impl From<&BcoAmStream> for Vec<u8> {
             BcoAmStream::BcoStream(s) => {
                 let mut raw = Vec::new();
                 raw.push(AmStream::HIER_LEVEL_1_COMPOUND_AM824);
-                raw.append(&mut Into::<Vec<u8>>::into(s));
+                raw.append(&mut s.to_raw());
                 raw
             }
             _ => Into::<Vec<u8>>::into(data),

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -26,26 +26,22 @@ impl BcoPlugAddrUnitType {
     const ISOC: u8 = 0x00;
     const EXT: u8 = 0x01;
     const ASYNC: u8 = 0x02;
-}
 
-impl From<u8> for BcoPlugAddrUnitType {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
-            BcoPlugAddrUnitType::ISOC => BcoPlugAddrUnitType::Isoc,
-            BcoPlugAddrUnitType::EXT => BcoPlugAddrUnitType::Ext,
-            BcoPlugAddrUnitType::ASYNC => BcoPlugAddrUnitType::Async,
-            _ => BcoPlugAddrUnitType::Reserved(val),
+            Self::ISOC => Self::Isoc,
+            Self::EXT => Self::Ext,
+            Self::ASYNC => Self::Async,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<BcoPlugAddrUnitType> for u8 {
-    fn from(unit_type: BcoPlugAddrUnitType) -> u8 {
-        match unit_type {
-            BcoPlugAddrUnitType::Isoc => BcoPlugAddrUnitType::ISOC,
-            BcoPlugAddrUnitType::Ext => BcoPlugAddrUnitType::EXT,
-            BcoPlugAddrUnitType::Async => BcoPlugAddrUnitType::ASYNC,
-            BcoPlugAddrUnitType::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Isoc => Self::ISOC,
+            Self::Ext => Self::EXT,
+            Self::Async => Self::ASYNC,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -57,18 +53,16 @@ pub struct BcoPlugAddrUnit {
     pub plug_id: u8,
 }
 
-impl From<&[u8; 3]> for BcoPlugAddrUnit {
-    fn from(raw: &[u8; 3]) -> Self {
-        BcoPlugAddrUnit {
-            plug_type: BcoPlugAddrUnitType::from(raw[0]),
+impl BcoPlugAddrUnit {
+    fn from_raw(raw: &[u8; 3]) -> Self {
+        Self {
+            plug_type: BcoPlugAddrUnitType::from_val(raw[0]),
             plug_id: raw[1],
         }
     }
-}
 
-impl From<&BcoPlugAddrUnit> for [u8; 3] {
-    fn from(data: &BcoPlugAddrUnit) -> Self {
-        [data.plug_type.into(), data.plug_id.into(), 0xff]
+    fn to_raw(&self) -> [u8; 3] {
+        [self.plug_type.to_val(), self.plug_id.into(), 0xff]
     }
 }
 
@@ -78,15 +72,13 @@ pub struct BcoPlugAddrSubunit {
     pub plug_id: u8,
 }
 
-impl From<&[u8; 3]> for BcoPlugAddrSubunit {
-    fn from(raw: &[u8; 3]) -> Self {
+impl BcoPlugAddrSubunit {
+    fn from_raw(raw: &[u8; 3]) -> Self {
         BcoPlugAddrSubunit { plug_id: raw[0] }
     }
-}
 
-impl From<&BcoPlugAddrSubunit> for [u8; 3] {
-    fn from(data: &BcoPlugAddrSubunit) -> Self {
-        [data.plug_id, 0xff, 0xff]
+    fn to_raw(&self) -> [u8; 3] {
+        [self.plug_id, 0xff, 0xff]
     }
 }
 
@@ -98,19 +90,17 @@ pub struct BcoPlugAddrFuncBlk {
     pub plug_id: u8,
 }
 
-impl From<&[u8; 3]> for BcoPlugAddrFuncBlk {
-    fn from(raw: &[u8; 3]) -> Self {
-        BcoPlugAddrFuncBlk {
+impl BcoPlugAddrFuncBlk {
+    fn from_raw(raw: &[u8; 3]) -> Self {
+        Self {
             func_blk_type: raw[0],
             func_blk_id: raw[1],
             plug_id: raw[2],
         }
     }
-}
 
-impl From<&BcoPlugAddrFuncBlk> for [u8; 3] {
-    fn from(data: &BcoPlugAddrFuncBlk) -> Self {
-        [data.func_blk_type, data.func_blk_id, data.plug_id]
+    fn to_raw(&self) -> [u8; 3] {
+        [self.func_blk_type, self.func_blk_id, self.plug_id]
     }
 }
 
@@ -127,38 +117,34 @@ impl BcoPlugAddrMode {
     const UNIT: u8 = 0x00;
     const SUBUNIT: u8 = 0x01;
     const FUNCBLK: u8 = 0x02;
-}
 
-impl From<&[u8; 4]> for BcoPlugAddrMode {
-    fn from(raw: &[u8; 4]) -> Self {
+    fn from_raw(raw: &[u8; 4]) -> Self {
         let mut r = [0; 3];
         r.copy_from_slice(&raw[1..]);
         match raw[0] {
-            BcoPlugAddrMode::UNIT => BcoPlugAddrMode::Unit(BcoPlugAddrUnit::from(&r)),
-            BcoPlugAddrMode::SUBUNIT => BcoPlugAddrMode::Subunit(BcoPlugAddrSubunit::from(&r)),
-            BcoPlugAddrMode::FUNCBLK => BcoPlugAddrMode::FuncBlk(BcoPlugAddrFuncBlk::from(&r)),
-            _ => BcoPlugAddrMode::Reserved(*raw),
+            Self::UNIT => Self::Unit(BcoPlugAddrUnit::from_raw(&r)),
+            Self::SUBUNIT => Self::Subunit(BcoPlugAddrSubunit::from_raw(&r)),
+            Self::FUNCBLK => Self::FuncBlk(BcoPlugAddrFuncBlk::from_raw(&r)),
+            _ => Self::Reserved(*raw),
         }
     }
-}
 
-impl From<&BcoPlugAddrMode> for [u8; 4] {
-    fn from(data: &BcoPlugAddrMode) -> Self {
+    fn to_raw(&self) -> [u8; 4] {
         let mut raw = [0; 4];
-        match data {
-            BcoPlugAddrMode::Unit(d) => {
-                raw[0] = BcoPlugAddrMode::UNIT;
-                raw[1..].copy_from_slice(&Into::<[u8; 3]>::into(d));
+        match self {
+            Self::Unit(d) => {
+                raw[0] = Self::UNIT;
+                raw[1..].copy_from_slice(&d.to_raw());
             }
-            BcoPlugAddrMode::Subunit(d) => {
-                raw[0] = BcoPlugAddrMode::SUBUNIT;
-                raw[1..].copy_from_slice(&Into::<[u8; 3]>::into(d));
+            Self::Subunit(d) => {
+                raw[0] = Self::SUBUNIT;
+                raw[1..].copy_from_slice(&d.to_raw());
             }
-            BcoPlugAddrMode::FuncBlk(d) => {
-                raw[0] = BcoPlugAddrMode::FUNCBLK;
-                raw[1..].copy_from_slice(&Into::<[u8; 3]>::into(d));
+            Self::FuncBlk(d) => {
+                raw[0] = Self::FUNCBLK;
+                raw[1..].copy_from_slice(&d.to_raw());
             }
-            BcoPlugAddrMode::Reserved(d) => {
+            Self::Reserved(d) => {
                 raw.copy_from_slice(d);
             }
         }
@@ -179,22 +165,20 @@ impl BcoPlugDirection {
     const OUTPUT: u8 = 0x01;
 }
 
-impl From<u8> for BcoPlugDirection {
-    fn from(val: u8) -> Self {
+impl BcoPlugDirection {
+    fn from_val(val: u8) -> Self {
         match val {
-            BcoPlugDirection::INPUT => BcoPlugDirection::Input,
-            BcoPlugDirection::OUTPUT => BcoPlugDirection::Output,
-            _ => BcoPlugDirection::Reserved(val),
+            Self::INPUT => Self::Input,
+            Self::OUTPUT => Self::Output,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<BcoPlugDirection> for u8 {
-    fn from(direction: BcoPlugDirection) -> u8 {
-        match direction {
-            BcoPlugDirection::Input => BcoPlugDirection::INPUT,
-            BcoPlugDirection::Output => BcoPlugDirection::OUTPUT,
-            BcoPlugDirection::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Input => Self::INPUT,
+            Self::Output => Self::OUTPUT,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -243,24 +227,20 @@ impl BcoPlugAddr {
             }),
         }
     }
-}
 
-impl From<&[u8; 5]> for BcoPlugAddr {
-    fn from(raw: &[u8; 5]) -> Self {
+    fn from_raw(raw: &[u8; 5]) -> Self {
         let mut r = [0; 4];
         r.copy_from_slice(&raw[1..]);
-        BcoPlugAddr {
-            direction: BcoPlugDirection::from(raw[0]),
-            mode: BcoPlugAddrMode::from(&r),
+        Self {
+            direction: BcoPlugDirection::from_val(raw[0]),
+            mode: BcoPlugAddrMode::from_raw(&r),
         }
     }
-}
 
-impl From<&BcoPlugAddr> for [u8; 5] {
-    fn from(data: &BcoPlugAddr) -> [u8; 5] {
+    fn to_raw(&self) -> [u8; 5] {
         let mut raw = [0; 5];
-        raw[0] = data.direction.into();
-        raw[1..].copy_from_slice(&Into::<[u8; 4]>::into(&data.mode));
+        raw[0] = self.direction.to_val();
+        raw[1..].copy_from_slice(&self.mode.to_raw());
         raw
     }
 }
@@ -280,7 +260,7 @@ impl From<&[u8; 6]> for BcoIoPlugAddrMode {
         match raw[0] {
             BcoPlugAddrMode::UNIT => {
                 r.copy_from_slice(&raw[1..4]);
-                BcoIoPlugAddrMode::Unit(BcoPlugAddrUnit::from(&r))
+                BcoIoPlugAddrMode::Unit(BcoPlugAddrUnit::from_raw(&r))
             }
             BcoPlugAddrMode::SUBUNIT => {
                 let subunit = AvcAddrSubunit {
@@ -288,7 +268,7 @@ impl From<&[u8; 6]> for BcoIoPlugAddrMode {
                     subunit_id: raw[2],
                 };
                 r.copy_from_slice(&raw[3..6]);
-                BcoIoPlugAddrMode::Subunit(subunit, BcoPlugAddrSubunit::from(&r))
+                BcoIoPlugAddrMode::Subunit(subunit, BcoPlugAddrSubunit::from_raw(&r))
             }
             BcoPlugAddrMode::FUNCBLK => {
                 let subunit = AvcAddrSubunit {
@@ -296,7 +276,7 @@ impl From<&[u8; 6]> for BcoIoPlugAddrMode {
                     subunit_id: raw[2],
                 };
                 r.copy_from_slice(&raw[3..6]);
-                BcoIoPlugAddrMode::FuncBlk(subunit, BcoPlugAddrFuncBlk::from(&r))
+                BcoIoPlugAddrMode::FuncBlk(subunit, BcoPlugAddrFuncBlk::from_raw(&r))
             }
             _ => BcoIoPlugAddrMode::Reserved(*raw),
         }
@@ -309,19 +289,19 @@ impl From<&BcoIoPlugAddrMode> for [u8; 6] {
         match data {
             BcoIoPlugAddrMode::Unit(d) => {
                 raw[0] = BcoPlugAddrMode::UNIT;
-                raw[1..4].copy_from_slice(&Into::<[u8; 3]>::into(d));
+                raw[1..4].copy_from_slice(&d.to_raw());
             }
             BcoIoPlugAddrMode::Subunit(s, d) => {
                 raw[0] = BcoPlugAddrMode::SUBUNIT;
                 raw[1] = s.subunit_type.into();
                 raw[2] = s.subunit_id;
-                raw[3..6].copy_from_slice(&Into::<[u8; 3]>::into(d));
+                raw[3..6].copy_from_slice(&d.to_raw());
             }
             BcoIoPlugAddrMode::FuncBlk(s, d) => {
                 raw[0] = BcoPlugAddrMode::FUNCBLK;
                 raw[1] = s.subunit_type.into();
                 raw[2] = s.subunit_id;
-                raw[3..6].copy_from_slice(&Into::<[u8; 3]>::into(d));
+                raw[3..6].copy_from_slice(&d.to_raw());
             }
             BcoIoPlugAddrMode::Reserved(d) => {
                 raw.copy_from_slice(d);
@@ -343,7 +323,7 @@ impl From<&[u8; 7]> for BcoIoPlugAddr {
         let mut r = [0; 6];
         r.copy_from_slice(&raw[1..]);
         BcoIoPlugAddr {
-            direction: BcoPlugDirection::from(raw[0]),
+            direction: BcoPlugDirection::from_val(raw[0]),
             mode: BcoIoPlugAddrMode::from(&r),
         }
     }
@@ -352,7 +332,7 @@ impl From<&[u8; 7]> for BcoIoPlugAddr {
 impl From<&BcoIoPlugAddr> for [u8; 7] {
     fn from(data: &BcoIoPlugAddr) -> [u8; 7] {
         let mut raw = [0; 7];
-        raw[0] = data.direction.into();
+        raw[0] = data.direction.to_val();
         raw[1..].copy_from_slice(&Into::<[u8; 6]>::into(&data.mode));
         raw
     }
@@ -822,7 +802,7 @@ impl AvcStatus for ExtendedPlugInfo {
     fn build_operands(&mut self, _: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         let mut operands = Vec::new();
         operands.push(Self::SUBFUNC);
-        operands.extend_from_slice(&Into::<[u8; 5]>::into(&self.addr));
+        operands.extend_from_slice(&self.addr.to_raw());
         operands.append(&mut Into::<Vec<u8>>::into(&self.info));
         Ok(operands)
     }
@@ -838,7 +818,7 @@ impl AvcStatus for ExtendedPlugInfo {
 
         let mut a = [0; 5];
         a.copy_from_slice(&operands[1..6]);
-        let addr = BcoPlugAddr::from(&a);
+        let addr = BcoPlugAddr::from_raw(&a);
         if addr != self.addr {
             Err(AvcRespParseError::UnexpectedOperands(1))?;
         }
@@ -1332,7 +1312,7 @@ impl AvcStatus for BcoExtendedStreamFormat {
     fn build_operands(&mut self, _: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
         let mut operands = Vec::new();
         operands.push(self.subfunc);
-        operands.extend_from_slice(&Into::<[u8; 5]>::into(&self.plug_addr));
+        operands.extend_from_slice(&self.plug_addr.to_raw());
         operands.push(self.support_status.to_val());
         Ok(operands)
     }
@@ -1348,7 +1328,7 @@ impl AvcStatus for BcoExtendedStreamFormat {
 
         let mut r = [0; 5];
         r.copy_from_slice(&operands[1..6]);
-        let plug_addr = BcoPlugAddr::from(&r);
+        let plug_addr = BcoPlugAddr::from_raw(&r);
         if plug_addr != self.plug_addr {
             Err(AvcRespParseError::UnexpectedOperands(1))?;
         }
@@ -1702,7 +1682,7 @@ mod test {
     fn bcoplugaddr_from() {
         // Input plug for Unit.
         let raw = [0x00, 0x00, 0x00, 0x03, 0xff];
-        let addr = BcoPlugAddr::from(&raw);
+        let addr = BcoPlugAddr::from_raw(&raw);
         assert_eq!(addr.direction, BcoPlugDirection::Input);
         if let BcoPlugAddrMode::Unit(d) = &addr.mode {
             assert_eq!(d.plug_type, BcoPlugAddrUnitType::Isoc);
@@ -1710,22 +1690,22 @@ mod test {
         } else {
             unreachable!();
         }
-        assert_eq!(raw, Into::<[u8; 5]>::into(&addr));
+        assert_eq!(raw, addr.to_raw());
 
         // Output plug for Subunit.
         let raw = [0x01, 0x01, 0x04, 0xff, 0xff];
-        let addr = BcoPlugAddr::from(&raw);
+        let addr = BcoPlugAddr::from_raw(&raw);
         assert_eq!(addr.direction, BcoPlugDirection::Output);
         if let BcoPlugAddrMode::Subunit(d) = &addr.mode {
             assert_eq!(d.plug_id, 0x04);
         } else {
             unreachable!();
         }
-        assert_eq!(raw, Into::<[u8; 5]>::into(&addr));
+        assert_eq!(raw, addr.to_raw());
 
         // Input plug for function block.
         let raw = [0x02, 0x02, 0x06, 0x03, 0x02];
-        let addr = BcoPlugAddr::from(&raw);
+        let addr = BcoPlugAddr::from_raw(&raw);
         assert_eq!(addr.direction, BcoPlugDirection::Reserved(0x02));
         if let BcoPlugAddrMode::FuncBlk(d) = &addr.mode {
             assert_eq!(d.func_blk_type, 0x06);
@@ -1734,7 +1714,7 @@ mod test {
         } else {
             unreachable!();
         }
-        assert_eq!(raw, Into::<[u8; 5]>::into(&addr));
+        assert_eq!(raw, addr.to_raw());
     }
 
     #[test]

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -1399,30 +1399,27 @@ pub enum BcoStreamFormat {
 impl BcoStreamFormat {
     const LENGTH_MIN: usize = 1;
 
-    fn as_bco_am_stream(&self) -> Result<&BcoAmStream, Error> {
+    fn as_bco_am_stream(&self) -> Option<&BcoAmStream> {
         if let BcoStreamFormat::Am(s) = self {
-            Ok(s)
+            Some(s)
         } else {
-            let label = "Bco Audio & Music stream is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 
-    pub fn as_am_stream(&self) -> Result<&AmStream, Error> {
+    pub fn as_am_stream(&self) -> Option<&AmStream> {
         if let BcoAmStream::AmStream(s) = self.as_bco_am_stream()? {
-            Ok(s)
+            Some(s)
         } else {
-            let label = "Audio & Music stream is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 
-    pub fn as_bco_compound_am824_stream(&self) -> Result<&BcoCompoundAm824Stream, Error> {
+    pub fn as_bco_compound_am824_stream(&self) -> Option<&BcoCompoundAm824Stream> {
         if let BcoAmStream::BcoStream(s) = self.as_bco_am_stream()? {
-            Ok(s)
+            Some(s)
         } else {
-            let label = "Bco Compound AM824 stream is not available for the unit";
-            Err(Error::new(FileError::Nxio, &label))
+            None
         }
     }
 

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -353,32 +353,28 @@ impl BcoPlugType {
     const SYNC: u8 = 0x03;
     const ANALOG: u8 = 0x04;
     const DIGITAL: u8 = 0x05;
-}
 
-impl From<u8> for BcoPlugType {
-    fn from(val: u8) -> Self {
+    fn from_val(val: u8) -> Self {
         match val {
-            BcoPlugType::ISOC_STREAM => BcoPlugType::Isoc,
-            BcoPlugType::ASYNC_STREAM => BcoPlugType::Async,
-            BcoPlugType::MIDI => BcoPlugType::Midi,
-            BcoPlugType::SYNC => BcoPlugType::Sync,
-            BcoPlugType::ANALOG => BcoPlugType::Analog,
-            BcoPlugType::DIGITAL => BcoPlugType::Digital,
-            _ => BcoPlugType::Reserved(val),
+            Self::ISOC_STREAM => Self::Isoc,
+            Self::ASYNC_STREAM => Self::Async,
+            Self::MIDI => Self::Midi,
+            Self::SYNC => Self::Sync,
+            Self::ANALOG => Self::Analog,
+            Self::DIGITAL => Self::Digital,
+            _ => Self::Reserved(val),
         }
     }
-}
 
-impl From<BcoPlugType> for u8 {
-    fn from(plug_type: BcoPlugType) -> u8 {
-        match plug_type {
-            BcoPlugType::Isoc => BcoPlugType::ISOC_STREAM,
-            BcoPlugType::Async => BcoPlugType::ASYNC_STREAM,
-            BcoPlugType::Midi => BcoPlugType::MIDI,
-            BcoPlugType::Sync => BcoPlugType::SYNC,
-            BcoPlugType::Analog => BcoPlugType::ANALOG,
-            BcoPlugType::Digital => BcoPlugType::DIGITAL,
-            BcoPlugType::Reserved(val) => val,
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Isoc => Self::ISOC_STREAM,
+            Self::Async => Self::ASYNC_STREAM,
+            Self::Midi => Self::MIDI,
+            Self::Sync => Self::SYNC,
+            Self::Analog => Self::ANALOG,
+            Self::Digital => Self::DIGITAL,
+            Self::Reserved(val) => *val,
         }
     }
 }
@@ -668,7 +664,7 @@ impl From<&BcoPlugInfo> for Vec<u8> {
         match data {
             BcoPlugInfo::Type(plug_type) => {
                 raw.push(BcoPlugInfo::TYPE);
-                raw.push(u8::from(*plug_type));
+                raw.push(plug_type.to_val());
             }
             BcoPlugInfo::Name(n) => {
                 raw.push(BcoPlugInfo::NAME);
@@ -716,7 +712,7 @@ impl From<&BcoPlugInfo> for Vec<u8> {
 impl From<&[u8]> for BcoPlugInfo {
     fn from(raw: &[u8]) -> Self {
         match raw[0] {
-            BcoPlugInfo::TYPE => BcoPlugInfo::Type(BcoPlugType::from(raw[1])),
+            BcoPlugInfo::TYPE => BcoPlugInfo::Type(BcoPlugType::from_val(raw[1])),
             BcoPlugInfo::NAME => {
                 let pos = 2 + raw[1] as usize;
                 let name = if pos > raw.len() {

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -839,9 +839,9 @@ pub struct ExtendedSubunitInfoEntry {
     pub output_plugs: u8,
 }
 
-impl From<&[u8; 5]> for ExtendedSubunitInfoEntry {
-    fn from(raw: &[u8; 5]) -> Self {
-        ExtendedSubunitInfoEntry {
+impl ExtendedSubunitInfoEntry {
+    fn from_raw(raw: &[u8; 5]) -> Self {
+        Self {
             func_blk_type: raw[0],
             func_blk_id: raw[1],
             func_blk_purpose: raw[2],
@@ -849,16 +849,15 @@ impl From<&[u8; 5]> for ExtendedSubunitInfoEntry {
             output_plugs: raw[4],
         }
     }
-}
 
-impl From<&ExtendedSubunitInfoEntry> for [u8; 5] {
-    fn from(data: &ExtendedSubunitInfoEntry) -> Self {
+    #[allow(dead_code)]
+    fn to_raw(&self) -> [u8; 5] {
         [
-            data.func_blk_type,
-            data.func_blk_id,
-            data.func_blk_purpose,
-            data.input_plugs,
-            data.output_plugs,
+            self.func_blk_type,
+            self.func_blk_id,
+            self.func_blk_purpose,
+            self.input_plugs,
+            self.output_plugs,
         ]
     }
 }
@@ -872,9 +871,8 @@ pub struct ExtendedSubunitInfo {
 }
 
 impl ExtendedSubunitInfo {
-    #[allow(dead_code)]
     pub fn new(page: u8, func_blk_type: u8) -> Self {
-        ExtendedSubunitInfo {
+        Self {
             page,
             func_blk_type,
             entries: Vec::new(),
@@ -909,7 +907,7 @@ impl AvcStatus for ExtendedSubunitInfo {
                     let pos = 2 + i * 5;
                     let mut raw = [0; 5];
                     raw.copy_from_slice(&operands[pos..(pos + 5)]);
-                    ExtendedSubunitInfoEntry::from(&raw)
+                    ExtendedSubunitInfoEntry::from_raw(&raw)
                 })
                 .collect();
             Ok(())

--- a/libs/bebob/protocols/src/bridgeco.rs
+++ b/libs/bebob/protocols/src/bridgeco.rs
@@ -45,6 +45,12 @@ impl BcoPlugAddrUnitType {
     }
 }
 
+impl Default for BcoPlugAddrUnitType {
+    fn default() -> Self {
+        Self::Isoc
+    }
+}
+
 /// Address to plug for unit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddrUnit {
@@ -71,6 +77,15 @@ impl BcoPlugAddrUnit {
     }
 }
 
+impl Default for BcoPlugAddrUnit {
+    fn default() -> Self {
+        Self {
+            plug_type: Default::default(),
+            plug_id: 0xff,
+        }
+    }
+}
+
 /// Address to plug for subunit.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddrSubunit {
@@ -90,6 +105,12 @@ impl BcoPlugAddrSubunit {
 
     fn to_raw(&self) -> [u8; Self::LENGTH] {
         [self.plug_id, 0xff, 0xff]
+    }
+}
+
+impl Default for BcoPlugAddrSubunit {
+    fn default() -> Self {
+        Self { plug_id: 0xff }
     }
 }
 
@@ -118,6 +139,16 @@ impl BcoPlugAddrFuncBlk {
 
     fn to_raw(&self) -> [u8; Self::LENGTH] {
         [self.func_blk_type, self.func_blk_id, self.plug_id]
+    }
+}
+
+impl Default for BcoPlugAddrFuncBlk {
+    fn default() -> Self {
+        Self {
+            func_blk_type: 0xff,
+            func_blk_id: 0xff,
+            plug_id: 0xff,
+        }
     }
 }
 
@@ -182,6 +213,12 @@ impl BcoPlugAddrMode {
     }
 }
 
+impl Default for BcoPlugAddrMode {
+    fn default() -> Self {
+        Self::Unit(Default::default())
+    }
+}
+
 /// Direction of plug.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum BcoPlugDirection {
@@ -192,9 +229,7 @@ pub enum BcoPlugDirection {
 impl BcoPlugDirection {
     const INPUT: u8 = 0x00;
     const OUTPUT: u8 = 0x01;
-}
 
-impl BcoPlugDirection {
     fn from_val(val: u8) -> Result<Self, AvcRespParseError> {
         let direction = match val {
             Self::INPUT => Self::Input,
@@ -212,8 +247,14 @@ impl BcoPlugDirection {
     }
 }
 
+impl Default for BcoPlugDirection {
+    fn default() -> Self {
+        Self::Input
+    }
+}
+
 /// Address of plug.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct BcoPlugAddr {
     pub direction: BcoPlugDirection,
     pub mode: BcoPlugAddrMode,
@@ -347,8 +388,14 @@ impl BcoIoPlugAddrMode {
     }
 }
 
+impl Default for BcoIoPlugAddrMode {
+    fn default() -> Self {
+        Self::Unit(Default::default())
+    }
+}
+
 /// Address to plug for input and output direction.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
 pub struct BcoIoPlugAddr {
     pub direction: BcoPlugDirection,
     pub mode: BcoIoPlugAddrMode,
@@ -417,6 +464,12 @@ impl BcoPlugType {
             Self::Analog => Self::ANALOG,
             Self::Digital => Self::DIGITAL,
         }
+    }
+}
+
+impl Default for BcoPlugType {
+    fn default() -> Self {
+        Self::Isoc
     }
 }
 
@@ -504,6 +557,12 @@ impl BcoLocation {
     }
 }
 
+impl Default for BcoLocation {
+    fn default() -> Self {
+        Self::NoPosition
+    }
+}
+
 /// Information about data channel for multi bit linear audio.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub struct BcoChannelInfo {
@@ -533,8 +592,17 @@ impl BcoChannelInfo {
     }
 }
 
+impl Default for BcoChannelInfo {
+    fn default() -> Self {
+        Self {
+            pos: 0xff,
+            loc: Default::default(),
+        }
+    }
+}
+
 /// Cluster with single or multiple data channels.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Clone, Eq, PartialEq)]
 pub struct BcoCluster {
     entries: Vec<BcoChannelInfo>,
 }
@@ -579,6 +647,15 @@ impl BcoCluster {
 pub struct BcoChannelName {
     pub ch: u8,
     pub name: String,
+}
+
+impl Default for BcoChannelName {
+    fn default() -> Self {
+        Self {
+            ch: 0xff,
+            name: Default::default(),
+        }
+    }
 }
 
 /// Type of physical port.
@@ -649,6 +726,12 @@ impl BcoPortType {
     }
 }
 
+impl Default for BcoPortType {
+    fn default() -> Self {
+        Self::NoType
+    }
+}
+
 /// Information about cluster of data channels.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct BcoClusterInfo {
@@ -687,6 +770,16 @@ impl BcoClusterInfo {
         raw.push(self.name.len() as u8);
         raw.append(&mut self.name.clone().into_bytes());
         raw
+    }
+}
+
+impl Default for BcoClusterInfo {
+    fn default() -> Self {
+        Self {
+            index: 0xff,
+            port_type: Default::default(),
+            name: Default::default(),
+        }
     }
 }
 
@@ -836,7 +929,14 @@ impl BcoPlugInfo {
     }
 }
 
+impl Default for BcoPlugInfo {
+    fn default() -> Self {
+        Self::Type(Default::default())
+    }
+}
+
 /// AV/C command for extend plug information.
+#[derive(Default)]
 pub struct ExtendedPlugInfo {
     /// The address of plug.
     pub addr: BcoPlugAddr,
@@ -850,7 +950,7 @@ impl ExtendedPlugInfo {
     /// Instantiate extended plug info structure with parameters.
     #[allow(dead_code)]
     pub fn new(addr: &BcoPlugAddr, info: BcoPlugInfo) -> Self {
-        ExtendedPlugInfo { addr: *addr, info }
+        Self { addr: *addr, info }
     }
 }
 
@@ -945,6 +1045,18 @@ impl ExtendedSubunitInfoEntry {
     }
 }
 
+impl Default for ExtendedSubunitInfoEntry {
+    fn default() -> Self {
+        Self {
+            func_blk_type: 0xff,
+            func_blk_id: 0xff,
+            func_blk_purpose: 0xff,
+            input_plugs: 0xff,
+            output_plugs: 0xff,
+        }
+    }
+}
+
 /// AV/C command for extended subunit information.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ExtendedSubunitInfo {
@@ -960,7 +1072,17 @@ impl ExtendedSubunitInfo {
         Self {
             page,
             func_blk_type,
-            entries: Vec::new(),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for ExtendedSubunitInfo {
+    fn default() -> Self {
+        Self {
+            page: 0xff,
+            func_blk_type: 0xff,
+            entries: Default::default(),
         }
     }
 }
@@ -1066,6 +1188,12 @@ impl BcoCompoundAm824StreamFormat {
     }
 }
 
+impl Default for BcoCompoundAm824StreamFormat {
+    fn default() -> Self {
+        Self::Reserved(0xff)
+    }
+}
+
 /// Entry for compound AM824 stream.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BcoCompoundAm824StreamEntry {
@@ -1089,6 +1217,15 @@ impl BcoCompoundAm824StreamEntry {
 
     fn to_raw(&self) -> [u8; Self::LENGTH] {
         [self.count, self.format.to_val()]
+    }
+}
+
+impl Default for BcoCompoundAm824StreamEntry {
+    fn default() -> Self {
+        Self {
+            count: 0xff,
+            format: Default::default(),
+        }
     }
 }
 
@@ -1190,8 +1327,19 @@ impl BcoCompoundAm824Stream {
     }
 }
 
+impl Default for BcoCompoundAm824Stream {
+    fn default() -> Self {
+        Self {
+            freq: 44100,
+            sync_src: Default::default(),
+            rate_ctl: Default::default(),
+            entries: Default::default(),
+        }
+    }
+}
+
 /// Format of isochronous packet stream for Audio and Music data transmission.
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum BcoAmStream {
     AmStream(AmStream),
     BcoStream(BcoCompoundAm824Stream),
@@ -1231,6 +1379,12 @@ impl BcoAmStream {
             }
             _ => self.to_raw(),
         }
+    }
+}
+
+impl Default for BcoAmStream {
+    fn default() -> Self {
+        Self::BcoStream(Default::default())
     }
 }
 
@@ -1301,6 +1455,12 @@ impl BcoStreamFormat {
     }
 }
 
+impl Default for BcoStreamFormat {
+    fn default() -> Self {
+        Self::Reserved(Default::default())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BcoSupportStatus {
     /// The format is already set and stream is available.
@@ -1359,10 +1519,20 @@ impl BcoExtendedStreamFormat {
     const LENGTH_MIN: usize = 7;
 
     fn new(subfunc: u8, plug_addr: &BcoPlugAddr) -> Self {
-        BcoExtendedStreamFormat {
+        Self {
             subfunc,
             plug_addr: *plug_addr,
-            support_status: BcoSupportStatus::NotUsed,
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for BcoExtendedStreamFormat {
+    fn default() -> Self {
+        Self {
+            subfunc: 0xff,
+            plug_addr: Default::default(),
+            support_status: Default::default(),
         }
     }
 }
@@ -1408,10 +1578,19 @@ impl ExtendedStreamFormatSingle {
     const SUBFUNC: u8 = 0xc0;
 
     pub fn new(plug_addr: &BcoPlugAddr) -> Self {
-        ExtendedStreamFormatSingle {
-            support_status: BcoSupportStatus::NotUsed,
-            stream_format: BcoStreamFormat::Reserved(Vec::new()),
+        Self {
             op: BcoExtendedStreamFormat::new(Self::SUBFUNC, plug_addr),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for ExtendedStreamFormatSingle {
+    fn default() -> Self {
+        Self {
+            support_status: Default::default(),
+            stream_format: Default::default(),
+            op: BcoExtendedStreamFormat::new(Self::SUBFUNC, &BcoPlugAddr::default()),
         }
     }
 }
@@ -1473,11 +1652,21 @@ impl ExtendedStreamFormatList {
 
     /// Instantiate extended stream format list structure with parameters.
     pub fn new(plug_addr: &BcoPlugAddr, index: u8) -> Self {
-        ExtendedStreamFormatList {
-            support_status: BcoSupportStatus::NotUsed,
+        Self {
             index,
-            stream_format: BcoStreamFormat::Reserved(Vec::new()),
             op: BcoExtendedStreamFormat::new(Self::SUBFUNC, plug_addr),
+            ..Default::default()
+        }
+    }
+}
+
+impl Default for ExtendedStreamFormatList {
+    fn default() -> Self {
+        Self {
+            support_status: Default::default(),
+            index: 0xff,
+            stream_format: Default::default(),
+            op: BcoExtendedStreamFormat::new(Self::SUBFUNC, &BcoPlugAddr::default()),
         }
     }
 }
@@ -1813,7 +2002,7 @@ mod test {
     #[test]
     fn bcoioplugaddr_from() {
         // Unit.
-        let raw: [u8; 7] = [0x00, 0x00, 0x02, 0x05, 0xff, 0xff, 0xff];
+        let raw = [0x00, 0x00, 0x02, 0x05, 0xff, 0xff, 0xff];
         let addr = BcoIoPlugAddr::from_raw(&raw).unwrap();
         assert_eq!(addr.direction, BcoPlugDirection::Input);
         if let BcoIoPlugAddrMode::Unit(d) = &addr.mode {
@@ -1825,7 +2014,7 @@ mod test {
         assert_eq!(raw, addr.to_raw());
 
         // Subunit.
-        let raw: [u8; 7] = [0x01, 0x01, 0x06, 0x05, 0x02, 0xff, 0xff];
+        let raw = [0x01, 0x01, 0x06, 0x05, 0x02, 0xff, 0xff];
         let addr = BcoIoPlugAddr::from_raw(&raw).unwrap();
         assert_eq!(addr.direction, BcoPlugDirection::Output);
         if let BcoIoPlugAddrMode::Subunit(s, d) = &addr.mode {
@@ -1838,7 +2027,7 @@ mod test {
         assert_eq!(raw, addr.to_raw());
 
         // Function block.
-        let raw: [u8; 7] = [0x00, 0x02, 0x04, 0x09, 0x80, 0x12, 0x23];
+        let raw = [0x00, 0x02, 0x04, 0x09, 0x80, 0x12, 0x23];
         let addr = BcoIoPlugAddr::from_raw(&raw).unwrap();
         assert_eq!(addr.direction, BcoPlugDirection::Input);
         if let BcoIoPlugAddrMode::FuncBlk(s, d) = &addr.mode {
@@ -1855,7 +2044,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_type_from() {
-        let raw: Vec<u8> = vec![0x00, 0x03];
+        let raw = vec![0x00, 0x03];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::Type(t) = &info {
             assert_eq!(*t, BcoPlugType::Sync);
@@ -1867,7 +2056,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_name_from() {
-        let raw: Vec<u8> = vec![0x01, 0x03, 0x31, 0x32, 0x33];
+        let raw = vec![0x01, 0x03, 0x31, 0x32, 0x33];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::Name(n) = &info {
             assert_eq!(n, "123");
@@ -1879,7 +2068,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_chcount_from() {
-        let raw: Vec<u8> = vec![0x02, 0xc3];
+        let raw = vec![0x02, 0xc3];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::ChCount(c) = &info {
             assert_eq!(*c, 0xc3);
@@ -1891,7 +2080,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_chpositions_from() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0x03, 0x04, 0x01, 0x00, 0x04, 0x02, 0x03, 0x08, 0x00, 0x09, 0x03, 0x04, 0x08, 0x06,
             0x08, 0x05, 0x07, 0x01, 0x09, 0xb,
         ];
@@ -1963,7 +2152,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_chname_from() {
-        let raw: Vec<u8> = vec![0x04, 0x9a, 0x01, 0x39];
+        let raw = vec![0x04, 0x9a, 0x01, 0x39];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::ChName(d) = &info {
             assert_eq!(d.ch, 0x9a);
@@ -1976,7 +2165,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_input_from() {
-        let raw: Vec<u8> = vec![0x05, 0x01, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff];
+        let raw = vec![0x05, 0x01, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::Input(plug_addr) = &info {
             assert_eq!(plug_addr.direction, BcoPlugDirection::Output);
@@ -1995,7 +2184,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_outputs_from() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0x06, 0x02, 0x01, 0x01, 0x0b, 0x07, 0x42, 0xff, 0xff, 0x01, 0x01, 0x0b, 0x07, 0x42,
             0xff, 0xff,
         ];
@@ -2027,7 +2216,7 @@ mod test {
 
     #[test]
     fn bcopluginfo_clusterinfo_from() {
-        let raw: Vec<u8> = vec![0x07, 0x01, 0x09, 0x05, 0x41, 0x42, 0x43, 0x44, 0x45];
+        let raw = vec![0x07, 0x01, 0x09, 0x05, 0x41, 0x42, 0x43, 0x44, 0x45];
         let info = BcoPlugInfo::from_raw(&raw).unwrap();
         if let BcoPlugInfo::ClusterInfo(d) = &info {
             assert_eq!(d.index, 0x01);
@@ -2041,7 +2230,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_type_operands() {
-        let raw: Vec<u8> = vec![0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x00, 0x00];
+        let raw = vec![0xc0, 0x01, 0x00, 0x00, 0x03, 0xff, 0x00, 0x00];
         let addr = BcoPlugAddr {
             direction: BcoPlugDirection::Output,
             mode: BcoPlugAddrMode::Unit(BcoPlugAddrUnit {
@@ -2062,7 +2251,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_name_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x00, 0x01, 0x17, 0xff, 0xff, 0x01, 0x05, 0x39, 0x38, 0x52, 0x36, 0x35,
         ];
         let addr = BcoPlugAddr {
@@ -2082,7 +2271,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_chcount_operands() {
-        let raw: Vec<u8> = vec![0xc0, 0x01, 0x02, 0x3e, 0x9a, 0x77, 0x02, 0xe4];
+        let raw = vec![0xc0, 0x01, 0x02, 0x3e, 0x9a, 0x77, 0x02, 0xe4];
         let addr = BcoPlugAddr {
             direction: BcoPlugDirection::Output,
             mode: BcoPlugAddrMode::FuncBlk(BcoPlugAddrFuncBlk {
@@ -2104,7 +2293,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_chpositions_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x00, 0x00, 0x01, 0x5c, 0xff, 0x03, 0x03, 0x01, 0x00, 0x0a, 0x02, 0x03, 0x04,
             0x02, 0x07, 0x03, 0x01, 0x0f, 0x04, 0x01, 0x05, 0x03,
         ];
@@ -2176,7 +2365,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_chname_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x00, 0x00, 0x02, 0x97, 0xff, 0x04, 0x9d, 0x02, 0x46, 0x54,
         ];
         let addr = BcoPlugAddr {
@@ -2203,7 +2392,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_input_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x01, 0x01, 0x5d, 0xff, 0xff, 0x05, 0x00, 0x02, 0x0c, 0x12, 0x80, 0xd9, 0x04,
         ];
         let addr = BcoPlugAddr {
@@ -2238,7 +2427,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_outputs_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x01, 0x00, 0x00, 0x11, 0xff, 0x06, 0x02, 0x00, 0x02, 0x0c, 0x12, 0x80, 0xd9,
             0x04, 0x00, 0x01, 0x0c, 0x03, 0x31, 0xff, 0xff,
         ];
@@ -2281,7 +2470,7 @@ mod test {
 
     #[test]
     fn extendedpluginfo_clusterinfo_operands() {
-        let raw: Vec<u8> = vec![
+        let raw = vec![
             0xc0, 0x01, 0x00, 0x01, 0x1e, 0xff, 0x07, 0x02, 0x05, 0x03, 0x60, 0x50, 0x70,
         ];
         let addr = BcoPlugAddr {

--- a/libs/bebob/protocols/src/lib.rs
+++ b/libs/bebob/protocols/src/lib.rs
@@ -135,6 +135,10 @@ pub trait MediaClockFrequencyOperation {
 
         op.stream_format
             .as_bco_compound_am824_stream()
+            .ok_or_else(|| {
+                let label = "Bco Compound AM824 stream is not available for the unit";
+                Error::new(FileError::Nxio, &label)
+            })
             .and_then(|format| {
                 Self::FREQ_LIST
                     .iter()

--- a/libs/bebob/protocols/src/maudio/normal.rs
+++ b/libs/bebob/protocols/src/maudio/normal.rs
@@ -678,22 +678,25 @@ impl Default for AudiophileSwitchState {
     }
 }
 
-impl From<AudiophileSwitchState> for u8 {
-    fn from(state: AudiophileSwitchState) -> Self {
-        match state {
-            AudiophileSwitchState::Off => 0x00,
-            AudiophileSwitchState::A => 0x01,
-            AudiophileSwitchState::B => 0x02,
+impl AudiophileSwitchState {
+    const VALUE_OFF: u8 = 0x00;
+    const VALUE_A: u8 = 0x01;
+    const VALUE_B: u8 = 0x02;
+
+    fn to_val(&self) -> u8 {
+        match self {
+            Self::Off => Self::VALUE_OFF,
+            Self::A => Self::VALUE_A,
+            Self::B => Self::VALUE_B,
         }
     }
-}
 
-impl From<u8> for AudiophileSwitchState {
-    fn from(val: u8) -> Self {
+    #[allow(dead_code)]
+    fn from_val(val: u8) -> Self {
         match val {
-            0x01 => AudiophileSwitchState::A,
-            0x02 => AudiophileSwitchState::B,
-            _ => AudiophileSwitchState::Off,
+            Self::VALUE_A => Self::A,
+            Self::VALUE_B => Self::B,
+            _ => Self::Off,
         }
     }
 }
@@ -731,7 +734,7 @@ impl AvcOp for AudiophileLedSwitch {
 
 impl AvcControl for AudiophileLedSwitch {
     fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
-        self.op.data[3] = self.state.into();
+        self.op.data[3] = self.state.to_val();
         AvcControl::build_operands(&mut self.op, addr)
     }
 


### PR DESCRIPTION
This patchset includes many code changes mainly to reduce unnecessary trait implementations and internal panics.

```
Takashi Sakamoto (27):
  bebob/protocols: localize serializer/deserializer for BcoPlugAddr
  bebob/protocols: localize serializer/deserializer for BcoIoPlugAddr
  bebob/protocols: localize serializer/deserializer for BcoPlugType
  bebob/protocols: localize serializer/deserializer for BcoCluster
  bebob/protocols: localize serializer/deserializer for BcoClusterInfo
  bebob/protocols: localize serializer/deserializer for BcoPortType
  bebob/protocols: localize serializer/deserializer for BcoPlugInfo
  bebob/protocols: localize serializer/deserializer for ExtendedSubunitInfoEntry
  bebob/protocols: localize serializer/deserializer for BcoCompoundAm824Stream
  bebob/protocols: localize serializer/deserializer for BcoAmStream
  bebob/protocols: localize serializer/deserializer for BcoStreamFormat
  bebob/protocols: check length of frame at deserialization for BcoPlugAddr
  bebob/protocols: check length of frame at deserialization for BcoClusterInfo
  bebob/protocols: check length of frame at deserialization for BcoClusterInfo
  bebob/protocols: check length of frame at deserialization for BcoIoPlugAddr
  bebob/protocols: check length of frame at deserialization for BcoPlugInfo
  bebob/protocols: check length of frame at deserialization for ExtendedSubunitInfo
  bebob/protocols: check length of frame at deserialization for ExtendedStreamFormat
  bebob/protocols: delete values undefined for address of plug in document
  bebob/protocols: delete values undefined for BcoPlugType
  bebob/protocols: delete values undefined for BcoLocation
  bebob/protocols: delete values undefined for BcoPortType
  bebob/protocols: delete values undefined for BcoIoPlugAddr
  bebob/protocols: delete values undefined for format of stream
  bebob/protocols: implement Default trait for public structures
  bebob/protocols: rewrite accessor to format of stream
  bebob/protocols: localize serializer/deserializer for M-Audio switch protocol

 libs/bebob/protocols/src/apogee/ensemble.rs |    8 +-
 libs/bebob/protocols/src/bridgeco.rs        | 1494 +++++++++++--------
 libs/bebob/protocols/src/lib.rs             |    4 +
 libs/bebob/protocols/src/maudio/normal.rs   |   29 +-
 4 files changed, 888 insertions(+), 647 deletions(-)
```