### PR TITLE
[PATCH 0/4] runtime: use clap crate to parse arguments of command line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2022/09/01
+2022/09/04
 Takashi Sakamoto
 
 Introduction
@@ -82,7 +82,10 @@ Build ::
 
 Execute temporarily ::
 
-    & cargo run --bin (the executable name) (the arguments of executable)
+    & cargo run --bin (the executable name) -- (the arguments of executable)
+
+All of executables can print help when either ``--help`` or ``-h`` is given as an argument of
+command line.
 
 Install executables ::
 

--- a/runtime/bebob/Cargo.toml
+++ b/runtime/bebob/Cargo.toml
@@ -20,4 +20,5 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.1"
 firewire-bebob-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
+++ b/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {bebob_runtime::BebobRuntime, core::cmdline::*};
+use {bebob_runtime::BebobRuntime, clap::Parser, core::cmdline::*};
 
 struct BebobServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, BebobRuntime> for BebobServiceCmd {
     const CMD_NAME: &'static str = "snd-bebob-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
+++ b/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
@@ -6,20 +6,15 @@ use {bebob_runtime::BebobRuntime, clap::Parser, core::cmdline::*};
 struct BebobServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-bebob-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, BebobRuntime> for BebobServiceCmd {
-    const CMD_NAME: &'static str = "snd-bebob-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, BebobRuntime> for BebobServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/bebob/src/lib.rs
+++ b/runtime/bebob/src/lib.rs
@@ -189,12 +189,12 @@ impl RuntimeOperation<u32> for BebobRuntime {
     }
 }
 
-impl<'a> BebobRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl BebobRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -18,3 +18,4 @@ hinawa = "0.7"
 hitaki = "0.2"
 alsactl = "0.4"
 alsaseq = "0.4"
+clap = { version = "3.2", features = ["derive"] }

--- a/runtime/core/src/cmdline.rs
+++ b/runtime/core/src/cmdline.rs
@@ -51,7 +51,7 @@ Usage:
             };
             Err(msg)
         } else {
-            Self::parse_args(&args)
+            Self::params(&args)
         })
         .and_then(|args| {
             R::new(args).map_err(|e| {

--- a/runtime/dice/Cargo.toml
+++ b/runtime/dice/Cargo.toml
@@ -19,4 +19,5 @@ hitaki = "0.2"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-dice-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/dice/src/bin/snd-dice-ctl-service.rs
+++ b/runtime/dice/src/bin/snd-dice-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, dice_runtime::DiceRuntime};
 struct DiceServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-dice-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, DiceRuntime> for DiceServiceCmd {
-    const CMD_NAME: &'static str = "snd-dice-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, DiceRuntime> for DiceServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/dice/src/bin/snd-dice-ctl-service.rs
+++ b/runtime/dice/src/bin/snd-dice-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, dice_runtime::DiceRuntime};
+use {clap::Parser, core::cmdline::*, dice_runtime::DiceRuntime};
 
 struct DiceServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, DiceRuntime> for DiceServiceCmd {
     const CMD_NAME: &'static str = "snd-dice-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/digi00x/Cargo.toml
+++ b/runtime/digi00x/Cargo.toml
@@ -20,4 +20,5 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.1"
 firewire-digi00x-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
+++ b/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, digi00x_runtime::Dg00xRuntime};
+use {clap::Parser, core::cmdline::*, digi00x_runtime::Dg00xRuntime};
 
 struct Dg00xServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, Dg00xRuntime> for Dg00xServiceCmd {
     const CMD_NAME: &'static str = "snd-firewire-digi00x-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
+++ b/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, digi00x_runtime::Dg00xRuntime};
 struct Dg00xServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-firewire-digi00x-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, Dg00xRuntime> for Dg00xServiceCmd {
-    const CMD_NAME: &'static str = "snd-firewire-digi00x-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, Dg00xRuntime> for Dg00xServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/digi00x/src/lib.rs
+++ b/runtime/digi00x/src/lib.rs
@@ -47,7 +47,7 @@ pub struct Dg00xRuntime {
     measured_elem_id_list: Vec<ElemId>,
 }
 
-impl<'a> Drop for Dg00xRuntime {
+impl Drop for Dg00xRuntime {
     fn drop(&mut self) {
         // At first, stop event loop in all of dispatchers to avoid queueing new events.
         for dispatcher in &mut self.dispatchers {
@@ -227,12 +227,12 @@ impl RuntimeOperation<u32> for Dg00xRuntime {
     }
 }
 
-impl<'a> Dg00xRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl Dg00xRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/runtime/fireface/Cargo.toml
+++ b/runtime/fireface/Cargo.toml
@@ -19,4 +19,5 @@ alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-fireface-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
+++ b/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, fireface_runtime::FfRuntime};
+use {clap::Parser, core::cmdline::*, fireface_runtime::FfRuntime};
 
 struct FfServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, FfRuntime> for FfServiceCmd {
     const CMD_NAME: &'static str = "snd-fireface-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
+++ b/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, fireface_runtime::FfRuntime};
 struct FfServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-fireface-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, FfRuntime> for FfServiceCmd {
-    const CMD_NAME: &'static str = "snd-fireface-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, FfRuntime> for FfServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/fireface/src/lib.rs
+++ b/runtime/fireface/src/lib.rs
@@ -152,12 +152,12 @@ impl Drop for FfRuntime {
     }
 }
 
-impl<'a> FfRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl FfRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/runtime/fireworks/Cargo.toml
+++ b/runtime/fireworks/Cargo.toml
@@ -20,4 +20,5 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.1"
 firewire-fireworks-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
+++ b/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, fireworks_runtime::EfwRuntime};
 struct EfwServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-fireworks-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, EfwRuntime> for EfwServiceCmd {
-    const CMD_NAME: &'static str = "snd-fireworks-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, EfwRuntime> for EfwServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
+++ b/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, fireworks_runtime::EfwRuntime};
+use {clap::Parser, core::cmdline::*, fireworks_runtime::EfwRuntime};
 
 struct EfwServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, EfwRuntime> for EfwServiceCmd {
     const CMD_NAME: &'static str = "snd-fireworks-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/motu/Cargo.toml
+++ b/runtime/motu/Cargo.toml
@@ -19,4 +19,5 @@ alsactl = "0.4"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-motu-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
+++ b/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, motu_runtime::MotuRuntime};
 struct MotuServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-firewire-motu-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, MotuRuntime> for MotuServiceCmd {
-    const CMD_NAME: &'static str = "snd-firewire-motu-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, MotuRuntime> for MotuServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
+++ b/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, motu_runtime::MotuRuntime};
+use {clap::Parser, core::cmdline::*, motu_runtime::MotuRuntime};
 
 struct MotuServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, MotuRuntime> for MotuServiceCmd {
     const CMD_NAME: &'static str = "snd-firewire-motu-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/oxfw/Cargo.toml
+++ b/runtime/oxfw/Cargo.toml
@@ -21,4 +21,5 @@ ta1394-avc-general = "0.1"
 ta1394-avc-audio = "0.1"
 ta1394-avc-stream-format = "0.1"
 firewire-oxfw-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
+++ b/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
@@ -6,20 +6,15 @@ use {clap::Parser, core::cmdline::*, oxfw_runtime::OxfwRuntime};
 struct OxfwServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-oxfw-ctl-service")]
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
 }
 
-impl ServiceCmd<u32, OxfwRuntime> for OxfwServiceCmd {
-    const CMD_NAME: &'static str = "snd-oxfw-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] =
-        &[("CARD_ID", "The numeric ID of sound card")];
-
-    fn params(_: &[String]) -> Result<u32, String> {
-        Arguments::try_parse()
-            .map(|args| args.card_id)
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, u32, OxfwRuntime> for OxfwServiceCmd {
+    fn params(args: &Arguments) -> u32 {
+        args.card_id
     }
 }
 

--- a/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
+++ b/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
@@ -1,17 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {core::cmdline::*, oxfw_runtime::OxfwRuntime};
+use {clap::Parser, core::cmdline::*, oxfw_runtime::OxfwRuntime};
 
 struct OxfwServiceCmd;
+
+#[derive(Parser, Default)]
+struct Arguments {
+    /// The numeric identifier of sound card in Linux sound subsystem.
+    card_id: u32,
+}
 
 impl ServiceCmd<u32, OxfwRuntime> for OxfwServiceCmd {
     const CMD_NAME: &'static str = "snd-oxfw-ctl-service";
     const ARGS: &'static [(&'static str, &'static str)] =
         &[("CARD_ID", "The numeric ID of sound card")];
 
-    fn parse_args(args: &[String]) -> Result<u32, String> {
-        parse_arg_as_u32(&args[0])
+    fn params(_: &[String]) -> Result<u32, String> {
+        Arguments::try_parse()
+            .map(|args| args.card_id)
+            .map_err(|err| err.to_string())
     }
 }
 

--- a/runtime/oxfw/src/common_model.rs
+++ b/runtime/oxfw/src/common_model.rs
@@ -9,7 +9,7 @@ pub struct CommonModel {
     common_ctl: CommonCtl<OxfwAvc>,
 }
 
-impl<'a> CommonModel {
+impl CommonModel {
     const FCP_TIMEOUT_MS: u32 = 100;
 }
 

--- a/runtime/oxfw/src/lib.rs
+++ b/runtime/oxfw/src/lib.rs
@@ -63,7 +63,7 @@ impl Drop for OxfwRuntime {
     }
 }
 
-impl<'a> RuntimeOperation<u32> for OxfwRuntime {
+impl RuntimeOperation<u32> for OxfwRuntime {
     fn new(card_id: u32) -> Result<Self, Error> {
         let cdev = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndUnit::new();
@@ -181,12 +181,12 @@ impl<'a> RuntimeOperation<u32> for OxfwRuntime {
     }
 }
 
-impl<'a> OxfwRuntime {
-    const NODE_DISPATCHER_NAME: &'a str = "node event dispatcher";
-    const SYSTEM_DISPATCHER_NAME: &'a str = "system event dispatcher";
-    const TIMER_DISPATCHER_NAME: &'a str = "interval timer dispatcher";
+impl OxfwRuntime {
+    const NODE_DISPATCHER_NAME: &'static str = "node event dispatcher";
+    const SYSTEM_DISPATCHER_NAME: &'static str = "system event dispatcher";
+    const TIMER_DISPATCHER_NAME: &'static str = "interval timer dispatcher";
 
-    const TIMER_NAME: &'a str = "metering";
+    const TIMER_NAME: &'static str = "metering";
     const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(50);
 
     fn launch_node_event_dispatcher(&mut self) -> Result<(), Error> {

--- a/runtime/tascam/Cargo.toml
+++ b/runtime/tascam/Cargo.toml
@@ -20,4 +20,5 @@ alsaseq = "0.4"
 ieee1212-config-rom = "0.1"
 alsa-ctl-tlv-codec = "0.1"
 firewire-tascam-protocols = "0.1"
+clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }

--- a/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
+++ b/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
@@ -6,6 +6,7 @@ use {clap::Parser, core::cmdline::*, tascam_runtime::TascamRuntime};
 struct TascamServiceCmd;
 
 #[derive(Parser, Default)]
+#[clap(name = "snd-firewire-tascam-ctl-service")]
 struct Arguments {
     /// The name of subsystem; 'snd' or 'fw'.
     subsystem: String,
@@ -13,20 +14,9 @@ struct Arguments {
     sysnum: u32,
 }
 
-impl ServiceCmd<(String, u32), TascamRuntime> for TascamServiceCmd {
-    const CMD_NAME: &'static str = "snd-firewire-tascam-ctl-service";
-    const ARGS: &'static [(&'static str, &'static str)] = &[
-        ("SUBSYSTEM", "The name of subsystem; 'snd' or 'fw'"),
-        (
-            "SYSNUM",
-            "The numeric ID of sound card or fw character device",
-        ),
-    ];
-
-    fn params(_: &[String]) -> Result<(String, u32), String> {
-        Arguments::try_parse()
-            .map(|args| (args.subsystem, args.sysnum))
-            .map_err(|err| err.to_string())
+impl ServiceCmd<Arguments, (String, u32), TascamRuntime> for TascamServiceCmd {
+    fn params(args: &Arguments) -> (String, u32) {
+        (args.subsystem.clone(), args.sysnum)
     }
 }
 


### PR DESCRIPTION
Current implementation includes code to parse arguments of command line,
while we have useful crate for the purpose; [clap crate](https://crates.io/crates/clap).

This commit adds new dependency to clap crate to obsolete own implementation
to parse the arguments. It brings a space to extend command line with additional
arguments, therefore it may be preferable.

```
Takashi Sakamoto (4):
  runtime/oxfw: remove useless named lifetime for CommonModel
  runtime/all: use static lifetime instead of named lifetime at top-level structure
  runtime/all: parse command line argument by clap crate
  runtime/core: use clap crate to build command

 README.rst                                    |   7 +-
 runtime/bebob/Cargo.toml                      |   1 +
 .../bebob/src/bin/snd-bebob-ctl-service.rs    |  17 +-
 runtime/bebob/src/lib.rs                      |  10 +-
 runtime/core/Cargo.toml                       |   1 +
 runtime/core/src/cmdline.rs                   | 172 +++++++-----------
 runtime/dice/Cargo.toml                       |   1 +
 runtime/dice/src/bin/snd-dice-ctl-service.rs  |  17 +-
 runtime/digi00x/Cargo.toml                    |   1 +
 .../bin/snd-firewire-digi00x-ctl-service.rs   |  17 +-
 runtime/digi00x/src/lib.rs                    |  12 +-
 runtime/fireface/Cargo.toml                   |   1 +
 .../src/bin/snd-fireface-ctl-service.rs       |  17 +-
 runtime/fireface/src/lib.rs                   |  10 +-
 runtime/fireworks/Cargo.toml                  |   1 +
 .../src/bin/snd-fireworks-ctl-service.rs      |  17 +-
 runtime/motu/Cargo.toml                       |   1 +
 .../src/bin/snd-firewire-motu-ctl-service.rs  |  17 +-
 runtime/oxfw/Cargo.toml                       |   1 +
 runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs  |  17 +-
 runtime/oxfw/src/common_model.rs              |   2 +-
 runtime/oxfw/src/lib.rs                       |  12 +-
 runtime/tascam/Cargo.toml                     |   1 +
 .../bin/snd-firewire-tascam-ctl-service.rs    |  34 ++--
 24 files changed, 189 insertions(+), 198 deletions(-)
```