### PR TITLE
[PATCH 00/19] protocols/bebob: add parameter structure to cache state of hardware for AV/C commands

### DIFF
--- a/protocols/bebob/src/apogee/ensemble.rs
+++ b/protocols/bebob/src/apogee/ensemble.rs
@@ -83,7 +83,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of Ensemble FireWire.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct EnsembleClkProtocol;
 
 impl MediaClockFrequencyOperation for EnsembleClkProtocol {

--- a/protocols/bebob/src/behringer.rs
+++ b/protocols/bebob/src/behringer.rs
@@ -50,7 +50,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of FCA 610.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fca610ClkProtocol;
 
 impl MediaClockFrequencyOperation for Fca610ClkProtocol {

--- a/protocols/bebob/src/digidesign.rs
+++ b/protocols/bebob/src/digidesign.rs
@@ -51,7 +51,7 @@
 use super::*;
 
 /// The protocol implementation of operation for media clock and sampling clock.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Mbox2proClkProtocol;
 
 impl MediaClockFrequencyOperation for Mbox2proClkProtocol {

--- a/protocols/bebob/src/esi.rs
+++ b/protocols/bebob/src/esi.rs
@@ -73,10 +73,10 @@ impl SamplingClockSourceOperation for Quatafire610ClkProtocol {
 }
 
 /// The protocol implementation for physical input of Quatafire 610.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Quatafire610PhysInputProtocol;
 
-impl AvcLevelOperation for Quatafire610PhysInputProtocol {
+impl AvcAudioFeatureSpecification for Quatafire610PhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // analog-input-1
         (0x01, AudioCh::Each(1)), // analog-input-2
@@ -87,13 +87,15 @@ impl AvcLevelOperation for Quatafire610PhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for Quatafire610PhysInputProtocol {}
+
 impl AvcLrBalanceOperation for Quatafire610PhysInputProtocol {}
 
 /// The protocol implementation for physical output of Quatafire 610.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Quatafire610PhysOutputProtocol;
 
-impl AvcLevelOperation for Quatafire610PhysOutputProtocol {
+impl AvcAudioFeatureSpecification for Quatafire610PhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x04, AudioCh::Each(0)), // analog-output-1
         (0x04, AudioCh::Each(1)), // analog-output-2
@@ -105,3 +107,5 @@ impl AvcLevelOperation for Quatafire610PhysOutputProtocol {
         (0x04, AudioCh::Each(7)), // analog-output-8
     ];
 }
+
+impl AvcLevelOperation for Quatafire610PhysOutputProtocol {}

--- a/protocols/bebob/src/esi.rs
+++ b/protocols/bebob/src/esi.rs
@@ -50,7 +50,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of Quatafire 610.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Quatafire610ClkProtocol;
 
 impl MediaClockFrequencyOperation for Quatafire610ClkProtocol {

--- a/protocols/bebob/src/icon.rs
+++ b/protocols/bebob/src/icon.rs
@@ -38,7 +38,7 @@
 use super::*;
 
 /// The protocol implementation of clock operation.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FirexonClkProtocol;
 
 impl MediaClockFrequencyOperation for FirexonClkProtocol {

--- a/protocols/bebob/src/icon.rs
+++ b/protocols/bebob/src/icon.rs
@@ -63,9 +63,10 @@ impl SamplingClockSourceOperation for FirexonClkProtocol {
 }
 
 /// The protocol implementation of physical output.
+#[derive(Default, Debug)]
 pub struct FirexonPhysOutputProtocol;
 
-impl AvcLevelOperation for FirexonPhysOutputProtocol {
+impl AvcAudioFeatureSpecification for FirexonPhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x06, AudioCh::Each(0)), // analog-output-1
         (0x06, AudioCh::Each(1)), // analog-output-2
@@ -73,6 +74,8 @@ impl AvcLevelOperation for FirexonPhysOutputProtocol {
         (0x07, AudioCh::Each(1)), // analog-output-4
     ];
 }
+
+impl AvcLevelOperation for FirexonPhysOutputProtocol {}
 
 impl AvcLrBalanceOperation for FirexonPhysOutputProtocol {}
 
@@ -86,9 +89,10 @@ impl AvcSelectorOperation for FirexonPhysOutputProtocol {
 }
 
 /// The protocol implementation of source to monitor mixer for physical inputs
+#[derive(Default, Debug)]
 pub struct FirexonMonitorSourceProtocol;
 
-impl AvcLevelOperation for FirexonMonitorSourceProtocol {
+impl AvcAudioFeatureSpecification for FirexonMonitorSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // analog-input-1
         (0x01, AudioCh::Each(1)), // analog-input-2
@@ -99,16 +103,21 @@ impl AvcLevelOperation for FirexonMonitorSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for FirexonMonitorSourceProtocol {}
+
 impl AvcLrBalanceOperation for FirexonMonitorSourceProtocol {}
 
 impl AvcMuteOperation for FirexonMonitorSourceProtocol {}
 
 /// The protocol implementation of source to mixer for stream input and output of the monitor mixer.
+#[derive(Default, Debug)]
 pub struct FirexonMixerSourceProtocol;
 
-impl AvcLevelOperation for FirexonMixerSourceProtocol {
+impl AvcAudioFeatureSpecification for FirexonMixerSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x04, AudioCh::Master), // stream-input-1/2
         (0x05, AudioCh::Master), // monitor-output-1/2
     ];
 }
+
+impl AvcLevelOperation for FirexonMixerSourceProtocol {}

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -438,8 +438,9 @@ pub trait AvcLrBalanceOperation: AvcAudioFeatureSpecification {
     }
 }
 
-/// The parameters of mute.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+/// The parameters of mute. The `Default` trait should be implemented to call
+/// `AvcMuteOperation::create_mute_parameters()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvcMuteParameters {
     /// Muted or not.
     pub mutes: Vec<bool>,
@@ -484,18 +485,6 @@ pub trait AvcMuteOperation: AvcAudioFeatureSpecification {
             })
     }
 
-    fn read_mute(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<bool, Error> {
-        if idx >= Self::ENTRIES.len() {
-            let msg = format!("Invalid index of function block list: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_mute_parameters();
-        Self::cache_mutes(avc, &mut params, timeout_ms)?;
-
-        Ok(params.mutes[idx])
-    }
-
     /// Update the hardware when detecting any changes in the parameters.
     fn update_mutes(
         avc: &BebobAvc,
@@ -523,19 +512,6 @@ pub trait AvcMuteOperation: AvcAudioFeatureSpecification {
                 avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
                     .map(|_| *old = new)
             })
-    }
-
-    fn write_mute(avc: &BebobAvc, idx: usize, mute: bool, timeout_ms: u32) -> Result<(), Error> {
-        if idx >= Self::ENTRIES.len() {
-            let msg = format!("Invalid index of function block list: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_mute_parameters();
-        params.mutes[idx] = mute;
-        let mut p = Self::create_mute_parameters();
-        p.mutes[idx] = !mute;
-        Self::update_mutes(avc, &params, &mut p, timeout_ms)
     }
 }
 

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -268,10 +268,14 @@ pub trait SamplingClockSourceOperation {
     }
 }
 
-/// The trait of level operation for audio function blocks by AV/C transaction.
-pub trait AvcLevelOperation {
+/// The specification of Feature Function Blocks of AV/C Audio subunit.
+pub trait AvcAudioFeatureSpecification {
+    /// The entries of pair of function block identifier and audio channel.
     const ENTRIES: &'static [(u8, AudioCh)];
+}
 
+/// The trait of level operation for audio function blocks by AV/C transaction.
+pub trait AvcLevelOperation: AvcAudioFeatureSpecification {
     const LEVEL_MIN: i16 = VolumeData::VALUE_NEG_INFINITY;
     const LEVEL_MAX: i16 = VolumeData::VALUE_ZERO;
     const LEVEL_STEP: i16 = 0x100;
@@ -314,7 +318,7 @@ pub trait AvcLevelOperation {
 }
 
 /// The trait of LR balance operation for audio function blocks.
-pub trait AvcLrBalanceOperation: AvcLevelOperation {
+pub trait AvcLrBalanceOperation: AvcAudioFeatureSpecification {
     const BALANCE_MIN: i16 = LrBalanceData::VALUE_LEFT_NEG_INFINITY;
     const BALANCE_MAX: i16 = LrBalanceData::VALUE_LEFT_MAX;
     const BALANCE_STEP: i16 = 0x80;
@@ -362,7 +366,7 @@ pub trait AvcLrBalanceOperation: AvcLevelOperation {
 }
 
 /// The trait of mute operation for audio function blocks.
-pub trait AvcMuteOperation: AvcLevelOperation {
+pub trait AvcMuteOperation: AvcAudioFeatureSpecification {
     fn read_mute(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<bool, Error> {
         let &(func_block_id, audio_ch) = Self::ENTRIES.iter().nth(idx).ok_or_else(|| {
             let msg = format!("Invalid index of function block list: {}", idx);

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -515,8 +515,9 @@ pub trait AvcMuteOperation: AvcAudioFeatureSpecification {
     }
 }
 
-/// The parameter of selectors.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+/// The parameter of selectors. The `Default` trait should be implemented to call
+/// `AvcSelectorOperation::create_selector_parameters()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvcSelectorParameters {
     /// The index for entry in the list of function block.
     pub selectors: Vec<usize>,
@@ -566,18 +567,6 @@ pub trait AvcSelectorOperation {
             })
     }
 
-    fn read_selector(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<usize, Error> {
-        if idx >= Self::FUNC_BLOCK_ID_LIST.len() {
-            let msg = format!("Invalid index of selector: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_selector_parameters();
-        Self::cache_selectors(avc, &mut params, timeout_ms)?;
-
-        Ok(params.selectors[idx])
-    }
-
     /// Update the hardware when detecting any changes in the parameters.
     fn update_selectors(
         avc: &BebobAvc,
@@ -598,24 +587,5 @@ pub trait AvcSelectorOperation {
                 avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
                     .map(|_| *old = new)
             })
-    }
-
-    fn write_selector(
-        avc: &BebobAvc,
-        idx: usize,
-        val: usize,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        if idx >= Self::FUNC_BLOCK_ID_LIST.len() {
-            let msg = format!("Invalid index of selector: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_selector_parameters();
-        params.selectors[idx] = val;
-        let mut p = Self::create_selector_parameters();
-        params.selectors[idx] = !val;
-
-        Self::update_selectors(avc, &params, &mut p, timeout_ms)
     }
 }

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -356,8 +356,9 @@ pub trait AvcLevelOperation: AvcAudioFeatureSpecification {
     }
 }
 
-/// The parameters of L/R balance.
-#[derive(Default, Debug, Clone, PartialEq, Eq)]
+/// The parameters of L/R balance. The `Default` trait should be implemented to call
+/// `AvcLrBalanceOperation::create_lr_balance_parameters()`.
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AvcLrBalanceParameters {
     /// The L/R balances.
     pub balances: Vec<i16>,
@@ -408,18 +409,6 @@ pub trait AvcLrBalanceOperation: AvcAudioFeatureSpecification {
             })
     }
 
-    fn read_lr_balance(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<i16, Error> {
-        if idx >= Self::ENTRIES.len() {
-            let msg = format!("Invalid index of function block list: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_lr_balance_parameters();
-        Self::cache_lr_balances(avc, &mut params, timeout_ms)?;
-
-        Ok(params.balances[idx])
-    }
-
     /// Update the hardware when detecting any changes in the parameters.
     fn update_lr_balances(
         avc: &BebobAvc,
@@ -446,24 +435,6 @@ pub trait AvcLrBalanceOperation: AvcAudioFeatureSpecification {
                 avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
                     .map(|_| *old = new)
             })
-    }
-
-    fn write_lr_balance(
-        avc: &BebobAvc,
-        idx: usize,
-        balance: i16,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        if idx >= Self::ENTRIES.len() {
-            let msg = format!("Invalid index of function block list: {}", idx);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-
-        let mut params = Self::create_lr_balance_parameters();
-        let mut p = Self::create_lr_balance_parameters();
-        params.balances[idx] = balance;
-        p.balances[idx] = !balance;
-        Self::update_lr_balances(avc, &params, &mut p, timeout_ms)
     }
 }
 

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -243,11 +243,6 @@ pub trait SamplingClockSourceOperation {
             .map(|src_idx| params.src_idx = src_idx)
     }
 
-    fn read_clk_src(avc: &BebobAvc, timeout_ms: u32) -> Result<usize, Error> {
-        let mut params = SamplingClockParameters::default();
-        Self::cache_src(avc, &mut params, timeout_ms).map(|_| params.src_idx)
-    }
-
     /// Update the hardware by the given parameter. This operation can involve INTERIM AV/C
     /// response to expand response time of AV/C transaction.
     fn update_src(
@@ -270,12 +265,6 @@ pub trait SamplingClockSourceOperation {
 
         avc.control(&AvcAddr::Unit, &mut op, timeout_ms)
             .map(|_| *old = *params)
-    }
-
-    fn write_clk_src(avc: &BebobAvc, src_idx: usize, timeout_ms: u32) -> Result<(), Error> {
-        let params = SamplingClockParameters { src_idx };
-        let mut old = SamplingClockParameters::default();
-        Self::update_src(avc, &params, &mut old, timeout_ms)
     }
 }
 

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -164,11 +164,6 @@ pub trait MediaClockFrequencyOperation {
             .map(|freq_idx| params.freq_idx = freq_idx)
     }
 
-    fn read_clk_freq(avc: &BebobAvc, timeout_ms: u32) -> Result<usize, Error> {
-        let mut params = MediaClockParameters::default();
-        Self::cache_freq(avc, &mut params, timeout_ms).map(|_| params.freq_idx)
-    }
-
     /// Update the hardware by the given parameter. This operation can involve INTERIM AV/C
     /// response to expand response time of AV/C transaction.
     fn update_freq(
@@ -206,13 +201,6 @@ pub trait MediaClockFrequencyOperation {
         *old = *params;
 
         Ok(())
-    }
-
-    fn write_clk_freq(avc: &BebobAvc, freq_idx: usize, timeout_ms: u32) -> Result<(), Error> {
-        let params = MediaClockParameters { freq_idx };
-        let mut p = MediaClockParameters::default();
-
-        Self::update_freq(avc, &params, &mut p, timeout_ms)
     }
 }
 

--- a/protocols/bebob/src/maudio/normal.rs
+++ b/protocols/bebob/src/maudio/normal.rs
@@ -187,7 +187,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410ClkProtocol;
 
 impl MediaClockFrequencyOperation for Fw410ClkProtocol {
@@ -362,7 +362,7 @@ impl MaudioNormalMixerOperation for Fw410HeadphoneProtocol {
 }
 
 /// The protocol implementation for media and sampling clock of FireWire Solo.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SoloClkProtocol;
 
 impl MediaClockFrequencyOperation for SoloClkProtocol {
@@ -458,7 +458,7 @@ impl MaudioNormalMixerOperation for SoloMixerProtocol {
 }
 
 /// The protocol implementation for media and sampling clock of FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophileClkProtocol;
 
 impl MediaClockFrequencyOperation for AudiophileClkProtocol {
@@ -599,7 +599,7 @@ impl MaudioNormalMixerOperation for AudiophileMixerProtocol {
 }
 
 /// The protocol implementation for media and sampling clock of Ozonic.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OzonicClkProtocol;
 
 impl MediaClockFrequencyOperation for OzonicClkProtocol {

--- a/protocols/bebob/src/maudio/normal.rs
+++ b/protocols/bebob/src/maudio/normal.rs
@@ -328,7 +328,7 @@ impl AvcSelectorOperation for Fw410HeadphoneProtocol {
 }
 
 /// The protocol implementation for source of S/PDIF output in FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410SpdifOutputProtocol;
 
 impl AvcSelectorOperation for Fw410SpdifOutputProtocol {
@@ -444,7 +444,7 @@ impl AvcLevelOperation for SoloStreamInputProtocol {}
 // NOTE: outputs are not configurable, connected to hardware dial directly.
 
 /// The protocol implementation for source of S/PDIF output in FireWire Solo.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SoloSpdifOutputProtocol;
 
 impl AvcSelectorOperation for SoloSpdifOutputProtocol {

--- a/protocols/bebob/src/maudio/normal.rs
+++ b/protocols/bebob/src/maudio/normal.rs
@@ -225,10 +225,10 @@ impl MaudioNormalMeterProtocol for Fw410MeterProtocol {
 }
 
 /// The protocol implementation for physical input of FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410PhysInputProtocol;
 
-impl AvcLevelOperation for Fw410PhysInputProtocol {
+impl AvcAudioFeatureSpecification for Fw410PhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x03, AudioCh::Each(0)), // analog-input-1
         (0x03, AudioCh::Each(1)), // analog-input-2
@@ -237,13 +237,15 @@ impl AvcLevelOperation for Fw410PhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for Fw410PhysInputProtocol {}
+
 impl AvcLrBalanceOperation for Fw410PhysInputProtocol {}
 
 /// The protocol implementation for physical output of FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410PhysOutputProtocol;
 
-impl AvcLevelOperation for Fw410PhysOutputProtocol {
+impl AvcAudioFeatureSpecification for Fw410PhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x0a, AudioCh::Each(0)), // analog-output-1
         (0x0a, AudioCh::Each(1)), // analog-output-2
@@ -258,6 +260,8 @@ impl AvcLevelOperation for Fw410PhysOutputProtocol {
     ];
 }
 
+impl AvcLevelOperation for Fw410PhysOutputProtocol {}
+
 impl AvcSelectorOperation for Fw410PhysOutputProtocol {
     // NOTE: "analog-output-1/2", "analog-output-3/4", "analog-output-5/6", "analog-output-7/8",
     //       "analog-output-9/10"
@@ -267,10 +271,10 @@ impl AvcSelectorOperation for Fw410PhysOutputProtocol {
 }
 
 /// The protocol implementation for source of aux mixer in FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410AuxSourceProtocol;
 
-impl AvcLevelOperation for Fw410AuxSourceProtocol {
+impl AvcAudioFeatureSpecification for Fw410AuxSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x07, AudioCh::Each(0)), // analog-input-1
         (0x07, AudioCh::Each(1)), // analog-input-2
@@ -289,27 +293,33 @@ impl AvcLevelOperation for Fw410AuxSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for Fw410AuxSourceProtocol {}
+
 /// The protocol implementation for output of aux mixer in FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410AuxOutputProtocol;
 
-impl AvcLevelOperation for Fw410AuxOutputProtocol {
+impl AvcAudioFeatureSpecification for Fw410AuxOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x09, AudioCh::Each(0)), // aux-output-1
         (0x09, AudioCh::Each(1)), // aux-output-2
     ];
 }
 
+impl AvcLevelOperation for Fw410AuxOutputProtocol {}
+
 /// The protocol implementation for output of headphone in FireWire 410.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fw410HeadphoneProtocol;
 
-impl AvcLevelOperation for Fw410HeadphoneProtocol {
+impl AvcAudioFeatureSpecification for Fw410HeadphoneProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x0f, AudioCh::Each(0)), // headphone-1
         (0x0f, AudioCh::Each(1)), // headphone-2
     ];
 }
+
+impl AvcLevelOperation for Fw410HeadphoneProtocol {}
 
 impl AvcSelectorOperation for Fw410HeadphoneProtocol {
     const FUNC_BLOCK_ID_LIST: &'static [u8] = &[0x07];
@@ -400,10 +410,10 @@ impl MaudioNormalMeterProtocol for SoloMeterProtocol {
 }
 
 /// The protocol implementation for physical input of FireWire Solo.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SoloPhysInputProtocol;
 
-impl AvcLevelOperation for SoloPhysInputProtocol {
+impl AvcAudioFeatureSpecification for SoloPhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x03, AudioCh::Each(0)), // analog-input-1
         (0x03, AudioCh::Each(1)), // analog-input-2
@@ -412,13 +422,15 @@ impl AvcLevelOperation for SoloPhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for SoloPhysInputProtocol {}
+
 impl AvcLrBalanceOperation for SoloPhysInputProtocol {}
 
 /// The protocol implementation for stream input of FireWire Solo.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct SoloStreamInputProtocol;
 
-impl AvcLevelOperation for SoloStreamInputProtocol {
+impl AvcAudioFeatureSpecification for SoloStreamInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // stream-input-1
         (0x01, AudioCh::Each(1)), // stream-input-2
@@ -426,6 +438,8 @@ impl AvcLevelOperation for SoloStreamInputProtocol {
         (0x02, AudioCh::Each(1)), // stream-input-4
     ];
 }
+
+impl AvcLevelOperation for SoloStreamInputProtocol {}
 
 // NOTE: outputs are not configurable, connected to hardware dial directly.
 
@@ -496,10 +510,10 @@ impl MaudioNormalMeterProtocol for AudiophileMeterProtocol {
 }
 
 /// The protocol implementation for physical input in FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophilePhysInputProtocol;
 
-impl AvcLevelOperation for AudiophilePhysInputProtocol {
+impl AvcAudioFeatureSpecification for AudiophilePhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x04, AudioCh::Each(0)), // analog-input-1
         (0x04, AudioCh::Each(1)), // analog-input-2
@@ -508,13 +522,15 @@ impl AvcLevelOperation for AudiophilePhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for AudiophilePhysInputProtocol {}
+
 impl AvcLrBalanceOperation for AudiophilePhysInputProtocol {}
 
 /// The protocol implementation for physical output in FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophilePhysOutputProtocol;
 
-impl AvcLevelOperation for AudiophilePhysOutputProtocol {
+impl AvcAudioFeatureSpecification for AudiophilePhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x0c, AudioCh::Each(0)), // analog-output-1
         (0x0c, AudioCh::Each(1)), // analog-output-2
@@ -525,6 +541,8 @@ impl AvcLevelOperation for AudiophilePhysOutputProtocol {
     ];
 }
 
+impl AvcLevelOperation for AudiophilePhysOutputProtocol {}
+
 impl AvcSelectorOperation for AudiophilePhysOutputProtocol {
     // NOTE: "analog-output-1/2", "analog-output-3/4", "analog-output-5/6"
     const FUNC_BLOCK_ID_LIST: &'static [u8] = &[0x01, 0x02, 0x03];
@@ -533,10 +551,10 @@ impl AvcSelectorOperation for AudiophilePhysOutputProtocol {
 }
 
 /// The protocol implementation for source of aux mixer in FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophileAuxSourceProtocol;
 
-impl AvcLevelOperation for AudiophileAuxSourceProtocol {
+impl AvcAudioFeatureSpecification for AudiophileAuxSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x09, AudioCh::Each(0)), // analog-input-1
         (0x09, AudioCh::Each(1)), // analog-input-2
@@ -551,27 +569,33 @@ impl AvcLevelOperation for AudiophileAuxSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for AudiophileAuxSourceProtocol {}
+
 /// The protocol implementation for output of aux mixer in FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophileAuxOutputProtocol;
 
-impl AvcLevelOperation for AudiophileAuxOutputProtocol {
+impl AvcAudioFeatureSpecification for AudiophileAuxOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x0b, AudioCh::Each(0)), // aux-output-1
         (0x0b, AudioCh::Each(1)), // aux-output-2
     ];
 }
 
+impl AvcLevelOperation for AudiophileAuxOutputProtocol {}
+
 /// The protocol implementation for output of headphone in FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AudiophileHeadphoneProtocol;
 
-impl AvcLevelOperation for AudiophileHeadphoneProtocol {
+impl AvcAudioFeatureSpecification for AudiophileHeadphoneProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x0f, AudioCh::Each(0)), // headphone-1
         (0x0f, AudioCh::Each(1)), // headphone-2
     ];
 }
+
+impl AvcLevelOperation for AudiophileHeadphoneProtocol {}
 
 impl AvcSelectorOperation for AudiophileHeadphoneProtocol {
     const FUNC_BLOCK_ID_LIST: &'static [u8] = &[0x04];
@@ -635,10 +659,10 @@ impl MaudioNormalMeterProtocol for OzonicMeterProtocol {
 }
 
 /// The protocol implementation for physical input of FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OzonicPhysInputProtocol;
 
-impl AvcLevelOperation for OzonicPhysInputProtocol {
+impl AvcAudioFeatureSpecification for OzonicPhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x03, AudioCh::Each(0)), // analog-input-1
         (0x03, AudioCh::Each(1)), // analog-input-2
@@ -647,13 +671,15 @@ impl AvcLevelOperation for OzonicPhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for OzonicPhysInputProtocol {}
+
 impl AvcLrBalanceOperation for OzonicPhysInputProtocol {}
 
 /// The protocol implementation for stream input of FireWire Audiophile.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct OzonicStreamInputProtocol;
 
-impl AvcLevelOperation for OzonicStreamInputProtocol {
+impl AvcAudioFeatureSpecification for OzonicStreamInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // stream-input-1
         (0x01, AudioCh::Each(1)), // stream-input-2
@@ -661,6 +687,8 @@ impl AvcLevelOperation for OzonicStreamInputProtocol {
         (0x02, AudioCh::Each(1)), // stream-input-4
     ];
 }
+
+impl AvcLevelOperation for OzonicStreamInputProtocol {}
 
 // NOTE: outputs are not configurable, connected to hardware dial directly.
 

--- a/protocols/bebob/src/maudio/pfl.rs
+++ b/protocols/bebob/src/maudio/pfl.rs
@@ -75,7 +75,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of ProFire Lightbridge.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct PflClkProtocol;
 
 impl MediaClockFrequencyOperation for PflClkProtocol {

--- a/protocols/bebob/src/presonus/firebox.rs
+++ b/protocols/bebob/src/presonus/firebox.rs
@@ -60,9 +60,10 @@ impl SamplingClockSourceOperation for FireboxClkProtocol {
 }
 
 /// The protocol implementation of physical output.
+#[derive(Default, Debug)]
 pub struct FireboxPhysOutputProtocol;
 
-impl AvcLevelOperation for FireboxPhysOutputProtocol {
+impl AvcAudioFeatureSpecification for FireboxPhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)),
         (0x01, AudioCh::Each(1)),
@@ -72,6 +73,8 @@ impl AvcLevelOperation for FireboxPhysOutputProtocol {
         (0x03, AudioCh::Each(1)),
     ];
 }
+
+impl AvcLevelOperation for FireboxPhysOutputProtocol {}
 
 impl AvcMuteOperation for FireboxPhysOutputProtocol {}
 
@@ -83,11 +86,14 @@ impl AvcSelectorOperation for FireboxPhysOutputProtocol {
 }
 
 /// The protocol implementation of headphone.
+#[derive(Default, Debug)]
 pub struct FireboxHeadphoneProtocol;
 
-impl AvcLevelOperation for FireboxHeadphoneProtocol {
+impl AvcAudioFeatureSpecification for FireboxHeadphoneProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x04, AudioCh::Each(0)), (0x04, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for FireboxHeadphoneProtocol {}
 
 impl AvcMuteOperation for FireboxHeadphoneProtocol {}
 
@@ -100,9 +106,10 @@ impl AvcSelectorOperation for FireboxHeadphoneProtocol {
 }
 
 /// The protocol implementation of physical source for mixer.
+#[derive(Default, Debug)]
 pub struct FireboxMixerPhysSourceProtocol;
 
-impl AvcLevelOperation for FireboxMixerPhysSourceProtocol {
+impl AvcAudioFeatureSpecification for FireboxMixerPhysSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x05, AudioCh::Each(0)),
         (0x05, AudioCh::Each(1)),
@@ -113,16 +120,21 @@ impl AvcLevelOperation for FireboxMixerPhysSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for FireboxMixerPhysSourceProtocol {}
+
 impl AvcLrBalanceOperation for FireboxMixerPhysSourceProtocol {}
 
 impl AvcMuteOperation for FireboxMixerPhysSourceProtocol {}
 
 /// The protocol implementation of stream source for mixer.
+#[derive(Default, Debug)]
 pub struct FireboxMixerStreamSourceProtocol;
 
-impl AvcLevelOperation for FireboxMixerStreamSourceProtocol {
+impl AvcAudioFeatureSpecification for FireboxMixerStreamSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x08, AudioCh::Each(0))];
 }
+
+impl AvcLevelOperation for FireboxMixerStreamSourceProtocol {}
 
 impl AvcMuteOperation for FireboxMixerStreamSourceProtocol {}
 
@@ -133,11 +145,14 @@ impl AvcSelectorOperation for FireboxMixerStreamSourceProtocol {
     const INPUT_PLUG_ID_LIST: &'static [u8] = &[0x00, 0x01, 0x02, 0x03];
 }
 /// The protocol implementation of mixer output.
+#[derive(Default, Debug)]
 pub struct FireboxMixerOutputProtocol;
 
-impl AvcLevelOperation for FireboxMixerOutputProtocol {
+impl AvcAudioFeatureSpecification for FireboxMixerOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x09, AudioCh::Each(0)), (0x09, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for FireboxMixerOutputProtocol {}
 
 impl AvcLrBalanceOperation for FireboxMixerOutputProtocol {}
 

--- a/protocols/bebob/src/presonus/firebox.rs
+++ b/protocols/bebob/src/presonus/firebox.rs
@@ -172,59 +172,67 @@ impl AvcSelectorOperation for FireboxAnalogInputProtocol {
     // NOTE: off(=0x7ffe)/on(=0x0000) for volume control of audio function block.
     const INPUT_PLUG_ID_LIST: &'static [u8] = &[0x00, 0x01];
 
-    fn read_selector(avc: &BebobAvc, idx: usize, timeout_ms: u32) -> Result<usize, Error> {
-        let func_block_id = Self::FUNC_BLOCK_ID_LIST
-            .iter()
-            .nth(idx)
-            .ok_or_else(|| {
-                let msg = format!("Invalid argument for index of selector: {}", idx);
-                Error::new(FileError::Inval, &msg)
-            })
-            .map(|func_block_id| *func_block_id)?;
-        let ch_id = idx % 2;
-
-        let mut op = AudioFeature::new(
-            func_block_id,
-            CtlAttr::Current,
-            AudioCh::Each(ch_id as u8),
-            FeatureCtl::Volume(VolumeData::new(1)),
-        );
-        avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
-
-        if let FeatureCtl::Volume(data) = op.ctl {
-            let val = if data.0[0] == Self::BOOST_OFF { 0 } else { 1 };
-            Ok(val)
-        } else {
-            unreachable!();
-        }
-    }
-
-    fn write_selector(
+    fn cache_selectors(
         avc: &BebobAvc,
-        idx: usize,
-        val: usize,
+        params: &mut AvcSelectorParameters,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let func_block_id = Self::FUNC_BLOCK_ID_LIST
-            .iter()
-            .nth(idx)
-            .ok_or_else(|| {
-                let msg = format!("Invalid argument for index of selector: {}", idx);
-                Error::new(FileError::Inval, &msg)
-            })
-            .map(|func_block_id| *func_block_id)?;
-        let ch_id = idx & 2;
+        assert_eq!(params.selectors.len(), Self::FUNC_BLOCK_ID_LIST.len());
 
-        let mut op = AudioFeature::new(
-            func_block_id,
-            CtlAttr::Current,
-            AudioCh::Each(ch_id as u8),
-            FeatureCtl::Volume(VolumeData(vec![if val == 0 {
-                Self::BOOST_OFF
-            } else {
-                Self::BOOST_ON
-            }])),
-        );
-        avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+        params
+            .selectors
+            .iter_mut()
+            .zip(Self::FUNC_BLOCK_ID_LIST)
+            .enumerate()
+            .try_for_each(|(i, (selector, &func_block_id))| {
+                let ch_id = i % 2;
+
+                let mut op = AudioFeature::new(
+                    func_block_id,
+                    CtlAttr::Current,
+                    AudioCh::Each(ch_id as u8),
+                    FeatureCtl::Volume(VolumeData::new(1)),
+                );
+                avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)?;
+
+                if let FeatureCtl::Volume(data) = op.ctl {
+                    *selector = if data.0[0] == Self::BOOST_OFF { 0 } else { 1 };
+                }
+
+                Ok(())
+            })
+    }
+
+    fn update_selectors(
+        avc: &BebobAvc,
+        params: &AvcSelectorParameters,
+        old: &mut AvcSelectorParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(params.selectors.len(), Self::FUNC_BLOCK_ID_LIST.len());
+        assert_eq!(old.selectors.len(), Self::FUNC_BLOCK_ID_LIST.len());
+
+        old.selectors
+            .iter_mut()
+            .zip(params.selectors.iter())
+            .zip(Self::FUNC_BLOCK_ID_LIST)
+            .enumerate()
+            .filter(|(_, ((o, n), _))| !n.eq(o))
+            .try_for_each(|(i, ((old, &new), &func_block_id))| {
+                let ch_id = i % 2;
+
+                let mut op = AudioFeature::new(
+                    func_block_id,
+                    CtlAttr::Current,
+                    AudioCh::Each(ch_id as u8),
+                    FeatureCtl::Volume(VolumeData(vec![if new == 0 {
+                        Self::BOOST_OFF
+                    } else {
+                        Self::BOOST_ON
+                    }])),
+                );
+                avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+                    .map(|_| *old = new)
+            })
     }
 }

--- a/protocols/bebob/src/presonus/firebox.rs
+++ b/protocols/bebob/src/presonus/firebox.rs
@@ -35,7 +35,7 @@
 use super::*;
 
 /// The protocol implementation of clock operation.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FireboxClkProtocol;
 
 impl MediaClockFrequencyOperation for FireboxClkProtocol {

--- a/protocols/bebob/src/presonus/fp10.rs
+++ b/protocols/bebob/src/presonus/fp10.rs
@@ -55,9 +55,10 @@ impl SamplingClockSourceOperation for Fp10ClkProtocol {
 }
 
 /// The protocol implementation for physical output.
+#[derive(Default, Debug)]
 pub struct Fp10PhysOutputProtocol;
 
-impl AvcLevelOperation for Fp10PhysOutputProtocol {
+impl AvcAudioFeatureSpecification for Fp10PhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)),
         (0x01, AudioCh::Each(1)),
@@ -69,6 +70,8 @@ impl AvcLevelOperation for Fp10PhysOutputProtocol {
         (0x04, AudioCh::Each(1)),
     ];
 }
+
+impl AvcLevelOperation for Fp10PhysOutputProtocol {}
 
 impl AvcLrBalanceOperation for Fp10PhysOutputProtocol {}
 

--- a/protocols/bebob/src/presonus/fp10.rs
+++ b/protocols/bebob/src/presonus/fp10.rs
@@ -30,7 +30,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of Firepod/FP10.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fp10ClkProtocol;
 
 impl MediaClockFrequencyOperation for Fp10ClkProtocol {

--- a/protocols/bebob/src/presonus/inspire1394.rs
+++ b/protocols/bebob/src/presonus/inspire1394.rs
@@ -78,10 +78,10 @@ pub struct Inspire1394MeterProtocol;
 impl Inspire1394MeterOperation for Inspire1394MeterProtocol {}
 
 /// The protocol implementation of physical input.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394PhysInputProtocol;
 
-impl AvcLevelOperation for Inspire1394PhysInputProtocol {
+impl AvcAudioFeatureSpecification for Inspire1394PhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x1, AudioCh::Each(0)),
         (0x1, AudioCh::Each(1)),
@@ -90,15 +90,19 @@ impl AvcLevelOperation for Inspire1394PhysInputProtocol {
     ];
 }
 
+impl AvcLevelOperation for Inspire1394PhysInputProtocol {}
+
 impl AvcMuteOperation for Inspire1394PhysInputProtocol {}
 
 /// The protocol implementation of physical output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394PhysOutputProtocol;
 
-impl AvcLevelOperation for Inspire1394PhysOutputProtocol {
+impl AvcAudioFeatureSpecification for Inspire1394PhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x06, AudioCh::Each(0)), (0x06, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for Inspire1394PhysOutputProtocol {}
 
 impl AvcMuteOperation for Inspire1394PhysOutputProtocol {}
 
@@ -109,20 +113,22 @@ impl AvcSelectorOperation for Inspire1394PhysOutputProtocol {
 }
 
 /// The protocol implementation of headphone.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394HeadphoneProtocol;
 
-impl AvcLevelOperation for Inspire1394HeadphoneProtocol {
+impl AvcAudioFeatureSpecification for Inspire1394HeadphoneProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x07, AudioCh::Each(0)), (0x07, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for Inspire1394HeadphoneProtocol {}
 
 impl AvcMuteOperation for Inspire1394HeadphoneProtocol {}
 
 /// The protocol implementation of analog source for mixer.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394MixerAnalogSourceProtocol;
 
-impl AvcLevelOperation for Inspire1394MixerAnalogSourceProtocol {
+impl AvcAudioFeatureSpecification for Inspire1394MixerAnalogSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x03, AudioCh::Each(0)),
         (0x03, AudioCh::Each(1)),
@@ -131,17 +137,21 @@ impl AvcLevelOperation for Inspire1394MixerAnalogSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for Inspire1394MixerAnalogSourceProtocol {}
+
 impl AvcLrBalanceOperation for Inspire1394MixerAnalogSourceProtocol {}
 
 impl AvcMuteOperation for Inspire1394MixerAnalogSourceProtocol {}
 
 /// The protocol implementation of stream source for mixer.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394MixerStreamSourceProtocol;
 
-impl AvcLevelOperation for Inspire1394MixerStreamSourceProtocol {
+impl AvcAudioFeatureSpecification for Inspire1394MixerStreamSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x05, AudioCh::Master)];
 }
+
+impl AvcLevelOperation for Inspire1394MixerStreamSourceProtocol {}
 
 impl AvcMuteOperation for Inspire1394MixerStreamSourceProtocol {}
 

--- a/protocols/bebob/src/presonus/inspire1394.rs
+++ b/protocols/bebob/src/presonus/inspire1394.rs
@@ -49,7 +49,7 @@
 use super::*;
 
 /// The protocol implementation of clock operation.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Inspire1394ClkProtocol;
 
 impl MediaClockFrequencyOperation for Inspire1394ClkProtocol {

--- a/protocols/bebob/src/roland.rs
+++ b/protocols/bebob/src/roland.rs
@@ -50,7 +50,7 @@ use super::*;
 
 /// The protocol implementation for media and sampling clock. They are not configurable by
 /// software.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct FaClkProtocol;
 
 impl MediaClockFrequencyOperation for FaClkProtocol {

--- a/protocols/bebob/src/roland.rs
+++ b/protocols/bebob/src/roland.rs
@@ -73,10 +73,10 @@ impl SamplingClockSourceOperation for FaClkProtocol {
 
 /// The protocol implementation for physical input of FA-66. Any operation is effective when
 /// enabling hardware switch with 'SOFT CTRL'.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fa66MixerAnalogSourceProtocol;
 
-impl AvcLevelOperation for Fa66MixerAnalogSourceProtocol {
+impl AvcAudioFeatureSpecification for Fa66MixerAnalogSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)),
         (0x01, AudioCh::Each(1)),
@@ -87,14 +87,16 @@ impl AvcLevelOperation for Fa66MixerAnalogSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for Fa66MixerAnalogSourceProtocol {}
+
 impl AvcLrBalanceOperation for Fa66MixerAnalogSourceProtocol {}
 
 /// The protocol implementation for physical input of FA-101. Any operation is effective when
 /// enabling hardware switch with 'SOFT CTRL'.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Fa101MixerAnalogSourceProtocol;
 
-impl AvcLevelOperation for Fa101MixerAnalogSourceProtocol {
+impl AvcAudioFeatureSpecification for Fa101MixerAnalogSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)),
         (0x01, AudioCh::Each(1)),
@@ -108,5 +110,7 @@ impl AvcLevelOperation for Fa101MixerAnalogSourceProtocol {
         (0x05, AudioCh::Each(1)),
     ];
 }
+
+impl AvcLevelOperation for Fa101MixerAnalogSourceProtocol {}
 
 impl AvcLrBalanceOperation for Fa101MixerAnalogSourceProtocol {}

--- a/protocols/bebob/src/stanton.rs
+++ b/protocols/bebob/src/stanton.rs
@@ -45,7 +45,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock of Scratchamp.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ScratchampClkProtocol;
 
 impl MediaClockFrequencyOperation for ScratchampClkProtocol {

--- a/protocols/bebob/src/stanton.rs
+++ b/protocols/bebob/src/stanton.rs
@@ -68,10 +68,10 @@ impl SamplingClockSourceOperation for ScratchampClkProtocol {
 }
 
 /// The protocol implementation for physical output of Scratchamp.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ScratchampOutputProtocol;
 
-impl AvcLevelOperation for ScratchampOutputProtocol {
+impl AvcAudioFeatureSpecification for ScratchampOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // analog-output-1
         (0x01, AudioCh::Each(1)), // analog-output-2
@@ -80,13 +80,17 @@ impl AvcLevelOperation for ScratchampOutputProtocol {
     ];
 }
 
+impl AvcLevelOperation for ScratchampOutputProtocol {}
+
 /// The protocol implementation for headphone output of Scratchamp.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct ScratchampHeadphoneProtocol;
 
-impl AvcLevelOperation for ScratchampHeadphoneProtocol {
+impl AvcAudioFeatureSpecification for ScratchampHeadphoneProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x03, AudioCh::Each(0)), // headphone-1
         (0x03, AudioCh::Each(1)), // headphone-2
     ];
 }
+
+impl AvcLevelOperation for ScratchampHeadphoneProtocol {}

--- a/protocols/bebob/src/terratec/aureon.rs
+++ b/protocols/bebob/src/terratec/aureon.rs
@@ -53,10 +53,10 @@ impl SamplingClockSourceOperation for AureonClkProtocol {
 }
 
 /// The protocol implementation of mixer output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonMixerOutputProtocol;
 
-impl AvcLevelOperation for AureonMixerOutputProtocol {
+impl AvcAudioFeatureSpecification for AureonMixerOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // mixer-output-1
         (0x01, AudioCh::Each(1)), // mixer-output-2
@@ -69,18 +69,22 @@ impl AvcLevelOperation for AureonMixerOutputProtocol {
     ];
 }
 
+impl AvcLevelOperation for AureonMixerOutputProtocol {}
+
 impl AvcMuteOperation for AureonMixerOutputProtocol {}
 
 /// The protocol implementation of analog input.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonPhysInputProtocol;
 
-impl AvcLevelOperation for AureonPhysInputProtocol {
+impl AvcAudioFeatureSpecification for AureonPhysInputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x02, AudioCh::Master), // analog-input-1/2
         (0x03, AudioCh::Master), // analog-input-3/4
     ];
 }
+
+impl AvcLevelOperation for AureonPhysInputProtocol {}
 
 /// The protocol implementation of monitor output.
 #[derive(Default)]
@@ -93,14 +97,16 @@ impl AvcSelectorOperation for AureonMonitorSourceProtocol {
 }
 
 /// The protocol implementation of monitor source.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonMonitorOutputProtocol;
 
-impl AvcLevelOperation for AureonMonitorOutputProtocol {
+impl AvcAudioFeatureSpecification for AureonMonitorOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x04, AudioCh::Master), // monitor-output-1/2
     ];
 }
+
+impl AvcLevelOperation for AureonMonitorOutputProtocol {}
 
 impl AvcMuteOperation for AureonMonitorOutputProtocol {}
 

--- a/protocols/bebob/src/terratec/aureon.rs
+++ b/protocols/bebob/src/terratec/aureon.rs
@@ -30,7 +30,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonClkProtocol;
 
 impl MediaClockFrequencyOperation for AureonClkProtocol {

--- a/protocols/bebob/src/terratec/aureon.rs
+++ b/protocols/bebob/src/terratec/aureon.rs
@@ -87,7 +87,7 @@ impl AvcAudioFeatureSpecification for AureonPhysInputProtocol {
 impl AvcLevelOperation for AureonPhysInputProtocol {}
 
 /// The protocol implementation of monitor output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonMonitorSourceProtocol;
 
 impl AvcSelectorOperation for AureonMonitorSourceProtocol {
@@ -111,7 +111,7 @@ impl AvcLevelOperation for AureonMonitorOutputProtocol {}
 impl AvcMuteOperation for AureonMonitorOutputProtocol {}
 
 /// The protocol implementation of spdif output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct AureonSpdifOutputProtocol;
 
 impl AvcSelectorOperation for AureonSpdifOutputProtocol {

--- a/protocols/bebob/src/terratec/phase88.rs
+++ b/protocols/bebob/src/terratec/phase88.rs
@@ -132,10 +132,10 @@ impl AvcSelectorOperation for Phase88PhysInputProtocol {
 }
 
 /// The protocol implementation of source of physical input to mixer.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Phase88MixerPhysSourceProtocol;
 
-impl AvcLevelOperation for Phase88MixerPhysSourceProtocol {
+impl AvcAudioFeatureSpecification for Phase88MixerPhysSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x02, AudioCh::Each(0)), // analog-input-1
         (0x02, AudioCh::Each(1)), // analog-input-2
@@ -150,18 +150,22 @@ impl AvcLevelOperation for Phase88MixerPhysSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for Phase88MixerPhysSourceProtocol {}
+
 impl AvcMuteOperation for Phase88MixerPhysSourceProtocol {}
 
 /// The protocol implementation of source of stream input to mixer.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Phase88MixerStreamSourceProtocol;
 
-impl AvcLevelOperation for Phase88MixerStreamSourceProtocol {
+impl AvcAudioFeatureSpecification for Phase88MixerStreamSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x07, AudioCh::Each(0)), // stream-source-1
         (0x07, AudioCh::Each(1)), // stream-source-2
     ];
 }
+
+impl AvcLevelOperation for Phase88MixerStreamSourceProtocol {}
 
 impl AvcMuteOperation for Phase88MixerStreamSourceProtocol {}
 
@@ -177,12 +181,14 @@ impl AvcSelectorOperation for Phase88MixerStreamSourceProtocol {
 }
 
 /// The protocol implementation of mixer output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Phase88MixerOutputProtocol;
 
-impl AvcLevelOperation for Phase88MixerOutputProtocol {
+impl AvcAudioFeatureSpecification for Phase88MixerOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x00, AudioCh::Each(0)), (0x01, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for Phase88MixerOutputProtocol {}
 
 impl AvcMuteOperation for Phase88MixerOutputProtocol {}
 

--- a/protocols/bebob/src/terratec/phase88.rs
+++ b/protocols/bebob/src/terratec/phase88.rs
@@ -38,7 +38,7 @@
 use super::*;
 
 /// The protocol implementation for media and sampling clock.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Phase88ClkProtocol;
 
 impl MediaClockFrequencyOperation for Phase88ClkProtocol {

--- a/protocols/bebob/src/yamaha_terratec.rs
+++ b/protocols/bebob/src/yamaha_terratec.rs
@@ -247,9 +247,10 @@ impl AvcSelectorOperation for GoPhase24CoaxPhysOutputProtocol {
     ];
 }
 /// The protocol implementation of physical output for optical models.
+#[derive(Default, Debug)]
 pub struct GoPhase24OptPhysOutputProtocol;
 
-impl AvcLevelOperation for GoPhase24OptPhysOutputProtocol {
+impl AvcAudioFeatureSpecification for GoPhase24OptPhysOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x01, AudioCh::Each(0)), // analog-output-1
         (0x01, AudioCh::Each(1)), // analog-output-2
@@ -257,6 +258,8 @@ impl AvcLevelOperation for GoPhase24OptPhysOutputProtocol {
         (0x01, AudioCh::Each(3)), // analog-output-4
     ];
 }
+
+impl AvcLevelOperation for GoPhase24OptPhysOutputProtocol {}
 
 impl AvcMuteOperation for GoPhase24OptPhysOutputProtocol {}
 
@@ -292,9 +295,10 @@ impl AvcSelectorOperation for GoPhase24CoaxHeadphoneProtocol {
 }
 
 /// The protocol implementation of mixer source gain.
+#[derive(Default, Debug)]
 pub struct GoPhase24MixerSourceProtocol;
 
-impl AvcLevelOperation for GoPhase24MixerSourceProtocol {
+impl AvcAudioFeatureSpecification for GoPhase24MixerSourceProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[
         (0x06, AudioCh::Each(0)), // analog-input-1/2
         (0x06, AudioCh::Each(1)), // analog-input-1/2
@@ -309,22 +313,30 @@ impl AvcLevelOperation for GoPhase24MixerSourceProtocol {
     ];
 }
 
+impl AvcLevelOperation for GoPhase24MixerSourceProtocol {}
+
 impl AvcMuteOperation for GoPhase24MixerSourceProtocol {}
 
 /// The protocol implementation of mixer output volume for coaxial models.
+#[derive(Default, Debug)]
 pub struct GoPhase24CoaxMixerOutputProtocol;
 
-impl AvcLevelOperation for GoPhase24CoaxMixerOutputProtocol {
+impl AvcAudioFeatureSpecification for GoPhase24CoaxMixerOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x01, AudioCh::Each(0)), (0x01, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for GoPhase24CoaxMixerOutputProtocol {}
 
 impl AvcMuteOperation for GoPhase24CoaxMixerOutputProtocol {}
 
 /// The protocol implementation of mixer output volume for optical models.
+#[derive(Default, Debug)]
 pub struct GoPhase24OptMixerOutputProtocol;
 
-impl AvcLevelOperation for GoPhase24OptMixerOutputProtocol {
+impl AvcAudioFeatureSpecification for GoPhase24OptMixerOutputProtocol {
     const ENTRIES: &'static [(u8, AudioCh)] = &[(0x02, AudioCh::Each(0)), (0x02, AudioCh::Each(1))];
 }
+
+impl AvcLevelOperation for GoPhase24OptMixerOutputProtocol {}
 
 impl AvcMuteOperation for GoPhase24OptMixerOutputProtocol {}

--- a/protocols/bebob/src/yamaha_terratec.rs
+++ b/protocols/bebob/src/yamaha_terratec.rs
@@ -113,6 +113,7 @@
 use super::*;
 
 /// The protocol implementation of media and sampling clock for Yamaha Go 44/46 and PHASE 24/X24 FW;
+#[derive(Default, Debug)]
 pub struct GoPhase24ClkProtocol;
 
 impl MediaClockFrequencyOperation for GoPhase24ClkProtocol {

--- a/protocols/bebob/src/yamaha_terratec.rs
+++ b/protocols/bebob/src/yamaha_terratec.rs
@@ -139,15 +139,25 @@ impl SamplingClockSourceOperation for GoPhase24ClkProtocol {
         SignalAddr::Unit(SignalUnitAddr::Ext(0x01)),
     ];
 
-    fn read_clk_src(avc: &BebobAvc, timeout_ms: u32) -> Result<usize, Error> {
+    fn cache_src(
+        avc: &BebobAvc,
+        params: &mut SamplingClockParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
         let mut op = AudioSelector::new(CLK_SRC_FB_ID, CtlAttr::Current, 0xff);
         avc.status(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
-            .map(|_| op.input_plug_id as usize)
+            .map(|_| params.src_idx = op.input_plug_id as usize)
     }
 
-    fn write_clk_src(avc: &BebobAvc, val: usize, timeout_ms: u32) -> Result<(), Error> {
-        let mut op = AudioSelector::new(CLK_SRC_FB_ID, CtlAttr::Current, val as u8);
+    fn update_src(
+        avc: &BebobAvc,
+        params: &SamplingClockParameters,
+        old: &mut SamplingClockParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut op = AudioSelector::new(CLK_SRC_FB_ID, CtlAttr::Current, params.src_idx as u8);
         avc.control(&AUDIO_SUBUNIT_0_ADDR, &mut op, timeout_ms)
+            .map(|_| *old = *params)
     }
 }
 

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -62,6 +62,7 @@ fn input_output_copy_from_meter(model: &mut EnsembleModel) {
 impl EnsembleModel {
     pub fn cache(&mut self, _: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         EnsembleMeterProtocol::whole_update(&mut self.avc, &mut self.meter_ctl.0, FCP_TIMEOUT_MS)?;
         EnsembleConverterProtocol::whole_update(
             &mut self.avc,
@@ -135,10 +136,7 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -23,7 +23,7 @@ pub struct EnsembleModel {
 }
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<EnsembleClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -38,6 +38,14 @@ impl MediaClkFreqCtlOperation<EnsembleClkProtocol> for ClkCtl {
 impl SamplingClkSrcCtlOperation<EnsembleClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] =
         &["Internal", "S/PDIF-coax", "Optical", "Word Clock"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 fn input_output_copy_from_meter(model: &mut EnsembleModel) {

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -22,10 +22,18 @@ pub struct EnsembleModel {
     stream_ctl: StreamCtl,
 }
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<EnsembleClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<EnsembleClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<EnsembleClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] =

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -53,6 +53,7 @@ fn input_output_copy_from_meter(model: &mut EnsembleModel) {
 
 impl EnsembleModel {
     pub fn cache(&mut self, _: &mut (SndUnit, FwNode)) -> Result<(), Error> {
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         EnsembleMeterProtocol::whole_update(&mut self.avc, &mut self.meter_ctl.0, FCP_TIMEOUT_MS)?;
         EnsembleConverterProtocol::whole_update(
             &mut self.avc,
@@ -124,10 +125,7 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -267,8 +265,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for EnsembleModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -47,6 +47,8 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
             .load_src(card_cntr)
             .map(|mut elem_id_list| self.clk_ctl.0.append(&mut elem_id_list))?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -56,10 +58,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -117,7 +116,6 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fca610Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -15,7 +15,7 @@ pub struct Fca610Model {
 }
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Fca610ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -30,6 +30,14 @@ impl MediaClkFreqCtlOperation<Fca610ClkProtocol> for ClkCtl {
 impl SamplingClkSrcCtlOperation<Fca610ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] =
         &["device-internal-clock", "S/PDIF", "firewire-bus"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for Fca610Model {

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -56,6 +56,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
             .map(|mut elem_id_list| self.clk_ctl.0.append(&mut elem_id_list))?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -68,10 +69,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -14,10 +14,18 @@ pub struct Fca610Model {
     clk_ctl: ClkCtl,
 }
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Fca610ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Fca610ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Fca610ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] =

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -76,16 +76,13 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
         Ok(elem_id_list)
     }
 
-    fn read_src(
-        &mut self,
-        avc: &BebobAvc,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
+    fn cache_src(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_src(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_src(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_SRC_NAME => {
-                T::cache_src(avc, self.state_mut(), timeout_ms)?;
                 elem_value.set_enum(&[self.state().src_idx as u32]);
                 Ok(true)
             }

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -187,9 +187,7 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
     }
 }
 
-pub trait AvcLrBalanceCtlOperation<T: AvcLevelOperation + AvcLrBalanceOperation>:
-    AvcLevelCtlOperation<T>
-{
+pub trait AvcLrBalanceCtlOperation<T: AvcLrBalanceOperation> {
     const BALANCE_NAME: &'static str;
 
     const BALANCE_MIN: i32 = T::BALANCE_MIN as i32;
@@ -248,9 +246,7 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLevelOperation + AvcLrBalanceOperation>
     }
 }
 
-pub trait AvcMuteCtlOperation<T: AvcLevelOperation + AvcMuteOperation>:
-    AvcLevelCtlOperation<T>
-{
+pub trait AvcMuteCtlOperation<T: AvcMuteOperation> {
     const MUTE_NAME: &'static str;
 
     fn load_mute(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -222,15 +222,16 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLrBalanceOperation> {
             .map(|_| ())
     }
 
-    fn read_balance(
+    fn cache_balances(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_lr_balances(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_balances(
         &mut self,
-        avc: &BebobAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
-        timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::BALANCE_NAME {
-            T::cache_lr_balances(avc, self.state_mut(), timeout_ms)?;
             let vals: Vec<i32> = self
                 .state()
                 .balances

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -344,15 +344,16 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
             .map(|_| ())
     }
 
-    fn read_selector(
+    fn cache_selectors(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_selectors(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_selectors(
         &mut self,
-        avc: &BebobAvc,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
-        timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::SELECTOR_NAME {
-            T::cache_selectors(avc, self.state_mut(), timeout_ms)?;
             let vals: Vec<u32> = self
                 .state()
                 .selectors

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -14,16 +14,13 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)
     }
 
-    fn read_freq(
-        &mut self,
-        avc: &BebobAvc,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
+    fn cache_freq(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_freq(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_freq(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_RATE_NAME => {
-                T::cache_freq(avc, self.state_mut(), timeout_ms)?;
                 elem_value.set_enum(&[self.state().freq_idx as u32]);
                 Ok(true)
             }

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -154,15 +154,12 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
             .map(|_| ())
     }
 
-    fn read_level(
-        &mut self,
-        avc: &BebobAvc,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
+    fn cache_levels(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_levels(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_levels(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::LEVEL_NAME {
-            T::cache_levels(avc, self.state_mut(), timeout_ms)?;
             let vals: Vec<i32> = self
                 .state()
                 .levels

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -281,15 +281,12 @@ pub trait AvcMuteCtlOperation<T: AvcMuteOperation> {
             .map(|_| ())
     }
 
-    fn read_mute(
-        &mut self,
-        avc: &BebobAvc,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
+    fn cache_mutes(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        T::cache_mutes(avc, self.state_mut(), timeout_ms)
+    }
+
+    fn read_mutes(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::MUTE_NAME {
-            T::cache_mutes(avc, self.state_mut(), timeout_ms)?;
             elem_value.set_bool(&self.state().mutes);
             Ok(true)
         } else {

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -57,6 +57,8 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         let req = FwReq::default();
         Mbox2proIoProtocol::init(&req, &unit.1, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -66,10 +68,7 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -127,8 +126,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Mbox2proModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -15,10 +15,18 @@ pub struct Mbox2proModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Mbox2proClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Mbox2proClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Mbox2proClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &[

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -16,7 +16,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Mbox2proClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -36,6 +36,14 @@ impl SamplingClkSrcCtlOperation<Mbox2proClkProtocol> for ClkCtl {
         "Word-clock-input",
         "Word-clock-or-S/PDIF-input",
     ];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -66,6 +66,7 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         Mbox2proIoProtocol::init(&req, &unit.1, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -78,10 +79,7 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -127,6 +127,8 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.input_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.output_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -141,20 +143,14 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .input_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .input_ctl
             .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -16,10 +16,18 @@ pub struct Quatafire610Model {
     output_ctl: Quatafire610OutputCtl,
 }
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Quatafire610ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -42,11 +42,14 @@ impl SamplingClkSrcCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct Quatafire610InputCtl(AvcLevelParameters);
+struct Quatafire610InputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for Quatafire610InputCtl {
     fn default() -> Self {
-        Self(Quatafire610PhysInputProtocol::create_level_parameters())
+        Self(
+            Quatafire610PhysInputProtocol::create_level_parameters(),
+            Quatafire610PhysInputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -72,6 +75,14 @@ impl AvcLevelCtlOperation<Quatafire610PhysInputProtocol> for Quatafire610InputCt
 
 impl AvcLrBalanceCtlOperation<Quatafire610PhysInputProtocol> for Quatafire610InputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -41,8 +41,14 @@ impl SamplingClkSrcCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct Quatafire610InputCtl;
+#[derive(Debug)]
+struct Quatafire610InputCtl(AvcLevelParameters);
+
+impl Default for Quatafire610InputCtl {
+    fn default() -> Self {
+        Self(Quatafire610PhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Quatafire610PhysInputProtocol> for Quatafire610InputCtl {
     const LEVEL_NAME: &'static str = "phys-input-gain";
@@ -54,14 +60,28 @@ impl AvcLevelCtlOperation<Quatafire610PhysInputProtocol> for Quatafire610InputCt
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Quatafire610PhysInputProtocol> for Quatafire610InputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
 }
 
-#[derive(Default)]
-struct Quatafire610OutputCtl;
+#[derive(Debug)]
+struct Quatafire610OutputCtl(AvcLevelParameters);
+
+impl Default for Quatafire610OutputCtl {
+    fn default() -> Self {
+        Self(Quatafire610PhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Quatafire610PhysOutputProtocol> for Quatafire610OutputCtl {
     const LEVEL_NAME: &'static str = OUT_VOL_NAME;
@@ -75,6 +95,14 @@ impl AvcLevelCtlOperation<Quatafire610PhysOutputProtocol> for Quatafire610Output
         "analog-output-7",
         "analog-output-8",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
@@ -216,11 +244,11 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = Quatafire610InputCtl::default();
+        let mut ctl = Quatafire610InputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = Quatafire610OutputCtl::default();
+        let mut ctl = Quatafire610OutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -89,6 +89,8 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         self.input_ctl.load_balance(card_cntr)?;
         self.output_ctl.load_level(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -98,10 +100,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -189,8 +188,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Quatafire610Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -17,7 +17,7 @@ pub struct Quatafire610Model {
 }
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -31,6 +31,14 @@ impl MediaClkFreqCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<Quatafire610ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -98,6 +98,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         self.output_ctl.load_level(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -110,10 +111,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .input_ctl

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -140,6 +140,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         self.input_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.output_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.input_ctl.cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -156,10 +157,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
             Ok(true)
         } else if self.input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .input_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.input_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -133,6 +133,7 @@ struct ReverbCtl(SaffireReverbParameters);
 
 impl SaffireModel {
     pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
         SaffireOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
         SaffireSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
@@ -199,10 +200,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -313,8 +311,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SaffireModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -142,6 +142,7 @@ struct ReverbCtl(SaffireReverbParameters);
 impl SaffireModel {
     pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
         SaffireOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
         SaffireSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
@@ -210,10 +211,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -19,10 +19,18 @@ pub struct SaffireModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<SaffireClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<SaffireClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<SaffireClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -20,7 +20,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<SaffireClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -34,6 +34,14 @@ impl MediaClkFreqCtlOperation<SaffireClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<SaffireClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default, Debug)]

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -21,7 +21,7 @@ const FCP_TIMEOUT_MS: u32 = 200;
 const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<SaffireLeClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -35,6 +35,14 @@ impl MediaClkFreqCtlOperation<SaffireLeClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<SaffireLeClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default, Debug)]

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -20,10 +20,18 @@ pub struct SaffireLeModel {
 const FCP_TIMEOUT_MS: u32 = 200;
 const TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<SaffireLeClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<SaffireLeClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<SaffireLeClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -92,6 +92,7 @@ impl SaffireThroughCtlOperation<SaffireLeThroughProtocol> for ThroughCtl {
 
 impl SaffireLeModel {
     pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireLeMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
         SaffireLeOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
         SaffireLeSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
@@ -153,10 +154,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -257,8 +255,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SaffireLeModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -101,6 +101,7 @@ impl SaffireThroughCtlOperation<SaffireLeThroughProtocol> for ThroughCtl {
 impl SaffireLeModel {
     pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireLeMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
         SaffireLeOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
         SaffireLeSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
@@ -164,10 +165,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -127,6 +127,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         self.mixer_src_ctl.load_level(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -139,10 +140,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -224,6 +224,8 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         self.phys_out_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
         self.mon_src_ctl.cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_src_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -242,10 +244,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.phys_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -256,10 +255,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.mon_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mon_src_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -47,6 +47,7 @@ struct PhysOutputCtl(
     AvcLevelParameters,
     AvcLrBalanceParameters,
     AvcMuteParameters,
+    AvcSelectorParameters,
 );
 
 impl Default for PhysOutputCtl {
@@ -55,6 +56,7 @@ impl Default for PhysOutputCtl {
             FirexonPhysOutputProtocol::create_level_parameters(),
             FirexonPhysOutputProtocol::create_lr_balance_parameters(),
             FirexonPhysOutputProtocol::create_mute_parameters(),
+            FirexonPhysOutputProtocol::create_selector_parameters(),
         )
     }
 }
@@ -106,6 +108,14 @@ impl AvcSelectorCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
     const SELECTOR_LABELS: &'static [&'static str] = &["analog-output-3/4"];
     const ITEM_LABELS: &'static [&'static str] =
         &["mixer-output-1/2", "stream-input-3/4", "stream-input-5/6"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.3
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.3
+    }
 }
 
 #[derive(Debug)]
@@ -392,7 +402,7 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -195,6 +195,9 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mon_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_src_ctl.cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -211,10 +214,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -228,10 +228,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.mon_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mon_src_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mon_src_ctl

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -42,8 +42,14 @@ impl SamplingClkSrcCtlOperation<FirexonClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(FirexonPhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = "analog-output-volume";
@@ -53,6 +59,14 @@ impl AvcLevelCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
         "analog-output-3",
         "analog-output-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
@@ -70,8 +84,14 @@ impl AvcSelectorCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
         &["mixer-output-1/2", "stream-input-3/4", "stream-input-5/6"];
 }
 
-#[derive(Default)]
-struct MonitorSrcCtl;
+#[derive(Debug)]
+struct MonitorSrcCtl(AvcLevelParameters);
+
+impl Default for MonitorSrcCtl {
+    fn default() -> Self {
+        Self(FirexonMonitorSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
     const LEVEL_NAME: &'static str = "monitor-source-gain";
@@ -83,6 +103,14 @@ impl AvcLevelCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
@@ -93,12 +121,26 @@ impl AvcMuteCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
     const MUTE_NAME: &'static str = "monitor-source-mute";
 }
 
-#[derive(Default)]
-struct MixerSrcCtl;
+#[derive(Debug)]
+struct MixerSrcCtl(AvcLevelParameters);
+
+impl Default for MixerSrcCtl {
+    fn default() -> Self {
+        Self(FirexonMixerSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FirexonMixerSourceProtocol> for MixerSrcCtl {
     const LEVEL_NAME: &'static str = "mixer-source-gain";
     const PORT_LABELS: &'static [&'static str] = &["stream-input-1/2", "monitor-output-1/2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
@@ -298,15 +340,15 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MonitorSrcCtl::default();
+        let mut ctl = MonitorSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerSrcCtl::default();
+        let mut ctl = MixerSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -118,6 +118,8 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         self.mon_src_ctl.load_mute(card_cntr)?;
         self.mixer_src_ctl.load_level(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -127,10 +129,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -268,8 +267,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for FirexonModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -236,6 +236,8 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         self.mon_src_ctl.cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mon_src_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -256,10 +258,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mon_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -43,13 +43,18 @@ impl SamplingClkSrcCtlOperation<FirexonClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct PhysOutputCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
         Self(
             FirexonPhysOutputProtocol::create_level_parameters(),
             FirexonPhysOutputProtocol::create_lr_balance_parameters(),
+            FirexonPhysOutputProtocol::create_mute_parameters(),
         )
     }
 }
@@ -86,6 +91,14 @@ impl AvcLrBalanceCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcMuteCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
     const MUTE_NAME: &'static str = "analog-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 impl AvcSelectorCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
@@ -96,13 +109,18 @@ impl AvcSelectorCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
 }
 
 #[derive(Debug)]
-struct MonitorSrcCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct MonitorSrcCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for MonitorSrcCtl {
     fn default() -> Self {
         Self(
             FirexonMonitorSourceProtocol::create_level_parameters(),
             FirexonMonitorSourceProtocol::create_lr_balance_parameters(),
+            FirexonMonitorSourceProtocol::create_mute_parameters(),
         )
     }
 }
@@ -141,6 +159,14 @@ impl AvcLrBalanceCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
 
 impl AvcMuteCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
     const MUTE_NAME: &'static str = "monitor-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -170,6 +170,9 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -184,10 +187,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -204,10 +204,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mon_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mon_src_ctl
@@ -219,10 +216,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -18,7 +18,7 @@ pub struct FirexonModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<FirexonClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -32,6 +32,14 @@ impl MediaClkFreqCtlOperation<FirexonClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<FirexonClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -43,11 +43,14 @@ impl SamplingClkSrcCtlOperation<FirexonClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(FirexonPhysOutputProtocol::create_level_parameters())
+        Self(
+            FirexonPhysOutputProtocol::create_level_parameters(),
+            FirexonPhysOutputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -71,6 +74,14 @@ impl AvcLevelCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcLrBalanceCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
     const BALANCE_NAME: &'static str = "analog-output-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
@@ -85,11 +96,14 @@ impl AvcSelectorCtlOperation<FirexonPhysOutputProtocol> for PhysOutputCtl {
 }
 
 #[derive(Debug)]
-struct MonitorSrcCtl(AvcLevelParameters);
+struct MonitorSrcCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for MonitorSrcCtl {
     fn default() -> Self {
-        Self(FirexonMonitorSourceProtocol::create_level_parameters())
+        Self(
+            FirexonMonitorSourceProtocol::create_level_parameters(),
+            FirexonMonitorSourceProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -115,6 +129,14 @@ impl AvcLevelCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
 
 impl AvcLrBalanceCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {
     const BALANCE_NAME: &'static str = "monitor-source-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<FirexonMonitorSourceProtocol> for MonitorSrcCtl {

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -17,10 +17,18 @@ pub struct FirexonModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<FirexonClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<FirexonClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<FirexonClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -204,6 +204,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -216,10 +217,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -21,7 +21,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<AudiophileClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -35,6 +35,14 @@ impl MediaClkFreqCtlOperation<AudiophileClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<AudiophileClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 struct MeterCtl(Vec<ElemId>, MaudioNormalMeter);

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -165,11 +165,14 @@ impl AvcLevelCtlOperation<AudiophileAuxOutputProtocol> for AuxOutputCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcSelectorParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(AudiophilePhysOutputProtocol::create_level_parameters())
+        Self(
+            AudiophilePhysOutputProtocol::create_level_parameters(),
+            AudiophilePhysOutputProtocol::create_selector_parameters(),
+        )
     }
 }
 
@@ -201,14 +204,25 @@ impl AvcSelectorCtlOperation<AudiophilePhysOutputProtocol> for PhysOutputCtl {
         "analog-output-5/6",
     ];
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output", "aux-output-1/2"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct HeadphoneCtl(AvcLevelParameters);
+struct HeadphoneCtl(AvcLevelParameters, AvcSelectorParameters);
 
 impl Default for HeadphoneCtl {
     fn default() -> Self {
-        Self(AudiophileHeadphoneProtocol::create_level_parameters())
+        Self(
+            AudiophileHeadphoneProtocol::create_level_parameters(),
+            AudiophileHeadphoneProtocol::create_selector_parameters(),
+        )
     }
 }
 
@@ -234,6 +248,14 @@ impl AvcSelectorCtlOperation<AudiophileHeadphoneProtocol> for HeadphoneCtl {
         "mixer-output-5/6",
         "aux-output-1/2",
     ];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Default)]
@@ -515,11 +537,11 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = HeadphoneCtl::default();
+        let mut ctl = HeadphoneCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -195,6 +195,8 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         self.mixer_ctl
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -204,10 +206,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -389,8 +388,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for AudiophileModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -318,6 +318,9 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_input_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_output_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -344,19 +347,11 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self.phys_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_output_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_output_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -68,11 +68,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 impl MaudioNormalMeterCtlOperation<AudiophileMeterProtocol> for MeterCtl {}
 
 #[derive(Debug)]
-struct PhysInputCtl(AvcLevelParameters);
+struct PhysInputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysInputCtl {
     fn default() -> Self {
-        Self(AudiophilePhysInputProtocol::create_level_parameters())
+        Self(
+            AudiophilePhysInputProtocol::create_level_parameters(),
+            AudiophilePhysInputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -96,6 +99,14 @@ impl AvcLevelCtlOperation<AudiophilePhysInputProtocol> for PhysInputCtl {
 
 impl AvcLrBalanceCtlOperation<AudiophilePhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -20,10 +20,18 @@ pub struct AudiophileModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<AudiophileClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<AudiophileClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<AudiophileClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -294,6 +294,8 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         self.phys_output_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -312,12 +314,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_input_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_input_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.aux_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -275,6 +275,14 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.aux_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.aux_output_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_output_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -291,10 +299,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_input_ctl.read_balance(
             &self.avc,
@@ -303,20 +308,11 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .aux_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.aux_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .aux_output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.aux_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_output_ctl.read_selector(
             &self.avc,
@@ -325,10 +321,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .hp_ctl

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -67,8 +67,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 
 impl MaudioNormalMeterCtlOperation<AudiophileMeterProtocol> for MeterCtl {}
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(AudiophilePhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AudiophilePhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "phys-input-gain";
@@ -78,14 +84,28 @@ impl AvcLevelCtlOperation<AudiophilePhysInputProtocol> for PhysInputCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<AudiophilePhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
 }
 
-#[derive(Default)]
-struct AuxSourceCtl;
+#[derive(Debug)]
+struct AuxSourceCtl(AvcLevelParameters);
+
+impl Default for AuxSourceCtl {
+    fn default() -> Self {
+        Self(AudiophileAuxSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AudiophileAuxSourceProtocol> for AuxSourceCtl {
     const LEVEL_NAME: &'static str = "aux-source-gain";
@@ -101,18 +121,46 @@ impl AvcLevelCtlOperation<AudiophileAuxSourceProtocol> for AuxSourceCtl {
         "stream-input-5",
         "stream-input-6",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct AuxOutputCtl;
+#[derive(Debug)]
+struct AuxOutputCtl(AvcLevelParameters);
+
+impl Default for AuxOutputCtl {
+    fn default() -> Self {
+        Self(AudiophileAuxOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AudiophileAuxOutputProtocol> for AuxOutputCtl {
     const LEVEL_NAME: &'static str = "aux-ouput-gain";
     const PORT_LABELS: &'static [&'static str] = &["aux-output-1", "aux-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(AudiophilePhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AudiophilePhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = "output-volume";
@@ -124,6 +172,14 @@ impl AvcLevelCtlOperation<AudiophilePhysOutputProtocol> for PhysOutputCtl {
         "digital-output-1",
         "digital-output-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcSelectorCtlOperation<AudiophilePhysOutputProtocol> for PhysOutputCtl {
@@ -136,12 +192,26 @@ impl AvcSelectorCtlOperation<AudiophilePhysOutputProtocol> for PhysOutputCtl {
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output", "aux-output-1/2"];
 }
 
-#[derive(Default)]
-struct HeadphoneCtl;
+#[derive(Debug)]
+struct HeadphoneCtl(AvcLevelParameters);
+
+impl Default for HeadphoneCtl {
+    fn default() -> Self {
+        Self(AudiophileHeadphoneProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AudiophileHeadphoneProtocol> for HeadphoneCtl {
     const LEVEL_NAME: &'static str = "headphone-volume";
     const PORT_LABELS: &'static [&'static str] = &["headphone-1", "headphone-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcSelectorCtlOperation<AudiophileHeadphoneProtocol> for HeadphoneCtl {
@@ -419,23 +489,23 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysInputCtl::default();
+        let mut ctl = PhysInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = AuxSourceCtl::default();
+        let mut ctl = AuxSourceCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = AuxOutputCtl::default();
+        let mut ctl = AuxOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = HeadphoneCtl::default();
+        let mut ctl = HeadphoneCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -22,7 +22,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Fw410ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -36,6 +36,14 @@ impl MediaClkFreqCtlOperation<Fw410ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<Fw410ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 struct MeterCtl(Vec<ElemId>, MaudioNormalMeter);

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -245,6 +245,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -257,10 +258,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -68,8 +68,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 
 impl MaudioNormalMeterCtlOperation<Fw410MeterProtocol> for MeterCtl {}
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(Fw410PhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fw410PhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "phys-input-gain";
@@ -79,14 +85,28 @@ impl AvcLevelCtlOperation<Fw410PhysInputProtocol> for PhysInputCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Fw410PhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
 }
 
-#[derive(Default)]
-struct AuxSourceCtl;
+#[derive(Debug)]
+struct AuxSourceCtl(AvcLevelParameters);
+
+impl Default for AuxSourceCtl {
+    fn default() -> Self {
+        Self(Fw410AuxSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fw410AuxSourceProtocol> for AuxSourceCtl {
     const LEVEL_NAME: &'static str = "aux-source-gain";
@@ -106,18 +126,46 @@ impl AvcLevelCtlOperation<Fw410AuxSourceProtocol> for AuxSourceCtl {
         "stream-input-9",
         "stream-input-10",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct AuxOutputCtl;
+#[derive(Debug)]
+struct AuxOutputCtl(AvcLevelParameters);
+
+impl Default for AuxOutputCtl {
+    fn default() -> Self {
+        Self(Fw410AuxOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fw410AuxOutputProtocol> for AuxOutputCtl {
     const LEVEL_NAME: &'static str = "aux-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["aux-output-1", "aux-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(Fw410PhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fw410PhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = "output-volume";
@@ -133,6 +181,14 @@ impl AvcLevelCtlOperation<Fw410PhysOutputProtocol> for PhysOutputCtl {
         "digital-output-1",
         "digital-output-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcSelectorCtlOperation<Fw410PhysOutputProtocol> for PhysOutputCtl {
@@ -147,12 +203,26 @@ impl AvcSelectorCtlOperation<Fw410PhysOutputProtocol> for PhysOutputCtl {
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output", "aux-output-1/2"];
 }
 
-#[derive(Default)]
-struct HeadphoneCtl;
+#[derive(Debug)]
+struct HeadphoneCtl(AvcLevelParameters);
+
+impl Default for HeadphoneCtl {
+    fn default() -> Self {
+        Self(Fw410HeadphoneProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fw410HeadphoneProtocol> for HeadphoneCtl {
     const LEVEL_NAME: &'static str = "headphone-volume";
     const PORT_LABELS: &'static [&'static str] = &["headphone-1", "headphone-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcSelectorCtlOperation<Fw410HeadphoneProtocol> for HeadphoneCtl {
@@ -482,23 +552,23 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysInputCtl::default();
+        let mut ctl = PhysInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = AuxSourceCtl::default();
+        let mut ctl = AuxSourceCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = AuxOutputCtl::default();
+        let mut ctl = AuxOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = HeadphoneCtl::default();
+        let mut ctl = HeadphoneCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -316,6 +316,14 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.aux_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.aux_output_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_output_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -332,10 +340,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_input_ctl.read_balance(
             &self.avc,
@@ -344,20 +349,11 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .aux_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.aux_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .aux_output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.aux_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_output_ctl.read_selector(
             &self.avc,
@@ -366,10 +362,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .hp_ctl

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -21,10 +21,18 @@ pub struct Fw410Model {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Fw410ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Fw410ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Fw410ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -170,11 +170,14 @@ impl AvcLevelCtlOperation<Fw410AuxOutputProtocol> for AuxOutputCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcSelectorParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(Fw410PhysOutputProtocol::create_level_parameters())
+        Self(
+            Fw410PhysOutputProtocol::create_level_parameters(),
+            Fw410PhysOutputProtocol::create_selector_parameters(),
+        )
     }
 }
 
@@ -212,14 +215,25 @@ impl AvcSelectorCtlOperation<Fw410PhysOutputProtocol> for PhysOutputCtl {
         "analog-output-9/10",
     ];
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output", "aux-output-1/2"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct HeadphoneCtl(AvcLevelParameters);
+struct HeadphoneCtl(AvcLevelParameters, AvcSelectorParameters);
 
 impl Default for HeadphoneCtl {
     fn default() -> Self {
-        Self(Fw410HeadphoneProtocol::create_level_parameters())
+        Self(
+            Fw410HeadphoneProtocol::create_level_parameters(),
+            Fw410HeadphoneProtocol::create_selector_parameters(),
+        )
     }
 }
 
@@ -240,6 +254,14 @@ impl AvcSelectorCtlOperation<Fw410HeadphoneProtocol> for HeadphoneCtl {
     const SELECTOR_NAME: &'static str = "headphone-source";
     const SELECTOR_LABELS: &'static [&'static str] = &["headphone-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output", "aux-output-1/2"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.1
+    }
 }
 
 impl MaudioNormalMixerCtlOperation<Fw410HeadphoneProtocol> for HeadphoneCtl {
@@ -256,13 +278,27 @@ impl MaudioNormalMixerCtlOperation<Fw410HeadphoneProtocol> for HeadphoneCtl {
     ];
 }
 
-#[derive(Default)]
-struct SpdifInputCtl;
+#[derive(Debug)]
+struct SpdifInputCtl(AvcSelectorParameters);
+
+impl Default for SpdifInputCtl {
+    fn default() -> Self {
+        Self(Fw410SpdifOutputProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<Fw410SpdifOutputProtocol> for SpdifInputCtl {
     const SELECTOR_NAME: &'static str = "S/PDIF-input-source";
     const SELECTOR_LABELS: &'static [&'static str] = &["S/PDIF-input-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["coaxial-input-1/2", "optical-input-1/2"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Default)]
@@ -578,15 +614,15 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = HeadphoneCtl::default();
+        let mut ctl = HeadphoneCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = SpdifInputCtl::default();
+        let mut ctl = SpdifInputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -236,6 +236,8 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         self.mixer_ctl
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -245,10 +247,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -452,8 +451,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fw410Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -69,11 +69,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 impl MaudioNormalMeterCtlOperation<Fw410MeterProtocol> for MeterCtl {}
 
 #[derive(Debug)]
-struct PhysInputCtl(AvcLevelParameters);
+struct PhysInputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysInputCtl {
     fn default() -> Self {
-        Self(Fw410PhysInputProtocol::create_level_parameters())
+        Self(
+            Fw410PhysInputProtocol::create_level_parameters(),
+            Fw410PhysInputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -97,6 +100,14 @@ impl AvcLevelCtlOperation<Fw410PhysInputProtocol> for PhysInputCtl {
 
 impl AvcLrBalanceCtlOperation<Fw410PhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -373,6 +373,11 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_input_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_output_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.spdif_input_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -399,33 +404,15 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self.phys_output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_output_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_output_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
-        } else if self.spdif_input_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.spdif_input_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
-        } else if self.spdif_input_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.spdif_input_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -335,6 +335,8 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         self.phys_output_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -353,12 +355,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_input_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_input_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.aux_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -136,6 +136,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -148,10 +149,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -127,6 +127,8 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         self.mixer_ctl
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -136,10 +138,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -263,8 +262,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for OzonicModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -17,10 +17,18 @@ pub struct OzonicModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<OzonicClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<OzonicClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<OzonicClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -165,6 +165,10 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.stream_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -181,10 +185,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_input_ctl.read_balance(
             &self.avc,
@@ -193,12 +194,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.stream_input_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.stream_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -65,11 +65,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 impl MaudioNormalMeterCtlOperation<OzonicMeterProtocol> for MeterCtl {}
 
 #[derive(Debug)]
-struct PhysInputCtl(AvcLevelParameters);
+struct PhysInputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysInputCtl {
     fn default() -> Self {
-        Self(OzonicPhysInputProtocol::create_level_parameters())
+        Self(
+            OzonicPhysInputProtocol::create_level_parameters(),
+            OzonicPhysInputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -93,6 +96,14 @@ impl AvcLevelCtlOperation<OzonicPhysInputProtocol> for PhysInputCtl {
 
 impl AvcLrBalanceCtlOperation<OzonicPhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -64,8 +64,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 
 impl MaudioNormalMeterCtlOperation<OzonicMeterProtocol> for MeterCtl {}
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(OzonicPhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<OzonicPhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "phys-input-gain";
@@ -75,14 +81,28 @@ impl AvcLevelCtlOperation<OzonicPhysInputProtocol> for PhysInputCtl {
         "analog-input-3",
         "analog-input-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<OzonicPhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
 }
 
-#[derive(Default)]
-struct StreamInputCtl;
+#[derive(Debug)]
+struct StreamInputCtl(AvcLevelParameters);
+
+impl Default for StreamInputCtl {
+    fn default() -> Self {
+        Self(OzonicStreamInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<OzonicStreamInputProtocol> for StreamInputCtl {
     const LEVEL_NAME: &'static str = "stream-input-gain";
@@ -92,6 +112,14 @@ impl AvcLevelCtlOperation<OzonicStreamInputProtocol> for StreamInputCtl {
         "stream-input-3",
         "stream-input-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Default)]
@@ -290,11 +318,11 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysInputCtl::default();
+        let mut ctl = PhysInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = StreamInputCtl::default();
+        let mut ctl = StreamInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -180,6 +180,8 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.stream_input_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -198,12 +200,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             Ok(true)
         } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_input_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_input_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.stream_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -18,7 +18,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<OzonicClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -32,6 +32,14 @@ impl MediaClkFreqCtlOperation<OzonicClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<OzonicClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 struct MeterCtl(Vec<ElemId>, MaudioNormalMeter);

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -71,6 +71,8 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         self.input_params_ctl
             .load_params(card_cntr, unit, &self.req, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -80,10 +82,7 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -169,8 +168,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for PflModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -18,10 +18,18 @@ pub struct PflModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<PflClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<PflClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<PflClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &[

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -80,6 +80,7 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
             .load_params(card_cntr, unit, &self.req, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -92,10 +93,7 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -19,7 +19,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<PflClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -41,6 +41,14 @@ impl SamplingClkSrcCtlOperation<PflClkProtocol> for ClkCtl {
         "ADAT-4",
         "Word-clock",
     ];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -192,6 +192,8 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.stream_input_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -210,12 +212,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phys_input_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.phys_input_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.stream_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -148,6 +148,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -160,10 +161,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -177,6 +177,10 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.stream_input_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -193,10 +197,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self.meter_ctl.read_meter(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_input_ctl.read_balance(
             &self.avc,
@@ -205,12 +206,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.stream_input_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.stream_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.spdif_output_ctl.read_selector(
             &self.avc,

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -208,6 +208,8 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_input_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.spdif_output_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -230,12 +232,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self.stream_input_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.spdif_output_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.spdif_output_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -19,7 +19,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<SoloClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -33,6 +33,14 @@ impl MediaClkFreqCtlOperation<SoloClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<SoloClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 struct MeterCtl(Vec<ElemId>, MaudioNormalMeter);

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -65,8 +65,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 
 impl MaudioNormalMeterCtlOperation<SoloMeterProtocol> for MeterCtl {}
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(SoloPhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<SoloPhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "phys-input-gain";
@@ -76,14 +82,28 @@ impl AvcLevelCtlOperation<SoloPhysInputProtocol> for PhysInputCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<SoloPhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
 }
 
-#[derive(Default)]
-struct StreamInputCtl;
+#[derive(Debug)]
+struct StreamInputCtl(AvcLevelParameters);
+
+impl Default for StreamInputCtl {
+    fn default() -> Self {
+        Self(SoloStreamInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<SoloStreamInputProtocol> for StreamInputCtl {
     const LEVEL_NAME: &'static str = "stream-input-gain";
@@ -93,6 +113,14 @@ impl AvcLevelCtlOperation<SoloStreamInputProtocol> for StreamInputCtl {
         "stream-input-3",
         "stream-input-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Default)]
@@ -320,11 +348,11 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysInputCtl::default();
+        let mut ctl = PhysInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = StreamInputCtl::default();
+        let mut ctl = StreamInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -18,10 +18,18 @@ pub struct SoloModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<SoloClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<SoloClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<SoloClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -66,11 +66,14 @@ impl AsRef<MaudioNormalMeter> for MeterCtl {
 impl MaudioNormalMeterCtlOperation<SoloMeterProtocol> for MeterCtl {}
 
 #[derive(Debug)]
-struct PhysInputCtl(AvcLevelParameters);
+struct PhysInputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysInputCtl {
     fn default() -> Self {
-        Self(SoloPhysInputProtocol::create_level_parameters())
+        Self(
+            SoloPhysInputProtocol::create_level_parameters(),
+            SoloPhysInputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -94,6 +97,14 @@ impl AvcLevelCtlOperation<SoloPhysInputProtocol> for PhysInputCtl {
 
 impl AvcLrBalanceCtlOperation<SoloPhysInputProtocol> for PhysInputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -134,13 +134,27 @@ impl AvcLevelCtlOperation<SoloStreamInputProtocol> for StreamInputCtl {
     }
 }
 
-#[derive(Default)]
-struct SpdifOutputCtl;
+#[derive(Debug)]
+struct SpdifOutputCtl(AvcSelectorParameters);
+
+impl Default for SpdifOutputCtl {
+    fn default() -> Self {
+        Self(SoloSpdifOutputProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<SoloSpdifOutputProtocol> for SpdifOutputCtl {
     const SELECTOR_NAME: &'static str = "S/PDIF-output-source";
     const SELECTOR_LABELS: &'static [&'static str] = &["S/PDIF-output-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["stream-input-3/4", "mixer-output-3/4"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Default)]
@@ -365,7 +379,7 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = SpdifOutputCtl::default();
+        let mut ctl = SpdifOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -139,6 +139,8 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         self.mixer_ctl
             .load_src_state(card_cntr, &self.avc, TIMEOUT_MS)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -148,10 +150,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -290,8 +289,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SoloModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/maudio/special_model.rs
+++ b/runtime/bebob/src/maudio/special_model.rs
@@ -26,10 +26,18 @@ pub struct SpecialModel<T: MediaClockFrequencyOperation> {
 const FCP_TIMEOUT_MS: u32 = 200;
 const TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl<T: MediaClockFrequencyOperation>(Vec<ElemId>, PhantomData<T>);
+#[derive(Default, Debug)]
+struct ClkCtl<T: MediaClockFrequencyOperation>(Vec<ElemId>, MediaClockParameters, PhantomData<T>);
 
-impl<T: MediaClockFrequencyOperation> MediaClkFreqCtlOperation<T> for ClkCtl<T> {}
+impl<T: MediaClockFrequencyOperation> MediaClkFreqCtlOperation<T> for ClkCtl<T> {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 #[derive(Default, Debug)]
 struct MeterCtl(MaudioSpecialMeterState, Vec<ElemId>);

--- a/runtime/bebob/src/maudio/special_model.rs
+++ b/runtime/bebob/src/maudio/special_model.rs
@@ -106,10 +106,7 @@ impl<T: MediaClockFrequencyOperation> CtlModel<(SndUnit, FwNode)> for SpecialMod
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_params(elem_id, elem_value)? {
             Ok(true)
@@ -285,8 +282,7 @@ impl<T: MediaClockFrequencyOperation> NotifyModel<(SndUnit, FwNode), bool> for S
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -411,7 +411,15 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         self.headphone_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_phys_src_ctl
             .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.headphone_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -430,21 +438,13 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.headphone_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.headphone_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self.headphone_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.headphone_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
@@ -456,12 +456,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .read_selectors(elem_id, elem_value)?
+        {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -194,6 +194,8 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
 
         self.analog_in_ctl.load_switch(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -203,10 +205,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -456,8 +455,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for FireboxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -46,11 +46,14 @@ impl SamplingClkSrcCtlOperation<FireboxClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(FireboxPhysOutputProtocol::create_level_parameters())
+        Self(
+            FireboxPhysOutputProtocol::create_level_parameters(),
+            FireboxPhysOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -76,6 +79,14 @@ impl AvcLevelCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcMuteCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
     const MUTE_NAME: &'static str = "phys-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
@@ -90,11 +101,14 @@ impl AvcSelectorCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
 }
 
 #[derive(Debug)]
-struct HeadphoneCtl(AvcLevelParameters);
+struct HeadphoneCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for HeadphoneCtl {
     fn default() -> Self {
-        Self(FireboxHeadphoneProtocol::create_level_parameters())
+        Self(
+            FireboxHeadphoneProtocol::create_level_parameters(),
+            FireboxHeadphoneProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -113,6 +127,14 @@ impl AvcLevelCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
 
 impl AvcMuteCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
     const MUTE_NAME: &'static str = "headphone-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
@@ -128,13 +150,18 @@ impl AvcSelectorCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
 }
 
 #[derive(Debug)]
-struct MixerPhysSrcCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct MixerPhysSrcCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for MixerPhysSrcCtl {
     fn default() -> Self {
         Self(
             FireboxMixerPhysSourceProtocol::create_level_parameters(),
             FireboxMixerPhysSourceProtocol::create_lr_balance_parameters(),
+            FireboxMixerPhysSourceProtocol::create_mute_parameters(),
         )
     }
 }
@@ -173,14 +200,25 @@ impl AvcLrBalanceCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCt
 
 impl AvcMuteCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const MUTE_NAME: &'static str = "mixer-phys-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Debug)]
-struct MixerStreamSrcCtl(AvcLevelParameters);
+struct MixerStreamSrcCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerStreamSrcCtl {
     fn default() -> Self {
-        Self(FireboxMixerStreamSourceProtocol::create_level_parameters())
+        Self(
+            FireboxMixerStreamSourceProtocol::create_level_parameters(),
+            FireboxMixerStreamSourceProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -199,6 +237,14 @@ impl AvcLevelCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSrcCt
 
 impl AvcMuteCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSrcCtl {
     const MUTE_NAME: &'static str = "mixer-stream-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSrcCtl {
@@ -213,13 +259,18 @@ impl AvcSelectorCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSr
 }
 
 #[derive(Debug)]
-struct MixerOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct MixerOutputCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for MixerOutputCtl {
     fn default() -> Self {
         Self(
             FireboxMixerOutputProtocol::create_level_parameters(),
             FireboxMixerOutputProtocol::create_lr_balance_parameters(),
+            FireboxMixerOutputProtocol::create_mute_parameters(),
         )
     }
 }
@@ -250,6 +301,14 @@ impl AvcLrBalanceCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
 
 impl AvcMuteCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-phys-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -45,8 +45,14 @@ impl SamplingClkSrcCtlOperation<FireboxClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(FireboxPhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = OUT_VOL_NAME;
@@ -58,6 +64,14 @@ impl AvcLevelCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
         "analog-output-5",
         "analog-output-6",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
@@ -75,12 +89,26 @@ impl AvcSelectorCtlOperation<FireboxPhysOutputProtocol> for PhysOutputCtl {
     const ITEM_LABELS: &'static [&'static str] = &["stream-input", "mixer-output-1/2"];
 }
 
-#[derive(Default)]
-struct HeadphoneCtl;
+#[derive(Debug)]
+struct HeadphoneCtl(AvcLevelParameters);
+
+impl Default for HeadphoneCtl {
+    fn default() -> Self {
+        Self(FireboxHeadphoneProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
     const LEVEL_NAME: &'static str = "headphone-gain";
     const PORT_LABELS: &'static [&'static str] = &["headphone-1", "headphone-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
@@ -99,8 +127,14 @@ impl AvcSelectorCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
     ];
 }
 
-#[derive(Default)]
-struct MixerPhysSrcCtl;
+#[derive(Debug)]
+struct MixerPhysSrcCtl(AvcLevelParameters);
+
+impl Default for MixerPhysSrcCtl {
+    fn default() -> Self {
+        Self(FireboxMixerPhysSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const LEVEL_NAME: &'static str = "mixer-phys-source-gain";
@@ -112,6 +146,14 @@ impl AvcLevelCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
@@ -122,12 +164,26 @@ impl AvcMuteCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const MUTE_NAME: &'static str = "mixer-phys-source-mute";
 }
 
-#[derive(Default)]
-struct MixerStreamSrcCtl;
+#[derive(Debug)]
+struct MixerStreamSrcCtl(AvcLevelParameters);
+
+impl Default for MixerStreamSrcCtl {
+    fn default() -> Self {
+        Self(FireboxMixerStreamSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSrcCtl {
     const LEVEL_NAME: &'static str = "mixer-stream-source-gain";
     const PORT_LABELS: &'static [&'static str] = &["stream-input-1/2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSrcCtl {
@@ -145,12 +201,25 @@ impl AvcSelectorCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSr
     ];
 }
 
-#[derive(Default)]
-struct MixerOutputCtl;
+#[derive(Debug)]
+struct MixerOutputCtl(AvcLevelParameters);
 
+impl Default for MixerOutputCtl {
+    fn default() -> Self {
+        Self(FireboxMixerOutputProtocol::create_level_parameters())
+    }
+}
 impl AvcLevelCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
     const LEVEL_NAME: &'static str = "mixer-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["mixer-output-1", "mixer-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
@@ -534,23 +603,23 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysOutputCtl::default();
+        let mut ctl = PhysOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = HeadphoneCtl::default();
+        let mut ctl = HeadphoneCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerPhysSrcCtl::default();
+        let mut ctl = MixerPhysSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerStreamSrcCtl::default();
+        let mut ctl = MixerStreamSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerOutputCtl::default();
+        let mut ctl = MixerOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -274,6 +274,7 @@ impl Default for MixerOutputCtl {
         )
     }
 }
+
 impl AvcLevelCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
     const LEVEL_NAME: &'static str = "mixer-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["mixer-output-1", "mixer-output-2"];
@@ -365,6 +366,11 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.headphone_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -381,10 +387,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -393,10 +396,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.headphone_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .headphone_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.headphone_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.headphone_ctl.read_selector(
             &self.avc,
@@ -409,21 +409,11 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_selector(
             &self.avc,
@@ -436,10 +426,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.mixer_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .analog_in_ctl

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -128,11 +128,14 @@ impl AvcSelectorCtlOperation<FireboxHeadphoneProtocol> for HeadphoneCtl {
 }
 
 #[derive(Debug)]
-struct MixerPhysSrcCtl(AvcLevelParameters);
+struct MixerPhysSrcCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for MixerPhysSrcCtl {
     fn default() -> Self {
-        Self(FireboxMixerPhysSourceProtocol::create_level_parameters())
+        Self(
+            FireboxMixerPhysSourceProtocol::create_level_parameters(),
+            FireboxMixerPhysSourceProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -158,6 +161,14 @@ impl AvcLevelCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
 
 impl AvcLrBalanceCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<FireboxMixerPhysSourceProtocol> for MixerPhysSrcCtl {
@@ -202,11 +213,14 @@ impl AvcSelectorCtlOperation<FireboxMixerStreamSourceProtocol> for MixerStreamSr
 }
 
 #[derive(Debug)]
-struct MixerOutputCtl(AvcLevelParameters);
+struct MixerOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for MixerOutputCtl {
     fn default() -> Self {
-        Self(FireboxMixerOutputProtocol::create_level_parameters())
+        Self(
+            FireboxMixerOutputProtocol::create_level_parameters(),
+            FireboxMixerOutputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 impl AvcLevelCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
@@ -224,6 +238,14 @@ impl AvcLevelCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
 
 impl AvcLrBalanceCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {
     const BALANCE_NAME: &'static str = "phys-input-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<FireboxMixerOutputProtocol> for MixerOutputCtl {

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -203,6 +203,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         self.analog_in_ctl.load_switch(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -215,10 +216,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -273,6 +273,13 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.headphone_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -287,10 +294,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -302,10 +306,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .headphone_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.headphone_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .headphone_ctl
@@ -319,12 +320,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_balance(
             &self.avc,
@@ -340,12 +336,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_mute(
             &self.avc,
@@ -361,10 +352,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -20,10 +20,18 @@ pub struct FireboxModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<FireboxClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<FireboxClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<FireboxClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -302,6 +302,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         self.mixer_stream_src_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -344,12 +348,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_mute(
             &self.avc,
@@ -376,10 +375,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -21,7 +21,7 @@ pub struct FireboxModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<FireboxClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -35,6 +35,14 @@ impl MediaClkFreqCtlOperation<FireboxClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<FireboxClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -87,6 +87,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         self.phys_out_ctl.load_mute(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -99,10 +100,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -15,10 +15,18 @@ pub struct Fp10Model {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Fp10ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Fp10ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Fp10ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -129,6 +129,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_out_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -147,10 +148,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             Ok(true)
         } else if self.phys_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -16,7 +16,7 @@ pub struct Fp10Model {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Fp10ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -30,6 +30,14 @@ impl MediaClkFreqCtlOperation<Fp10ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<Fp10ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -41,13 +41,18 @@ impl SamplingClkSrcCtlOperation<Fp10ClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct PhysOutputCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
         Self(
             Fp10PhysOutputProtocol::create_level_parameters(),
             Fp10PhysOutputProtocol::create_lr_balance_parameters(),
+            Fp10PhysOutputProtocol::create_mute_parameters(),
         )
     }
 }
@@ -89,6 +94,14 @@ impl AvcLrBalanceCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcMuteCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
     const MUTE_NAME: &'static str = "output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for Fp10Model {

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -78,6 +78,8 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         self.phys_out_ctl.load_balance(card_cntr)?;
         self.phys_out_ctl.load_mute(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -87,10 +89,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -178,7 +177,6 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fp10Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -41,11 +41,14 @@ impl SamplingClkSrcCtlOperation<Fp10ClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(Fp10PhysOutputProtocol::create_level_parameters())
+        Self(
+            Fp10PhysOutputProtocol::create_level_parameters(),
+            Fp10PhysOutputProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -74,6 +77,14 @@ impl AvcLevelCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcLrBalanceCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
     const BALANCE_NAME: &'static str = "output-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -114,6 +114,8 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -130,10 +132,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             Ok(true)
         } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -40,8 +40,14 @@ impl SamplingClkSrcCtlOperation<Fp10ClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(Fp10PhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = OUT_VOL_NAME;
@@ -56,6 +62,14 @@ impl AvcLevelCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {
         "analog-output-7",
         "analog-output-8",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Fp10PhysOutputProtocol> for PhysOutputCtl {

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -102,6 +102,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -116,10 +117,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -23,7 +23,7 @@ const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Inspire1394ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -37,6 +37,14 @@ impl MediaClkFreqCtlOperation<Inspire1394ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<Inspire1394ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -373,6 +373,8 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_stream_src_ctl
             .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -427,10 +429,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -174,11 +174,14 @@ impl AvcMuteCtlOperation<Inspire1394HeadphoneProtocol> for HeadphoneCtl {
 }
 
 #[derive(Debug)]
-struct MixerPhysSourceCtl(AvcLevelParameters);
+struct MixerPhysSourceCtl(AvcLevelParameters, AvcLrBalanceParameters);
 
 impl Default for MixerPhysSourceCtl {
     fn default() -> Self {
-        Self(Inspire1394MixerAnalogSourceProtocol::create_level_parameters())
+        Self(
+            Inspire1394MixerAnalogSourceProtocol::create_level_parameters(),
+            Inspire1394MixerAnalogSourceProtocol::create_lr_balance_parameters(),
+        )
     }
 }
 
@@ -202,6 +205,14 @@ impl AvcLevelCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSou
 
 impl AvcLrBalanceCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSourceCtl {
     const BALANCE_NAME: &'static str = "mixer-analog-source-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcMuteCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSourceCtl {

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -299,6 +299,8 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_stream_src_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -373,12 +375,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_balance(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_mute(
             &self.avc,

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -358,6 +358,12 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_phys_src_ctl
             .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -374,10 +380,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.phys_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_in_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_in_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if SwitchCtlOperation::<Inspire1394MicPhantomProtocol>::read_switch(
             &self.phys_in_ctl,
@@ -413,10 +416,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -425,30 +425,17 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -64,8 +64,14 @@ impl AsMut<Inspire1394Meter> for MeterCtl {
 
 impl MeterCtlOperation<Inspire1394MeterProtocol> for MeterCtl {}
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(Inspire1394PhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Inspire1394PhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "analog-input-gain";
@@ -75,6 +81,14 @@ impl AvcLevelCtlOperation<Inspire1394PhysInputProtocol> for PhysInputCtl {
         "analog-input-3",
         "analog-input-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Inspire1394PhysInputProtocol> for PhysInputCtl {
@@ -101,12 +115,26 @@ impl SwitchCtlOperation<Inspire1394PhonoProtocol> for PhysInputCtl {
     const SWITCH_LABELS: &'static [&'static str] = &["analog-input-3/4"];
 }
 
-#[derive(Default)]
-struct PhysOutputCtl;
+#[derive(Debug)]
+struct PhysOutputCtl(AvcLevelParameters);
+
+impl Default for PhysOutputCtl {
+    fn default() -> Self {
+        Self(Inspire1394PhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
     const LEVEL_NAME: &'static str = "analog-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["analog-output-1", "analog-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
@@ -119,20 +147,40 @@ impl AvcSelectorCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output-1/2", "stream-input-1/2"];
 }
 
-#[derive(Default)]
-struct HeadphoneCtl;
+#[derive(Debug)]
+struct HeadphoneCtl(AvcLevelParameters);
+
+impl Default for HeadphoneCtl {
+    fn default() -> Self {
+        Self(Inspire1394HeadphoneProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Inspire1394HeadphoneProtocol> for HeadphoneCtl {
     const LEVEL_NAME: &'static str = "headphone-volume";
     const PORT_LABELS: &'static [&'static str] = &["headphone-1", "headphone-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Inspire1394HeadphoneProtocol> for HeadphoneCtl {
     const MUTE_NAME: &'static str = "headphone-mute";
 }
 
-#[derive(Default)]
-struct MixerPhysSourceCtl;
+#[derive(Debug)]
+struct MixerPhysSourceCtl(AvcLevelParameters);
+
+impl Default for MixerPhysSourceCtl {
+    fn default() -> Self {
+        Self(Inspire1394MixerAnalogSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSourceCtl {
     const LEVEL_NAME: &'static str = "mixer-analog-source-gain";
@@ -142,6 +190,14 @@ impl AvcLevelCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSou
         "analog-input-3",
         "analog-input-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSourceCtl {
@@ -152,12 +208,26 @@ impl AvcMuteCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSour
     const MUTE_NAME: &'static str = "mixer-analog-source-mute";
 }
 
-#[derive(Default)]
-struct MixerStreamSourceCtl;
+#[derive(Debug)]
+struct MixerStreamSourceCtl(AvcLevelParameters);
+
+impl Default for MixerStreamSourceCtl {
+    fn default() -> Self {
+        Self(Inspire1394MixerStreamSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Inspire1394MixerStreamSourceProtocol> for MixerStreamSourceCtl {
     const LEVEL_NAME: &'static str = "mixer-stream-source-gain";
     const PORT_LABELS: &'static [&'static str] = &["stream-input-1/2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Inspire1394MixerStreamSourceProtocol> for MixerStreamSourceCtl {

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -127,13 +127,14 @@ impl SwitchCtlOperation<Inspire1394PhonoProtocol> for PhysInputCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters, AvcMuteParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcMuteParameters, AvcSelectorParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
         Self(
             Inspire1394PhysOutputProtocol::create_level_parameters(),
             Inspire1394PhysOutputProtocol::create_mute_parameters(),
+            Inspire1394PhysOutputProtocol::create_selector_parameters(),
         )
     }
 }
@@ -167,6 +168,14 @@ impl AvcSelectorCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
     const SELECTOR_NAME: &'static str = "output-source";
     const SELECTOR_LABELS: &'static [&'static str] = &["analog-output-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output-1/2", "stream-input-1/2"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Debug)]

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -202,6 +202,8 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         self.mixer_stream_src_ctl.load_level(card_cntr)?;
         self.mixer_stream_src_ctl.load_mute(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -211,10 +213,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -485,8 +484,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Inspire1394Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -211,6 +211,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         self.mixer_stream_src_ctl.load_mute(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -223,10 +224,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_in_ctl

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -22,10 +22,18 @@ pub struct Inspire1394Model {
 const FCP_TIMEOUT_MS: u32 = 100;
 const TIMEOUT_MS: u32 = 50;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Inspire1394ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Inspire1394ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Inspire1394ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -65,11 +65,14 @@ impl AsMut<Inspire1394Meter> for MeterCtl {
 impl MeterCtlOperation<Inspire1394MeterProtocol> for MeterCtl {}
 
 #[derive(Debug)]
-struct PhysInputCtl(AvcLevelParameters);
+struct PhysInputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for PhysInputCtl {
     fn default() -> Self {
-        Self(Inspire1394PhysInputProtocol::create_level_parameters())
+        Self(
+            Inspire1394PhysInputProtocol::create_level_parameters(),
+            Inspire1394PhysInputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -93,6 +96,14 @@ impl AvcLevelCtlOperation<Inspire1394PhysInputProtocol> for PhysInputCtl {
 
 impl AvcMuteCtlOperation<Inspire1394PhysInputProtocol> for PhysInputCtl {
     const MUTE_NAME: &'static str = "analog-input-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl SwitchCtlOperation<Inspire1394MicPhantomProtocol> for PhysInputCtl {
@@ -116,11 +127,14 @@ impl SwitchCtlOperation<Inspire1394PhonoProtocol> for PhysInputCtl {
 }
 
 #[derive(Debug)]
-struct PhysOutputCtl(AvcLevelParameters);
+struct PhysOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for PhysOutputCtl {
     fn default() -> Self {
-        Self(Inspire1394PhysOutputProtocol::create_level_parameters())
+        Self(
+            Inspire1394PhysOutputProtocol::create_level_parameters(),
+            Inspire1394PhysOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -139,6 +153,14 @@ impl AvcLevelCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
 
 impl AvcMuteCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
     const MUTE_NAME: &'static str = "analog-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
@@ -148,11 +170,14 @@ impl AvcSelectorCtlOperation<Inspire1394PhysOutputProtocol> for PhysOutputCtl {
 }
 
 #[derive(Debug)]
-struct HeadphoneCtl(AvcLevelParameters);
+struct HeadphoneCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for HeadphoneCtl {
     fn default() -> Self {
-        Self(Inspire1394HeadphoneProtocol::create_level_parameters())
+        Self(
+            Inspire1394HeadphoneProtocol::create_level_parameters(),
+            Inspire1394HeadphoneProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -171,16 +196,29 @@ impl AvcLevelCtlOperation<Inspire1394HeadphoneProtocol> for HeadphoneCtl {
 
 impl AvcMuteCtlOperation<Inspire1394HeadphoneProtocol> for HeadphoneCtl {
     const MUTE_NAME: &'static str = "headphone-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct MixerPhysSourceCtl(AvcLevelParameters, AvcLrBalanceParameters);
+struct MixerPhysSourceCtl(
+    AvcLevelParameters,
+    AvcLrBalanceParameters,
+    AvcMuteParameters,
+);
 
 impl Default for MixerPhysSourceCtl {
     fn default() -> Self {
         Self(
             Inspire1394MixerAnalogSourceProtocol::create_level_parameters(),
             Inspire1394MixerAnalogSourceProtocol::create_lr_balance_parameters(),
+            Inspire1394MixerAnalogSourceProtocol::create_mute_parameters(),
         )
     }
 }
@@ -217,14 +255,25 @@ impl AvcLrBalanceCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhy
 
 impl AvcMuteCtlOperation<Inspire1394MixerAnalogSourceProtocol> for MixerPhysSourceCtl {
     const MUTE_NAME: &'static str = "mixer-analog-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Debug)]
-struct MixerStreamSourceCtl(AvcLevelParameters);
+struct MixerStreamSourceCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerStreamSourceCtl {
     fn default() -> Self {
-        Self(Inspire1394MixerStreamSourceProtocol::create_level_parameters())
+        Self(
+            Inspire1394MixerStreamSourceProtocol::create_level_parameters(),
+            Inspire1394MixerStreamSourceProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -243,6 +292,14 @@ impl AvcLevelCtlOperation<Inspire1394MixerStreamSourceProtocol> for MixerStreamS
 
 impl AvcMuteCtlOperation<Inspire1394MixerStreamSourceProtocol> for MixerStreamSourceCtl {
     const MUTE_NAME: &'static str = "mixer-stream-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -282,6 +282,12 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -296,10 +302,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_in_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_in_ctl
@@ -338,10 +341,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -353,22 +353,14 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .hp_ctl
             .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_balance(
             &self.avc,
@@ -384,12 +376,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_mute(
             &self.avc,

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -147,6 +147,7 @@ where
         self.analog_in_ctl.load_balance(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.analog_in_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -159,10 +160,7 @@ where
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .analog_in_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.analog_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .analog_in_ctl

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -56,8 +56,17 @@ impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default, Debug)]
-pub struct MixerAnalogSourceCtl<T: AvcAudioFeatureSpecification>(PhantomData<T>);
+#[derive(Debug)]
+pub struct MixerAnalogSourceCtl<T: AvcAudioFeatureSpecification>(
+    AvcLevelParameters,
+    PhantomData<T>,
+);
+
+impl<T: AvcLevelOperation> Default for MixerAnalogSourceCtl<T> {
+    fn default() -> Self {
+        Self(T::create_level_parameters(), Default::default())
+    }
+}
 
 impl AvcLevelCtlOperation<Fa66MixerAnalogSourceProtocol>
     for MixerAnalogSourceCtl<Fa66MixerAnalogSourceProtocol>
@@ -72,6 +81,14 @@ impl AvcLevelCtlOperation<Fa66MixerAnalogSourceProtocol>
         "analog-input-5",
         "analog-input-6",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Fa66MixerAnalogSourceProtocol>
@@ -97,6 +114,14 @@ impl AvcLevelCtlOperation<Fa101MixerAnalogSourceProtocol>
         "analog-input-9",
         "analog-input-10",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLrBalanceCtlOperation<Fa101MixerAnalogSourceProtocol>
@@ -190,11 +215,11 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = MixerAnalogSourceCtl::<Fa66MixerAnalogSourceProtocol>::default();
+        let mut ctl = MixerAnalogSourceCtl::<Fa66MixerAnalogSourceProtocol>::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerAnalogSourceCtl::<Fa66MixerAnalogSourceProtocol>::default();
+        let mut ctl = MixerAnalogSourceCtl::<Fa66MixerAnalogSourceProtocol>::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -59,12 +59,17 @@ impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
 #[derive(Debug)]
 pub struct MixerAnalogSourceCtl<T: AvcAudioFeatureSpecification>(
     AvcLevelParameters,
+    AvcLrBalanceParameters,
     PhantomData<T>,
 );
 
-impl<T: AvcLevelOperation> Default for MixerAnalogSourceCtl<T> {
+impl<T: AvcLevelOperation + AvcLrBalanceOperation> Default for MixerAnalogSourceCtl<T> {
     fn default() -> Self {
-        Self(T::create_level_parameters(), Default::default())
+        Self(
+            T::create_level_parameters(),
+            T::create_lr_balance_parameters(),
+            Default::default(),
+        )
     }
 }
 
@@ -95,6 +100,14 @@ impl AvcLrBalanceCtlOperation<Fa66MixerAnalogSourceProtocol>
     for MixerAnalogSourceCtl<Fa66MixerAnalogSourceProtocol>
 {
     const BALANCE_NAME: &'static str = "mixer-source-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl AvcLevelCtlOperation<Fa101MixerAnalogSourceProtocol>
@@ -128,6 +141,14 @@ impl AvcLrBalanceCtlOperation<Fa101MixerAnalogSourceProtocol>
     for MixerAnalogSourceCtl<Fa101MixerAnalogSourceProtocol>
 {
     const BALANCE_NAME: &'static str = "mixer-source-balance";
+
+    fn state(&self) -> &AvcLrBalanceParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLrBalanceParameters {
+        &mut self.1
+    }
 }
 
 impl<T> CtlModel<(SndUnit, FwNode)> for FaModel<T>

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -57,7 +57,7 @@ impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
 }
 
 #[derive(Default, Debug)]
-pub struct MixerAnalogSourceCtl<T: AvcLevelOperation>(PhantomData<T>);
+pub struct MixerAnalogSourceCtl<T: AvcAudioFeatureSpecification>(PhantomData<T>);
 
 impl AvcLevelCtlOperation<Fa66MixerAnalogSourceProtocol>
     for MixerAnalogSourceCtl<Fa66MixerAnalogSourceProtocol>

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -121,6 +121,8 @@ where
         self.analog_in_ctl.load_level(card_cntr)?;
         self.analog_in_ctl.load_balance(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -130,10 +132,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .analog_in_ctl

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -169,6 +169,8 @@ where
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.analog_in_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.analog_in_ctl
+            .cache_balances(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -183,10 +185,7 @@ where
             Ok(true)
         } else if self.analog_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .analog_in_ctl
-            .read_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.analog_in_ctl.read_balances(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -24,12 +24,20 @@ where
 const FCP_TIMEOUT_MS: u32 = 100;
 
 // Read only, configured by hardware only.
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
 impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+
     fn write_freq(
-        &self,
+        &mut self,
         _: &mut SndUnit,
         _: &BebobAvc,
         elem_id: &ElemId,

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -41,8 +41,14 @@ impl SamplingClkSrcCtlOperation<ScratchampClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct ScratchampOutputCtl;
+#[derive(Debug)]
+struct ScratchampOutputCtl(AvcLevelParameters);
+
+impl Default for ScratchampOutputCtl {
+    fn default() -> Self {
+        Self(ScratchampOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<ScratchampOutputProtocol> for ScratchampOutputCtl {
     const LEVEL_NAME: &'static str = OUT_VOL_NAME;
@@ -52,14 +58,36 @@ impl AvcLevelCtlOperation<ScratchampOutputProtocol> for ScratchampOutputCtl {
         "analog-output-3",
         "analog-output-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct ScratchampHeadphoneCtl;
+#[derive(Debug)]
+struct ScratchampHeadphoneCtl(AvcLevelParameters);
+
+impl Default for ScratchampHeadphoneCtl {
+    fn default() -> Self {
+        Self(ScratchampHeadphoneProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<ScratchampHeadphoneProtocol> for ScratchampHeadphoneCtl {
     const LEVEL_NAME: &'static str = "headphone-volume";
     const PORT_LABELS: &'static [&'static str] = &["headphone-1", "headphone-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
@@ -190,11 +218,11 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = ScratchampOutputCtl::default();
+        let mut ctl = ScratchampOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = ScratchampHeadphoneCtl::default();
+        let mut ctl = ScratchampHeadphoneCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -82,6 +82,7 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         self.headphone_ctl.load_level(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -94,10 +95,7 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .output_ctl

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -111,6 +111,8 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.output_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.headphone_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -125,15 +127,9 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .output_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.output_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .headphone_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.headphone_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -16,10 +16,18 @@ pub struct ScratchampModel {
     headphone_ctl: ScratchampHeadphoneCtl,
 }
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<ScratchampClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<ScratchampClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<ScratchampClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -73,6 +73,8 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         self.output_ctl.load_level(card_cntr)?;
         self.headphone_ctl.load_level(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -82,10 +84,7 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -163,8 +162,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for ScratchampModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -17,7 +17,7 @@ pub struct ScratchampModel {
 }
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<ScratchampClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -31,6 +31,14 @@ impl MediaClkFreqCtlOperation<ScratchampClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<ScratchampClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -214,6 +214,10 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mon_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_src_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.spdif_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -228,10 +232,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self.phys_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mon_src_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_src_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mon_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
@@ -241,12 +242,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self.spdif_out_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.spdif_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -184,6 +184,8 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         self.phys_in_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mon_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -205,17 +207,11 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self.mon_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mon_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.spdif_out_ctl.read_selector(
             &self.avc,

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -116,6 +116,8 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         self.mixer_out_ctl.load_mute(card_cntr)?;
         self.spdif_out_ctl.load_selector(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -125,10 +127,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_in_ctl
@@ -244,8 +243,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for AureonModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -54,8 +54,14 @@ impl AvcLevelCtlOperation<AureonPhysInputProtocol> for PhysInputCtl {
     }
 }
 
-#[derive(Default)]
-struct MonitorSourceCtl;
+#[derive(Debug)]
+struct MonitorSourceCtl(AvcSelectorParameters);
+
+impl Default for MonitorSourceCtl {
+    fn default() -> Self {
+        Self(AureonMonitorSourceProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<AureonMonitorSourceProtocol> for MonitorSourceCtl {
     const SELECTOR_NAME: &'static str = "monitor-source";
@@ -66,6 +72,14 @@ impl AvcSelectorCtlOperation<AureonMonitorSourceProtocol> for MonitorSourceCtl {
         "analog-input-5/6",
         "digital-input-1/2",
     ];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Debug)]
@@ -117,13 +131,27 @@ impl Default for MixerOutputCtl {
     }
 }
 
-#[derive(Default)]
-struct SpdifOutputCtl;
+#[derive(Debug)]
+struct SpdifOutputCtl(AvcSelectorParameters);
+
+impl Default for SpdifOutputCtl {
+    fn default() -> Self {
+        Self(AureonSpdifOutputProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<AureonSpdifOutputProtocol> for SpdifOutputCtl {
     const SELECTOR_NAME: &'static str = "spdif-output-source";
     const SELECTOR_LABELS: &'static [&'static str] = &["spdif-output-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["mixer-output-1/2", "stream-input-9/10"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
 impl AvcLevelCtlOperation<AureonMixerOutputProtocol> for MixerOutputCtl {
@@ -336,11 +364,11 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = MonitorSourceCtl::default();
+        let mut ctl = MonitorSourceCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = SpdifOutputCtl::default();
+        let mut ctl = SpdifOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -159,6 +159,9 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         self.spdif_out_ctl.load_selector(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_in_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mon_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -171,30 +174,21 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_in_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_in_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mon_src_ctl
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mon_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mon_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mon_out_ctl
             .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -69,11 +69,14 @@ impl AvcSelectorCtlOperation<AureonMonitorSourceProtocol> for MonitorSourceCtl {
 }
 
 #[derive(Debug)]
-struct MonitorOutputCtl(AvcLevelParameters);
+struct MonitorOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MonitorOutputCtl {
     fn default() -> Self {
-        Self(AureonMonitorOutputProtocol::create_level_parameters())
+        Self(
+            AureonMonitorOutputProtocol::create_level_parameters(),
+            AureonMonitorOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -92,14 +95,25 @@ impl AvcLevelCtlOperation<AureonMonitorOutputProtocol> for MonitorOutputCtl {
 
 impl AvcMuteCtlOperation<AureonMonitorOutputProtocol> for MonitorOutputCtl {
     const MUTE_NAME: &'static str = "monitor-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct MixerOutputCtl(AvcLevelParameters);
+struct MixerOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerOutputCtl {
     fn default() -> Self {
-        Self(AureonMixerOutputProtocol::create_level_parameters())
+        Self(
+            AureonMixerOutputProtocol::create_level_parameters(),
+            AureonMixerOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -136,6 +150,14 @@ impl AvcLevelCtlOperation<AureonMixerOutputProtocol> for MixerOutputCtl {
 
 impl AvcMuteCtlOperation<AureonMixerOutputProtocol> for MixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for AureonModel {

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -19,10 +19,18 @@ pub struct AureonModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<AureonClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<AureonClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 #[derive(Default)]
 struct PhysInputCtl;

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -32,12 +32,26 @@ impl MediaClkFreqCtlOperation<AureonClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct PhysInputCtl;
+#[derive(Debug)]
+struct PhysInputCtl(AvcLevelParameters);
+
+impl Default for PhysInputCtl {
+    fn default() -> Self {
+        Self(AureonPhysInputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AureonPhysInputProtocol> for PhysInputCtl {
     const LEVEL_NAME: &'static str = "analog-input-gain";
     const PORT_LABELS: &'static [&'static str] = &["analog-input-1/2", "analog-input-3/4"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Default)]
@@ -54,20 +68,40 @@ impl AvcSelectorCtlOperation<AureonMonitorSourceProtocol> for MonitorSourceCtl {
     ];
 }
 
-#[derive(Default)]
-struct MonitorOutputCtl;
+#[derive(Debug)]
+struct MonitorOutputCtl(AvcLevelParameters);
+
+impl Default for MonitorOutputCtl {
+    fn default() -> Self {
+        Self(AureonMonitorOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<AureonMonitorOutputProtocol> for MonitorOutputCtl {
     const LEVEL_NAME: &'static str = "monitor-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["monitor-output-1/2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<AureonMonitorOutputProtocol> for MonitorOutputCtl {
     const MUTE_NAME: &'static str = "monitor-output-mute";
 }
 
-#[derive(Default)]
-struct MixerOutputCtl;
+#[derive(Debug)]
+struct MixerOutputCtl(AvcLevelParameters);
+
+impl Default for MixerOutputCtl {
+    fn default() -> Self {
+        Self(AureonMixerOutputProtocol::create_level_parameters())
+    }
+}
 
 #[derive(Default)]
 struct SpdifOutputCtl;
@@ -90,6 +124,14 @@ impl AvcLevelCtlOperation<AureonMixerOutputProtocol> for MixerOutputCtl {
         "mixer-output-7",
         "mixer-output-8",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<AureonMixerOutputProtocol> for MixerOutputCtl {
@@ -265,15 +307,15 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = PhysInputCtl::default();
+        let mut ctl = PhysInputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MonitorOutputCtl::default();
+        let mut ctl = MonitorOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerOutputCtl::default();
+        let mut ctl = MixerOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -194,6 +194,11 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -213,12 +218,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_mute(
             &self.avc,
@@ -227,12 +227,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_level(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_mute(
             &self.avc,
@@ -248,10 +243,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -232,6 +232,11 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         self.mixer_stream_src_ctl
             .cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_phys_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -253,21 +258,11 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_phys_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_mute(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_stream_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_selector(
             &self.avc,
@@ -278,10 +273,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_out_ctl.read_selector(
             &self.avc,

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -18,10 +18,18 @@ pub struct Phase88Model {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<Phase88ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<Phase88ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<Phase88ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF", "Word-clock"];

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -53,11 +53,14 @@ impl AvcSelectorCtlOperation<Phase88PhysInputProtocol> for PhysInputCtl {
 }
 
 #[derive(Debug)]
-struct MixerPhysSrcCtl(AvcLevelParameters);
+struct MixerPhysSrcCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerPhysSrcCtl {
     fn default() -> Self {
-        Self(Phase88MixerPhysSourceProtocol::create_level_parameters())
+        Self(
+            Phase88MixerPhysSourceProtocol::create_level_parameters(),
+            Phase88MixerPhysSourceProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -87,14 +90,25 @@ impl AvcLevelCtlOperation<Phase88MixerPhysSourceProtocol> for MixerPhysSrcCtl {
 
 impl AvcMuteCtlOperation<Phase88MixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const MUTE_NAME: &'static str = "mixer-phys-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct MixerStreamSrcCtl(AvcLevelParameters);
+struct MixerStreamSrcCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerStreamSrcCtl {
     fn default() -> Self {
-        Self(Phase88MixerStreamSourceProtocol::create_level_parameters())
+        Self(
+            Phase88MixerStreamSourceProtocol::create_level_parameters(),
+            Phase88MixerStreamSourceProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -113,6 +127,14 @@ impl AvcLevelCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSrcCt
 
 impl AvcMuteCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSrcCtl {
     const MUTE_NAME: &'static str = "mixer-stream-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSrcCtl {
@@ -128,11 +150,14 @@ impl AvcSelectorCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSr
 }
 
 #[derive(Debug)]
-struct MixerOutputCtl(AvcLevelParameters);
+struct MixerOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerOutputCtl {
     fn default() -> Self {
-        Self(Phase88MixerOutputProtocol::create_level_parameters())
+        Self(
+            Phase88MixerOutputProtocol::create_level_parameters(),
+            Phase88MixerOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -151,6 +176,14 @@ impl AvcLevelCtlOperation<Phase88MixerOutputProtocol> for MixerOutputCtl {
 
 impl AvcMuteCtlOperation<Phase88MixerOutputProtocol> for MixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<Phase88MixerOutputProtocol> for MixerOutputCtl {

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -52,8 +52,14 @@ impl AvcSelectorCtlOperation<Phase88PhysInputProtocol> for PhysInputCtl {
     const ITEM_LABELS: &'static [&'static str] = &["line", "mic"];
 }
 
-#[derive(Default)]
-struct MixerPhysSrcCtl;
+#[derive(Debug)]
+struct MixerPhysSrcCtl(AvcLevelParameters);
+
+impl Default for MixerPhysSrcCtl {
+    fn default() -> Self {
+        Self(Phase88MixerPhysSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Phase88MixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const LEVEL_NAME: &'static str = "mixer-phys-source-gain";
@@ -69,18 +75,40 @@ impl AvcLevelCtlOperation<Phase88MixerPhysSourceProtocol> for MixerPhysSrcCtl {
         "digital-input-1",
         "digital-input-2",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Phase88MixerPhysSourceProtocol> for MixerPhysSrcCtl {
     const MUTE_NAME: &'static str = "mixer-phys-source-mute";
 }
 
-#[derive(Default)]
-struct MixerStreamSrcCtl;
+#[derive(Debug)]
+struct MixerStreamSrcCtl(AvcLevelParameters);
+
+impl Default for MixerStreamSrcCtl {
+    fn default() -> Self {
+        Self(Phase88MixerStreamSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSrcCtl {
     const LEVEL_NAME: &'static str = "mixer-stream-source-gain";
     const PORT_LABELS: &'static [&'static str] = &["stream-source-1", "stream-source-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSrcCtl {
@@ -99,12 +127,26 @@ impl AvcSelectorCtlOperation<Phase88MixerStreamSourceProtocol> for MixerStreamSr
     ];
 }
 
-#[derive(Default)]
-struct MixerOutputCtl;
+#[derive(Debug)]
+struct MixerOutputCtl(AvcLevelParameters);
+
+impl Default for MixerOutputCtl {
+    fn default() -> Self {
+        Self(Phase88MixerOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<Phase88MixerOutputProtocol> for MixerOutputCtl {
     const LEVEL_NAME: &'static str = "mixer-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["mixer-output-1", "mixer-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<Phase88MixerOutputProtocol> for MixerOutputCtl {
@@ -359,15 +401,15 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = MixerPhysSrcCtl::default();
+        let mut ctl = MixerPhysSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerStreamSrcCtl::default();
+        let mut ctl = MixerStreamSrcCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerOutputCtl::default();
+        let mut ctl = MixerOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -151,6 +151,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         self.mixer_out_ctl.load_selector(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -163,10 +164,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_in_ctl

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -19,7 +19,7 @@ pub struct Phase88Model {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<Phase88ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -33,6 +33,14 @@ impl MediaClkFreqCtlOperation<Phase88ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<Phase88ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF", "Word-clock"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -142,6 +142,8 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         self.mixer_out_ctl.load_mute(card_cntr)?;
         self.mixer_out_ctl.load_selector(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -151,10 +153,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -329,8 +328,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Phase88Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -270,6 +270,13 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             .cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
+        self.phys_in_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_stream_src_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -283,10 +290,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_in_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_in_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_phys_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
@@ -296,23 +300,16 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self.mixer_stream_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .read_selectors(elem_id, elem_value)?
+        {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_out_ctl.read_selector(
-            &self.avc,
-            elem_id,
-            elem_value,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self.mixer_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -29,7 +29,7 @@ pub struct GoPhase24OptModel {
 const FCP_TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-struct ClkCtl(Vec<ElemId>, MediaClockParameters);
+struct ClkCtl(Vec<ElemId>, MediaClockParameters, SamplingClockParameters);
 
 impl MediaClkFreqCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
     fn state(&self) -> &MediaClockParameters {
@@ -43,6 +43,14 @@ impl MediaClkFreqCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
 
 impl SamplingClkSrcCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];
+
+    fn state(&self) -> &SamplingClockParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut SamplingClockParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Default)]

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -356,6 +356,11 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_src_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_in_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl
+            .cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
+        self.hp_ctl.cache_selectors(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -370,20 +375,11 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_in_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_in_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.hp_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
@@ -531,10 +527,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_selectors(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -200,6 +200,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         self.mixer_out_ctl.load_mute(card_cntr)?;
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -212,10 +213,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_in_ctl
@@ -377,10 +375,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .read_src(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -257,6 +257,8 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
 
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -286,20 +288,14 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_src_ctl
             .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl
@@ -420,6 +416,10 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         self.mixer_out_ctl.load_level(card_cntr)?;
         self.mixer_out_ctl.load_mute(card_cntr)?;
 
+        self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -433,10 +433,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -448,20 +445,14 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             .read_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_src_ctl
             .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .mixer_out_ctl

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -101,17 +101,37 @@ impl AvcMuteCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
     }
 }
 
-#[derive(Default)]
-struct CoaxPhysInputCtl;
+#[derive(Debug)]
+struct CoaxPhysInputCtl(AvcSelectorParameters);
+
+impl Default for CoaxPhysInputCtl {
+    fn default() -> Self {
+        Self(GoPhase24CoaxPhysInputProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<GoPhase24CoaxPhysInputProtocol> for CoaxPhysInputCtl {
     const SELECTOR_NAME: &'static str = "analog-input-level";
     const SELECTOR_LABELS: &'static [&'static str] = &["analog-input-1/2"];
     const ITEM_LABELS: &'static [&'static str] = &["low", "middle", "high"];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct CoaxPhysOutputCtl;
+#[derive(Debug)]
+struct CoaxPhysOutputCtl(AvcSelectorParameters);
+
+impl Default for CoaxPhysOutputCtl {
+    fn default() -> Self {
+        Self(GoPhase24CoaxPhysOutputProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<GoPhase24CoaxPhysOutputProtocol> for CoaxPhysOutputCtl {
     const SELECTOR_NAME: &'static str = "phys-output-source";
@@ -124,10 +144,24 @@ impl AvcSelectorCtlOperation<GoPhase24CoaxPhysOutputProtocol> for CoaxPhysOutput
         "mixer-output-1/2",
         "stream-input-5/6",
     ];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
-#[derive(Default)]
-struct CoaxHeadphoneCtl;
+#[derive(Debug)]
+struct CoaxHeadphoneCtl(AvcSelectorParameters);
+
+impl Default for CoaxHeadphoneCtl {
+    fn default() -> Self {
+        Self(GoPhase24CoaxHeadphoneProtocol::create_selector_parameters())
+    }
+}
 
 impl AvcSelectorCtlOperation<GoPhase24CoaxHeadphoneProtocol> for CoaxHeadphoneCtl {
     const SELECTOR_NAME: &'static str = "headphone-source";
@@ -140,16 +174,25 @@ impl AvcSelectorCtlOperation<GoPhase24CoaxHeadphoneProtocol> for CoaxHeadphoneCt
         "mixer-output-1/2",
         "stream-input-5/6",
     ];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.0
+    }
 }
 
 #[derive(Debug)]
-struct OptPhysOutputCtl(AvcLevelParameters, AvcMuteParameters);
+struct OptPhysOutputCtl(AvcLevelParameters, AvcMuteParameters, AvcSelectorParameters);
 
 impl Default for OptPhysOutputCtl {
     fn default() -> Self {
         Self(
             GoPhase24OptPhysOutputProtocol::create_level_parameters(),
             GoPhase24OptPhysOutputProtocol::create_mute_parameters(),
+            GoPhase24OptPhysOutputProtocol::create_selector_parameters(),
         )
     }
 }
@@ -199,6 +242,14 @@ impl AvcSelectorCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCt
         "mixer-output-1/2",
         "stream-input-5/6",
     ];
+
+    fn state(&self) -> &AvcSelectorParameters {
+        &self.2
+    }
+
+    fn state_mut(&mut self) -> &mut AvcSelectorParameters {
+        &mut self.2
+    }
 }
 
 #[derive(Debug)]
@@ -622,19 +673,19 @@ mod test {
     fn test_selector_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = CoaxPhysInputCtl::default();
+        let mut ctl = CoaxPhysInputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = CoaxPhysOutputCtl::default();
+        let mut ctl = CoaxPhysOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = CoaxHeadphoneCtl::default();
+        let mut ctl = CoaxHeadphoneCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = OptPhysOutputCtl::default();
+        let mut ctl = OptPhysOutputCtl::default();
         let error = ctl.load_selector(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -53,8 +53,14 @@ impl SamplingClkSrcCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
     }
 }
 
-#[derive(Default)]
-struct MixerSourceCtl;
+#[derive(Debug)]
+struct MixerSourceCtl(AvcLevelParameters);
+
+impl Default for MixerSourceCtl {
+    fn default() -> Self {
+        Self(GoPhase24MixerSourceProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
     const LEVEL_NAME: &'static str = "mixer-source-gain";
@@ -70,6 +76,14 @@ impl AvcLevelCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
         "stream-input-5",
         "stream-input-6",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
@@ -117,8 +131,14 @@ impl AvcSelectorCtlOperation<GoPhase24CoaxHeadphoneProtocol> for CoaxHeadphoneCt
     ];
 }
 
-#[derive(Default)]
-struct OptPhysOutputCtl;
+#[derive(Debug)]
+struct OptPhysOutputCtl(AvcLevelParameters);
+
+impl Default for OptPhysOutputCtl {
+    fn default() -> Self {
+        Self(GoPhase24OptPhysOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
     const LEVEL_NAME: &'static str = "phy-output-volume";
@@ -128,6 +148,14 @@ impl AvcLevelCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
         "analog-output-3",
         "analog-output-4",
     ];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
@@ -151,24 +179,52 @@ impl AvcSelectorCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCt
     ];
 }
 
-#[derive(Default)]
-struct CoaxMixerOutputCtl;
+#[derive(Debug)]
+struct CoaxMixerOutputCtl(AvcLevelParameters);
+
+impl Default for CoaxMixerOutputCtl {
+    fn default() -> Self {
+        Self(GoPhase24CoaxMixerOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<GoPhase24CoaxMixerOutputProtocol> for CoaxMixerOutputCtl {
     const LEVEL_NAME: &'static str = "mixer-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["mixer-output-1", "mixer-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<GoPhase24CoaxMixerOutputProtocol> for CoaxMixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-output-mute";
 }
 
-#[derive(Default)]
-struct OptMixerOutputCtl;
+#[derive(Debug)]
+struct OptMixerOutputCtl(AvcLevelParameters);
+
+impl Default for OptMixerOutputCtl {
+    fn default() -> Self {
+        Self(GoPhase24OptMixerOutputProtocol::create_level_parameters())
+    }
+}
 
 impl AvcLevelCtlOperation<GoPhase24OptMixerOutputProtocol> for OptMixerOutputCtl {
     const LEVEL_NAME: &'static str = "mixer-output-volume";
     const PORT_LABELS: &'static [&'static str] = &["mixer-output-1", "mixer-output-2"];
+
+    fn state(&self) -> &AvcLevelParameters {
+        &self.0
+    }
+
+    fn state_mut(&mut self) -> &mut AvcLevelParameters {
+        &mut self.0
+    }
 }
 
 impl AvcMuteCtlOperation<GoPhase24OptMixerOutputProtocol> for OptMixerOutputCtl {
@@ -520,19 +576,19 @@ mod test {
     fn test_level_ctl_definition() {
         let mut card_cntr = CardCntr::default();
 
-        let ctl = OptPhysOutputCtl::default();
+        let mut ctl = OptPhysOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = CoaxMixerOutputCtl::default();
+        let mut ctl = CoaxMixerOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = MixerSourceCtl::default();
+        let mut ctl = MixerSourceCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
 
-        let ctl = OptMixerOutputCtl::default();
+        let mut ctl = OptMixerOutputCtl::default();
         let error = ctl.load_level(&mut card_cntr).unwrap_err();
         assert_eq!(error.kind::<CardError>(), Some(CardError::Failed));
     }

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -54,11 +54,14 @@ impl SamplingClkSrcCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
 }
 
 #[derive(Debug)]
-struct MixerSourceCtl(AvcLevelParameters);
+struct MixerSourceCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for MixerSourceCtl {
     fn default() -> Self {
-        Self(GoPhase24MixerSourceProtocol::create_level_parameters())
+        Self(
+            GoPhase24MixerSourceProtocol::create_level_parameters(),
+            GoPhase24MixerSourceProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -88,6 +91,14 @@ impl AvcLevelCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
 
 impl AvcMuteCtlOperation<GoPhase24MixerSourceProtocol> for MixerSourceCtl {
     const MUTE_NAME: &'static str = "mixer-source-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Default)]
@@ -132,11 +143,14 @@ impl AvcSelectorCtlOperation<GoPhase24CoaxHeadphoneProtocol> for CoaxHeadphoneCt
 }
 
 #[derive(Debug)]
-struct OptPhysOutputCtl(AvcLevelParameters);
+struct OptPhysOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for OptPhysOutputCtl {
     fn default() -> Self {
-        Self(GoPhase24OptPhysOutputProtocol::create_level_parameters())
+        Self(
+            GoPhase24OptPhysOutputProtocol::create_level_parameters(),
+            GoPhase24OptPhysOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -160,6 +174,14 @@ impl AvcLevelCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
 
 impl AvcMuteCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
     const MUTE_NAME: &'static str = "phys-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl AvcSelectorCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCtl {
@@ -180,11 +202,14 @@ impl AvcSelectorCtlOperation<GoPhase24OptPhysOutputProtocol> for OptPhysOutputCt
 }
 
 #[derive(Debug)]
-struct CoaxMixerOutputCtl(AvcLevelParameters);
+struct CoaxMixerOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for CoaxMixerOutputCtl {
     fn default() -> Self {
-        Self(GoPhase24CoaxMixerOutputProtocol::create_level_parameters())
+        Self(
+            GoPhase24CoaxMixerOutputProtocol::create_level_parameters(),
+            GoPhase24CoaxMixerOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -203,14 +228,25 @@ impl AvcLevelCtlOperation<GoPhase24CoaxMixerOutputProtocol> for CoaxMixerOutputC
 
 impl AvcMuteCtlOperation<GoPhase24CoaxMixerOutputProtocol> for CoaxMixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 #[derive(Debug)]
-struct OptMixerOutputCtl(AvcLevelParameters);
+struct OptMixerOutputCtl(AvcLevelParameters, AvcMuteParameters);
 
 impl Default for OptMixerOutputCtl {
     fn default() -> Self {
-        Self(GoPhase24OptMixerOutputProtocol::create_level_parameters())
+        Self(
+            GoPhase24OptMixerOutputProtocol::create_level_parameters(),
+            GoPhase24OptMixerOutputProtocol::create_mute_parameters(),
+        )
     }
 }
 
@@ -229,6 +265,14 @@ impl AvcLevelCtlOperation<GoPhase24OptMixerOutputProtocol> for OptMixerOutputCtl
 
 impl AvcMuteCtlOperation<GoPhase24OptMixerOutputProtocol> for OptMixerOutputCtl {
     const MUTE_NAME: &'static str = "mixer-output-mute";
+
+    fn state(&self) -> &AvcMuteParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut AvcMuteParameters {
+        &mut self.1
+    }
 }
 
 impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -303,6 +303,8 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_src_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -334,17 +336,11 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -463,6 +459,9 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         self.phys_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_src_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
         self.mixer_out_ctl.cache_levels(&self.avc, FCP_TIMEOUT_MS)?;
+        self.phys_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_src_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_out_ctl.cache_mutes(&self.avc, FCP_TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -479,10 +478,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self.phys_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .phys_out_ctl
@@ -491,17 +487,11 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self.mixer_src_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_src_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_out_ctl.read_levels(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .read_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.read_mutes(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -28,10 +28,18 @@ pub struct GoPhase24OptModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-#[derive(Default)]
-struct ClkCtl(Vec<ElemId>);
+#[derive(Default, Debug)]
+struct ClkCtl(Vec<ElemId>, MediaClockParameters);
 
-impl MediaClkFreqCtlOperation<GoPhase24ClkProtocol> for ClkCtl {}
+impl MediaClkFreqCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
+    fn state(&self) -> &MediaClockParameters {
+        &self.1
+    }
+
+    fn state_mut(&mut self) -> &mut MediaClockParameters {
+        &mut self.1
+    }
+}
 
 impl SamplingClkSrcCtlOperation<GoPhase24ClkProtocol> for ClkCtl {
     const SRC_LABELS: &'static [&'static str] = &["Internal", "S/PDIF"];

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -191,6 +191,8 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         self.mixer_out_ctl.load_level(card_cntr)?;
         self.mixer_out_ctl.load_mute(card_cntr)?;
 
+        self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
@@ -200,10 +202,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -331,8 +330,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for GoPhase24CoaxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 
@@ -369,10 +367,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .clk_ctl
@@ -500,8 +495,7 @@ impl NotifyModel<(SndUnit, FwNode), bool> for GoPhase24OptModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.clk_ctl
-            .read_freq(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)
+        self.clk_ctl.read_freq(elem_id, elem_value)
     }
 }
 


### PR DESCRIPTION
The protocol crate for bebob includes some trait definitions for AV/C commands.
They are not designed to help runtime implementations caching hardware state.

This commit adds parameters structures so that the implementations caches
the state by the similar fasion.

```
Takashi Sakamoto (19):
  protocols/bebob: add state cache for media clock frequency of common function
  runtime/bebob: use state cache for media clock parameters
  runtime/bebob: add common cache function for frequency of media clock
  protocols/bebob: add state cache for sampling clock source of common function
  runtime/bebob: use state cache for sampling clock parameters
  runtime/bebob: add common cache function for source of sampling clock
  protocols/bebob: split specification from operation trait for audio feature
  protocols/bebob: add methods to cache/update signal levels
  runtime/bebob: use state cache for signal level parameters
  runtime/bebob: add common cache function for signal level function
  protocols/bebob: add methods to cache/update signal L/R balance
  runtime/bebob: use state cache for L/R balance parameters
  runtime/bebob: add common cache function for L/R balance parameters
  protocols/bebob: add methods to cache/update mute channels
  runtime/bebob: use state cache for mute parameters
  runtime/bebob: add common cache function for mute parameters
  protocols/bebob: add methods to cache/update selectors
  runtime/bebob: use state cache for selector parameters
  runtime/bebob: add common cache function for selector parameters

 protocols/bebob/src/apogee/ensemble.rs        |   2 +-
 protocols/bebob/src/behringer.rs              |   2 +-
 protocols/bebob/src/digidesign.rs             |   2 +-
 protocols/bebob/src/esi.rs                    |  14 +-
 protocols/bebob/src/focusrite/saffire.rs      |  31 +-
 protocols/bebob/src/icon.rs                   |  17 +-
 protocols/bebob/src/lib.rs                    | 468 ++++++++++++------
 protocols/bebob/src/maudio/normal.rs          |  96 ++--
 protocols/bebob/src/maudio/pfl.rs             |   2 +-
 protocols/bebob/src/maudio/special.rs         |  28 +-
 protocols/bebob/src/presonus/firebox.rs       | 129 +++--
 protocols/bebob/src/presonus/fp10.rs          |   7 +-
 protocols/bebob/src/presonus/inspire1394.rs   |  32 +-
 protocols/bebob/src/roland.rs                 |  14 +-
 protocols/bebob/src/stanton.rs                |  14 +-
 protocols/bebob/src/terratec/aureon.rs        |  24 +-
 protocols/bebob/src/terratec/phase88.rs       | 156 +++---
 protocols/bebob/src/yamaha_terratec.rs        | 105 ++--
 runtime/bebob/src/apogee/ensemble_model.rs    |  37 +-
 runtime/bebob/src/behringer.rs                |  38 +-
 runtime/bebob/src/common_ctls.rs              | 238 +++++----
 runtime/bebob/src/digidesign.rs               |  38 +-
 runtime/bebob/src/esi.rs                      | 107 ++--
 runtime/bebob/src/focusrite/saffire_model.rs  |  37 +-
 .../bebob/src/focusrite/saffirele_model.rs    |  37 +-
 runtime/bebob/src/icon.rs                     | 208 ++++++--
 runtime/bebob/src/maudio/audiophile_model.rs  | 232 ++++++---
 runtime/bebob/src/maudio/fw410_model.rs       | 262 +++++++---
 runtime/bebob/src/maudio/ozonic_model.rs      | 114 +++--
 .../src/maudio/profirelightbridge_model.rs    |  38 +-
 runtime/bebob/src/maudio/solo_model.rs        | 137 +++--
 runtime/bebob/src/maudio/special_model.rs     |  22 +-
 runtime/bebob/src/presonus/firebox_model.rs   | 416 +++++++++++-----
 runtime/bebob/src/presonus/fp10_model.rs      |  99 +++-
 .../bebob/src/presonus/inspire1394_model.rs   | 291 ++++++++---
 runtime/bebob/src/roland.rs                   |  88 +++-
 runtime/bebob/src/stanton.rs                  |  90 +++-
 runtime/bebob/src/terratec/aureon_model.rs    | 186 +++++--
 runtime/bebob/src/terratec/phase88_model.rs   | 242 ++++++---
 runtime/bebob/src/yamaha_terratec.rs          | 314 ++++++++----
 40 files changed, 3014 insertions(+), 1400 deletions(-)
```