### PR TITLE
[PATCH 00/10] runtime/motu: code refactoring to use Debug trait implementation

### DIFF
--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -105,8 +105,13 @@ impl RegisterDspStereoInputCtlOperation<AudioExpressProtocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(F828mk2Protocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<F828mk2Protocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -66,8 +66,16 @@ impl RegisterDspMixerReturnCtlOperation<AudioExpressProtocol> for MixerReturnCtl
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerStereoSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            AudioExpressProtocol::create_mixer_stereo_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerStereoSourceCtlOperation<AudioExpressProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerStereoSourceState {

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -100,8 +100,16 @@ impl RegisterDspOutputCtlOperation<AudioExpressProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(RegisterDspStereoInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            AudioExpressProtocol::create_stereo_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspStereoInputCtlOperation<AudioExpressProtocol> for InputCtl {
     fn state(&self) -> &RegisterDspStereoInputState {

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -3024,9 +3024,6 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     const F32_CONVERT_SCALE: f32 = 1000000.0;
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        let state = T::create_output_state();
-        *self.state_mut() = state;
-
         let mut notified_elem_id_list = Vec::new();
 
         [

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -614,9 +614,6 @@ pub trait CommandDspMixerCtlOperation<T: CommandDspMixerOperation> {
     const F32_CONVERT_SCALE: f32 = 1000000.0;
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        let state = T::create_mixer_state();
-        *self.state_mut() = state;
-
         let mut notified_elem_id_list = Vec::new();
 
         let labels: Vec<String> = T::OUTPUT_PORTS

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -3455,8 +3455,6 @@ pub trait CommandDspMeterCtlOperation<T: CommandDspMeterOperation> {
     const F32_CONVERT_SCALE: f32 = 1000000.0;
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        *self.state_mut() = T::create_meter_state();
-
         let mut measured_elem_id_list = Vec::new();
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_METER_NAME, 0);

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -2553,9 +2553,6 @@ pub trait CommandDspInputCtlOperation<T: CommandDspInputOperation> {
     const F32_CONVERT_SCALE: f32 = 1000000.0;
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        let state = T::create_input_state();
-        *self.state_mut() = state;
-
         let mut notified_elem_id_list = Vec::new();
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_PHASE_NAME, 0);

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -133,8 +133,13 @@ impl RegisterDspLineInputCtlOperation<F828mk2Protocol> for LineInputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(F828mk2Protocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<F828mk2Protocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -128,8 +128,16 @@ impl RegisterDspOutputCtlOperation<F828mk2Protocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct LineInputCtl(RegisterDspLineInputState, Vec<ElemId>);
+
+impl Default for LineInputCtl {
+    fn default() -> Self {
+        Self(
+            F828mk2Protocol::create_line_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspLineInputCtlOperation<F828mk2Protocol> for LineInputCtl {
     fn state(&self) -> &RegisterDspLineInputState {

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -94,8 +94,16 @@ impl RegisterDspMixerReturnCtlOperation<F828mk2Protocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            F828mk2Protocol::create_mixer_monaural_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerMonauralSourceCtlOperation<F828mk2Protocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerMonauralSourceState {

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -100,8 +100,13 @@ impl CommandDspMonitorCtlOperation<F828mk3Protocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(F828mk3Protocol::create_mixer_state(), Default::default())
+    }
+}
 
 impl CommandDspMixerCtlOperation<F828mk3Protocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -167,8 +167,13 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(F828mk3Protocol::create_meter_state(), Default::default())
+    }
+}
 
 impl CommandDspMeterCtlOperation<F828mk3Protocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -118,8 +118,13 @@ impl CommandDspMixerCtlOperation<F828mk3Protocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(F828mk3Protocol::create_input_state(), Default::default())
+    }
+}
 
 impl CommandDspInputCtlOperation<F828mk3Protocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -136,8 +136,13 @@ impl CommandDspInputCtlOperation<F828mk3Protocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(F828mk3Protocol::create_output_state(), Default::default())
+    }
+}
 
 impl CommandDspOutputCtlOperation<F828mk3Protocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -100,8 +100,16 @@ impl CommandDspMonitorCtlOperation<F828mk3HybridProtocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(
+            F828mk3HybridProtocol::create_mixer_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMixerCtlOperation<F828mk3HybridProtocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -176,8 +176,16 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(
+            F828mk3HybridProtocol::create_meter_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMeterCtlOperation<F828mk3HybridProtocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -121,8 +121,16 @@ impl CommandDspMixerCtlOperation<F828mk3HybridProtocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            F828mk3HybridProtocol::create_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspInputCtlOperation<F828mk3HybridProtocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -142,8 +142,16 @@ impl CommandDspInputCtlOperation<F828mk3HybridProtocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(
+            F828mk3HybridProtocol::create_output_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspOutputCtlOperation<F828mk3HybridProtocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -123,8 +123,13 @@ impl RegisterDspOutputCtlOperation<F896hdProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(F896hdProtocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<F896hdProtocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -97,8 +97,16 @@ impl RegisterDspMixerReturnCtlOperation<F896hdProtocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            F896hdProtocol::create_mixer_monaural_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerMonauralSourceCtlOperation<F896hdProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerMonauralSourceState {

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -79,8 +79,16 @@ impl RegisterDspMixerReturnCtlOperation<F8preProtocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            F8preProtocol::create_mixer_monaural_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerMonauralSourceCtlOperation<F8preProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerMonauralSourceState {

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -105,8 +105,13 @@ impl RegisterDspOutputCtlOperation<F8preProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(F896hdProtocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<F896hdProtocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -100,8 +100,16 @@ impl RegisterDspOutputCtlOperation<H4preProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(RegisterDspStereoInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            H4preProtocol::create_stereo_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspStereoInputCtlOperation<H4preProtocol> for InputCtl {
     fn state(&self) -> &RegisterDspStereoInputState {

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -105,8 +105,13 @@ impl RegisterDspStereoInputCtlOperation<H4preProtocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(H4preProtocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<H4preProtocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -66,8 +66,16 @@ impl RegisterDspMixerReturnCtlOperation<H4preProtocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerStereoSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            H4preProtocol::create_mixer_stereo_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerStereoSourceCtlOperation<H4preProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerStereoSourceState {

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -961,9 +961,7 @@ pub trait RegisterDspStereoInputCtlOperation<T: RegisterDspStereoInputOperation>
         req: &mut FwReq,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_stereo_input_state();
-        T::read_stereo_input_state(req, &mut unit.1, &mut state, timeout_ms)?;
-        *self.state_mut() = state;
+        T::read_stereo_input_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
 
         let mut notified_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -1129,13 +1129,9 @@ pub trait RegisterDspMeterCtlOperation<T: RegisterDspMeterOperation> {
         req: &mut FwReq,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_meter_state();
-
         if T::SELECTABLE {
-            T::select_output(req, &mut unit.1, 0, &mut state, timeout_ms)?;
+            T::select_output(req, &mut unit.1, 0, self.state_mut(), timeout_ms)?;
         }
-
-        *self.state_mut() = state;
 
         let mut measured_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -396,10 +396,8 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
         params: &SndMotuRegisterDspParameter,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_mixer_stereo_source_state();
         self.parse_dsp_parameter(params);
-        T::read_mixer_stereo_source_state(req, &mut unit.1, &mut state, timeout_ms)?;
-        *self.state_mut() = state;
+        T::read_mixer_stereo_source_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
 
         let mut notified_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -227,9 +227,7 @@ pub trait RegisterDspMixerMonauralSourceCtlOperation<T: RegisterDspMixerMonaural
         req: &mut FwReq,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_mixer_monaural_source_state();
-        T::read_mixer_monaural_source_state(req, &mut unit.1, &mut state, timeout_ms)?;
-        *self.state_mut() = state;
+        T::read_mixer_monaural_source_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
 
         let mut notified_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -864,9 +864,7 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
         req: &mut FwReq,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_monaural_input_state();
-        T::read_monaural_input_state(req, &mut unit.1, &mut state, timeout_ms)?;
-        *self.state_mut() = state;
+        T::read_monaural_input_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
 
         let mut notified_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -755,9 +755,7 @@ pub trait RegisterDspLineInputCtlOperation<T: Traveler828mk2LineInputOperation> 
         req: &mut FwReq,
         timeout_ms: u32,
     ) -> Result<Vec<ElemId>, Error> {
-        let mut state = T::create_line_input_state();
-        T::read_line_input_state(req, &mut unit.1, &mut state, timeout_ms)?;
-        *self.state_mut() = state;
+        T::read_line_input_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
 
         let mut notified_elem_id_list = Vec::new();
 

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -86,8 +86,13 @@ impl CommandDspMonitorCtlOperation<Track16Protocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(Track16Protocol::create_mixer_state(), Default::default())
+    }
+}
 
 impl CommandDspMixerCtlOperation<Track16Protocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -153,8 +153,13 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(Track16Protocol::create_meter_state(), Default::default())
+    }
+}
 
 impl CommandDspMeterCtlOperation<Track16Protocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -122,8 +122,13 @@ impl CommandDspInputCtlOperation<Track16Protocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(Track16Protocol::create_output_state(), Default::default())
+    }
+}
 
 impl CommandDspOutputCtlOperation<Track16Protocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -104,8 +104,13 @@ impl CommandDspMixerCtlOperation<Track16Protocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(Track16Protocol::create_input_state(), Default::default())
+    }
+}
 
 impl CommandDspInputCtlOperation<Track16Protocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -137,8 +137,13 @@ impl RegisterDspLineInputCtlOperation<TravelerProtocol> for LineInputCtl {
 #[derive(Default)]
 struct MicInputCtl(TravelerMicInputState, Vec<ElemId>);
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(H4preProtocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<H4preProtocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -129,8 +129,16 @@ impl RegisterDspOutputCtlOperation<TravelerProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct LineInputCtl(RegisterDspLineInputState, Vec<ElemId>);
+
+impl Default for LineInputCtl {
+    fn default() -> Self {
+        Self(
+            TravelerProtocol::create_line_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspLineInputCtlOperation<TravelerProtocol> for LineInputCtl {
     fn state(&self) -> &RegisterDspLineInputState {

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -95,8 +95,16 @@ impl RegisterDspMixerReturnCtlOperation<TravelerProtocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            TravelerProtocol::create_mixer_monaural_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerMonauralSourceCtlOperation<TravelerProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerMonauralSourceState {

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -100,8 +100,16 @@ impl CommandDspMonitorCtlOperation<TravelerMk3Protocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(
+            TravelerMk3Protocol::create_mixer_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMixerCtlOperation<TravelerMk3Protocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -142,8 +142,16 @@ impl CommandDspInputCtlOperation<TravelerMk3Protocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(
+            TravelerMk3Protocol::create_output_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspOutputCtlOperation<TravelerMk3Protocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -176,8 +176,16 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(
+            TravelerMk3Protocol::create_meter_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMeterCtlOperation<TravelerMk3Protocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -121,8 +121,16 @@ impl CommandDspMixerCtlOperation<TravelerMk3Protocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            TravelerMk3Protocol::create_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspInputCtlOperation<TravelerMk3Protocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -104,8 +104,16 @@ impl RegisterDspOutputCtlOperation<UltraliteProtocol> for OutputCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(RegisterDspMonauralInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteProtocol::create_monaural_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMonauralInputCtlOperation<UltraliteProtocol> for InputCtl {
     fn state(&self) -> &RegisterDspMonauralInputState {

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -109,8 +109,13 @@ impl RegisterDspMonauralInputCtlOperation<UltraliteProtocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(UltraliteProtocol::create_meter_state(), Default::default())
+    }
+}
 
 impl RegisterDspMeterCtlOperation<UltraliteProtocol> for MeterCtl {
     fn state(&self) -> &RegisterDspMeterState {

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -70,8 +70,16 @@ impl RegisterDspMixerReturnCtlOperation<UltraliteProtocol> for MixerReturnCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteProtocol::create_mixer_monaural_source_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl RegisterDspMixerMonauralSourceCtlOperation<UltraliteProtocol> for MixerSourceCtl {
     fn state(&self) -> &RegisterDspMixerMonauralSourceState {

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -80,8 +80,16 @@ impl CommandDspMonitorCtlOperation<UltraliteMk3Protocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3Protocol::create_mixer_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMixerCtlOperation<UltraliteMk3Protocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -156,8 +156,16 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3Protocol::create_meter_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMeterCtlOperation<UltraliteMk3Protocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -101,8 +101,16 @@ impl CommandDspMixerCtlOperation<UltraliteMk3Protocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3Protocol::create_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspInputCtlOperation<UltraliteMk3Protocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -122,8 +122,16 @@ impl CommandDspInputCtlOperation<UltraliteMk3Protocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3Protocol::create_output_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspOutputCtlOperation<UltraliteMk3Protocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -101,8 +101,16 @@ impl CommandDspMixerCtlOperation<UltraliteMk3HybridProtocol> for MixerCtl {
     }
 }
 
-#[derive(Default)]
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
+
+impl Default for InputCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3HybridProtocol::create_input_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspInputCtlOperation<UltraliteMk3HybridProtocol> for InputCtl {
     fn state(&self) -> &CommandDspInputState {

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -80,8 +80,16 @@ impl CommandDspMonitorCtlOperation<UltraliteMk3HybridProtocol> for MonitorCtl {
     }
 }
 
-#[derive(Default)]
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
+
+impl Default for MixerCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3HybridProtocol::create_mixer_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMixerCtlOperation<UltraliteMk3HybridProtocol> for MixerCtl {
     fn state(&self) -> &CommandDspMixerState {

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -122,8 +122,16 @@ impl CommandDspInputCtlOperation<UltraliteMk3HybridProtocol> for InputCtl {
     }
 }
 
-#[derive(Default)]
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
+
+impl Default for OutputCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3HybridProtocol::create_output_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspOutputCtlOperation<UltraliteMk3HybridProtocol> for OutputCtl {
     fn state(&self) -> &CommandDspOutputState {

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -156,8 +156,16 @@ impl CommandDspResourcebCtlOperation for ResourceCtl {
     }
 }
 
-#[derive(Default)]
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
+
+impl Default for MeterCtl {
+    fn default() -> Self {
+        Self(
+            UltraliteMk3HybridProtocol::create_meter_state(),
+            Default::default(),
+        )
+    }
+}
 
 impl CommandDspMeterCtlOperation<UltraliteMk3HybridProtocol> for MeterCtl {
     fn state(&self) -> &CommandDspMeterState {


### PR DESCRIPTION
Current implementation instantiates parameters inner helper trait,
while it's preferable to implement Default trait for the purpose.

This patchset adds Default trait implementations for each models for the purpose.

```
Takashi Sakamoto (10):
  runtime/motu: code refactoring for mixer parameters of command DSP models
  runtime/motu: code refactoring for input parameters of command DSP models
  runtime/motu: code refactoring for output parameters of command DSP models
  runtime/motu: code refactoring for meter state of command DSP models
  runtime/motu: code refactoring for meter state of register DSP models
  runtime/motu: code refactoring for monaural mixer source of register DSP models
  runtime/motu: code refactoring for stereo mixer source of register DSP models
  runtime/motu: code refactoring for line input state of register DSP models
  runtime/motu: code refactoring for monaural input state of register DSP models
  runtime/motu: code refactoring for stereo input state of register DSP models

 runtime/motu/src/audioexpress.rs         | 27 ++++++++++++++--
 runtime/motu/src/command_dsp_ctls.rs     | 11 -------
 runtime/motu/src/f828mk2.rs              | 27 ++++++++++++++--
 runtime/motu/src/f828mk3.rs              | 28 ++++++++++++++---
 runtime/motu/src/f828mk3_hybrid.rs       | 40 +++++++++++++++++++++---
 runtime/motu/src/f896hd.rs               | 17 ++++++++--
 runtime/motu/src/f8pre.rs                | 17 ++++++++--
 runtime/motu/src/h4pre.rs                | 27 ++++++++++++++--
 runtime/motu/src/register_dsp_ctls.rs    | 26 ++++-----------
 runtime/motu/src/track16.rs              | 28 ++++++++++++++---
 runtime/motu/src/traveler.rs             | 27 ++++++++++++++--
 runtime/motu/src/traveler_mk3.rs         | 40 +++++++++++++++++++++---
 runtime/motu/src/ultralite.rs            | 27 ++++++++++++++--
 runtime/motu/src/ultralite_mk3.rs        | 40 +++++++++++++++++++++---
 runtime/motu/src/ultralite_mk3_hybrid.rs | 40 +++++++++++++++++++++---
 15 files changed, 348 insertions(+), 74 deletions(-)
```