### PR TITLE
[PATCH 0/3] runtime/dice: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,9 +87,6 @@ Execute temporarily ::
 All of executables can print help when either ``--help`` or ``-h`` is given as an argument of
 command line.
 
-Some executables support debug logging as well when either ``-l`` or ``--log-level`` is given
-with log level. At present, ``debug`` is just supported only for ``snd-bebob-ctl-service``.
-
 Install executables ::
 
     $ cargo install --path (path to runtime crate)
@@ -270,6 +267,21 @@ Supported protocols
    * Protocol extension for TCD2210/TCD2220 ASIC in Digital Interface Communication Engine (DICE)
    * Protocol for former models of Fireface series of RME GmbH
    * Protocol for latter models of Fireface series of RME GmbH
+
+Runtime debugging
+=================
+
+Some executables support an option for log level for debugging. When either ``-l`` or
+``--log-level`` is given with log level, they prints verbose logs to standard output.
+At present, ``debug`` is just supported for the log level.
+
+Currently this function is available for below executables:
+
+* snd-bebob-ctl-service
+* snd-dice-ctl-service
+
+This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
+`tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.
 
 Design note
 ===========

--- a/runtime/dice/Cargo.toml
+++ b/runtime/dice/Cargo.toml
@@ -21,3 +21,5 @@ ieee1212-config-rom = "0.1"
 firewire-dice-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/dice/src/bin/snd-dice-ctl-service.rs
+++ b/runtime/dice/src/bin/snd-dice-ctl-service.rs
@@ -14,11 +14,15 @@ struct DiceServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, DiceRuntime> for DiceServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -28,13 +28,23 @@ where
         sections: &mut GeneralSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::whole_cache(req, node, &mut sections.global, timeout_ms)?;
-        T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms)?;
-        T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms)?;
+        let res = T::whole_cache(req, node, &mut sections.global, timeout_ms);
+        debug!(params = ?sections.global.params, ?res);
+        res?;
+
+        let res = T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms);
+        debug!(params = ?sections.tx_stream_format.params, ?res);
+        res?;
+
+        let res = T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms);
+        debug!(params = ?sections.rx_stream_format.params, ?res);
+        res?;
 
         // Old firmware doesn't support it.
         if sections.ext_sync.size > 0 {
-            T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms)?;
+            let res = T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms);
+            debug!(params = ?sections.ext_sync.params, ?res);
+            res?;
         }
 
         Ok(())
@@ -202,6 +212,7 @@ where
                 unit.lock()?;
                 let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
                 let _ = unit.unlock();
+                debug!(?params, ?res);
                 res.map(|_| true)
             }
             CLK_SRC_NAME => {
@@ -226,6 +237,7 @@ where
                 unit.lock()?;
                 let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
                 let _ = unit.unlock();
+                debug!(?params, ?res);
                 res.map(|_| true)
             }
             NICKNAME => {
@@ -235,8 +247,9 @@ where
                     let msg = format!("Invalid bytes for string: {}", e);
                     Error::new(FileError::Inval, &msg)
                 })?;
-                T::partial_update(req, node, &params, &mut sections.global, timeout_ms)?;
-                Ok(true)
+                let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
+                debug!(?params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -249,11 +262,15 @@ where
         sections: &mut GeneralSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::partial_cache(req, node, &mut sections.global, timeout_ms)?;
+        let res = T::partial_cache(req, node, &mut sections.global, timeout_ms);
+        debug!(params = ?sections.global.params, ?res);
+        res?;
 
         // Old firmware doesn't support it.
         if sections.ext_sync.size > 0 {
-            T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms)?;
+            let res = T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms);
+            debug!(params = ?sections.ext_sync.params, ?res);
+            res?;
         }
 
         Ok(())
@@ -268,13 +285,19 @@ where
         timeout_ms: u32,
     ) -> Result<(), Error> {
         if T::notified(&sections.global, msg) {
-            T::whole_cache(req, node, &mut sections.global, timeout_ms)?;
+            let res = T::whole_cache(req, node, &mut sections.global, timeout_ms);
+            debug!(params = ?sections.global.params, ?res);
+            res?;
         }
         if T::notified(&sections.tx_stream_format, msg) {
-            T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms)?;
+            let res = T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms);
+            debug!(params = ?sections.global.params, ?res);
+            res?;
         }
         if T::notified(&sections.rx_stream_format, msg) {
-            T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms)?;
+            let res = T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms);
+            debug!(params = ?sections.global.params, ?res);
+            res?;
         }
 
         Ok(())

--- a/runtime/dice/src/lib.rs
+++ b/runtime/dice/src/lib.rs
@@ -32,6 +32,7 @@ use {
     nix::sys::signal,
     protocols::tcat::{global_section::*, *},
     std::sync::mpsc,
+    tracing::Level,
 };
 
 enum Event {
@@ -54,7 +55,14 @@ pub struct DiceRuntime {
 }
 
 impl RuntimeOperation<u32> for DiceRuntime {
-    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
+    fn new(card_id: u32, log_level: Option<LogLevel>) -> Result<Self, Error> {
+        if let Some(level) = log_level {
+            let fmt_level = match level {
+                LogLevel::Debug => Level::DEBUG,
+            };
+            tracing_subscriber::fmt().with_max_level(fmt_level).init();
+        }
+
         let unit = SndDice::new();
         let path = format!("/dev/snd/hwC{}D0", card_id);
         unit.open(&path, 0)?;


### PR DESCRIPTION
It's really helpful to dump logs for debugging purpose. This patchset utilizes
tracing and tracing-subscriber crates for the purpose. An option is newly added
to dice runtime, then implement tracing events.

At present, common controls and corresponding protocol parameters are target
of logging. The other parameters will be added in future commits.

```
Takashi Sakamoto (3):
  runtime/dice: use tracing-subscriber crate to dump debug logs
  runtime/dice: add tracing span and event to runtime structure
  runtime/dice: add tracing event to common controls

 README.rst                                   |  18 ++-
 runtime/dice/Cargo.toml                      |   2 +
 runtime/dice/src/bin/snd-dice-ctl-service.rs |   6 +-
 runtime/dice/src/common_ctl.rs               |  45 ++++++--
 runtime/dice/src/lib.rs                      | 113 ++++++++++++-------
 5 files changed, 129 insertions(+), 55 deletions(-)
```