### PR TITLE
[PATCH 0/6] runtime/bebob: apogee: add conveter between parameters and commands

### DIFF
--- a/protocols/bebob/src/apogee/ensemble.rs
+++ b/protocols/bebob/src/apogee/ensemble.rs
@@ -114,9 +114,13 @@ impl SamplingClockSourceOperation for EnsembleClkProtocol {
 /// Parameters of sample format converter.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleConverterParameters {
+    /// The target of sample format converter.
     pub format_target: FormatConvertTarget,
+    /// The target of sampling rate converter.
     pub rate_target: RateConvertTarget,
+    /// The sampling rate to convert.
     pub converted_rate: RateConvertRate,
+    /// The mode of CD (44.1 kHz/16 bit sample).
     pub cd_mode: bool,
 }
 
@@ -161,9 +165,13 @@ impl EnsembleParameterProtocol<EnsembleConverterParameters> for EnsembleConverte
 /// Parameters of display meters.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleDisplayParameters {
+    /// Whether to enable/disable display.
     pub enabled: bool,
+    /// Force to illuminate display.
     pub illuminate: bool,
+    /// The target for meter display.
     pub target: DisplayMeterTarget,
+    /// Whether to enable/disable overhold of peak detection.
     pub overhold: bool,
 }
 
@@ -212,11 +220,17 @@ impl EnsembleParameterProtocol<EnsembleDisplayParameters> for EnsembleDisplayPro
 /// are available when channel 0-3 levels are for mic.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleInputParameters {
+    /// Whether to enable/disable limitter of analog inputs.
     pub limits: [bool; 8],
+    /// The level of analog inputs.
     pub levels: [InputNominalLevel; 8],
+    /// The gain of microphone inputs.
     pub gains: [u8; 4],
+    /// Whether to enable/disable phantom powering for microphone inputs.
     pub phantoms: [bool; 4],
+    /// Whether to invert polarity for microphone inputs.
     pub polarities: [bool; 4],
+    /// The mode of optical inputs.
     pub opt_iface_mode: OptIfaceMode,
 }
 
@@ -320,9 +334,13 @@ impl EnsembleParameterProtocol<EnsembleInputParameters> for EnsembleInputProtoco
 /// Parameters of analog/digital outputs.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleOutputParameters {
+    /// The volume of 1st pair of analog outputs.
     pub vol: u8,
+    /// The volume of headphone outputs.
     pub headphone_vols: [u8; 2],
+    /// The level of outputs.
     pub levels: [OutputNominalLevel; 8],
+    /// The mode of optical outputs.
     pub opt_iface_mode: OptIfaceMode,
 }
 
@@ -778,6 +796,7 @@ impl EnsembleParameterProtocol<EnsembleMixerParameters> for EnsembleMixerProtoco
 /// Parameters of stream mode.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleStreamParameters {
+    /// The mode of isochronous stream in IEEE 1394 bus.
     pub mode: StreamMode,
 }
 
@@ -872,11 +891,15 @@ pub trait EnsembleParameterProtocol<T: Copy>: EnsembleParametersConverter<T> {
 }
 
 /// The target of input for knob.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum KnobInputTarget {
+    /// 1st microphone.
     Mic0,
+    /// 2nd microphone.
     Mic1,
+    /// 3rd microphone.
     Mic2,
+    /// 4th microphone.
     Mic3,
 }
 
@@ -887,10 +910,13 @@ impl Default for KnobInputTarget {
 }
 
 /// The target of output for knob.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum KnobOutputTarget {
+    /// 1st pair of analog outputs.
     AnalogOutputPair0,
+    /// 1st pair of headphone outputs.
     HeadphonePair0,
+    /// 2nd pair of headphone outputs.
     HeadphonePair1,
 }
 
@@ -901,13 +927,19 @@ impl Default for KnobOutputTarget {
 }
 
 /// Information of hardware metering.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EnsembleMeter {
+    /// The target of hardware input knob.
     pub knob_input_target: KnobInputTarget,
+    /// The target of hardware output knob.
     pub knob_output_target: KnobOutputTarget,
+    /// The value of hardware input knob.
     pub knob_input_vals: [u8; 4],
+    /// The value of hardware output knob.
     pub knob_output_vals: [u8; 3],
+    /// The detected signal level of inputs.
     pub phys_inputs: [u8; 18],
+    /// The detected signal level of outputs.
     pub phys_outputs: [u8; 16],
 }
 
@@ -949,16 +981,25 @@ const OUT_METER_POS: [usize; 16] = [
 
 /// Protocol implementation for hardware metering.
 impl EnsembleMeterProtocol {
+    /// The minimum value of hardware output knob.
     pub const OUT_KNOB_VAL_MIN: u8 = EnsembleOutputProtocol::VOL_MIN;
+    /// The maximum value of hardware output knob.
     pub const OUT_KNOB_VAL_MAX: u8 = EnsembleOutputProtocol::VOL_MAX;
+    /// The step value of hardware output knob.
     pub const OUT_KNOB_VAL_STEP: u8 = EnsembleOutputProtocol::VOL_STEP;
 
+    /// The minimum value of hardware input knob.
     pub const IN_KNOB_VAL_MIN: u8 = EnsembleInputProtocol::GAIN_MIN;
+    /// The maximum value of hardware input knob.
     pub const IN_KNOB_VAL_MAX: u8 = EnsembleInputProtocol::GAIN_MAX;
+    /// The step value of hardware input knob.
     pub const IN_KNOB_VAL_STEP: u8 = EnsembleInputProtocol::GAIN_STEP;
 
+    /// The minimum value of detected signal level.
     pub const LEVEL_MIN: u8 = u8::MIN;
+    /// The maximum value of detected signal level.
     pub const LEVEL_MAX: u8 = u8::MAX;
+    /// The step value of detected signal level.
     pub const LEVEL_STEP: u8 = 1;
 
     /// Update the given parameters by the state of hardware.

--- a/protocols/bebob/src/apogee/ensemble.rs
+++ b/protocols/bebob/src/apogee/ensemble.rs
@@ -222,7 +222,7 @@ impl EnsembleParameterProtocol<EnsembleDisplayParameters> for EnsembleDisplayPro
 pub struct EnsembleInputParameters {
     /// Whether to enable/disable limitter of analog inputs.
     pub limits: [bool; 8],
-    /// The level of analog inputs.
+    /// The nominal level of analog inputs.
     pub levels: [InputNominalLevel; 8],
     /// The gain of microphone inputs.
     pub gains: [u8; 4],
@@ -338,7 +338,7 @@ pub struct EnsembleOutputParameters {
     pub vol: u8,
     /// The volume of headphone outputs.
     pub headphone_vols: [u8; 2],
-    /// The level of outputs.
+    /// The nominal level of outputs.
     pub levels: [OutputNominalLevel; 8],
     /// The mode of optical outputs.
     pub opt_iface_mode: OptIfaceMode,
@@ -1054,7 +1054,7 @@ impl EnsembleMeterProtocol {
 }
 
 /// The nominal level of analog input 0-7.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum InputNominalLevel {
     /// +4 dBu.
     Professional,
@@ -1071,7 +1071,7 @@ impl Default for InputNominalLevel {
 }
 
 /// The nominal level of analog ouput 0-7.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OutputNominalLevel {
     /// +4 dBu.
     Professional,
@@ -1086,7 +1086,7 @@ impl Default for OutputNominalLevel {
 }
 
 /// The mode of signal in optical interface.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OptIfaceMode {
     Spdif,
     Adat,
@@ -1115,16 +1115,25 @@ fn opt_iface_mode_from_val(val: u8) -> OptIfaceMode {
 }
 
 /// The target to convert sample format from 24 bit to 16 bit.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FormatConvertTarget {
+    /// Disabled.
     Disabled,
+    /// 1st pair of analog inputs.
     AnalogInputPair0,
+    /// 2nd pair of analog inputs.
     AnalogInputPair1,
+    /// 3rd pair of analog inputs.
     AnalogInputPair2,
+    /// 4th pair of analog inputs.
     AnalogInputPair3,
+    /// The pair of S/PDIF input in optical interface.
     SpdifOpticalInputPair0,
+    /// The pair of S/PDIF input in coaxial interface.
     SpdifCoaxialInputPair0,
+    /// The pair of S/PDIF output in optical interface.
     SpdifCoaxialOutputPair0,
+    /// The pair of S/PDIF output in coaxial interface.
     SpdifOpticalOutputPair0,
 }
 
@@ -1135,12 +1144,17 @@ impl Default for FormatConvertTarget {
 }
 
 /// The target to convert sample rate.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum RateConvertTarget {
+    /// Disabled.
     Disabled,
+    /// The pair of S/PDIF output in optical interface.
     SpdifOpticalOutputPair0,
+    /// The pair of S/PDIF output in coaxial interface.
     SpdifCoaxialOutputPair0,
+    /// The pair of S/PDIF input in optical interface.
     SpdifOpticalInputPair0,
+    /// The pair of S/PDIF input in coaxial interface.
     SpdifCoaxialInputPair0,
 }
 
@@ -1153,11 +1167,17 @@ impl Default for RateConvertTarget {
 /// The rate to convert sample rate.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum RateConvertRate {
+    /// To 44.1 kHz.
     R44100,
+    /// To 48.0 kHz.
     R48000,
+    /// To 88.2 kHz.
     R88200,
+    /// To 96.0 kHz.
     R96000,
+    /// To 176.0 kHz.
     R176400,
+    /// To 192.0 kHz.
     R192000,
 }
 
@@ -1174,25 +1194,45 @@ const MIXER_COEFFICIENT_COUNT: usize = 18;
 /// Command specific to Apogee Ensemble.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum EnsembleCmd {
+    /// Limitter for 8 analog inputs.
     InputLimit(usize, bool), // index, state
-    MicPower(usize, bool),   // index, state
+    /// Phantom powering for 4 microphone inputs.
+    MicPower(usize, bool), // index, state
+    /// The nominal level of 8 analog inputs.
     InputNominalLevel(usize, InputNominalLevel),
+    /// The nominal level of 8 analog outputs.
     OutputNominalLevel(usize, OutputNominalLevel),
+    /// The routing between source and destination.
     IoRouting(usize, usize), // destination, source
+    /// Hardware type of command.
     Hw(HwCmd),
+    /// The source of 4 headphone outputs.
     HpSrc(usize, usize), // destination, source
+    /// The source of 1st nine pairs of coefficients for two pairs of mixers.
     MixerSrc0(usize, [i16; MIXER_COEFFICIENT_COUNT]),
+    /// The source of 2nd nine pairs of coefficients for two pairs of mixers.
     MixerSrc1(usize, [i16; MIXER_COEFFICIENT_COUNT]),
+    /// The source of 3rd nine pairs of coefficients for two pairs of mixers.
     MixerSrc2(usize, [i16; MIXER_COEFFICIENT_COUNT]),
+    /// The source of 4th nine pairs of coefficients for two pairs of mixers.
     MixerSrc3(usize, [i16; MIXER_COEFFICIENT_COUNT]),
+    /// The gain of 4 microphone inputs, between 10 and 75.
     MicGain(usize, u8), // 1/2/3/4, dB(10-75), also available as knob control
+    /// The mode of output in optical interface.
     OutputOptIface(OptIfaceMode),
+    /// The mode of input in optical interface.
     InputOptIface(OptIfaceMode),
+    /// The target of converter for sample format.
     FormatConvert(FormatConvertTarget),
+    /// The parameters of sampling rate converter.
     RateConvert(RateConvertTarget, RateConvertRate),
+    /// The polarity for 4 microphone inputs.
     MicPolarity(usize, bool), // index, state
-    OutVol(usize, u8),        // main/hp0/hp1, dB(127-0), also available as knob control
+    /// The volume of output.
+    OutVol(usize, u8), // main/hp0/hp1, dB(127-0), also available as knob control
+    /// The short expression of hardware status.
     HwStatusShort([u8; METER_SHORT_FRAME_SIZE]),
+    /// The long expression of hardware status.
     HwStatusLong([u8; METER_LONG_FRAME_SIZE]),
     Reserved(Vec<u8>),
 }
@@ -1486,10 +1526,13 @@ impl From<&[u8]> for EnsembleCmd {
 }
 
 /// The mode of stream format.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StreamMode {
+    /// For 18 channels capture and 18 channels playback.
     Format18x18,
+    /// For 10 channels capture and 10 channels playback.
     Format10x10,
+    /// For 8 channels capture and 8 channels playback.
     Format8x8,
 }
 
@@ -1500,9 +1543,11 @@ impl Default for StreamMode {
 }
 
 /// The target of display meter.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DisplayMeterTarget {
+    /// For outputs.
     Output,
+    /// For inputs.
     Input,
 }
 
@@ -1513,15 +1558,21 @@ impl Default for DisplayMeterTarget {
 }
 
 /// Command for functions in hardware category specific to Apogee Ensemble.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HwCmd {
-    /// STREAM_MODE command generates bus reset to change available stream formats.
+    /// The mode of isochronous stream in IEEE 1394 bus. Any change generates bus reset in the bus.
     StreamMode(StreamMode),
+    /// Whether to illuminate display.
     DisplayIlluminate(bool),
+    /// Whether to enable/disable display.
     DisplayMode(bool),
+    /// The target of metering display.
     DisplayTarget(DisplayMeterTarget),
+    /// Whether to enable/disable overhold of peak detection.
     DisplayOverhold(bool),
+    /// Reset display metering.
     MeterReset,
+    /// The mode of CD (44.1 kHz/16 bit sample).
     CdMode(bool),
     Reserved(Vec<u8>),
 }

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -430,7 +430,7 @@ const RATE_CONVERT_RATE_NAME: &str = "sample-rate-convert-rate";
 const CD_MODE_NAME: &str = "cd-mode";
 
 #[derive(Default)]
-struct ConvertCtl(EnsembleConvertParameters);
+struct ConvertCtl(EnsembleConverterParameters);
 
 fn format_convert_target_to_str(target: &FormatConvertTarget) -> &str {
     match target {
@@ -802,9 +802,9 @@ impl InputCtl {
             .add_int_elems(
                 &elem_id,
                 1,
-                EnsembleInputParameters::GAIN_MIN as i32,
-                EnsembleInputParameters::GAIN_MAX as i32,
-                EnsembleInputParameters::GAIN_STEP as i32,
+                EnsembleInputProtocol::GAIN_MIN as i32,
+                EnsembleInputProtocol::GAIN_MAX as i32,
+                EnsembleInputProtocol::GAIN_STEP as i32,
                 Self::MIC_LABELS.len(),
                 None,
                 true,
@@ -1000,9 +1000,9 @@ impl<'a> OutputCtl {
             .add_int_elems(
                 &elem_id,
                 1,
-                EnsembleOutputParameters::VOL_MIN as i32,
-                EnsembleOutputParameters::VOL_MAX as i32,
-                EnsembleOutputParameters::VOL_STEP as i32,
+                EnsembleOutputProtocol::VOL_MIN as i32,
+                EnsembleOutputProtocol::VOL_MAX as i32,
+                EnsembleOutputProtocol::VOL_STEP as i32,
                 1,
                 None,
                 true,
@@ -1014,9 +1014,9 @@ impl<'a> OutputCtl {
             .add_int_elems(
                 &elem_id,
                 1,
-                EnsembleOutputParameters::VOL_MIN as i32,
-                EnsembleOutputParameters::VOL_MAX as i32,
-                EnsembleOutputParameters::VOL_STEP as i32,
+                EnsembleOutputProtocol::VOL_MIN as i32,
+                EnsembleOutputProtocol::VOL_MAX as i32,
+                EnsembleOutputProtocol::VOL_STEP as i32,
                 Self::HP_LABELS.len(),
                 None,
                 true,
@@ -1449,9 +1449,9 @@ impl MixerCtl {
         let _ = card_cntr.add_int_elems(
             &elem_id,
             Self::MIXER_LABELS.len(),
-            EnsembleMixerParameters::GAIN_MIN as i32,
-            EnsembleMixerParameters::GAIN_MAX as i32,
-            EnsembleMixerParameters::GAIN_STEP as i32,
+            EnsembleMixerProtocol::GAIN_MIN as i32,
+            EnsembleMixerProtocol::GAIN_MAX as i32,
+            EnsembleMixerProtocol::GAIN_STEP as i32,
             Self::MIXER_SRC_LABELS.len(),
             Some(&Into::<Vec<u32>>::into(Self::GAIN_TLV)),
             true,

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -386,7 +386,7 @@ impl MeterCtl {
     }
 
     fn measure_state(&mut self, avc: &mut BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleMeterProtocol::measure_meter(avc, &mut self.0, timeout_ms)
+        EnsembleMeterProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_state(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -527,7 +527,7 @@ impl ConvertCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, CD_MODE_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleConverterProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -583,13 +583,13 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.format_target = target;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             CD_MODE_NAME => {
                 let mut params = self.0.clone();
                 params.cd_mode = elem_value.boolean()[0];
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             RATE_CONVERT_TARGET_NAME => {
@@ -603,7 +603,7 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.rate_target = target;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             RATE_CONVERT_RATE_NAME => {
@@ -617,7 +617,7 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.converted_rate = converted_rate;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -666,7 +666,7 @@ impl DisplayCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, DISPLAY_OVERHOLD_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleDisplayProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -706,13 +706,13 @@ impl DisplayCtl {
             DISPLAY_ENABLE_NAME => {
                 let mut params = self.0.clone();
                 params.enabled = elem_value.boolean()[0];
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             DISPLAY_ILLUMINATE_NAME => {
                 let mut params = self.0.clone();
                 params.illuminate = elem_value.boolean()[0];
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             DISPLAY_TARGET_NAME => {
@@ -726,13 +726,13 @@ impl DisplayCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.target = target;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             DISPLAY_OVERHOLD_NAME => {
                 let mut params = self.0.clone();
                 params.overhold = elem_value.boolean()[0];
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -824,7 +824,7 @@ impl InputCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_OPT_IFACE_MODE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleInputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -883,7 +883,7 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             INPUT_LEVEL_NAME => {
@@ -903,7 +903,7 @@ impl InputCtl {
                             })
                             .map(|&l| *level = l)
                     })?;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             MIC_GAIN_NAME => {
@@ -914,7 +914,7 @@ impl InputCtl {
                     .iter_mut()
                     .enumerate()
                     .for_each(|(i, gain)| *gain = vals[i] as u8);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             MIC_PHANTOM_NAME => {
@@ -924,7 +924,7 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             MIC_POLARITY_NAME => {
@@ -934,7 +934,7 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             INPUT_OPT_IFACE_MODE_NAME => {
@@ -945,7 +945,7 @@ impl InputCtl {
                 })?;
                 let mut params = self.0.clone();
                 params.opt_iface_mode = mode;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -1031,7 +1031,7 @@ impl<'a> OutputCtl {
             ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUTPUT_OPT_IFACE_MODE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleOutputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1100,13 +1100,13 @@ impl<'a> OutputCtl {
                             })
                             .map(|&l| *level = l)
                     })?;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             OUTPUT_VOL_NAME => {
                 let mut params = self.0.clone();
                 params.vol = elem_value.int()[0] as u8;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             HP_VOL_NAME => {
@@ -1117,7 +1117,7 @@ impl<'a> OutputCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(vol, &val)| *vol = val as u8);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             OUTPUT_OPT_IFACE_MODE_NAME => {
@@ -1128,7 +1128,7 @@ impl<'a> OutputCtl {
                     Error::new(FileError::Inval, &msg)
                 })?;
                 params.opt_iface_mode = mode;
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -1295,7 +1295,7 @@ impl RouteCtl {
             true,
         )?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleSourceProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1350,7 +1350,7 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             CAPTURE_SOURCE_NAME => {
@@ -1361,7 +1361,7 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             HP_SRC_NAME => {
@@ -1372,7 +1372,7 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -1457,7 +1457,7 @@ impl MixerCtl {
             true,
         )?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleMixerProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1493,7 +1493,7 @@ impl MixerCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(gain, &val)| *gain = val as i16);
-                avc.update_params(&params, &mut self.0, timeout_ms)
+                EnsembleMixerProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),
@@ -1535,7 +1535,7 @@ impl StreamCtl {
             alsactl::ElemId::new_by_name(alsactl::ElemIfaceType::Card, 0, 0, STREAM_MODE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        avc.init_params(&mut self.0, timeout_ms)
+        EnsembleStreamProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1570,7 +1570,8 @@ impl StreamCtl {
                 let mut params = self.0.clone();
                 params.mode = mode;
                 unit.0.lock()?;
-                let res = avc.update_params(&params, &mut self.0, timeout_ms);
+                let res =
+                    EnsembleStreamProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
                 let _ = unit.0.unlock();
                 res.map(|_| true)
             }

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -264,7 +264,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for EnsembleModel {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct MeterCtl(EnsembleMeter, Vec<ElemId>);
 
 const KNOB_IN_TARGET_NAME: &str = "knob-input-target";
@@ -447,7 +447,7 @@ const RATE_CONVERT_TARGET_NAME: &str = "sample-rate-convert-target";
 const RATE_CONVERT_RATE_NAME: &str = "sample-rate-convert-rate";
 const CD_MODE_NAME: &str = "cd-mode";
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ConvertCtl(EnsembleConverterParameters);
 
 fn format_convert_target_to_str(target: &FormatConvertTarget) -> &str {
@@ -638,7 +638,7 @@ impl ConvertCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct DisplayCtl(EnsembleDisplayParameters);
 
 fn display_meter_target_to_str(target: &DisplayMeterTarget) -> &str {
@@ -748,7 +748,7 @@ impl DisplayCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct InputCtl(EnsembleInputParameters, Vec<ElemId>);
 
 const INPUT_LIMIT_NAME: &str = "input-limit";
@@ -963,7 +963,7 @@ fn output_nominal_level_to_str(level: &OutputNominalLevel) -> &str {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct OutputCtl(EnsembleOutputParameters, Vec<ElemId>);
 
 const OUTPUT_LEVEL_NAME: &str = "output-level";
@@ -1136,7 +1136,7 @@ impl<'a> OutputCtl {
 
 const CAPTURE_SOURCE_NAME: &str = "capture-source";
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct RouteCtl(EnsembleSourceParameters);
 
 impl RouteCtl {
@@ -1373,7 +1373,7 @@ impl RouteCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct MixerCtl(EnsembleMixerParameters);
 
 const MIXER_SRC_GAIN_NAME: &str = "mixer-source-gain";
@@ -1489,7 +1489,7 @@ impl MixerCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct StreamCtl(EnsembleStreamParameters);
 
 fn stream_mode_to_str(mode: &StreamMode) -> &str {


### PR DESCRIPTION
The parameters of Ensemble model have no tests. It's not preferable.

This patchset reorganize implementation of parameters and protocols by adding
converter between parameters and vendor-dependent AV/C command operation
with enough tests.

```
Takashi Sakamoto (6):
  protocols/bebob: apogee: implement converter to parameters for vendor specific command
  protocols/bebob: apogee: rename public methods to update hardware for parameters
  runtime/bebob: apogee: code refactoring for cache function
  runtime/bebob: apogee: implement Debug trait for specific controls
  protocols/bebob: apogee: add doc comments to parameters
  protocols/bebob: apogee: add doc comments to vendor specific commands

 protocols/bebob/src/apogee/ensemble.rs     | 808 ++++++++++++++++++---
 runtime/bebob/src/apogee/ensemble_model.rs | 218 +++---
 2 files changed, 797 insertions(+), 229 deletions(-)
```