### PR TITLE
[PATCH 00/20] runtime/bebob: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,9 @@ Execute temporarily ::
 All of executables can print help when either ``--help`` or ``-h`` is given as an argument of
 command line.
 
+Some executables support debug logging as well when either ``-l`` or ``--log-level`` is given
+with log level. At present, ``debug`` is just supported only for ``snd-bebob-ctl-service``.
+
 Install executables ::
 
     $ cargo install --path (path to runtime crate)

--- a/protocols/bebob/src/apogee/ensemble.rs
+++ b/protocols/bebob/src/apogee/ensemble.rs
@@ -1004,7 +1004,7 @@ impl EnsembleMeterProtocol {
 
     /// Update the given parameters by the state of hardware.
     pub fn whole_update(
-        avc: &mut BebobAvc,
+        avc: &BebobAvc,
         meter: &mut EnsembleMeter,
         timeout_ms: u32,
     ) -> Result<(), Error> {

--- a/runtime/bebob/Cargo.toml
+++ b/runtime/bebob/Cargo.toml
@@ -22,3 +22,5 @@ ta1394-avc-general = "0.1"
 firewire-bebob-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -261,7 +261,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for EnsembleModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -63,30 +63,14 @@ impl EnsembleModel {
     pub fn cache(&mut self, _: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
-        EnsembleMeterProtocol::whole_update(&mut self.avc, &mut self.meter_ctl.0, FCP_TIMEOUT_MS)?;
-        EnsembleConverterProtocol::whole_update(
-            &mut self.avc,
-            &mut self.convert_ctl.0,
-            FCP_TIMEOUT_MS,
-        )?;
-        EnsembleDisplayProtocol::whole_update(
-            &mut self.avc,
-            &mut self.display_ctl.0,
-            FCP_TIMEOUT_MS,
-        )?;
-        EnsembleInputProtocol::whole_update(&mut self.avc, &mut self.input_ctl.0, FCP_TIMEOUT_MS)?;
-        EnsembleOutputProtocol::whole_update(
-            &mut self.avc,
-            &mut self.output_ctl.0,
-            FCP_TIMEOUT_MS,
-        )?;
-        EnsembleSourceProtocol::whole_update(&mut self.avc, &mut self.route_ctl.0, FCP_TIMEOUT_MS)?;
-        EnsembleMixerProtocol::whole_update(&mut self.avc, &mut self.mixer_ctl.0, FCP_TIMEOUT_MS)?;
-        EnsembleStreamProtocol::whole_update(
-            &mut self.avc,
-            &mut self.stream_ctl.0,
-            FCP_TIMEOUT_MS,
-        )?;
+        self.meter_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.convert_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.display_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.input_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.output_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.route_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.mixer_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
+        self.stream_ctl.cache(&self.avc, FCP_TIMEOUT_MS)?;
         Ok(())
     }
 }
@@ -234,7 +218,7 @@ impl MeasureModel<(SndUnit, FwNode)> for EnsembleModel {
 
     fn measure_states(&mut self, _: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
-            .measure_state(&mut self.avc, FCP_TIMEOUT_MS)
+            .cache(&mut self.avc, FCP_TIMEOUT_MS)
             .map(|_| input_output_copy_from_meter(self))
     }
 
@@ -417,7 +401,7 @@ impl MeterCtl {
         Ok(())
     }
 
-    fn measure_state(&mut self, avc: &mut BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
         EnsembleMeterProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
@@ -557,6 +541,10 @@ impl ConvertCtl {
         Ok(())
     }
 
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleConverterProtocol::whole_update(avc, &mut self.0, timeout_ms)
+    }
+
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             FORMAT_CONVERT_TARGET_NAME => {
@@ -689,6 +677,10 @@ impl DisplayCtl {
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
         Ok(())
+    }
+
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleDisplayProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -842,6 +834,10 @@ impl InputCtl {
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         Ok(())
+    }
+
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleInputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1044,6 +1040,10 @@ impl<'a> OutputCtl {
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         Ok(())
+    }
+
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleOutputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1305,6 +1305,10 @@ impl RouteCtl {
         Ok(())
     }
 
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleSourceProtocol::whole_update(avc, &mut self.0, timeout_ms)
+    }
+
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUT_SRC_NAME => {
@@ -1462,6 +1466,10 @@ impl MixerCtl {
         Ok(())
     }
 
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleMixerProtocol::whole_update(avc, &mut self.0, timeout_ms)
+    }
+
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
@@ -1533,6 +1541,10 @@ impl StreamCtl {
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
         Ok(())
+    }
+
+    fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
+        EnsembleStreamProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
     fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -402,7 +402,9 @@ impl MeterCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleMeterProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleMeterProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_state(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -542,7 +544,9 @@ impl ConvertCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleConverterProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleConverterProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -598,14 +602,26 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.format_target = target;
-                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = EnsembleConverterProtocol::partial_update(
+                    avc,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             CD_MODE_NAME => {
                 let mut params = self.0.clone();
                 params.cd_mode = elem_value.boolean()[0];
-                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = EnsembleConverterProtocol::partial_update(
+                    avc,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             RATE_CONVERT_TARGET_NAME => {
                 let val = elem_value.enumerated()[0];
@@ -618,8 +634,14 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.rate_target = target;
-                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = EnsembleConverterProtocol::partial_update(
+                    avc,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             RATE_CONVERT_RATE_NAME => {
                 let val = elem_value.enumerated()[0];
@@ -632,8 +654,14 @@ impl ConvertCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.converted_rate = converted_rate;
-                EnsembleConverterProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = EnsembleConverterProtocol::partial_update(
+                    avc,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -680,7 +708,9 @@ impl DisplayCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleDisplayProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleDisplayProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -720,14 +750,18 @@ impl DisplayCtl {
             DISPLAY_ENABLE_NAME => {
                 let mut params = self.0.clone();
                 params.enabled = elem_value.boolean()[0];
-                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             DISPLAY_ILLUMINATE_NAME => {
                 let mut params = self.0.clone();
                 params.illuminate = elem_value.boolean()[0];
-                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             DISPLAY_TARGET_NAME => {
                 let val = elem_value.enumerated()[0];
@@ -740,14 +774,18 @@ impl DisplayCtl {
                     })?;
                 let mut params = self.0.clone();
                 params.target = target;
-                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             DISPLAY_OVERHOLD_NAME => {
                 let mut params = self.0.clone();
                 params.overhold = elem_value.boolean()[0];
-                EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleDisplayProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -837,7 +875,9 @@ impl InputCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleInputProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleInputProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -896,8 +936,10 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_LEVEL_NAME => {
                 let vals = &elem_value.enumerated()[..Self::INPUT_LABELS.len()];
@@ -916,8 +958,10 @@ impl InputCtl {
                             })
                             .map(|&l| *level = l)
                     })?;
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIC_GAIN_NAME => {
                 let vals = &elem_value.int()[..Self::MIC_LABELS.len()];
@@ -927,8 +971,10 @@ impl InputCtl {
                     .iter_mut()
                     .enumerate()
                     .for_each(|(i, gain)| *gain = vals[i] as u8);
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIC_PHANTOM_NAME => {
                 let mut params = self.0.clone();
@@ -937,8 +983,10 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIC_POLARITY_NAME => {
                 let mut params = self.0.clone();
@@ -947,8 +995,10 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_OPT_IFACE_MODE_NAME => {
                 let val = elem_value.enumerated()[0];
@@ -958,8 +1008,10 @@ impl InputCtl {
                 })?;
                 let mut params = self.0.clone();
                 params.opt_iface_mode = mode;
-                EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleInputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -1043,7 +1095,9 @@ impl<'a> OutputCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleOutputProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleOutputProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1112,14 +1166,18 @@ impl<'a> OutputCtl {
                             })
                             .map(|&l| *level = l)
                     })?;
-                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_VOL_NAME => {
                 let mut params = self.0.clone();
                 params.vol = elem_value.int()[0] as u8;
-                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             HP_VOL_NAME => {
                 let vals = &elem_value.int()[..Self::HP_LABELS.len()];
@@ -1129,8 +1187,10 @@ impl<'a> OutputCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(vol, &val)| *vol = val as u8);
-                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_OPT_IFACE_MODE_NAME => {
                 let val = elem_value.enumerated()[0];
@@ -1140,8 +1200,10 @@ impl<'a> OutputCtl {
                     Error::new(FileError::Inval, &msg)
                 })?;
                 params.opt_iface_mode = mode;
-                EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleOutputProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -1306,7 +1368,9 @@ impl RouteCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleSourceProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleSourceProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1361,8 +1425,10 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             CAPTURE_SOURCE_NAME => {
                 let vals = &elem_value.enumerated()[..Self::CAPTURE_LABELS.len()];
@@ -1372,8 +1438,10 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             HP_SRC_NAME => {
                 let vals = &elem_value.enumerated()[..Self::HEADPHONE_LABELS.len()];
@@ -1383,8 +1451,10 @@ impl RouteCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(src, &val)| *src = val as usize);
-                EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleSourceProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -1467,7 +1537,9 @@ impl MixerCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleMixerProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleMixerProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1503,8 +1575,10 @@ impl MixerCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(gain, &val)| *gain = val as i16);
-                EnsembleMixerProtocol::partial_update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    EnsembleMixerProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -1544,7 +1618,9 @@ impl StreamCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        EnsembleStreamProtocol::whole_update(avc, &mut self.0, timeout_ms)
+        let res = EnsembleStreamProtocol::whole_update(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -1581,6 +1657,7 @@ impl StreamCtl {
                 unit.0.lock()?;
                 let res =
                     EnsembleStreamProtocol::partial_update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
                 let _ = unit.0.unlock();
                 res.map(|_| true)
             }

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -545,7 +545,7 @@ impl ConvertCtl {
         EnsembleConverterProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             FORMAT_CONVERT_TARGET_NAME => {
                 let pos = Self::FORMAT_CONVERT_TARGETS
@@ -683,7 +683,7 @@ impl DisplayCtl {
         EnsembleDisplayProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             DISPLAY_ENABLE_NAME => {
                 elem_value.set_bool(&[self.0.enabled]);
@@ -840,7 +840,7 @@ impl InputCtl {
         EnsembleInputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             INPUT_LIMIT_NAME => {
                 elem_value.set_bool(&self.0.limits);
@@ -1046,7 +1046,7 @@ impl<'a> OutputCtl {
         EnsembleOutputProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUTPUT_LEVEL_NAME => {
                 ElemValueAccessor::<u32>::set_vals(elem_value, Self::OUT_LABELS.len(), |i| {
@@ -1309,7 +1309,7 @@ impl RouteCtl {
         EnsembleSourceProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUT_SRC_NAME => {
                 let vals: Vec<u32> = self
@@ -1470,7 +1470,7 @@ impl MixerCtl {
         EnsembleMixerProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -1547,7 +1547,7 @@ impl StreamCtl {
         EnsembleStreamProtocol::whole_update(avc, &mut self.0, timeout_ms)
     }
 
-    fn read_params(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             STREAM_MODE_NAME => {
                 let pos = Self::STREAM_MODES

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -118,7 +118,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fca610Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
+++ b/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {bebob_runtime::BebobRuntime, clap::Parser, core::cmdline::*};
+use {
+    bebob_runtime::BebobRuntime,
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+};
 
 struct BebobServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, BebobRuntime> for BebobServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
+++ b/runtime/bebob/src/bin/snd-bebob-ctl-service.rs
@@ -14,11 +14,15 @@ struct BebobServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, BebobRuntime> for BebobServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -15,7 +15,9 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
     }
 
     fn cache_freq(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_freq(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_freq(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_freq(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -42,9 +44,10 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
                 unit.lock()?;
                 let mut params = self.state().clone();
                 params.freq_idx = new.enumerated()[0] as usize;
-                let res = T::update_freq(avc, &params, self.state_mut(), timeout_ms).map(|_| true);
+                let res = T::update_freq(avc, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
                 let _ = unit.unlock();
-                res
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -77,7 +80,9 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
     }
 
     fn cache_src(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_src(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_src(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_src(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -104,9 +109,10 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
                 unit.lock()?;
                 let mut params = self.state().clone();
                 params.src_idx = new.enumerated()[0] as usize;
-                let res = T::update_src(avc, &params, self.state_mut(), timeout_ms).map(|_| true);
+                let res = T::update_src(avc, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
                 let _ = unit.unlock();
-                res
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -155,7 +161,9 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
     }
 
     fn cache_levels(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_levels(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_levels(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_levels(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -189,7 +197,9 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
                 .iter_mut()
                 .zip(vals)
                 .for_each(|(level, &val)| *level = val as i16);
-            T::update_levels(avc, &params, self.state_mut(), timeout_ms).map(|_| true)
+            let res = T::update_levels(avc, &params, self.state_mut(), timeout_ms);
+            debug!(params = ?self.state(), ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }
@@ -223,7 +233,9 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLrBalanceOperation> {
     }
 
     fn cache_balances(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_lr_balances(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_lr_balances(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_balances(
@@ -261,7 +273,9 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLrBalanceOperation> {
                 .iter_mut()
                 .zip(vals)
                 .for_each(|(balance, &val)| *balance = val as i16);
-            T::update_lr_balances(avc, &params, self.state_mut(), timeout_ms).map(|_| true)
+            let res = T::update_lr_balances(avc, &params, self.state_mut(), timeout_ms);
+            debug!(params = ?self.state(), ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }
@@ -282,7 +296,9 @@ pub trait AvcMuteCtlOperation<T: AvcMuteOperation> {
     }
 
     fn cache_mutes(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_mutes(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_mutes(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_mutes(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -306,7 +322,9 @@ pub trait AvcMuteCtlOperation<T: AvcMuteOperation> {
             let mut params = self.state().clone();
             let vals = &new.boolean()[..params.mutes.len()];
             params.mutes.copy_from_slice(&vals);
-            T::update_mutes(avc, &params, self.state_mut(), timeout_ms).map(|_| true)
+            let res = T::update_mutes(avc, &params, self.state_mut(), timeout_ms);
+            debug!(params = ?self.state(), ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }
@@ -345,7 +363,9 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
     }
 
     fn cache_selectors(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        T::cache_selectors(avc, self.state_mut(), timeout_ms)
+        let res = T::cache_selectors(avc, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_selectors(
@@ -383,7 +403,9 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
                 .iter_mut()
                 .zip(vals)
                 .for_each(|(selector, &val)| *selector = val as usize);
-            T::update_selectors(avc, &params, self.state_mut(), timeout_ms).map(|_| true)
+            let res = T::update_selectors(avc, &params, self.state_mut(), timeout_ms);
+            debug!(params = ?self.state(), ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -128,7 +128,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Mbox2proModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -223,7 +223,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Quatafire610Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/focusrite.rs
+++ b/runtime/bebob/src/focusrite.rs
@@ -88,7 +88,7 @@ trait SaffireOutputCtlOperation<
         Ok(measure_elem_id_list)
     }
 
-    fn measure_params(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
         T::cache(req, node, self.state_mut(), timeout_ms)
     }
 
@@ -185,6 +185,10 @@ trait SaffireThroughCtlOperation<T: SaffireParametersOperation<SaffireThroughPar
         card_cntr.add_bool_elems(&elem_id, 1, 1, false)?;
 
         Ok(())
+    }
+
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        T::cache(req, node, self.state_mut(), timeout_ms)
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {

--- a/runtime/bebob/src/focusrite.rs
+++ b/runtime/bebob/src/focusrite.rs
@@ -89,7 +89,9 @@ trait SaffireOutputCtlOperation<
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -133,7 +135,9 @@ trait SaffireOutputCtlOperation<
                 params
                     .mutes
                     .copy_from_slice(&elem_value.boolean()[..T::MUTE_COUNT]);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             OUT_VOL_NAME => {
                 let mut params = self.state().clone();
@@ -142,28 +146,36 @@ trait SaffireOutputCtlOperation<
                     .iter_mut()
                     .zip(&elem_value.int()[..T::VOL_COUNT])
                     .for_each(|(vol, val)| *vol = *val as u8);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             OUT_HWCTL_NAME => {
                 let mut params = self.state().clone();
                 params
                     .hwctls
                     .copy_from_slice(&elem_value.boolean()[..T::HWCTL_COUNT]);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             OUT_DIM_NAME => {
                 let mut params = self.state().clone();
                 params
                     .dims
                     .copy_from_slice(&elem_value.boolean()[..T::DIM_COUNT]);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             OUT_PAD_NAME => {
                 let mut params = self.state().clone();
                 params
                     .pads
                     .copy_from_slice(&elem_value.boolean()[..T::PAD_COUNT]);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -188,7 +200,9 @@ trait SaffireThroughCtlOperation<T: SaffireParametersOperation<SaffireThroughPar
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -217,12 +231,16 @@ trait SaffireThroughCtlOperation<T: SaffireParametersOperation<SaffireThroughPar
             MIDI_THROUGH_NAME => {
                 let mut params = self.state().clone();
                 params.midi = elem_value.boolean()[0];
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             AC3_THROUGH_NAME => {
                 let mut params = self.state().clone();
                 params.ac3 = elem_value.boolean()[0];
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -144,7 +144,7 @@ impl SaffireModel {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
-        SaffireOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
+        self.out_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         SaffireSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
         SaffireSeparatedMixerProtocol::cache(
             &self.req,
@@ -334,8 +334,7 @@ impl MeasureModel<(SndUnit, FwNode)> for SaffireModel {
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl.measure_meter(unit, &self.req, TIMEOUT_MS)?;
-        self.out_ctl
-            .measure_params(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.out_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -307,7 +307,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SaffireModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -103,7 +103,7 @@ impl SaffireLeModel {
         self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
         self.clk_ctl.cache_src(&self.avc, FCP_TIMEOUT_MS)?;
         SaffireLeMeterProtocol::cache(&self.req, &unit.1, &mut self.meter_ctl.1, TIMEOUT_MS)?;
-        SaffireLeOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.1, TIMEOUT_MS)?;
+        self.out_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         SaffireLeSpecificProtocol::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;
         SaffireLeMixerLowRateProtocol::cache(
             &self.req,
@@ -117,7 +117,7 @@ impl SaffireLeModel {
             &mut self.mixer_middle_rate_ctl.0,
             TIMEOUT_MS,
         )?;
-        SaffireLeThroughProtocol::cache(&self.req, &unit.1, &mut self.through_ctl.0, TIMEOUT_MS)?;
+        self.through_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -276,8 +276,7 @@ impl MeasureModel<(SndUnit, FwNode)> for SaffireLeModel {
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl.measure_meter(unit, &self.req, TIMEOUT_MS)?;
-        self.out_ctl
-            .measure_params(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.out_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -251,7 +251,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SaffireLeModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/focusrite/saffireproio_model.rs
+++ b/runtime/bebob/src/focusrite/saffireproio_model.rs
@@ -381,7 +381,9 @@ trait SaffireProMediaClkFreqCtlOperation<T: SaffireProioMediaClockSpecification>
     }
 
     fn cache_freq(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_freq(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -410,6 +412,7 @@ trait SaffireProMediaClkFreqCtlOperation<T: SaffireProioMediaClockSpecification>
                 let res =
                     T::update(req, &unit.1, &params, self.state_mut(), timeout_ms).map(|_| true);
                 let _ = unit.0.unlock();
+                debug!(params = ?self.state(), ?res);
                 res
             }
             _ => Ok(false),
@@ -447,7 +450,9 @@ trait SaffireProSamplingClkSrcCtlOperation<T: SaffireProioSamplingClockSpecifica
     }
 
     fn cache_src(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_src(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -476,7 +481,8 @@ trait SaffireProSamplingClkSrcCtlOperation<T: SaffireProioSamplingClockSpecifica
                 let res =
                     T::update(req, &unit.1, &params, self.state_mut(), timeout_ms).map(|_| true);
                 let _ = unit.0.unlock();
-                res
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -523,7 +529,9 @@ trait SaffireProioMeterCtlOperation<T: SaffireProioMeterOperation> {
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_state(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -613,7 +621,9 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol> {
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -668,7 +678,9 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol> {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(gain, &val)| *gain = val as i16);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             PRO_MONITOR_SPDIF_INPUT_NAME => {
                 let idx = elem_id.index() as usize;
@@ -679,7 +691,9 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol> {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(gain, &val)| *gain = val as i16);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             PRO_MONITOR_ADAT_INPUT_NAME => {
                 let idx = elem_id.index() as usize;
@@ -692,7 +706,9 @@ trait SaffireProioMonitorCtlOperation<T: SaffireProioMonitorProtocol> {
                         .zip(vals)
                         .for_each(|(gain, &val)| *gain = val as i16);
                 }
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -761,7 +777,9 @@ impl SaffireProioMixerCtl {
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        SaffireProioMixerProtocol::cache(req, node, &mut self.0, timeout_ms)
+        let res = SaffireProioMixerProtocol::cache(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -817,8 +835,9 @@ impl SaffireProioMixerCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(level, &val)| *level = val as i16);
-                SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             PRO_MIXER_STREAM_SRC_PAIR_0_NAME => {
                 let mut params = self.0.clone();
@@ -828,8 +847,9 @@ impl SaffireProioMixerCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(level, &val)| *level = val as i16);
-                SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             PRO_MIXER_STREAM_SRC_NAME => {
                 let mut params = self.0.clone();
@@ -839,8 +859,9 @@ impl SaffireProioMixerCtl {
                     .iter_mut()
                     .zip(vals)
                     .for_each(|(level, &val)| *level = val as i16);
-                SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = SaffireProioMixerProtocol::update(req, node, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -901,7 +922,9 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation> {
     }
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        T::cache(req, node, self.state_mut(), timeout_ms)
+        let res = T::cache(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_params(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -950,21 +973,27 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation> {
             HEAD_ROOM_NAME => {
                 let mut params = self.state().clone();
                 params.head_room = elem_value.boolean()[0];
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             PHANTOM_POWERING_NAME => {
                 let mut params = self.state().clone();
                 let phantom_powerings = &mut params.phantom_powerings;
                 let vals = &elem_value.boolean()[..phantom_powerings.len()];
                 phantom_powerings.copy_from_slice(&vals);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             INSERT_SWAP_NAME => {
                 let mut params = self.state().clone();
                 let insert_swaps = &mut params.insert_swaps;
                 let vals = &elem_value.boolean()[..insert_swaps.len()];
                 insert_swaps.copy_from_slice(&vals);
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             STANDALONE_MODE_NAME => {
                 let mut params = self.state().clone();
@@ -977,17 +1006,23 @@ trait SaffireProioSpecificCtlOperation<T: SaffireProioSpecificOperation> {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             ADAT_ENABLE_NAME => {
                 let mut params = self.state().clone();
                 params.adat_enabled = elem_value.boolean()[0];
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             DIRECT_MONITORING_NAME => {
                 let mut params = self.state().clone();
                 params.direct_monitoring = elem_value.boolean()[0];
-                T::update(req, node, &params, self.state_mut(), timeout_ms).map(|_| true)
+                let res = T::update(req, node, &params, self.state_mut(), timeout_ms);
+                debug!(params = ?self.state(), ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/bebob/src/focusrite/saffireproio_model.rs
+++ b/runtime/bebob/src/focusrite/saffireproio_model.rs
@@ -189,13 +189,8 @@ where
         C::cache(&self.req, &unit.1, &mut self.clk_ctl.0, TIMEOUT_MS)?;
         C::cache(&self.req, &unit.1, &mut self.clk_ctl.1, TIMEOUT_MS)?;
         M::cache(&self.req, &unit.1, &mut self.meter_ctl.0, TIMEOUT_MS)?;
-        SaffireProioOutputProtocol::cache(&self.req, &unit.1, &mut self.out_ctl.0, TIMEOUT_MS)?;
-        SaffireProioThroughProtocol::cache(
-            &self.req,
-            &unit.1,
-            &mut self.through_ctl.0,
-            TIMEOUT_MS,
-        )?;
+        self.out_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.through_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         O::cache(&self.req, &unit.1, &mut self.monitor_ctl.0, TIMEOUT_MS)?;
         SaffireProioMixerProtocol::cache(&self.req, &unit.1, &mut self.mixer_ctl.0, TIMEOUT_MS)?;
         S::cache(&self.req, &unit.1, &mut self.specific_ctl.0, TIMEOUT_MS)?;

--- a/runtime/bebob/src/focusrite/saffireproio_model.rs
+++ b/runtime/bebob/src/focusrite/saffireproio_model.rs
@@ -384,7 +384,7 @@ trait SaffireProMediaClkFreqCtlOperation<T: SaffireProioMediaClockSpecification>
         T::cache(req, node, self.state_mut(), timeout_ms)
     }
 
-    fn read_freq(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_freq(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 elem_value.set_enum(&[self.state().freq_idx as u32]);
@@ -450,7 +450,7 @@ trait SaffireProSamplingClkSrcCtlOperation<T: SaffireProioSamplingClockSpecifica
         T::cache(req, node, self.state_mut(), timeout_ms)
     }
 
-    fn read_src(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read_src(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_SRC_NAME => {
                 elem_value.set_enum(&[self.state().src_idx as u32]);

--- a/runtime/bebob/src/focusrite/saffireproio_model.rs
+++ b/runtime/bebob/src/focusrite/saffireproio_model.rs
@@ -331,7 +331,10 @@ where
         elem_id_list.extend_from_slice(&self.clk_ctl.2);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, unit: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            C::cache(&self.req, &unit.1, &mut self.clk_ctl.0, TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -355,7 +355,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for FirexonModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/lib.rs
+++ b/runtime/bebob/src/lib.rs
@@ -21,7 +21,7 @@ mod yamaha_terratec;
 use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
     firewire_bebob_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{
@@ -71,7 +71,7 @@ impl Drop for BebobRuntime {
 }
 
 impl RuntimeOperation<u32> for BebobRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let path = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndUnit::new();
         unit.open(&path, 0)?;

--- a/runtime/bebob/src/lib.rs
+++ b/runtime/bebob/src/lib.rs
@@ -34,6 +34,7 @@ use {
     nix::sys::signal,
     std::{convert::TryFrom, sync::mpsc},
     ta1394_avc_general::config_rom::*,
+    tracing::Level,
 };
 
 enum Event {
@@ -71,7 +72,14 @@ impl Drop for BebobRuntime {
 }
 
 impl RuntimeOperation<u32> for BebobRuntime {
-    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
+    fn new(card_id: u32, log_level: Option<LogLevel>) -> Result<Self, Error> {
+        if let Some(level) = log_level {
+            let fmt_level = match level {
+                LogLevel::Debug => Level::DEBUG,
+            };
+            tracing_subscriber::fmt().with_max_level(fmt_level).init();
+        }
+
         let path = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndUnit::new();
         unit.open(&path, 0)?;

--- a/runtime/bebob/src/maudio.rs
+++ b/runtime/bebob/src/maudio.rs
@@ -180,7 +180,9 @@ trait MaudioNormalMeterCtlOperation<O: MaudioNormalMeterProtocol> {
         let meter = self.state_mut();
         let switch_state = meter.switch;
 
-        O::read_meter(req, node, meter, timeout_ms)?;
+        let res = O::read_meter(req, node, meter, timeout_ms);
+        debug!(params = ?meter, res = ?res);
+        res?;
 
         if switch_state != meter.switch {
             let state = meter.switch.unwrap();
@@ -352,7 +354,9 @@ pub trait MaudioNormalMixerCtlOperation<O: MaudioNormalMixerOperation> {
         params.0.iter_mut().for_each(|levels| {
             levels.iter_mut().for_each(|level| *level = !(*level));
         });
-        O::update(avc, self.state(), &mut params, timeout_ms)
+        let res = O::update(avc, self.state(), &mut params, timeout_ms);
+        debug!(params = ?self.state(), ?res);
+        res
     }
 
     fn read_src_state(
@@ -382,7 +386,9 @@ pub trait MaudioNormalMixerCtlOperation<O: MaudioNormalMixerOperation> {
             let mut params = self.state().clone();
             let vals = &new.boolean()[..Self::SRC_COUNT];
             params.0[dst_idx].copy_from_slice(&vals);
-            O::update(avc, &params, self.state_mut(), timeout_ms).map(|_| true)
+            let res = O::update(avc, &params, self.state_mut(), timeout_ms);
+            debug!(params = ?self.state(), ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -486,7 +486,14 @@ impl NotifyModel<(SndUnit, FwNode), bool> for AudiophileModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -566,7 +566,14 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fw410Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -303,7 +303,14 @@ impl NotifyModel<(SndUnit, FwNode), bool> for OzonicModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -175,7 +175,14 @@ impl NotifyModel<(SndUnit, FwNode), bool> for PflModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -263,7 +263,7 @@ impl MeterCtl {
         PflMeterProtocol::cache(req, node, &mut self.0, timeout_ms)
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             Self::DETECTED_RATE_NAME => {
                 let freq = Self::DETECTED_INPUT_FREQ_LIST
@@ -308,7 +308,7 @@ impl InputParamsCtl {
         PflInputParametersProtocol::update(req, node, &mut self.0, timeout_ms)
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             Self::ADAT_MUTE_NAME => {
                 ElemValueAccessor::<bool>::set_vals(elem_value, 4, |idx| Ok(self.0.adat_mute[idx]))

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -342,7 +342,14 @@ impl NotifyModel<(SndUnit, FwNode), bool> for SoloModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/maudio/special_model.rs
+++ b/runtime/bebob/src/maudio/special_model.rs
@@ -272,7 +272,14 @@ impl<T: MediaClockFrequencyOperation> NotifyModel<(SndUnit, FwNode), bool> for S
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndUnit, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -353,7 +353,9 @@ impl AnalogInputCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        FireboxAnalogInputProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = FireboxAnalogInputProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -379,8 +381,9 @@ impl AnalogInputCtl {
                 let mut params = self.0.clone();
                 let vals = &new.boolean()[..params.boosts.len()];
                 params.boosts.copy_from_slice(&vals);
-                FireboxAnalogInputProtocol::update(avc, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res = FireboxAnalogInputProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -356,7 +356,7 @@ impl AnalogInputCtl {
         FireboxAnalogInputProtocol::cache(avc, &mut self.0, timeout_ms)
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             Self::SWITCH_NAME => {
                 elem_value.set_bool(&self.0.boosts);

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -641,7 +641,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for FireboxModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -212,7 +212,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Fp10Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -678,7 +678,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Inspire1394Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -114,7 +114,9 @@ impl MeterCtl {
         unit: &(SndUnit, FwNode),
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        Inspire1394MeterProtocol::cache(req, &unit.1, &mut self.1, timeout_ms)
+        let res = Inspire1394MeterProtocol::cache(req, &unit.1, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -394,7 +396,9 @@ impl InputSwitchCtl {
     }
 
     fn cache(&mut self, avc: &BebobAvc, timeout_ms: u32) -> Result<(), Error> {
-        Inspire1394SwitchProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = Inspire1394SwitchProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
@@ -432,28 +436,32 @@ impl InputSwitchCtl {
                 let mut params = self.0.clone();
                 let vals = &new.boolean()[..2];
                 params.pair0_phantom.copy_from_slice(&vals);
-                Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms)?;
-                Ok(true)
+                let res = Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MIC_BOOST_NAME => {
                 let mut params = self.0.clone();
                 let vals = &new.boolean()[..2];
                 params.pair0_boost.copy_from_slice(&vals);
-                Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms)?;
-                Ok(true)
+                let res = Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MIC_LIMIT_NAME => {
                 let mut params = self.0.clone();
                 let vals = &new.boolean()[..2];
                 params.pair0_limit.copy_from_slice(&vals);
-                Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms)?;
-                Ok(true)
+                let res = Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::LINE_PHONO_NAME => {
                 let mut params = self.0.clone();
                 params.pair1_phono = new.boolean()[0];
-                Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms)?;
-                Ok(true)
+                let res = Inspire1394SwitchProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -188,7 +188,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for ScratchampModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -317,7 +317,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for AureonModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -418,7 +418,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for Phase88Model {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -471,7 +471,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for GoPhase24CoaxModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 
@@ -625,7 +628,10 @@ impl NotifyModel<(SndUnit, FwNode), bool> for GoPhase24OptModel {
         elem_id_list.extend_from_slice(&self.clk_ctl.0);
     }
 
-    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), _: &bool) -> Result<(), Error> {
+    fn parse_notification(&mut self, _: &mut (SndUnit, FwNode), &locked: &bool) -> Result<(), Error> {
+        if locked {
+            self.clk_ctl.cache_freq(&self.avc, FCP_TIMEOUT_MS)?;
+        }
         Ok(())
     }
 

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -19,3 +19,4 @@ hitaki = "0.2"
 alsactl = "0.4"
 alsaseq = "0.4"
 clap = { version = "3.2", features = ["derive"] }
+tracing = "0.1"

--- a/runtime/core/src/card_cntr.rs
+++ b/runtime/core/src/card_cntr.rs
@@ -643,7 +643,7 @@ impl CardCntr {
                 .iter_mut()
                 .filter(|(elem_info, _)| match_elem_id(elem_info, elem_id))
                 .try_for_each(|(elem_info, elem_value)| {
-                    let _enter = debug_span!("hardware");
+                    let _enter = debug_span!("hardware").entered();
 
                     let res = ctl_model.measure_elem(unit, elem_id, elem_value);
                     debug!(
@@ -653,13 +653,17 @@ impl CardCntr {
                     );
                     res?;
 
-                    let _enter = debug_span!("kernel");
+                    _enter.exit();
+
+                    let _enter = debug_span!("kernel").entered();
                     let res = card.write_elem_value(elem_id, elem_value);
                     debug!(
                         numid = elem_id.numid(),
                         values = value_array_literal(elem_info, &elem_value),
                         ?res,
                     );
+                    _enter.exit();
+
                     res
                 })
         })
@@ -688,7 +692,7 @@ impl CardCntr {
                 .iter_mut()
                 .filter(|(elem_info, _)| match_elem_id(elem_info, elem_id))
                 .try_for_each(|(elem_info, elem_value)| {
-                    let _enter = debug_span!("hardware");
+                    let _enter = debug_span!("hardware").entered();
                     let res = ctl_model.read_notified_elem(unit, elem_id, elem_value);
                     debug!(
                         numid = elem_id.numid(),
@@ -697,13 +701,18 @@ impl CardCntr {
                     );
                     res?;
 
-                    let _enter = debug_span!("kernel");
+                    _enter.exit();
+
+                    let _enter = debug_span!("kernel").entered();
                     let res = card.write_elem_value(elem_id, elem_value);
                     debug!(
                         numid = elem_id.numid(),
                         values = value_array_literal(elem_info, &elem_value),
                         ?res,
                     );
+
+                    _enter.exit();
+
                     res
                 })
         })

--- a/runtime/core/src/lib.rs
+++ b/runtime/core/src/lib.rs
@@ -5,10 +5,22 @@ pub mod cmdline;
 pub mod dispatcher;
 pub mod elem_value_accessor;
 
-use glib::Error;
+use {clap::ArgEnum, glib::Error};
+
+/// The level to debug runtime.
+#[derive(ArgEnum, Debug, Copy, Clone, Eq, PartialEq)]
+pub enum LogLevel {
+    Debug,
+}
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        Self::Debug
+    }
+}
 
 pub trait RuntimeOperation<T>: Sized {
-    fn new(arg: T) -> Result<Self, Error>;
+    fn new(arg: T, log_level: Option<LogLevel>) -> Result<Self, Error>;
     fn listen(&mut self) -> Result<(), Error>;
     fn run(&mut self) -> Result<(), Error>;
 }

--- a/runtime/dice/src/bin/snd-dice-ctl-service.rs
+++ b/runtime/dice/src/bin/snd-dice-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, dice_runtime::DiceRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    dice_runtime::DiceRuntime,
+};
 
 struct DiceServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, DiceRuntime> for DiceServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/dice/src/lib.rs
+++ b/runtime/dice/src/lib.rs
@@ -20,7 +20,7 @@ use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
     common_ctl::*,
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
     firewire_dice_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{
@@ -54,7 +54,7 @@ pub struct DiceRuntime {
 }
 
 impl RuntimeOperation<u32> for DiceRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let unit = SndDice::new();
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path, 0)?;

--- a/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
+++ b/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, digi00x_runtime::Dg00xRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    digi00x_runtime::Dg00xRuntime,
+};
 
 struct Dg00xServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, Dg00xRuntime> for Dg00xServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/digi00x/src/lib.rs
+++ b/runtime/digi00x/src/lib.rs
@@ -4,7 +4,7 @@ mod model;
 
 use {
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
     firewire_digi00x_protocols as protocols,
     glib::{
         source, {Error, FileError},
@@ -71,7 +71,7 @@ const SPECIFIER_ID_DIGI003: u32 = 0x0000aa;
 const SPECIFIER_ID_DIGI003_RACK: u32 = 0x0000ab;
 
 impl RuntimeOperation<u32> for Dg00xRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let unit = SndDigi00x::new();
         unit.open(&format!("/dev/snd/hwC{}D0", card_id), 0)?;
 

--- a/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
+++ b/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, fireface_runtime::FfRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    fireface_runtime::FfRuntime,
+};
 
 struct FfServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, FfRuntime> for FfServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/fireface/src/lib.rs
+++ b/runtime/fireface/src/lib.rs
@@ -13,7 +13,7 @@ mod latter_ctls;
 
 use {
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
     firewire_fireface_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{
@@ -45,7 +45,7 @@ pub struct FfRuntime {
 }
 
 impl RuntimeOperation<u32> for FfRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let unit = SndUnit::new();
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path, 0)?;

--- a/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
+++ b/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, fireworks_runtime::EfwRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    fireworks_runtime::EfwRuntime,
+};
 
 struct EfwServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, EfwRuntime> for EfwServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None) 
     }
 }
 

--- a/runtime/fireworks/src/lib.rs
+++ b/runtime/fireworks/src/lib.rs
@@ -63,7 +63,7 @@ impl Drop for EfwRuntime {
 }
 
 impl RuntimeOperation<u32> for EfwRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let unit = SndEfw::default();
         unit.open(&format!("/dev/snd/hwC{}D0", card_id), 0)?;
 

--- a/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
+++ b/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, motu_runtime::MotuRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    motu_runtime::MotuRuntime,
+};
 
 struct MotuServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, MotuRuntime> for MotuServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/motu/src/lib.rs
+++ b/runtime/motu/src/lib.rs
@@ -31,7 +31,7 @@ mod v3_ctls;
 
 use {
     self::{command_dsp_runtime::*, register_dsp_runtime::*, v1_runtime::*},
-    core::RuntimeOperation,
+    core::*,
     firewire_motu_protocols as protocols,
     glib::{Error, FileError},
     hinawa::{
@@ -63,7 +63,7 @@ pub enum MotuRuntime {
 }
 
 impl RuntimeOperation<u32> for MotuRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let cdev = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndMotu::new();
         unit.open(&cdev, 0)?;

--- a/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
+++ b/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, oxfw_runtime::OxfwRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    oxfw_runtime::OxfwRuntime,
+};
 
 struct OxfwServiceCmd;
 
@@ -13,8 +17,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, u32, OxfwRuntime> for OxfwServiceCmd {
-    fn params(args: &Arguments) -> u32 {
-        args.card_id
+    fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
+        (args.card_id, None)
     }
 }
 

--- a/runtime/oxfw/src/lib.rs
+++ b/runtime/oxfw/src/lib.rs
@@ -13,7 +13,7 @@ mod common_ctl;
 use {
     alsactl::{prelude::*, *},
     common_ctl::*,
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, RuntimeOperation},
+    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
     firewire_oxfw_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{
@@ -64,7 +64,7 @@ impl Drop for OxfwRuntime {
 }
 
 impl RuntimeOperation<u32> for OxfwRuntime {
-    fn new(card_id: u32) -> Result<Self, Error> {
+    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
         let cdev = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndUnit::new();
         unit.open(&cdev, 0)?;

--- a/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
+++ b/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2022 Takashi Sakamoto
 
-use {clap::Parser, core::cmdline::*, tascam_runtime::TascamRuntime};
+use {
+    clap::Parser,
+    core::{cmdline::*, LogLevel},
+    tascam_runtime::TascamRuntime,
+};
 
 struct TascamServiceCmd;
 
@@ -15,8 +19,8 @@ struct Arguments {
 }
 
 impl ServiceCmd<Arguments, (String, u32), TascamRuntime> for TascamServiceCmd {
-    fn params(args: &Arguments) -> (String, u32) {
-        (args.subsystem.clone(), args.sysnum)
+    fn params(args: &Arguments) -> ((String, u32), Option<LogLevel>) {
+        ((args.subsystem.clone(), args.sysnum), None)
     }
 }
 

--- a/runtime/tascam/src/lib.rs
+++ b/runtime/tascam/src/lib.rs
@@ -16,7 +16,7 @@ mod seq_cntr;
 use {
     alsaseq::{prelude::*, *},
     asynch_runtime::*,
-    core::{card_cntr::*, RuntimeOperation},
+    core::{card_cntr::*, *},
     firewire_tascam_protocols as protocols,
     glib::{source, Error, FileError, IsA},
     hinawa::{
@@ -46,7 +46,7 @@ const FW1082_SW_VERSION: u32 = 0x800003;
 const FW1804_SW_VERSION: u32 = 0x800004;
 
 impl RuntimeOperation<(String, u32)> for TascamRuntime {
-    fn new((subsystem, sysnum): (String, u32)) -> Result<Self, Error> {
+    fn new((subsystem, sysnum): (String, u32), _: Option<LogLevel>) -> Result<Self, Error> {
         match subsystem.as_str() {
             "snd" => {
                 let unit = SndTascam::new();


### PR DESCRIPTION
It's really helpful to dump logs for debugging purpose. This patchset utilizes
tracing and tracing-subscriber crates for the purpose. An option is newly added
to bebob runtime, then implement tracing events.

```
Takashi Sakamoto (20):
  runtime/bebob: cache media clock and sampling clock source after stream lock
  runtime/bebob: maudio: code refactoring to add cache function for Profire Lightbridge
  runtime/bebob: maudio: code refactoring to add cache function for controls of special models
  runtime/bebob: apogee: code refactoring to add cache function for controls of Ensemble model
  runtime/bebob: focusrite: code refactoring to add cache function to common controls
  runtime/bebob: focusrite: code refactoring to add cache function for controls of Saffire model
  runtime/bebob: focusrite: code refactoring to add cache function for controls of Saffire LE model
  runtime/bebob: focusrite: code refactoring to add cache function for controls of Saffire Pro i/o model
  runtime/bebob: use immutable reference at parameter parsing
  runtime/core: add an argument for log level
  runtime/core: cache element information
  runtime/core: use element information to detect element identifier
  runtime/core: add tracing events for operations related to ALSA control interface
  runtime/bebob: use tracing-subscriber crate to dump debug logs
  runtime/bebob: add tracing span and event to runtime structure
  runtime/bebob: add tracing span and event to common controls
  runtime/bebob: add tracing span and event to Apogee specific controls
  runtime/bebob: add tracing event to Focusrite Saffire specific controls
  runtime/bebob: add tracing event to PreSonus specific controls
  runtime/bebob: add tracing event to M-Audio specific controls

 README.rst                                    |   3 +
 protocols/bebob/src/apogee/ensemble.rs        |   2 +-
 runtime/bebob/Cargo.toml                      |   2 +
 runtime/bebob/src/apogee/ensemble_model.rs    | 250 ++++++----
 runtime/bebob/src/behringer.rs                |   5 +-
 .../bebob/src/bin/snd-bebob-ctl-service.rs    |  14 +-
 runtime/bebob/src/common_ctls.rs              |  50 +-
 runtime/bebob/src/digidesign.rs               |   5 +-
 runtime/bebob/src/esi.rs                      |   5 +-
 runtime/bebob/src/focusrite.rs                |  40 +-
 runtime/bebob/src/focusrite/saffire_model.rs  | 159 ++++---
 .../bebob/src/focusrite/saffirele_model.rs    |  55 +--
 .../bebob/src/focusrite/saffireproio_model.rs | 128 ++++--
 runtime/bebob/src/icon.rs                     |   5 +-
 runtime/bebob/src/lib.rs                      |  36 +-
 runtime/bebob/src/maudio.rs                   |  12 +-
 runtime/bebob/src/maudio/audiophile_model.rs  |   9 +-
 runtime/bebob/src/maudio/fw410_model.rs       |   9 +-
 runtime/bebob/src/maudio/ozonic_model.rs      |   9 +-
 .../src/maudio/profirelightbridge_model.rs    |  67 ++-
 runtime/bebob/src/maudio/solo_model.rs        |   9 +-
 runtime/bebob/src/maudio/special_model.rs     |  92 ++--
 runtime/bebob/src/presonus/firebox_model.rs   |  16 +-
 runtime/bebob/src/presonus/fp10_model.rs      |   5 +-
 .../bebob/src/presonus/inspire1394_model.rs   |  33 +-
 runtime/bebob/src/stanton.rs                  |   5 +-
 runtime/bebob/src/terratec/aureon_model.rs    |   5 +-
 runtime/bebob/src/terratec/phase88_model.rs   |   5 +-
 runtime/bebob/src/yamaha_terratec.rs          |  10 +-
 runtime/core/Cargo.toml                       |   1 +
 runtime/core/src/card_cntr.rs                 | 430 +++++++++++++++---
 runtime/core/src/cmdline.rs                   |  26 +-
 runtime/core/src/lib.rs                       |  16 +-
 runtime/dice/src/bin/snd-dice-ctl-service.rs  |  10 +-
 runtime/dice/src/lib.rs                       |   4 +-
 .../bin/snd-firewire-digi00x-ctl-service.rs   |  10 +-
 runtime/digi00x/src/lib.rs                    |   4 +-
 .../src/bin/snd-fireface-ctl-service.rs       |  10 +-
 runtime/fireface/src/lib.rs                   |   4 +-
 .../src/bin/snd-fireworks-ctl-service.rs      |  10 +-
 runtime/fireworks/src/lib.rs                  |   2 +-
 .../src/bin/snd-firewire-motu-ctl-service.rs  |  10 +-
 runtime/motu/src/lib.rs                       |   4 +-
 runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs  |  10 +-
 runtime/oxfw/src/lib.rs                       |   4 +-
 .../bin/snd-firewire-tascam-ctl-service.rs    |  10 +-
 runtime/tascam/src/lib.rs                     |   4 +-
 47 files changed, 1158 insertions(+), 456 deletions(-)
```