### PR TITLE
[PATCH 00/23] protocols/dice: tcelectronic: renew protocol traits

### DIFF
--- a/protocols/dice/src/tcat.rs
+++ b/protocols/dice/src/tcat.rs
@@ -130,6 +130,8 @@ pub enum GeneralProtocolError {
     RxStreamFormat,
     /// Error to operate for external synchronization states.
     ExtendedSync,
+    /// Any error in application implementation developed by vendors.
+    VendorDependent,
     Invalid(i32),
 }
 
@@ -140,6 +142,7 @@ impl std::fmt::Display for GeneralProtocolError {
             GeneralProtocolError::TxStreamFormat => "tx-stream-format",
             GeneralProtocolError::RxStreamFormat => "rx-stream-format",
             GeneralProtocolError::ExtendedSync => "external-sync",
+            GeneralProtocolError::VendorDependent => "vendor-dependent",
             GeneralProtocolError::Invalid(_) => "invalid",
         };
 
@@ -158,6 +161,7 @@ impl ErrorDomain for GeneralProtocolError {
             GeneralProtocolError::TxStreamFormat => 1,
             GeneralProtocolError::RxStreamFormat => 2,
             GeneralProtocolError::ExtendedSync => 3,
+            GeneralProtocolError::VendorDependent => 4,
             GeneralProtocolError::Invalid(v) => v,
         }
     }
@@ -168,6 +172,7 @@ impl ErrorDomain for GeneralProtocolError {
             1 => GeneralProtocolError::TxStreamFormat,
             2 => GeneralProtocolError::RxStreamFormat,
             3 => GeneralProtocolError::ExtendedSync,
+            4 => GeneralProtocolError::VendorDependent,
             _ => GeneralProtocolError::Invalid(code),
         };
         Some(enumeration)

--- a/protocols/dice/src/tcelectronic.rs
+++ b/protocols/dice/src/tcelectronic.rs
@@ -58,6 +58,134 @@ where
     }
 }
 
+/// Serialize and deserialize for segment in TC Konnekt protocol.
+pub trait TcKonnektSegmentSerdes<T> {
+    /// The name of segment.
+    const NAME: &'static str;
+
+    /// The offset of segment.
+    const OFFSET: usize;
+
+    /// The size of segment.
+    const SIZE: usize;
+
+    /// Serialize for parameter.
+    fn serialize(params: &T, raw: &mut [u8]) -> Result<(), String>;
+
+    /// Deserialize for parameter.
+    fn deserialize(params: &mut T, raw: &[u8]) -> Result<(), String>;
+}
+
+fn generate_error(segment_name: &str, cause: &str, raw: &[u8]) -> Error {
+    let msg = format!(
+        "segment: {}, cause: '{}', raw: {:02x?}",
+        segment_name, cause, raw
+    );
+    Error::new(GeneralProtocolError::VendorDependent, &msg)
+}
+
+/// Operation to cache content of segment in TC Electronic Konnekt series.
+pub trait TcKonnektSegmentOperation<T>: TcatOperation + TcKonnektSegmentSerdes<T>
+where
+    T: TcKonnektSegmentData,
+{
+    /// Cache whole segment and deserialize for parameters.
+    fn cache_whole_segment(
+        req: &FwReq,
+        node: &FwNode,
+        segment: &mut TcKonnektSegment<T>,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(segment.raw.len(), Self::SIZE);
+
+        Self::read(
+            req,
+            node,
+            BASE_OFFSET + Self::OFFSET,
+            &mut segment.raw,
+            timeout_ms,
+        )?;
+
+        Self::deserialize(&mut segment.data, &segment.raw).map_err(|cause| {
+            generate_error(Self::NAME, &cause, &segment.raw)
+        })
+    }
+}
+
+impl<O: TcatOperation + TcKonnektSegmentSerdes<T>, T: TcKonnektSegmentData>
+    TcKonnektSegmentOperation<T> for O
+{
+}
+
+/// Operation to update content of segment in TC Electronic Konnekt series.
+pub trait TcKonnektMutableSegmentOperation<T>: TcatOperation + TcKonnektSegmentSerdes<T>
+where
+    T: TcKonnektSegmentData,
+{
+    /// Update part of segment for any change at the parameters.
+    fn update_partial_segment(
+        req: &FwReq,
+        node: &FwNode,
+        params: &T,
+        segment: &mut TcKonnektSegment<T>,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(segment.raw.len(), Self::SIZE);
+
+        let mut raw = segment.raw.clone();
+        Self::serialize(params, &mut raw).map_err(|cause| {
+            generate_error(Self::NAME, &cause, &segment.raw)
+        })?;
+
+        (0..Self::SIZE).step_by(4).try_for_each(|pos| {
+            let new = &mut raw[pos..(pos + 4)];
+            if new != &segment.raw[pos..(pos + 4)] {
+                Self::write(req, node, BASE_OFFSET + Self::OFFSET + pos, new, timeout_ms)
+                    .map(|_| segment.raw[pos..(pos + 4)].copy_from_slice(new))
+            } else {
+                Ok(())
+            }
+        })?;
+
+        Self::deserialize(&mut segment.data, &raw).map_err(|cause| {
+            generate_error(Self::NAME, &cause, &segment.raw)
+        })
+    }
+
+    /// Update whole segment by the parameters.
+    fn update_whole_segment(
+        req: &FwReq,
+        node: &FwNode,
+        params: &T,
+        segment: &mut TcKonnektSegment<T>,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(segment.raw.len(), Self::SIZE);
+
+        let mut raw = segment.raw.clone();
+        Self::serialize(&params, &mut raw).map_err(|cause| {
+            generate_error(Self::NAME, &cause, &segment.raw)
+        })?;
+
+        Self::write(req, node, BASE_OFFSET + Self::OFFSET, &mut raw, timeout_ms)?;
+
+        segment.raw.copy_from_slice(&raw);
+        Self::deserialize(&mut segment.data, &segment.raw).map_err(|cause| {
+            generate_error(Self::NAME, &cause, &segment.raw)
+        })
+    }
+}
+
+/// Operation for segment in which any change is notified in TC Electronic Konnekt series.
+pub trait TcKonnektNotifiedSegmentOperation<T: TcKonnektSegmentData> {
+    const NOTIFY_FLAG: u32;
+
+    /// Check message to be notified or not.
+    fn is_notified_segment(_: &TcKonnektSegment<T>, msg: u32) -> bool {
+        msg & Self::NOTIFY_FLAG > 0
+    }
+}
+
 /// Operation of segment in TC Electronics Konnekt series.
 pub trait SegmentOperation<T>
 where

--- a/protocols/dice/src/tcelectronic.rs
+++ b/protocols/dice/src/tcelectronic.rs
@@ -41,21 +41,10 @@ pub struct TcKonnektSegment<U>
 where
     U: TcKonnektSegmentData,
 {
+    /// Intermediate structured data for parameters.
     pub data: U,
+    /// Raw byte data for memory layout in hardware.
     raw: Vec<u8>,
-}
-
-impl<U> Default for TcKonnektSegment<U>
-where
-    U: TcKonnektSegmentData,
-    TcKonnektSegment<U>: TcKonnektSegmentSpec,
-{
-    fn default() -> Self {
-        TcKonnektSegment {
-            data: Default::default(),
-            raw: vec![0; Self::SIZE],
-        }
-    }
 }
 
 /// Serialize and deserialize for segment in TC Konnekt protocol.
@@ -96,6 +85,7 @@ where
         segment: &mut TcKonnektSegment<T>,
         timeout_ms: u32,
     ) -> Result<(), Error> {
+        // NOTE: Something wrong to implement Default trait.
         assert_eq!(segment.raw.len(), Self::SIZE);
 
         Self::read(
@@ -130,6 +120,7 @@ where
         segment: &mut TcKonnektSegment<T>,
         timeout_ms: u32,
     ) -> Result<(), Error> {
+        // NOTE: Something wrong to implement Default trait.
         assert_eq!(segment.raw.len(), Self::SIZE);
 
         let mut raw = segment.raw.clone();
@@ -160,6 +151,7 @@ where
         segment: &mut TcKonnektSegment<T>,
         timeout_ms: u32,
     ) -> Result<(), Error> {
+        // NOTE: Something wrong to implement Default trait.
         assert_eq!(segment.raw.len(), Self::SIZE);
 
         let mut raw = segment.raw.clone();

--- a/protocols/dice/src/tcelectronic/ch_strip.rs
+++ b/protocols/dice/src/tcelectronic/ch_strip.rs
@@ -9,7 +9,7 @@
 use super::*;
 
 /// Type of source.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChStripSrcType {
     FemaleVocal,
     MaleVocal,
@@ -128,7 +128,7 @@ impl From<ChStripSrcType> for u32 {
 }
 
 /// State of compressor part.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CompState {
     /// The gain of input. 0..360 (-18.0..18.0 dB).
     pub input_gain: u32,
@@ -143,7 +143,7 @@ pub struct CompState {
 }
 
 /// State of deesser part.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DeesserState {
     /// The ratio to deesser. 0..10 (0..100 %)
     pub ratio: u32,
@@ -151,7 +151,7 @@ pub struct DeesserState {
 }
 
 /// State of equalizer part.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EqState {
     pub enabled: bool,
     // The bandwidth. 0..39
@@ -164,14 +164,14 @@ pub struct EqState {
 }
 
 /// State of limitter part.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LimitterState {
     /// The threshold to limit. 0..72 (-18.0..+18.0)
     pub threshold: u32,
 }
 
 /// State entry of channel strip effect.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ChStripState {
     pub src_type: ChStripSrcType,
     /// Compressor for low/mid/high frequencies.
@@ -308,7 +308,7 @@ impl ChStripStatesConvert for [ChStripState] {
 }
 
 /// Meter entry of channel strip effect.
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ChStripMeter {
     /// Input meter. -72..0 (-72.0..0.0 dB)
     pub input: i32,

--- a/protocols/dice/src/tcelectronic/ch_strip.rs
+++ b/protocols/dice/src/tcelectronic/ch_strip.rs
@@ -128,7 +128,7 @@ impl From<ChStripSrcType> for u32 {
 }
 
 /// State of compressor part.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct CompState {
     /// The gain of input. 0..360 (-18.0..18.0 dB).
     pub input_gain: u32,
@@ -164,14 +164,14 @@ pub struct EqState {
 }
 
 /// State of limitter part.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct LimitterState {
     /// The threshold to limit. 0..72 (-18.0..+18.0)
     pub threshold: u32,
 }
 
 /// State entry of channel strip effect.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct ChStripState {
     pub src_type: ChStripSrcType,
     /// Compressor for low/mid/high frequencies.
@@ -308,7 +308,7 @@ impl ChStripStatesConvert for [ChStripState] {
 }
 
 /// Meter entry of channel strip effect.
-#[derive(Default, Debug, Clone)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct ChStripMeter {
     /// Input meter. -72..0 (-72.0..0.0 dB)
     pub input: i32,

--- a/protocols/dice/src/tcelectronic/desktop.rs
+++ b/protocols/dice/src/tcelectronic/desktop.rs
@@ -41,6 +41,25 @@ impl SegmentOperation<DesktopPanel> for Desktopk6Protocol {}
 pub type Desktopk6MeterSegment = TcKonnektSegment<DesktopMeter>;
 impl SegmentOperation<DesktopMeter> for Desktopk6Protocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(Desktopk6Protocol, DesktopHwState);
+segment_default!(Desktopk6Protocol, DesktopConfig);
+segment_default!(Desktopk6Protocol, DesktopMixerState);
+segment_default!(Desktopk6Protocol, DesktopPanel);
+segment_default!(Desktopk6Protocol, DesktopMeter);
+
 /// Target of meter.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MeterTarget {

--- a/protocols/dice/src/tcelectronic/desktop.rs
+++ b/protocols/dice/src/tcelectronic/desktop.rs
@@ -23,23 +23,18 @@ impl TcatGlobalSectionSpecification for Desktopk6Protocol {}
 
 /// Segment for panel. 0x0008..0x0097 (36 quads).
 pub type Desktopk6HwStateSegment = TcKonnektSegment<DesktopHwState>;
-impl SegmentOperation<DesktopHwState> for Desktopk6Protocol {}
 
 /// Segment for configuration. 0x0098..0x00b7 (8 quads).
 pub type Desktopk6ConfigSegment = TcKonnektSegment<DesktopConfig>;
-impl SegmentOperation<DesktopConfig> for Desktopk6Protocol {}
 
 /// Segment for state of mixer. 0x00b8..0x0367 (172 quads).
 pub type Desktopk6MixerStateSegment = TcKonnektSegment<DesktopMixerState>;
-impl SegmentOperation<DesktopMixerState> for Desktopk6Protocol {}
 
 /// Segment for panel. 0x2008..0x2047 (15 quads).
 pub type Desktopk6PanelSegment = TcKonnektSegment<DesktopPanel>;
-impl SegmentOperation<DesktopPanel> for Desktopk6Protocol {}
 
 /// Segment for meter. 0x20e4..0x213f (23 quads).
 pub type Desktopk6MeterSegment = TcKonnektSegment<DesktopMeter>;
-impl SegmentOperation<DesktopMeter> for Desktopk6Protocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -215,26 +210,6 @@ impl TcKonnektNotifiedSegmentOperation<DesktopHwState> for Desktopk6Protocol {
     const NOTIFY_FLAG: u32 = DESKTOP_HW_STATE_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for DesktopHwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopHwState> {
-    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopHwState>>::OFFSET;
-    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopHwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopHwState> {
-    const NOTIFY_FLAG: u32 =
-        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopHwState>>::NOTIFY_FLAG;
-}
-
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopConfig {
@@ -261,26 +236,6 @@ impl TcKonnektMutableSegmentOperation<DesktopConfig> for Desktopk6Protocol {}
 
 impl TcKonnektNotifiedSegmentOperation<DesktopConfig> for Desktopk6Protocol {
     const NOTIFY_FLAG: u32 = DESKTOP_CONFIG_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for DesktopConfig {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopConfig> {
-    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopConfig>>::OFFSET;
-    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopConfig>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopConfig> {
-    const NOTIFY_FLAG: u32 =
-        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopConfig>>::NOTIFY_FLAG;
 }
 
 /// Source of headphone.
@@ -397,26 +352,6 @@ impl TcKonnektNotifiedSegmentOperation<DesktopMixerState> for Desktopk6Protocol 
     const NOTIFY_FLAG: u32 = DESKTOP_MIXER_STATE_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for DesktopMixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopMixerState> {
-    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMixerState>>::OFFSET;
-    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopMixerState> {
-    const NOTIFY_FLAG: u32 =
-        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopMixerState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopPanel {
     /// The count of panel button to push.
@@ -468,26 +403,6 @@ impl TcKonnektMutableSegmentOperation<DesktopPanel> for Desktopk6Protocol {}
 impl TcKonnektNotifiedSegmentOperation<DesktopPanel> for Desktopk6Protocol {
     const NOTIFY_FLAG: u32 = DESKTOP_PANEL_NOTIFY_FLAG;
 }
-impl TcKonnektSegmentData for DesktopPanel {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopPanel> {
-    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopPanel>>::OFFSET;
-    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopPanel>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopPanel> {
-    const NOTIFY_FLAG: u32 =
-        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopPanel>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopMeter {
     pub analog_inputs: [i32; 2],
@@ -513,19 +428,4 @@ impl TcKonnektSegmentSerdes<DesktopMeter> for Desktopk6Protocol {
         params.stream_inputs.parse_quadlet_block(&raw[48..56]);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for DesktopMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopMeter> {
-    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMeter>>::OFFSET;
-    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMeter>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/desktop.rs
+++ b/protocols/dice/src/tcelectronic/desktop.rs
@@ -42,7 +42,7 @@ pub type Desktopk6MeterSegment = TcKonnektSegment<DesktopMeter>;
 impl SegmentOperation<DesktopMeter> for Desktopk6Protocol {}
 
 /// Target of meter.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MeterTarget {
     Input,
     Pre,
@@ -76,7 +76,7 @@ impl From<MeterTarget> for u32 {
 }
 
 /// Current scene.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum InputScene {
     MicInst,
     DualInst,
@@ -110,7 +110,7 @@ impl From<InputScene> for u32 {
 }
 
 /// State of panel.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopHwState {
     pub meter_target: MeterTarget,
     pub mixer_output_monaural: bool,
@@ -132,95 +132,140 @@ pub struct DesktopHwState {
 }
 
 impl DesktopHwState {
-    const SIZE: usize = 144;
-
     const REVERB_TO_MAIN_MASK: u32 = 0x00000001;
     const REVERB_TO_HP_MASK: u32 = 0x00000002;
 }
 
-impl TcKonnektSegmentData for DesktopHwState {
-    fn build(&self, raw: &mut [u8]) {
-        self.meter_target.build_quadlet(&mut raw[..4]);
-        self.mixer_output_monaural.build_quadlet(&mut raw[4..8]);
-        self.knob_assign_to_hp.build_quadlet(&mut raw[8..12]);
-        self.mixer_output_dim_enabled
+impl TcKonnektSegmentSerdes<DesktopHwState> for Desktopk6Protocol {
+    const NAME: &'static str = "hardware-state";
+    const OFFSET: usize = 0x0008;
+    const SIZE: usize = 144;
+
+    fn serialize(params: &DesktopHwState, raw: &mut [u8]) -> Result<(), String> {
+        params.meter_target.build_quadlet(&mut raw[..4]);
+        params.mixer_output_monaural.build_quadlet(&mut raw[4..8]);
+        params.knob_assign_to_hp.build_quadlet(&mut raw[8..12]);
+        params
+            .mixer_output_dim_enabled
             .build_quadlet(&mut raw[12..16]);
-        self.mixer_output_dim_volume.build_quadlet(&mut raw[16..20]);
-        self.input_scene.build_quadlet(&mut raw[20..24]);
+        params
+            .mixer_output_dim_volume
+            .build_quadlet(&mut raw[16..20]);
+        params.input_scene.build_quadlet(&mut raw[20..24]);
 
         let mut val = 0;
-        if self.reverb_to_master {
-            val |= Self::REVERB_TO_MAIN_MASK;
+        if params.reverb_to_master {
+            val |= DesktopHwState::REVERB_TO_MAIN_MASK;
         }
-        if self.reverb_to_hp {
-            val |= Self::REVERB_TO_HP_MASK;
+        if params.reverb_to_hp {
+            val |= DesktopHwState::REVERB_TO_HP_MASK;
         }
         val.build_quadlet(&mut raw[28..32]);
 
-        self.master_knob_backlight.build_quadlet(&mut raw[32..36]);
-        self.mic_0_phantom.build_quadlet(&mut raw[52..56]);
-        self.mic_0_boost.build_quadlet(&mut raw[56..60]);
+        params.master_knob_backlight.build_quadlet(&mut raw[32..36]);
+        params.mic_0_phantom.build_quadlet(&mut raw[52..56]);
+        params.mic_0_boost.build_quadlet(&mut raw[56..60]);
+
+        Ok(())
     }
 
-    fn parse(&mut self, raw: &[u8]) {
-        self.meter_target.parse_quadlet(&raw[..4]);
-        self.mixer_output_monaural.parse_quadlet(&raw[4..8]);
-        self.knob_assign_to_hp.parse_quadlet(&raw[8..12]);
-        self.mixer_output_dim_enabled.parse_quadlet(&raw[12..16]);
-        self.mixer_output_dim_volume.parse_quadlet(&raw[16..20]);
-        self.input_scene.parse_quadlet(&raw[20..24]);
+    fn deserialize(params: &mut DesktopHwState, raw: &[u8]) -> Result<(), String> {
+        params.meter_target.parse_quadlet(&raw[..4]);
+        params.mixer_output_monaural.parse_quadlet(&raw[4..8]);
+        params.knob_assign_to_hp.parse_quadlet(&raw[8..12]);
+        params.mixer_output_dim_enabled.parse_quadlet(&raw[12..16]);
+        params.mixer_output_dim_volume.parse_quadlet(&raw[16..20]);
+        params.input_scene.parse_quadlet(&raw[20..24]);
 
         let mut val = 0;
         val.parse_quadlet(&raw[28..32]);
-        self.reverb_to_master = val & Self::REVERB_TO_MAIN_MASK > 0;
-        self.reverb_to_hp = val & Self::REVERB_TO_HP_MASK > 0;
+        params.reverb_to_master = val & DesktopHwState::REVERB_TO_MAIN_MASK > 0;
+        params.reverb_to_hp = val & DesktopHwState::REVERB_TO_HP_MASK > 0;
 
-        self.master_knob_backlight.parse_quadlet(&raw[32..36]);
-        self.mic_0_phantom.parse_quadlet(&raw[52..56]);
-        self.mic_0_boost.parse_quadlet(&raw[56..60]);
+        params.master_knob_backlight.parse_quadlet(&raw[32..36]);
+        params.mic_0_phantom.parse_quadlet(&raw[52..56]);
+        params.mic_0_boost.parse_quadlet(&raw[56..60]);
+
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<DesktopHwState> for Desktopk6Protocol {}
+
+impl TcKonnektNotifiedSegmentOperation<DesktopHwState> for Desktopk6Protocol {
+    const NOTIFY_FLAG: u32 = DESKTOP_HW_STATE_NOTIFY_FLAG;
+}
+
+impl TcKonnektSegmentData for DesktopHwState {
+    fn build(&self, raw: &mut [u8]) {
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
+    }
+
+    fn parse(&mut self, raw: &[u8]) {
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopHwState> {
-    const OFFSET: usize = 0x0008;
-    const SIZE: usize = DesktopHwState::SIZE;
+    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopHwState>>::OFFSET;
+    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopHwState>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopHwState> {
-    const NOTIFY_FLAG: u32 = DESKTOP_HW_STATE_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopHwState>>::NOTIFY_FLAG;
 }
 
 /// Configuration.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopConfig {
     pub standalone_rate: TcKonnektStandaloneClkRate,
 }
 
-impl DesktopConfig {
+impl TcKonnektSegmentSerdes<DesktopConfig> for Desktopk6Protocol {
+    const NAME: &'static str = "configuration";
+    const OFFSET: usize = 0x0098;
     const SIZE: usize = 32;
+
+    fn serialize(params: &DesktopConfig, raw: &mut [u8]) -> Result<(), String> {
+        params.standalone_rate.build_quadlet(&mut raw[4..8]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut DesktopConfig, raw: &[u8]) -> Result<(), String> {
+        params.standalone_rate.parse_quadlet(&raw[4..8]);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<DesktopConfig> for Desktopk6Protocol {}
+
+impl TcKonnektNotifiedSegmentOperation<DesktopConfig> for Desktopk6Protocol {
+    const NOTIFY_FLAG: u32 = DESKTOP_CONFIG_NOTIFY_FLAG;
 }
 
 impl TcKonnektSegmentData for DesktopConfig {
     fn build(&self, raw: &mut [u8]) {
-        self.standalone_rate.build_quadlet(&mut raw[4..8]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.standalone_rate.parse_quadlet(&raw[4..8]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopConfig> {
-    const OFFSET: usize = 0x0098;
-    const SIZE: usize = DesktopConfig::SIZE;
+    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopConfig>>::OFFSET;
+    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopConfig>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopConfig> {
-    const NOTIFY_FLAG: u32 = DESKTOP_CONFIG_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopConfig>>::NOTIFY_FLAG;
 }
 
 /// Source of headphone.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DesktopHpSrc {
     Stream23,
     Mixer01,
@@ -251,7 +296,7 @@ impl From<DesktopHpSrc> for u32 {
 }
 
 /// State of mixer.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopMixerState {
     /// The input level for ch 0 and 1. -1000..0 (-94.0..0.0 dB)
     pub mic_inst_level: [i32; 2],
@@ -275,66 +320,85 @@ pub struct DesktopMixerState {
     pub hp_src: DesktopHpSrc,
 }
 
-impl DesktopMixerState {
+impl TcKonnektSegmentSerdes<DesktopMixerState> for Desktopk6Protocol {
+    const NAME: &'static str = "mixer-state";
+    const OFFSET: usize = 0x00b8;
     const SIZE: usize = 688;
+
+    fn serialize(params: &DesktopMixerState, raw: &mut [u8]) -> Result<(), String> {
+        params.mic_inst_level[0].build_quadlet(&mut raw[12..16]);
+        params.mic_inst_pan[0].build_quadlet(&mut raw[16..20]);
+        params.mic_inst_send[0].build_quadlet(&mut raw[20..24]);
+        params.mic_inst_level[1].build_quadlet(&mut raw[28..32]);
+        params.mic_inst_pan[1].build_quadlet(&mut raw[32..36]);
+        params.mic_inst_send[1].build_quadlet(&mut raw[40..44]);
+
+        params.dual_inst_level[0].build_quadlet(&mut raw[228..232]);
+        params.dual_inst_pan[0].build_quadlet(&mut raw[232..236]);
+        params.dual_inst_send[0].build_quadlet(&mut raw[240..244]);
+        params.dual_inst_level[1].build_quadlet(&mut raw[248..252]);
+        params.dual_inst_pan[1].build_quadlet(&mut raw[252..256]);
+        params.dual_inst_send[1].build_quadlet(&mut raw[260..264]);
+
+        params.stereo_in_level.build_quadlet(&mut raw[444..448]);
+        params.stereo_in_pan.build_quadlet(&mut raw[448..452]);
+        params.stereo_in_send.build_quadlet(&mut raw[452..456]);
+
+        params.hp_src.build_quadlet(&mut raw[648..652]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut DesktopMixerState, raw: &[u8]) -> Result<(), String> {
+        params.mic_inst_level[0].parse_quadlet(&raw[12..16]);
+        params.mic_inst_pan[0].parse_quadlet(&raw[16..20]);
+        params.mic_inst_send[0].parse_quadlet(&raw[20..24]);
+        params.mic_inst_level[1].parse_quadlet(&raw[28..32]);
+        params.mic_inst_pan[1].parse_quadlet(&raw[32..36]);
+        params.mic_inst_send[1].parse_quadlet(&raw[40..44]);
+
+        params.dual_inst_level[0].parse_quadlet(&raw[228..232]);
+        params.dual_inst_pan[0].parse_quadlet(&raw[232..236]);
+        params.dual_inst_send[0].parse_quadlet(&raw[240..244]);
+        params.dual_inst_level[1].parse_quadlet(&raw[248..252]);
+        params.dual_inst_pan[1].parse_quadlet(&raw[252..256]);
+        params.dual_inst_send[1].parse_quadlet(&raw[260..264]);
+
+        params.stereo_in_level.parse_quadlet(&raw[444..448]);
+        params.stereo_in_pan.parse_quadlet(&raw[448..452]);
+        params.stereo_in_send.parse_quadlet(&raw[452..456]);
+
+        params.hp_src.parse_quadlet(&raw[648..652]);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<DesktopMixerState> for Desktopk6Protocol {}
+
+impl TcKonnektNotifiedSegmentOperation<DesktopMixerState> for Desktopk6Protocol {
+    const NOTIFY_FLAG: u32 = DESKTOP_MIXER_STATE_NOTIFY_FLAG;
 }
 
 impl TcKonnektSegmentData for DesktopMixerState {
     fn build(&self, raw: &mut [u8]) {
-        self.mic_inst_level[0].build_quadlet(&mut raw[12..16]);
-        self.mic_inst_pan[0].build_quadlet(&mut raw[16..20]);
-        self.mic_inst_send[0].build_quadlet(&mut raw[20..24]);
-        self.mic_inst_level[1].build_quadlet(&mut raw[28..32]);
-        self.mic_inst_pan[1].build_quadlet(&mut raw[32..36]);
-        self.mic_inst_send[1].build_quadlet(&mut raw[40..44]);
-
-        self.dual_inst_level[0].build_quadlet(&mut raw[228..232]);
-        self.dual_inst_pan[0].build_quadlet(&mut raw[232..236]);
-        self.dual_inst_send[0].build_quadlet(&mut raw[240..244]);
-        self.dual_inst_level[1].build_quadlet(&mut raw[248..252]);
-        self.dual_inst_pan[1].build_quadlet(&mut raw[252..256]);
-        self.dual_inst_send[1].build_quadlet(&mut raw[260..264]);
-
-        self.stereo_in_level.build_quadlet(&mut raw[444..448]);
-        self.stereo_in_pan.build_quadlet(&mut raw[448..452]);
-        self.stereo_in_send.build_quadlet(&mut raw[452..456]);
-
-        self.hp_src.build_quadlet(&mut raw[648..652]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.mic_inst_level[0].parse_quadlet(&raw[12..16]);
-        self.mic_inst_pan[0].parse_quadlet(&raw[16..20]);
-        self.mic_inst_send[0].parse_quadlet(&raw[20..24]);
-        self.mic_inst_level[1].parse_quadlet(&raw[28..32]);
-        self.mic_inst_pan[1].parse_quadlet(&raw[32..36]);
-        self.mic_inst_send[1].parse_quadlet(&raw[40..44]);
-
-        self.dual_inst_level[0].parse_quadlet(&raw[228..232]);
-        self.dual_inst_pan[0].parse_quadlet(&raw[232..236]);
-        self.dual_inst_send[0].parse_quadlet(&raw[240..244]);
-        self.dual_inst_level[1].parse_quadlet(&raw[248..252]);
-        self.dual_inst_pan[1].parse_quadlet(&raw[252..256]);
-        self.dual_inst_send[1].parse_quadlet(&raw[260..264]);
-
-        self.stereo_in_level.parse_quadlet(&raw[444..448]);
-        self.stereo_in_pan.parse_quadlet(&raw[448..452]);
-        self.stereo_in_send.parse_quadlet(&raw[452..456]);
-
-        self.hp_src.parse_quadlet(&raw[648..652]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopMixerState> {
-    const OFFSET: usize = 0x00b8;
-    const SIZE: usize = DesktopMixerState::SIZE;
+    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMixerState>>::OFFSET;
+    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMixerState>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopMixerState> {
-    const NOTIFY_FLAG: u32 = DESKTOP_MIXER_STATE_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopMixerState>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopPanel {
     /// The count of panel button to push.
     pub panel_button_count: u32,
@@ -352,67 +416,97 @@ pub struct DesktopPanel {
     pub firewire_led: FireWireLedState,
 }
 
-impl DesktopPanel {
+impl TcKonnektSegmentSerdes<DesktopPanel> for Desktopk6Protocol {
+    const NAME: &'static str = "hardware-panel";
+    const OFFSET: usize = 0x2008;
     const SIZE: usize = 64;
+
+    fn serialize(params: &DesktopPanel, raw: &mut [u8]) -> Result<(), String> {
+        params.panel_button_count.build_quadlet(&mut raw[..4]);
+        params.main_knob_value.build_quadlet(&mut raw[4..8]);
+        params.phone_knob_value.build_quadlet(&mut raw[8..12]);
+        params.mix_knob_value.build_quadlet(&mut raw[12..16]);
+        params.reverb_led_on.build_quadlet(&mut raw[16..20]);
+        params.reverb_knob_value.build_quadlet(&mut raw[24..28]);
+        params.firewire_led.build_quadlet(&mut raw[36..40]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut DesktopPanel, raw: &[u8]) -> Result<(), String> {
+        params.panel_button_count.parse_quadlet(&raw[..4]);
+        params.main_knob_value.parse_quadlet(&raw[4..8]);
+        params.phone_knob_value.parse_quadlet(&raw[8..12]);
+        params.mix_knob_value.parse_quadlet(&raw[12..16]);
+        params.reverb_led_on.parse_quadlet(&raw[16..20]);
+        params.reverb_knob_value.parse_quadlet(&raw[24..28]);
+        params.firewire_led.parse_quadlet(&raw[36..40]);
+        Ok(())
+    }
 }
 
+impl TcKonnektMutableSegmentOperation<DesktopPanel> for Desktopk6Protocol {}
+
+impl TcKonnektNotifiedSegmentOperation<DesktopPanel> for Desktopk6Protocol {
+    const NOTIFY_FLAG: u32 = DESKTOP_PANEL_NOTIFY_FLAG;
+}
 impl TcKonnektSegmentData for DesktopPanel {
     fn build(&self, raw: &mut [u8]) {
-        self.panel_button_count.build_quadlet(&mut raw[..4]);
-        self.main_knob_value.build_quadlet(&mut raw[4..8]);
-        self.phone_knob_value.build_quadlet(&mut raw[8..12]);
-        self.mix_knob_value.build_quadlet(&mut raw[12..16]);
-        self.reverb_led_on.build_quadlet(&mut raw[16..20]);
-        self.reverb_knob_value.build_quadlet(&mut raw[24..28]);
-        self.firewire_led.build_quadlet(&mut raw[36..40]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.panel_button_count.parse_quadlet(&raw[..4]);
-        self.main_knob_value.parse_quadlet(&raw[4..8]);
-        self.phone_knob_value.parse_quadlet(&raw[8..12]);
-        self.mix_knob_value.parse_quadlet(&raw[12..16]);
-        self.reverb_led_on.parse_quadlet(&raw[16..20]);
-        self.reverb_knob_value.parse_quadlet(&raw[24..28]);
-        self.firewire_led.parse_quadlet(&raw[36..40]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopPanel> {
-    const OFFSET: usize = 0x2008;
-    const SIZE: usize = DesktopPanel::SIZE;
+    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopPanel>>::OFFSET;
+    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopPanel>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<DesktopPanel> {
-    const NOTIFY_FLAG: u32 = DESKTOP_PANEL_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <Desktopk6Protocol as TcKonnektNotifiedSegmentOperation<DesktopPanel>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopMeter {
     pub analog_inputs: [i32; 2],
     pub mixer_outputs: [i32; 2],
     pub stream_inputs: [i32; 2],
 }
 
-impl DesktopMeter {
+impl TcKonnektSegmentSerdes<DesktopMeter> for Desktopk6Protocol {
+    const NAME: &'static str = "hardware-meter";
+    const OFFSET: usize = 0x20e4;
     const SIZE: usize = 92;
+
+    fn serialize(params: &DesktopMeter, raw: &mut [u8]) -> Result<(), String> {
+        params.analog_inputs.build_quadlet_block(&mut raw[..8]);
+        params.mixer_outputs.build_quadlet_block(&mut raw[40..48]);
+        params.stream_inputs.build_quadlet_block(&mut raw[48..56]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut DesktopMeter, raw: &[u8]) -> Result<(), String> {
+        params.analog_inputs.parse_quadlet_block(&raw[..8]);
+        params.mixer_outputs.parse_quadlet_block(&raw[40..48]);
+        params.stream_inputs.parse_quadlet_block(&raw[48..56]);
+        Ok(())
+    }
 }
 
 impl TcKonnektSegmentData for DesktopMeter {
     fn build(&self, raw: &mut [u8]) {
-        self.analog_inputs.build_quadlet_block(&mut raw[..8]);
-        self.mixer_outputs.build_quadlet_block(&mut raw[40..48]);
-        self.stream_inputs.build_quadlet_block(&mut raw[48..56]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.analog_inputs.parse_quadlet_block(&raw[..8]);
-        self.mixer_outputs.parse_quadlet_block(&raw[40..48]);
-        self.stream_inputs.parse_quadlet_block(&raw[48..56]);
+        let _ = <Desktopk6Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<DesktopMeter> {
-    const OFFSET: usize = 0x20e4;
-    const SIZE: usize = DesktopMeter::SIZE;
+    const OFFSET: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMeter>>::OFFSET;
+    const SIZE: usize = <Desktopk6Protocol as TcKonnektSegmentSerdes<DesktopMeter>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/fw_led.rs
+++ b/protocols/dice/src/tcelectronic/fw_led.rs
@@ -4,7 +4,7 @@
 //! Common structure for hardware state for TC Electronic Konnekt series.
 
 /// The state of FireWire LED.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FireWireLedState {
     Off,
     On,

--- a/protocols/dice/src/tcelectronic/midi_send.rs
+++ b/protocols/dice/src/tcelectronic/midi_send.rs
@@ -9,7 +9,7 @@
 use super::*;
 
 /// Channel and control code of MIDI event.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TcKonnektMidiMsgParams {
     /// The channel for MIDI message.
     pub ch: u8,
@@ -18,7 +18,7 @@ pub struct TcKonnektMidiMsgParams {
 }
 
 /// MIDI sender.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct TcKonnektMidiSender {
     /// The parameter of MIDI message generated normally.
     pub normal: TcKonnektMidiMsgParams,

--- a/protocols/dice/src/tcelectronic/prog.rs
+++ b/protocols/dice/src/tcelectronic/prog.rs
@@ -7,7 +7,7 @@
 
 use super::*;
 
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct TcKonnektLoadedProgram(pub u32);
 
 impl TcKonnektLoadedProgram {

--- a/protocols/dice/src/tcelectronic/reverb.rs
+++ b/protocols/dice/src/tcelectronic/reverb.rs
@@ -9,7 +9,7 @@
 use super::*;
 
 /// Algorithm of reverb effect.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ReverbAlgorithm {
     Live1,
     Hall,
@@ -96,7 +96,7 @@ impl From<ReverbAlgorithm> for u32 {
 }
 
 /// State of reverb effect.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ReverbState {
     /// The level of input. -24..0 (-24.0..0.0 dB).
     pub input_level: i32,
@@ -185,7 +185,7 @@ impl ReverbState {
 }
 
 /// Meter of reverb effect.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ReverbMeter {
     /// The meter of left and right outputs. -1000..500 (-24.0..12.0 dB)
     pub outputs: [i32; 2],

--- a/protocols/dice/src/tcelectronic/shell.rs
+++ b/protocols/dice/src/tcelectronic/shell.rs
@@ -676,7 +676,7 @@ impl From<u32> for ShellStandaloneClkSrc {
     }
 }
 
-pub trait ShellStandaloneClkSpec: TcKonnektSegmentData {
+pub trait ShellStandaloneClkSpec {
     const STANDALONE_CLOCK_SOURCES: &'static [ShellStandaloneClkSrc];
 }
 

--- a/protocols/dice/src/tcelectronic/shell.rs
+++ b/protocols/dice/src/tcelectronic/shell.rs
@@ -25,7 +25,7 @@ const SHELL_HW_STATE_NOTIFY_FLAG: u32 = 0x01000000;
 const SHELL_CH_STRIP_COUNT: usize = 2;
 
 /// State of jack sense for analog input.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellAnalogJackState {
     FrontSelected,
     FrontInserted,
@@ -103,7 +103,7 @@ impl ShellHwState {
 }
 
 /// Parameter of monitor source.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct MonitorSrcParam {
     ///  ch 1 gain to mixer ch 1/2 (0xfffffc18..0x00000000, -90.0..0.00 dB)
     pub gain_to_mixer: i32,
@@ -142,7 +142,7 @@ impl MonitorSrcParam {
 }
 
 /// Monitor source.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct ShellMonitorSrcPair {
     ///  ch 1/2 stereo link (0 or 1)
     pub stereo_link: bool,
@@ -198,7 +198,7 @@ impl ShellMixerState {
 }
 
 /// The type of monitor source.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellMixerMonitorSrcType {
     Stream,
     Analog,
@@ -345,7 +345,7 @@ pub trait ShellMixerStateConvert {
 }
 
 /// Return configuration of reverb effect.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct ShellReverbReturn {
     /// Whether to use reverb effect as plugin. When enabled, return of reverb effect is delivered
     /// by rx stream.
@@ -505,7 +505,7 @@ pub trait ShellMixerMeterConvert {
 }
 
 /// Available source for sampling clock.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellPhysOutSrc {
     Stream,
     Analog01,
@@ -542,7 +542,7 @@ impl From<ShellPhysOutSrc> for u32 {
 }
 
 /// Format of optical input interface.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellOptInputIfaceFormat {
     Adat0to7,
     Adat0to5Spdif01,
@@ -576,7 +576,7 @@ impl From<ShellOptInputIfaceFormat> for u32 {
 }
 
 /// Format of optical output interface.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellOptOutputIfaceFormat {
     Adat,
     Spdif,
@@ -607,11 +607,11 @@ impl From<ShellOptOutputIfaceFormat> for u32 {
 }
 
 /// Source for optical output interface.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ShellOptOutputSrc(pub ShellPhysOutSrc);
 
 /// Configuration for optical interface.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ShellOptIfaceConfig {
     pub input_format: ShellOptInputIfaceFormat,
     pub output_format: ShellOptOutputIfaceFormat,
@@ -639,11 +639,11 @@ impl ShellOptIfaceConfig {
 }
 
 /// Source of coaxial output interface.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ShellCoaxOutPairSrc(pub ShellPhysOutSrc);
 
 /// Available source for sampling clock.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellStandaloneClkSrc {
     Optical,
     Coaxial,
@@ -681,7 +681,7 @@ pub trait ShellStandaloneClkSpec: TcKonnektSegmentData {
 }
 
 /// Source pair of stream to mixer.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ShellMixerStreamSrcPair {
     Stream01,
     Stream23,
@@ -732,7 +732,7 @@ pub trait ShellMixerStreamSrcPairSpec {
 }
 
 /// Target of knob.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct ShellKnobTarget(pub u32);
 
 /// Maximum value of knob.
@@ -742,7 +742,7 @@ pub trait ShellKnobTargetSpec {
 }
 
 /// Target of knob 2.
-#[derive(Debug, Default, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq)]
 pub struct ShellKnob2Target(pub u32);
 
 /// Maximum value of knob 2.

--- a/protocols/dice/src/tcelectronic/shell.rs
+++ b/protocols/dice/src/tcelectronic/shell.rs
@@ -78,7 +78,7 @@ impl From<ShellAnalogJackState> for u32 {
 pub const SHELL_ANALOG_JACK_STATE_COUNT: usize = 2;
 
 /// Hardware state.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ShellHwState {
     pub analog_jack_states: [ShellAnalogJackState; SHELL_ANALOG_JACK_STATE_COUNT],
     pub firewire_led: FireWireLedState,
@@ -169,7 +169,7 @@ impl ShellMonitorSrcPair {
 }
 
 /// Mute state for monitor sources.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShellMonitorSrcMute {
     pub stream: bool,
     pub analog: Vec<bool>,
@@ -177,7 +177,7 @@ pub struct ShellMonitorSrcMute {
 }
 
 /// State of mixer.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShellMixerState {
     pub stream: ShellMonitorSrcPair,
     pub analog: Vec<ShellMonitorSrcPair>,
@@ -377,7 +377,7 @@ impl ShellReverbReturn {
 }
 
 /// Meter information. -1000..0 (-94.0..0 dB).
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct ShellMixerMeter {
     pub stream_inputs: [i32; Self::STREAM_INPUT_COUNT],
     pub analog_inputs: Vec<i32>,

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -54,6 +54,29 @@ impl SegmentOperation<ItwinReverbMeter> for ItwinProtocol {}
 pub type ItwinChStripMetersSegment = TcKonnektSegment<ItwinChStripMeters>;
 impl SegmentOperation<ItwinChStripMeters> for ItwinProtocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(ItwinProtocol, ItwinKnob);
+segment_default!(ItwinProtocol, ItwinConfig);
+segment_default!(ItwinProtocol, ItwinMixerState);
+segment_default!(ItwinProtocol, ItwinReverbState);
+segment_default!(ItwinProtocol, ItwinChStripStates);
+segment_default!(ItwinProtocol, ItwinMixerMeter);
+segment_default!(ItwinProtocol, ItwinHwState);
+segment_default!(ItwinProtocol, ItwinReverbMeter);
+segment_default!(ItwinProtocol, ItwinChStripMeters);
+
 /// State of knob.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinKnob {

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -18,41 +18,32 @@ impl TcatGlobalSectionSpecification for ItwinProtocol {}
 
 /// Segment for knob. 0x0000..0x0027 (36 quads).
 pub type ItwinKnobSegment = TcKonnektSegment<ItwinKnob>;
-impl SegmentOperation<ItwinKnob> for ItwinProtocol {}
 
 /// Segment for configuration. 0x0028..0x00cf (168 quads).
 pub type ItwinConfigSegment = TcKonnektSegment<ItwinConfig>;
-impl SegmentOperation<ItwinConfig> for ItwinProtocol {}
 
 /// Segment for state of mixer. 0x00d0..0x0243 (93 quads).
 pub type ItwinMixerStateSegment = TcKonnektSegment<ItwinMixerState>;
-impl SegmentOperation<ItwinMixerState> for ItwinProtocol {}
 
 /// Segment for state of reverb effect. 0x0244..0x0287. (17 quads)
 pub type ItwinReverbStateSegment = TcKonnektSegment<ItwinReverbState>;
-impl SegmentOperation<ItwinReverbState> for ItwinProtocol {}
 
 /// Segment for states of channel strip effect. 0x028c..0x03ab (72 quads).
 pub type ItwinChStripStatesSegment = TcKonnektSegment<ItwinChStripStates>;
-impl SegmentOperation<ItwinChStripStates> for ItwinProtocol {}
 
 // NOTE: Segment for tuner. 0x03ac..0x03c8 (8 quads).
 
 /// Segment for mixer meter. 0x106c..0x10c7 (23 quads).
 pub type ItwinMixerMeterSegment = TcKonnektSegment<ItwinMixerMeter>;
-impl SegmentOperation<ItwinMixerMeter> for ItwinProtocol {}
 
 /// Segment for state of hardware. 0x1008..0x1023 (7 quads).
 pub type ItwinHwStateSegment = TcKonnektSegment<ItwinHwState>;
-impl SegmentOperation<ItwinHwState> for ItwinProtocol {}
 
 /// Segment for meter of reverb effect. 0x10c8..0x010df (6 quads).
 pub type ItwinReverbMeterSegment = TcKonnektSegment<ItwinReverbMeter>;
-impl SegmentOperation<ItwinReverbMeter> for ItwinProtocol {}
 
 /// Segment for meters of channel strip effect. 0x10e0..0x111b (15 quads).
 pub type ItwinChStripMetersSegment = TcKonnektSegment<ItwinChStripMeters>;
-impl SegmentOperation<ItwinChStripMeters> for ItwinProtocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -106,31 +97,6 @@ impl TcKonnektMutableSegmentOperation<ItwinKnob> for ItwinProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<ItwinKnob> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for ItwinKnob {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl ShellKnobTargetSpec for ItwinKnob {
-    const HAS_SPDIF: bool = false;
-    const HAS_EFFECTS: bool = true;
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinKnob> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinKnob>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinKnob>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinKnob> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinKnob>>::NOTIFY_FLAG;
 }
 
 /// The number of pair for physical output.
@@ -259,26 +225,6 @@ impl TcKonnektNotifiedSegmentOperation<ItwinConfig> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for ItwinConfig {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinConfig> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinConfig>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinConfig>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinConfig> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinConfig>>::NOTIFY_FLAG;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItwinMixerState {
     pub mixer: ShellMixerState,
@@ -348,26 +294,6 @@ impl TcKonnektNotifiedSegmentOperation<ItwinMixerState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for ItwinMixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinMixerState> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinMixerState>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinMixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinMixerState> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinMixerState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinReverbState(pub ReverbState);
 
@@ -393,26 +319,6 @@ impl TcKonnektNotifiedSegmentOperation<ItwinReverbState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for ItwinReverbState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinReverbState> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinReverbState>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinReverbState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinReverbState> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinReverbState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinChStripStates(pub [ChStripState; SHELL_CH_STRIP_COUNT]);
 
@@ -436,26 +342,6 @@ impl TcKonnektMutableSegmentOperation<ItwinChStripStates> for ItwinProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<ItwinChStripStates> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for ItwinChStripStates {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinChStripStates> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinChStripStates>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinChStripStates>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinChStripStates> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinChStripStates>>::NOTIFY_FLAG;
 }
 
 /// The mode to listen for analog outputs.
@@ -528,26 +414,6 @@ impl TcKonnektNotifiedSegmentOperation<ItwinHwState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for ItwinHwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinHwState> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinHwState>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinHwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<ItwinHwState> {
-    const NOTIFY_FLAG: u32 =
-        <ItwinProtocol as TcKonnektNotifiedSegmentOperation<ItwinHwState>>::NOTIFY_FLAG;
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItwinMixerMeter(pub ShellMixerMeter);
 
@@ -586,21 +452,6 @@ impl TcKonnektSegmentSerdes<ItwinMixerMeter> for ItwinProtocol {
     }
 }
 
-impl TcKonnektSegmentData for ItwinMixerMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinMixerMeter> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinMixerMeter>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinMixerMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinReverbMeter(pub ReverbMeter);
 
@@ -620,21 +471,6 @@ impl TcKonnektSegmentSerdes<ItwinReverbMeter> for ItwinProtocol {
     }
 }
 
-impl TcKonnektSegmentData for ItwinReverbMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinReverbMeter> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinReverbMeter>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinReverbMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);
 
@@ -652,19 +488,4 @@ impl TcKonnektSegmentSerdes<ItwinChStripMeters> for ItwinProtocol {
         params.0.parse(raw);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for ItwinChStripMeters {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <ItwinProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<ItwinChStripMeters> {
-    const OFFSET: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinChStripMeters>>::OFFSET;
-    const SIZE: usize = <ItwinProtocol as TcKonnektSegmentSerdes<ItwinChStripMeters>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -18,41 +18,32 @@ impl TcatGlobalSectionSpecification for K24dProtocol {}
 
 /// Segment for knob. 0x0000..0x0027 (36 quads).
 pub type K24dKnobSegment = TcKonnektSegment<K24dKnob>;
-impl SegmentOperation<K24dKnob> for K24dProtocol {}
 
 /// Segment for configuration. 0x0028..0x0073 (76 quads).
 pub type K24dConfigSegment = TcKonnektSegment<K24dConfig>;
-impl SegmentOperation<K24dConfig> for K24dProtocol {}
 
 /// Segment for state of mixer. 0x0074..0x01cf (87 quads).
 pub type K24dMixerStateSegment = TcKonnektSegment<K24dMixerState>;
-impl SegmentOperation<K24dMixerState> for K24dProtocol {}
 
 /// Segment for state of reverb effect. 0x01d0..0x0213. (17 quads)
 pub type K24dReverbStateSegment = TcKonnektSegment<K24dReverbState>;
-impl SegmentOperation<K24dReverbState> for K24dProtocol {}
 
 /// Segment for states of channel strip effect. 0x0218..0x0337 (72 quads).
 pub type K24dChStripStatesSegment = TcKonnektSegment<K24dChStripStates>;
-impl SegmentOperation<K24dChStripStates> for K24dProtocol {}
 
 // NOTE: Segment for tuner. 0x0338..0x033b (8 quads).
 
 /// Segment for mixer meter. 0x105c..0x10b7 (23 quads).
 pub type K24dMixerMeterSegment = TcKonnektSegment<K24dMixerMeter>;
-impl SegmentOperation<K24dMixerMeter> for K24dProtocol {}
 
 /// Segment for state of hardware. 0x100c..0x1027 (7 quads).
 pub type K24dHwStateSegment = TcKonnektSegment<K24dHwState>;
-impl SegmentOperation<K24dHwState> for K24dProtocol {}
 
 /// Segment for meter of reverb effect. 0x10b8..0x010cf (6 quads).
 pub type K24dReverbMeterSegment = TcKonnektSegment<K24dReverbMeter>;
-impl SegmentOperation<K24dReverbMeter> for K24dProtocol {}
 
 /// Segment for meters of channel strip effect. 0x10d0..0x110b (15 quads).
 pub type K24dChStripMetersSegment = TcKonnektSegment<K24dChStripMeters>;
-impl SegmentOperation<K24dChStripMeters> for K24dProtocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -120,26 +111,6 @@ impl TcKonnektNotifiedSegmentOperation<K24dKnob> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for K24dKnob {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dKnob> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dKnob>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dKnob>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dKnob> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dKnob>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dConfig {
     pub opt: ShellOptIfaceConfig,
@@ -185,26 +156,6 @@ impl TcKonnektMutableSegmentOperation<K24dConfig> for K24dProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for K24dConfig {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dConfig> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dConfig>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dConfig>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dConfig> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dConfig>>::NOTIFY_FLAG;
 }
 
 /// State of mixer.
@@ -294,26 +245,6 @@ impl TcKonnektNotifiedSegmentOperation<K24dMixerState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for K24dMixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dMixerState> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerState>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dMixerState> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dMixerState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbState(pub ReverbState);
 
@@ -337,26 +268,6 @@ impl TcKonnektMutableSegmentOperation<K24dReverbState> for K24dProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<K24dReverbState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for K24dReverbState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dReverbState> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbState>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dReverbState> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dReverbState>>::NOTIFY_FLAG;
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -384,26 +295,6 @@ impl TcKonnektNotifiedSegmentOperation<K24dChStripStates> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for K24dChStripStates {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dChStripStates> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripStates>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripStates>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dChStripStates> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dChStripStates>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dHwState(pub ShellHwState);
 
@@ -427,26 +318,6 @@ impl TcKonnektMutableSegmentOperation<K24dHwState> for K24dProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<K24dHwState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for K24dHwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dHwState> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dHwState>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dHwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dHwState> {
-    const NOTIFY_FLAG: u32 =
-        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dHwState>>::NOTIFY_FLAG;
 }
 
 const K24D_METER_ANALOG_INPUT_COUNT: usize = 2;
@@ -490,21 +361,6 @@ impl TcKonnektSegmentSerdes<K24dMixerMeter> for K24dProtocol {
     }
 }
 
-impl TcKonnektSegmentData for K24dMixerMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dMixerMeter> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerMeter>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbMeter(pub ReverbMeter);
 
@@ -524,21 +380,6 @@ impl TcKonnektSegmentSerdes<K24dReverbMeter> for K24dProtocol {
     }
 }
 
-impl TcKonnektSegmentData for K24dReverbMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dReverbMeter> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbMeter>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);
 
@@ -556,19 +397,4 @@ impl TcKonnektSegmentSerdes<K24dChStripMeters> for K24dProtocol {
         params.0.parse(raw);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for K24dChStripMeters {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K24dChStripMeters> {
-    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripMeters>>::OFFSET;
-    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripMeters>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -55,7 +55,7 @@ pub type K24dChStripMetersSegment = TcKonnektSegment<K24dChStripMeters>;
 impl SegmentOperation<K24dChStripMeters> for K24dProtocol {}
 
 /// State of knob.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dKnob {
     pub target: ShellKnobTarget,
     pub knob2_target: ShellKnob2Target,
@@ -71,30 +71,53 @@ impl ShellKnob2TargetSpec for K24dKnob {
     const KNOB2_TARGET_COUNT: usize = 8;
 }
 
+impl TcKonnektSegmentSerdes<K24dKnob> for K24dProtocol {
+    const NAME: &'static str = "knob";
+    const OFFSET: usize = 0x0004;
+    const SIZE: usize = SHELL_KNOB_SIZE;
+
+    fn serialize(params: &K24dKnob, raw: &mut [u8]) -> Result<(), String> {
+        params.target.0.build_quadlet(&mut raw[..4]);
+        params.knob2_target.0.build_quadlet(&mut raw[4..8]);
+        params.prog.build(&mut raw[8..12]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dKnob, raw: &[u8]) -> Result<(), String> {
+        params.target.0.parse_quadlet(&raw[..4]);
+        params.knob2_target.0.parse_quadlet(&raw[4..8]);
+        params.prog.parse(&raw[8..12]);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dKnob> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dKnob> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
+}
+
 impl TcKonnektSegmentData for K24dKnob {
     fn build(&self, raw: &mut [u8]) {
-        self.target.0.build_quadlet(&mut raw[..4]);
-        self.knob2_target.0.build_quadlet(&mut raw[4..8]);
-        self.prog.build(&mut raw[8..12]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.target.0.parse_quadlet(&raw[..4]);
-        self.knob2_target.0.parse_quadlet(&raw[4..8]);
-        self.prog.parse(&raw[8..12]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dKnob> {
-    const OFFSET: usize = 0x0004;
-    const SIZE: usize = SHELL_KNOB_SIZE;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dKnob>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dKnob>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dKnob> {
-    const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dKnob>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dConfig {
     pub opt: ShellOptIfaceConfig,
     pub coax_out_src: ShellCoaxOutPairSrc,
@@ -111,35 +134,58 @@ impl ShellStandaloneClkSpec for K24dConfig {
     ];
 }
 
+impl TcKonnektSegmentSerdes<K24dConfig> for K24dProtocol {
+    const NAME: &'static str = "configuration";
+    const OFFSET: usize = 0x0028;
+    const SIZE: usize = 76;
+
+    fn serialize(params: &K24dConfig, raw: &mut [u8]) -> Result<(), String> {
+        params.opt.build(&mut raw[..12]);
+        params.coax_out_src.0.build_quadlet(&mut raw[12..16]);
+        params.out_23_src.build_quadlet(&mut raw[16..20]);
+        params.standalone_src.build_quadlet(&mut raw[20..24]);
+        params.standalone_rate.build_quadlet(&mut raw[24..28]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dConfig, raw: &[u8]) -> Result<(), String> {
+        params.opt.parse(&raw[..12]);
+        params.coax_out_src.0.parse_quadlet(&raw[12..16]);
+        params.out_23_src.parse_quadlet(&raw[16..20]);
+        params.standalone_src.parse_quadlet(&raw[20..24]);
+        params.standalone_rate.parse_quadlet(&raw[24..28]);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dConfig> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
+}
+
 impl TcKonnektSegmentData for K24dConfig {
     fn build(&self, raw: &mut [u8]) {
-        self.opt.build(&mut raw[..12]);
-        self.coax_out_src.0.build_quadlet(&mut raw[12..16]);
-        self.out_23_src.build_quadlet(&mut raw[16..20]);
-        self.standalone_src.build_quadlet(&mut raw[20..24]);
-        self.standalone_rate.build_quadlet(&mut raw[24..28]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.opt.parse(&raw[..12]);
-        self.coax_out_src.0.parse_quadlet(&raw[12..16]);
-        self.out_23_src.parse_quadlet(&raw[16..20]);
-        self.standalone_src.parse_quadlet(&raw[20..24]);
-        self.standalone_rate.parse_quadlet(&raw[24..28]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dConfig> {
-    const OFFSET: usize = 0x0028;
-    const SIZE: usize = 76;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dConfig>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dConfig>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dConfig> {
-    const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dConfig>>::NOTIFY_FLAG;
 }
 
 /// State of mixer.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct K24dMixerState {
     /// The common structure for state of mixer.
     pub mixer: ShellMixerState,
@@ -189,107 +235,201 @@ impl ShellMixerStateConvert for K24dMixerState {
     }
 }
 
+impl TcKonnektSegmentSerdes<K24dMixerState> for K24dProtocol {
+    const NAME: &'static str = "mixer-state";
+    const OFFSET: usize = 0x0074;
+    const SIZE: usize = ShellMixerState::SIZE + 32;
+
+    fn serialize(params: &K24dMixerState, raw: &mut [u8]) -> Result<(), String> {
+        ShellMixerStateConvert::build(params, raw);
+
+        params.reverb_return.build(&mut raw[316..328]);
+        params
+            .use_ch_strip_as_plugin
+            .build_quadlet(&mut raw[328..332]);
+        params
+            .use_reverb_at_mid_rate
+            .build_quadlet(&mut raw[332..336]);
+        params.enabled.build_quadlet(&mut raw[340..344]);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dMixerState, raw: &[u8]) -> Result<(), String> {
+        ShellMixerStateConvert::parse(params, raw);
+
+        params.reverb_return.parse(&raw[316..328]);
+        params.use_ch_strip_as_plugin.parse_quadlet(&raw[328..332]);
+        params.use_reverb_at_mid_rate.parse_quadlet(&raw[332..336]);
+        params.enabled.parse_quadlet(&raw[340..344]);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dMixerState> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dMixerState> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
+}
+
 impl TcKonnektSegmentData for K24dMixerState {
     fn build(&self, raw: &mut [u8]) {
-        ShellMixerStateConvert::build(self, raw);
-
-        self.reverb_return.build(&mut raw[316..328]);
-        self.use_ch_strip_as_plugin
-            .build_quadlet(&mut raw[328..332]);
-        self.use_reverb_at_mid_rate
-            .build_quadlet(&mut raw[332..336]);
-        self.enabled.build_quadlet(&mut raw[340..344]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        ShellMixerStateConvert::parse(self, raw);
-
-        self.reverb_return.parse(&raw[316..328]);
-        self.use_ch_strip_as_plugin.parse_quadlet(&raw[328..332]);
-        self.use_reverb_at_mid_rate.parse_quadlet(&raw[332..336]);
-        self.enabled.parse_quadlet(&raw[340..344]);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dMixerState> {
-    const OFFSET: usize = 0x0074;
-    const SIZE: usize = ShellMixerState::SIZE + 32;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerState>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerState>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dMixerState> {
-    const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dMixerState>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbState(pub ReverbState);
+
+impl TcKonnektSegmentSerdes<K24dReverbState> for K24dProtocol {
+    const NAME: &'static str = "reverb-state";
+    const OFFSET: usize = 0x01d0;
+    const SIZE: usize = ReverbState::SIZE;
+
+    fn serialize(params: &K24dReverbState, raw: &mut [u8]) -> Result<(), String> {
+        params.0.build(raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dReverbState, raw: &[u8]) -> Result<(), String> {
+        params.0.parse(raw);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dReverbState> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dReverbState> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
+}
 
 impl TcKonnektSegmentData for K24dReverbState {
     fn build(&self, raw: &mut [u8]) {
-        self.0.build(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.0.parse(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dReverbState> {
-    const OFFSET: usize = 0x01d0;
-    const SIZE: usize = ReverbState::SIZE;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbState>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbState>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dReverbState> {
-    const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dReverbState>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dChStripStates(pub [ChStripState; SHELL_CH_STRIP_COUNT]);
+
+impl TcKonnektSegmentSerdes<K24dChStripStates> for K24dProtocol {
+    const NAME: &'static str = "channel-strip-state";
+    const OFFSET: usize = 0x0218;
+    const SIZE: usize = ChStripState::SIZE * SHELL_CH_STRIP_COUNT + 4;
+
+    fn serialize(params: &K24dChStripStates, raw: &mut [u8]) -> Result<(), String> {
+        params.0.build(raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dChStripStates, raw: &[u8]) -> Result<(), String> {
+        params.0.parse(raw);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dChStripStates> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dChStripStates> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
+}
 
 impl TcKonnektSegmentData for K24dChStripStates {
     fn build(&self, raw: &mut [u8]) {
-        self.0.build(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.0.parse(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dChStripStates> {
-    const OFFSET: usize = 0x0218;
-    const SIZE: usize = ChStripState::SIZE * SHELL_CH_STRIP_COUNT + 4;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripStates>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripStates>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dChStripStates> {
-    const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dChStripStates>>::NOTIFY_FLAG;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dHwState(pub ShellHwState);
+
+impl TcKonnektSegmentSerdes<K24dHwState> for K24dProtocol {
+    const NAME: &'static str = "hardware-state";
+    const OFFSET: usize = 0x100c;
+    const SIZE: usize = ShellHwState::SIZE;
+
+    fn serialize(params: &K24dHwState, raw: &mut [u8]) -> Result<(), String> {
+        params.0.build(raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dHwState, raw: &[u8]) -> Result<(), String> {
+        params.0.parse(raw);
+        Ok(())
+    }
+}
+
+impl TcKonnektMutableSegmentOperation<K24dHwState> for K24dProtocol {}
+
+impl TcKonnektNotifiedSegmentOperation<K24dHwState> for K24dProtocol {
+    const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
+}
 
 impl TcKonnektSegmentData for K24dHwState {
     fn build(&self, raw: &mut [u8]) {
-        self.0.build(raw);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.0.parse(raw);
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dHwState> {
-    const OFFSET: usize = 0x100c;
-    const SIZE: usize = ShellHwState::SIZE;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dHwState>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dHwState>>::SIZE;
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K24dHwState> {
-    const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 =
+        <K24dProtocol as TcKonnektNotifiedSegmentOperation<K24dHwState>>::NOTIFY_FLAG;
 }
 
 const K24D_METER_ANALOG_INPUT_COUNT: usize = 2;
 const K24D_METER_DIGITAL_INPUT_COUNT: usize = 2;
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct K24dMixerMeter(pub ShellMixerMeter);
 
 impl Default for K24dMixerMeter {
@@ -311,53 +451,101 @@ impl ShellMixerMeterConvert for K24dMixerMeter {
     }
 }
 
+impl TcKonnektSegmentSerdes<K24dMixerMeter> for K24dProtocol {
+    const NAME: &'static str = "mixer-meter";
+    const OFFSET: usize = 0x105c;
+    const SIZE: usize = ShellMixerMeter::SIZE;
+
+    fn serialize(params: &K24dMixerMeter, raw: &mut [u8]) -> Result<(), String> {
+        ShellMixerMeterConvert::build(params, raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dMixerMeter, raw: &[u8]) -> Result<(), String> {
+        ShellMixerMeterConvert::parse(params, raw);
+        Ok(())
+    }
+}
+
 impl TcKonnektSegmentData for K24dMixerMeter {
     fn build(&self, raw: &mut [u8]) {
-        ShellMixerMeterConvert::build(self, raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        ShellMixerMeterConvert::parse(self, raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dMixerMeter> {
-    const OFFSET: usize = 0x105c;
-    const SIZE: usize = ShellMixerMeter::SIZE;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerMeter>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dMixerMeter>>::SIZE;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbMeter(pub ReverbMeter);
+
+impl TcKonnektSegmentSerdes<K24dReverbMeter> for K24dProtocol {
+    const NAME: &'static str = "reverb-meter";
+    const OFFSET: usize = 0x10b8;
+    const SIZE: usize = ReverbMeter::SIZE;
+
+    fn serialize(params: &K24dReverbMeter, raw: &mut [u8]) -> Result<(), String> {
+        params.0.build(raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dReverbMeter, raw: &[u8]) -> Result<(), String> {
+        params.0.parse(raw);
+        Ok(())
+    }
+}
 
 impl TcKonnektSegmentData for K24dReverbMeter {
     fn build(&self, raw: &mut [u8]) {
-        self.0.build(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.0.parse(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dReverbMeter> {
-    const OFFSET: usize = 0x10b8;
-    const SIZE: usize = ReverbMeter::SIZE;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbMeter>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dReverbMeter>>::SIZE;
 }
 
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);
+
+impl TcKonnektSegmentSerdes<K24dChStripMeters> for K24dProtocol {
+    const NAME: &'static str = "channel-strip-meter";
+    const OFFSET: usize = 0x10d0;
+    const SIZE: usize = ChStripMeter::SIZE * SHELL_CH_STRIP_COUNT + 4;
+
+    fn serialize(params: &K24dChStripMeters, raw: &mut [u8]) -> Result<(), String> {
+        params.0.build(raw);
+        Ok(())
+    }
+
+    fn deserialize(params: &mut K24dChStripMeters, raw: &[u8]) -> Result<(), String> {
+        params.0.parse(raw);
+        Ok(())
+    }
+}
 
 impl TcKonnektSegmentData for K24dChStripMeters {
     fn build(&self, raw: &mut [u8]) {
-        self.0.build(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
     }
 
     fn parse(&mut self, raw: &[u8]) {
-        self.0.parse(raw)
+        let _ = <K24dProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
     }
 }
 
 impl TcKonnektSegmentSpec for TcKonnektSegment<K24dChStripMeters> {
-    const OFFSET: usize = 0x10d0;
-    const SIZE: usize = ChStripMeter::SIZE * SHELL_CH_STRIP_COUNT + 4;
+    const OFFSET: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripMeters>>::OFFSET;
+    const SIZE: usize = <K24dProtocol as TcKonnektSegmentSerdes<K24dChStripMeters>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -54,6 +54,29 @@ impl SegmentOperation<K24dReverbMeter> for K24dProtocol {}
 pub type K24dChStripMetersSegment = TcKonnektSegment<K24dChStripMeters>;
 impl SegmentOperation<K24dChStripMeters> for K24dProtocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(K24dProtocol, K24dKnob);
+segment_default!(K24dProtocol, K24dConfig);
+segment_default!(K24dProtocol, K24dMixerState);
+segment_default!(K24dProtocol, K24dReverbState);
+segment_default!(K24dProtocol, K24dChStripStates);
+segment_default!(K24dProtocol, K24dMixerMeter);
+segment_default!(K24dProtocol, K24dHwState);
+segment_default!(K24dProtocol, K24dReverbMeter);
+segment_default!(K24dProtocol, K24dChStripMeters);
+
 /// State of knob.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dKnob {

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -18,23 +18,18 @@ impl TcatGlobalSectionSpecification for K8Protocol {}
 
 /// Segment for knob. 0x0000..0x0027 (36 quads).
 pub type K8KnobSegment = TcKonnektSegment<K8Knob>;
-impl SegmentOperation<K8Knob> for K8Protocol {}
 
 /// Segment for configuration. 0x0028..0x0073 (19 quads).
 pub type K8ConfigSegment = TcKonnektSegment<K8Config>;
-impl SegmentOperation<K8Config> for K8Protocol {}
 
 /// Segment for state of mixer. 0x0074..0x01cf (87 quads).
 pub type K8MixerStateSegment = TcKonnektSegment<K8MixerState>;
-impl SegmentOperation<K8MixerState> for K8Protocol {}
 
 /// Segment for mixer meter. 0x105c..0x10b7 (23 quads).
 pub type K8MixerMeterSegment = TcKonnektSegment<K8MixerMeter>;
-impl SegmentOperation<K8MixerMeter> for K8Protocol {}
 
 /// Segment tor state of hardware. 0x100c..0x1027 (7 quads).
 pub type K8HwStateSegment = TcKonnektSegment<K8HwState>;
-impl SegmentOperation<K8HwState> for K8Protocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -95,25 +90,6 @@ impl TcKonnektNotifiedSegmentOperation<K8Knob> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for K8Knob {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8Knob>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8Knob>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K8Knob> {
-    const OFFSET: usize = <K8Protocol as TcKonnektSegmentSerdes<K8Knob>>::OFFSET;
-    const SIZE: usize = <K8Protocol as TcKonnektSegmentSerdes<K8Knob>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K8Knob> {
-    const NOTIFY_FLAG: u32 = <K8Protocol as TcKonnektNotifiedSegmentOperation<K8Knob>>::NOTIFY_FLAG;
-}
-
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8Config {
@@ -153,26 +129,6 @@ impl TcKonnektMutableSegmentOperation<K8Config> for K8Protocol {}
 
 impl TcKonnektNotifiedSegmentOperation<K8Config> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for K8Config {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8Config>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8Config>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K8Config> {
-    const OFFSET: usize = <K8Protocol as TcKonnektSegmentSerdes<K8Config>>::OFFSET;
-    const SIZE: usize = <K8Protocol as TcKonnektSegmentSerdes<K8Config>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K8Config> {
-    const NOTIFY_FLAG: u32 =
-        <K8Protocol as TcKonnektNotifiedSegmentOperation<K8Config>>::NOTIFY_FLAG;
 }
 
 /// State of mixer.
@@ -240,26 +196,6 @@ impl TcKonnektNotifiedSegmentOperation<K8MixerState> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for K8MixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8MixerState>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8MixerState>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K8MixerState> {
-    const OFFSET: usize = <K8Protocol as TcKonnektSegmentSerdes<K8MixerState>>::OFFSET;
-    const SIZE: usize = <K8Protocol as TcKonnektSegmentSerdes<K8MixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K8MixerState> {
-    const NOTIFY_FLAG: u32 =
-        <K8Protocol as TcKonnektNotifiedSegmentOperation<K8MixerState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8HwState {
     pub hw_state: ShellHwState,
@@ -288,26 +224,6 @@ impl TcKonnektMutableSegmentOperation<K8HwState> for K8Protocol {}
 
 impl TcKonnektNotifiedSegmentOperation<K8HwState> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for K8HwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8HwState>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8HwState>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K8HwState> {
-    const OFFSET: usize = <K8Protocol as TcKonnektSegmentSerdes<K8HwState>>::OFFSET;
-    const SIZE: usize = <K8Protocol as TcKonnektSegmentSerdes<K8HwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K8HwState> {
-    const NOTIFY_FLAG: u32 =
-        <K8Protocol as TcKonnektNotifiedSegmentOperation<K8HwState>>::NOTIFY_FLAG;
 }
 
 const K8_METER_ANALOG_INPUT_COUNT: usize = 2;
@@ -349,19 +265,4 @@ impl TcKonnektSegmentSerdes<K8MixerMeter> for K8Protocol {
         ShellMixerMeterConvert::parse(params, raw);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for K8MixerMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8MixerMeter>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <K8Protocol as TcKonnektSegmentSerdes<K8MixerMeter>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<K8MixerMeter> {
-    const OFFSET: usize = <K8Protocol as TcKonnektSegmentSerdes<K8MixerMeter>>::OFFSET;
-    const SIZE: usize = <K8Protocol as TcKonnektSegmentSerdes<K8MixerMeter>>::SIZE;
 }

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -92,8 +92,7 @@ impl TcKonnektSegmentSpec for TcKonnektSegment<K8Knob> {
 }
 
 impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<K8Knob> {
-    const NOTIFY_FLAG: u32 =
-        <K8Protocol as TcKonnektNotifiedSegmentOperation<K8Knob>>::NOTIFY_FLAG;
+    const NOTIFY_FLAG: u32 = <K8Protocol as TcKonnektNotifiedSegmentOperation<K8Knob>>::NOTIFY_FLAG;
 }
 
 /// Configuration.

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -36,6 +36,25 @@ impl SegmentOperation<K8MixerMeter> for K8Protocol {}
 pub type K8HwStateSegment = TcKonnektSegment<K8HwState>;
 impl SegmentOperation<K8HwState> for K8Protocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(K8Protocol, K8Knob);
+segment_default!(K8Protocol, K8Config);
+segment_default!(K8Protocol, K8MixerState);
+segment_default!(K8Protocol, K8MixerMeter);
+segment_default!(K8Protocol, K8HwState);
+
 /// State of knob.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8Knob {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -18,41 +18,32 @@ impl TcatGlobalSectionSpecification for KliveProtocol {}
 
 /// Segment for knob. 0x0000..0x0027 (36 quads).
 pub type KliveKnobSegment = TcKonnektSegment<KliveKnob>;
-impl SegmentOperation<KliveKnob> for KliveProtocol {}
 
 /// Segment for configuration. 0x0028..0x00ab (33 quads).
 pub type KliveConfigSegment = TcKonnektSegment<KliveConfig>;
-impl SegmentOperation<KliveConfig> for KliveProtocol {}
 
 /// Segment for state of mixer. 0x00ac..0x0217 (91 quads).
 pub type KliveMixerStateSegment = TcKonnektSegment<KliveMixerState>;
-impl SegmentOperation<KliveMixerState> for KliveProtocol {}
 
 /// Segment for state of reverb effect. 0x0218..0x025b. (17 quads)
 pub type KliveReverbStateSegment = TcKonnektSegment<KliveReverbState>;
-impl SegmentOperation<KliveReverbState> for KliveProtocol {}
 
 /// Segment for states of channel strip effect. 0x0260..0x037f (72 quads).
 pub type KliveChStripStatesSegment = TcKonnektSegment<KliveChStripStates>;
-impl SegmentOperation<KliveChStripStates> for KliveProtocol {}
 
 // NOTE: Segment for tuner. 0x0384..0x039c (8 quads).
 
 /// Segment for mixer meter. 0x1068..0x10c3 (23 quads).
 pub type KliveMixerMeterSegment = TcKonnektSegment<KliveMixerMeter>;
-impl SegmentOperation<KliveMixerMeter> for KliveProtocol {}
 
 /// Segment for state of hardware. 0x1008..0x1023 (7 quads).
 pub type KliveHwStateSegment = TcKonnektSegment<KliveHwState>;
-impl SegmentOperation<KliveHwState> for KliveProtocol {}
 
 /// Segment for meter of reverb effect. 0x10c4..0x010db (6 quads).
 pub type KliveReverbMeterSegment = TcKonnektSegment<KliveReverbMeter>;
-impl SegmentOperation<KliveReverbMeter> for KliveProtocol {}
 
 /// Segment for meters of channel strip effect. 0x10dc..0x1117 (15 quads).
 pub type KliveChStripMetersSegment = TcKonnektSegment<KliveChStripMeters>;
-impl SegmentOperation<KliveChStripMeters> for KliveProtocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -114,35 +105,6 @@ impl TcKonnektNotifiedSegmentOperation<KliveKnob> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for KliveKnob {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl ShellKnobTargetSpec for KliveKnob {
-    const HAS_SPDIF: bool = false;
-    const HAS_EFFECTS: bool = false;
-}
-
-impl ShellKnob2TargetSpec for KliveKnob {
-    const KNOB2_TARGET_COUNT: usize = 9;
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveKnob> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveKnob>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveKnob>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveKnob> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveKnob>>::NOTIFY_FLAG;
-}
-
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveConfig {
@@ -202,26 +164,6 @@ impl TcKonnektMutableSegmentOperation<KliveConfig> for KliveProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<KliveConfig> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for KliveConfig {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveConfig> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveConfig>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveConfig>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveConfig> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveConfig>>::NOTIFY_FLAG;
 }
 
 /// The source of channel strip effect.
@@ -407,26 +349,6 @@ impl TcKonnektNotifiedSegmentOperation<KliveMixerState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for KliveMixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveMixerState> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveMixerState>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveMixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveMixerState> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveMixerState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveReverbState(pub ReverbState);
 
@@ -450,26 +372,6 @@ impl TcKonnektMutableSegmentOperation<KliveReverbState> for KliveProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<KliveReverbState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for KliveReverbState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveReverbState> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveReverbState>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveReverbState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveReverbState> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveReverbState>>::NOTIFY_FLAG;
 }
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -497,26 +399,6 @@ impl TcKonnektNotifiedSegmentOperation<KliveChStripStates> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for KliveChStripStates {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveChStripStates> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveChStripStates>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveChStripStates>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveChStripStates> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveChStripStates>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveHwState(pub ShellHwState);
 
@@ -540,26 +422,6 @@ impl TcKonnektMutableSegmentOperation<KliveHwState> for KliveProtocol {}
 
 impl TcKonnektNotifiedSegmentOperation<KliveHwState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for KliveHwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveHwState> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveHwState>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveHwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<KliveHwState> {
-    const NOTIFY_FLAG: u32 =
-        <KliveProtocol as TcKonnektNotifiedSegmentOperation<KliveHwState>>::NOTIFY_FLAG;
 }
 
 const KLIVE_METER_ANALOG_INPUT_COUNT: usize = 4;
@@ -603,21 +465,6 @@ impl TcKonnektSegmentSerdes<KliveMixerMeter> for KliveProtocol {
     }
 }
 
-impl TcKonnektSegmentData for KliveMixerMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveMixerMeter> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveMixerMeter>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveMixerMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveReverbMeter(pub ReverbMeter);
 
@@ -637,21 +484,6 @@ impl TcKonnektSegmentSerdes<KliveReverbMeter> for KliveProtocol {
     }
 }
 
-impl TcKonnektSegmentData for KliveReverbMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveReverbMeter> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveReverbMeter>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveReverbMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);
 
@@ -669,21 +501,6 @@ impl TcKonnektSegmentSerdes<KliveChStripMeters> for KliveProtocol {
         params.0.parse(raw);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for KliveChStripMeters {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <KliveProtocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<KliveChStripMeters> {
-    const OFFSET: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveChStripMeters>>::OFFSET;
-    const SIZE: usize = <KliveProtocol as TcKonnektSegmentSerdes<KliveChStripMeters>>::SIZE;
 }
 
 /// Impedance of output.

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -54,6 +54,29 @@ impl SegmentOperation<KliveReverbMeter> for KliveProtocol {}
 pub type KliveChStripMetersSegment = TcKonnektSegment<KliveChStripMeters>;
 impl SegmentOperation<KliveChStripMeters> for KliveProtocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(KliveProtocol, KliveKnob);
+segment_default!(KliveProtocol, KliveConfig);
+segment_default!(KliveProtocol, KliveMixerState);
+segment_default!(KliveProtocol, KliveReverbState);
+segment_default!(KliveProtocol, KliveChStripStates);
+segment_default!(KliveProtocol, KliveMixerMeter);
+segment_default!(KliveProtocol, KliveHwState);
+segment_default!(KliveProtocol, KliveReverbMeter);
+segment_default!(KliveProtocol, KliveChStripMeters);
+
 /// State of knob.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveKnob {

--- a/protocols/dice/src/tcelectronic/standalone.rs
+++ b/protocols/dice/src/tcelectronic/standalone.rs
@@ -7,7 +7,7 @@
 //! for Konnekt series.
 
 /// Available rate for sampling clock in standalone mode.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TcKonnektStandaloneClkRate {
     R44100,
     R48000,

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -66,6 +66,31 @@ impl SegmentOperation<StudioReverbMeter> for Studiok48Protocol {}
 pub type Studiok48ChStripMetersSegment = TcKonnektSegment<StudioChStripMeters>;
 impl SegmentOperation<StudioChStripMeters> for Studiok48Protocol {}
 
+macro_rules! segment_default {
+    ($p:ty, $t:ty) => {
+        impl Default for TcKonnektSegment<$t> {
+            fn default() -> Self {
+                Self {
+                    data: <$t>::default(),
+                    raw: vec![0; <$p as TcKonnektSegmentSerdes<$t>>::SIZE],
+                }
+            }
+        }
+    };
+}
+
+segment_default!(Studiok48Protocol, StudioLineOutLevel);
+segment_default!(Studiok48Protocol, StudioRemote);
+segment_default!(Studiok48Protocol, StudioConfig);
+segment_default!(Studiok48Protocol, StudioMixerState);
+segment_default!(Studiok48Protocol, StudioPhysOut);
+segment_default!(Studiok48Protocol, StudioReverbState);
+segment_default!(Studiok48Protocol, StudioChStripStates);
+segment_default!(Studiok48Protocol, StudioHwState);
+segment_default!(Studiok48Protocol, StudioMixerMeter);
+segment_default!(Studiok48Protocol, StudioReverbMeter);
+segment_default!(Studiok48Protocol, StudioChStripMeters);
+
 const STUDIO_LINE_OUT_LEVEL_NOTIFY_FLAG: u32 = 0x00010000;
 const STUDIO_REMOTE_NOTIFY_FLAG: u32 = 0x00020000;
 const STUDIO_CONFIG_NOTIFY_FLAG: u32 = 0x00040000;

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -18,53 +18,42 @@ impl TcatGlobalSectionSpecification for Studiok48Protocol {}
 
 /// Segment for output level. 0x0000..0x0013 (4 quads).
 pub type Studiok48LineOutLevelSegment = TcKonnektSegment<StudioLineOutLevel>;
-impl SegmentOperation<StudioLineOutLevel> for Studiok48Protocol {}
 
 /// Segment for remote controller. 0x0014..0x0043 (12 quads).
 pub type Studiok48RemoteSegment = TcKonnektSegment<StudioRemote>;
-impl SegmentOperation<StudioRemote> for Studiok48Protocol {}
 
 /// Segment for configuration. 0x0044..0x00a7 (25 quads).
 pub type Studiok48ConfigSegment = TcKonnektSegment<StudioConfig>;
-impl SegmentOperation<StudioConfig> for Studiok48Protocol {}
 
 /// Segment for state of mixer. 0x00a8..0x03db (205 quads).
 pub type Studiok48MixerStateSegment = TcKonnektSegment<StudioMixerState>;
-impl SegmentOperation<StudioMixerState> for Studiok48Protocol {}
 
 /// Segment for physical output. 0x03dc..0x0593 (110 quads).
 pub type Studiok48PhysOutSegment = TcKonnektSegment<StudioPhysOut>;
-impl SegmentOperation<StudioPhysOut> for Studiok48Protocol {}
 
 /// Segment for state of reverb effect. 0x0594..0x05d7. (17 quads)
 pub type Studiok48ReverbStateSegment = TcKonnektSegment<StudioReverbState>;
-impl SegmentOperation<StudioReverbState> for Studiok48Protocol {}
 
 /// Segment for states of channel strip effect. 0x05dc..0x081f (145 quads).
 pub type Studiok48ChStripStatesSegment = TcKonnektSegment<StudioChStripStates>;
-impl SegmentOperation<StudioChStripStates> for Studiok48Protocol {}
 
 // NOTE: Segment for tuner. 0x0820..0x083f (8 quads).
 
 /// Segment for state of hardware. 0x2008..0x204b (17 quads).
 pub type Studiok48HwStateSegment = TcKonnektSegment<StudioHwState>;
-impl SegmentOperation<StudioHwState> for Studiok48Protocol {}
 
 // NOTE: Segment for meter of remote controller. 0x204c..0x205b (4 quads).
 
 /// Segment for meter of mixer. 0x20b8..0x2137 (32 quads).
 pub type Studiok48MixerMeterSegment = TcKonnektSegment<StudioMixerMeter>;
-impl SegmentOperation<StudioMixerMeter> for Studiok48Protocol {}
 
 // NOTE: Segment for inidentified meter. 0x2138..0x2163 (11 quads).
 
 /// Segment for meter of reverb effect. 0x2164..0x217b (6 quads).
 pub type Studiok48ReverbMeterSegment = TcKonnektSegment<StudioReverbMeter>;
-impl SegmentOperation<StudioReverbMeter> for Studiok48Protocol {}
 
 /// Segment for meters of channel strip effect. 0x217c..0x21b7 (30 quads).
 pub type Studiok48ChStripMetersSegment = TcKonnektSegment<StudioChStripMeters>;
-impl SegmentOperation<StudioChStripMeters> for Studiok48Protocol {}
 
 macro_rules! segment_default {
     ($p:ty, $t:ty) => {
@@ -173,26 +162,6 @@ impl TcKonnektMutableSegmentOperation<StudioLineOutLevel> for Studiok48Protocol 
 
 impl TcKonnektNotifiedSegmentOperation<StudioLineOutLevel> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_LINE_OUT_LEVEL_NOTIFY_FLAG;
-}
-
-impl TcKonnektSegmentData for StudioLineOutLevel {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioLineOutLevel> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioLineOutLevel>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioLineOutLevel>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioLineOutLevel> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioLineOutLevel>>::NOTIFY_FLAG;
 }
 
 /// Mode of remote effect button.
@@ -316,26 +285,6 @@ impl TcKonnektNotifiedSegmentOperation<StudioRemote> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_REMOTE_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for StudioRemote {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioRemote> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioRemote>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioRemote>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioRemote> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioRemote>>::NOTIFY_FLAG;
-}
-
 /// Mode of optical interface.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OptIfaceMode {
@@ -446,25 +395,6 @@ impl TcKonnektMutableSegmentOperation<StudioConfig> for Studiok48Protocol {}
 
 impl TcKonnektNotifiedSegmentOperation<StudioConfig> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_CONFIG_NOTIFY_FLAG;
-}
-impl TcKonnektSegmentData for StudioConfig {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioConfig> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioConfig>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioConfig>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioConfig> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioConfig>>::NOTIFY_FLAG;
 }
 
 /// Entry of signal source.
@@ -760,25 +690,6 @@ impl TcKonnektMutableSegmentOperation<StudioMixerState> for Studiok48Protocol {}
 
 impl TcKonnektNotifiedSegmentOperation<StudioMixerState> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_MIXER_STATE_NOTIFY_FLAG;
-}
-impl TcKonnektSegmentData for StudioMixerState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioMixerState> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioMixerState>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioMixerState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioMixerState> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioMixerState>>::NOTIFY_FLAG;
 }
 
 /// Parameter of each channel for source of physical output.
@@ -1130,26 +1041,6 @@ impl TcKonnektNotifiedSegmentOperation<StudioPhysOut> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_PHYS_OUT_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for StudioPhysOut {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioPhysOut> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioPhysOut>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioPhysOut>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioPhysOut> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioPhysOut>>::NOTIFY_FLAG;
-}
-
 const STUDIO_CH_STRIP_COUNT: usize = 4;
 
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
@@ -1177,26 +1068,6 @@ impl TcKonnektNotifiedSegmentOperation<StudioReverbState> for Studiok48Protocol 
     const NOTIFY_FLAG: u32 = STUDIO_REVERB_NOTIFY_CHANGE;
 }
 
-impl TcKonnektSegmentData for StudioReverbState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioReverbState> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioReverbState>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioReverbState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioReverbState> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioReverbState>>::NOTIFY_FLAG;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioChStripStates(pub [ChStripState; STUDIO_CH_STRIP_COUNT]);
 
@@ -1220,27 +1091,6 @@ impl TcKonnektMutableSegmentOperation<StudioChStripStates> for Studiok48Protocol
 
 impl TcKonnektNotifiedSegmentOperation<StudioChStripStates> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_CH_STRIP_NOTIFY_01_CHANGE | STUDIO_CH_STRIP_NOTIFY_23_CHANGE;
-}
-
-impl TcKonnektSegmentData for StudioChStripStates {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioChStripStates> {
-    const OFFSET: usize =
-        <Studiok48Protocol as TcKonnektSegmentSerdes<StudioChStripStates>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioChStripStates>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioChStripStates> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioChStripStates>>::NOTIFY_FLAG;
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -1322,26 +1172,6 @@ impl TcKonnektNotifiedSegmentOperation<StudioHwState> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_HW_STATE_NOTIFY_FLAG;
 }
 
-impl TcKonnektSegmentData for StudioHwState {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioHwState> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioHwState>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioHwState>>::SIZE;
-}
-
-impl TcKonnektNotifiedSegmentSpec for TcKonnektSegment<StudioHwState> {
-    const NOTIFY_FLAG: u32 =
-        <Studiok48Protocol as TcKonnektNotifiedSegmentOperation<StudioHwState>>::NOTIFY_FLAG;
-}
-
 /// Meter for input/output of mixer.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioMixerMeter {
@@ -1370,21 +1200,6 @@ impl TcKonnektSegmentSerdes<StudioMixerMeter> for Studiok48Protocol {
     }
 }
 
-impl TcKonnektSegmentData for StudioMixerMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioMixerMeter> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioMixerMeter>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioMixerMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioReverbMeter(pub ReverbMeter);
 
@@ -1404,21 +1219,6 @@ impl TcKonnektSegmentSerdes<StudioReverbMeter> for Studiok48Protocol {
     }
 }
 
-impl TcKonnektSegmentData for StudioReverbMeter {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioReverbMeter> {
-    const OFFSET: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioReverbMeter>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioReverbMeter>>::SIZE;
-}
-
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioChStripMeters(pub [ChStripMeter; STUDIO_CH_STRIP_COUNT]);
 
@@ -1436,20 +1236,4 @@ impl TcKonnektSegmentSerdes<StudioChStripMeters> for Studiok48Protocol {
         params.0.parse(raw);
         Ok(())
     }
-}
-
-impl TcKonnektSegmentData for StudioChStripMeters {
-    fn build(&self, raw: &mut [u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::serialize(self, raw);
-    }
-
-    fn parse(&mut self, raw: &[u8]) {
-        let _ = <Studiok48Protocol as TcKonnektSegmentSerdes<Self>>::deserialize(self, raw);
-    }
-}
-
-impl TcKonnektSegmentSpec for TcKonnektSegment<StudioChStripMeters> {
-    const OFFSET: usize =
-        <Studiok48Protocol as TcKonnektSegmentSerdes<StudioChStripMeters>>::OFFSET;
-    const SIZE: usize = <Studiok48Protocol as TcKonnektSegmentSerdes<StudioChStripMeters>>::SIZE;
 }

--- a/runtime/dice/src/tcelectronic/ch_strip_ctl.rs
+++ b/runtime/dice/src/tcelectronic/ch_strip_ctl.rs
@@ -59,8 +59,7 @@ fn src_type_to_str(t: &ChStripSrcType) -> &'static str {
 
 pub trait ChStripCtlOperation<S, T, U>
 where
-    S: TcKonnektSegmentData + Clone,
-    T: TcKonnektSegmentData,
+    S: Clone,
     U: TcKonnektSegmentOperation<S>
         + TcKonnektMutableSegmentOperation<S>
         + TcKonnektNotifiedSegmentOperation<S>

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -939,16 +939,20 @@ impl MixerCtl {
 struct PanelCtl(Desktopk6PanelSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<DesktopPanel, Desktopk6Protocol> for PanelCtl {
+    fn segment(&self) -> &Desktopk6PanelSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Desktopk6PanelSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.firewire_led
+    fn firewire_led(params: &DesktopPanel) -> &FireWireLedState {
+        &params.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.firewire_led
+    fn firewire_led_mut(params: &mut DesktopPanel) -> &mut FireWireLedState {
+        &mut params.firewire_led
     }
 }
 
@@ -1091,7 +1095,7 @@ impl PanelCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_firewire_led(unit, req, elem_id, elem_value, timeout_ms)? {
+        if self.write_firewire_led(req, &unit.1, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -107,7 +107,7 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
             Ok(true)
         } else if self
             .config_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -521,16 +521,20 @@ impl HwStateCtl {
 struct ConfigCtl(Desktopk6ConfigSegment);
 
 impl StandaloneCtlOperation<DesktopConfig, Desktopk6Protocol> for ConfigCtl {
+    fn segment(&self) -> &Desktopk6ConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Desktopk6ConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &DesktopConfig) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut DesktopConfig) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 
@@ -555,13 +559,13 @@ impl ConfigCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        self.write_standalone_rate(unit, req, elem_id, elem_value, timeout_ms)
+        self.write_standalone_rate(req, node, elem_id, elem_value, timeout_ms)
     }
 
     fn parse_notification(

--- a/runtime/dice/src/tcelectronic/fw_led_ctl.rs
+++ b/runtime/dice/src/tcelectronic/fw_led_ctl.rs
@@ -16,7 +16,7 @@ pub fn firewire_led_state_to_str(state: &FireWireLedState) -> &'static str {
 
 pub trait FirewireLedCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -259,7 +259,7 @@ struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
 
 impl CommonCtlOperation<ItwinProtocol> for CommonCtl {}
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct KnobCtl(ItwinKnobSegment, Vec<ElemId>);
 
 impl ShellKnobCtlOperation<ItwinKnob, ItwinProtocol> for KnobCtl {
@@ -270,16 +270,20 @@ impl ShellKnobCtlOperation<ItwinKnob, ItwinProtocol> for KnobCtl {
         "Mixer-1/2",
     ];
 
+    fn segment(&self) -> &ItwinKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut ItwinKnobSegment {
         &mut self.0
     }
 
-    fn knob_target(&self) -> &ShellKnobTarget {
-        &self.0.data.target
+    fn knob_target(params: &ItwinKnob) -> &ShellKnobTarget {
+        &params.target
     }
 
-    fn knob_target_mut(&mut self) -> &mut ShellKnobTarget {
-        &mut self.0.data.target
+    fn knob_target_mut(params: &mut ItwinKnob) -> &mut ShellKnobTarget {
+        &mut params.target
     }
 }
 
@@ -327,7 +331,7 @@ impl KnobCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob_target(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_knob_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -371,20 +375,24 @@ impl KnobCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ConfigCtl(ItwinConfigSegment, Vec<ElemId>);
 
 impl ShellMixerStreamSrcCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
+    fn segment(&self) -> &ItwinConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut ItwinConfigSegment {
         &mut self.0
     }
 
-    fn mixer_stream_src(&self) -> &ShellMixerStreamSrcPair {
-        &self.0.data.mixer_stream_src_pair
+    fn mixer_stream_src(params: &ItwinConfig) -> &ShellMixerStreamSrcPair {
+        &params.mixer_stream_src_pair
     }
 
-    fn mixer_stream_src_mut(&mut self) -> &mut ShellMixerStreamSrcPair {
-        &mut self.0.data.mixer_stream_src_pair
+    fn mixer_stream_src_mut(params: &mut ItwinConfig) -> &mut ShellMixerStreamSrcPair {
+        &mut params.mixer_stream_src_pair
     }
 }
 
@@ -407,12 +415,12 @@ impl StandaloneCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
 }
 
 impl ShellStandaloneCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
-    fn standalone_src(&self) -> &ShellStandaloneClkSrc {
-        &self.0.data.standalone_src
+    fn standalone_src(params: &ItwinConfig) -> &ShellStandaloneClkSrc {
+        &params.standalone_src
     }
 
-    fn standalone_src_mut(&mut self) -> &mut ShellStandaloneClkSrc {
-        &mut self.0.data.standalone_src
+    fn standalone_src_mut(params: &mut ItwinConfig) -> &mut ShellStandaloneClkSrc {
+        &mut params.standalone_src
     }
 }
 
@@ -521,9 +529,9 @@ impl ConfigCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer_stream_src(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_mixer_stream_src(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_standalone(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -599,12 +607,12 @@ impl ShellMixerCtlOperation<ItwinMixerState, ItwinMixerMeter, ItwinProtocol> for
         &mut self.1
     }
 
-    fn state(&self) -> &ShellMixerState {
-        &self.0.data.mixer
+    fn state(params: &ItwinMixerState) -> &ShellMixerState {
+        &params.mixer
     }
 
-    fn state_mut(&mut self) -> &mut ShellMixerState {
-        &mut self.0.data.mixer
+    fn state_mut(params: &mut ItwinMixerState) -> &mut ShellMixerState {
+        &mut params.mixer
     }
 
     fn meter(&self) -> &ShellMixerMeter {
@@ -668,7 +676,7 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
+        if self.write_mixer(req, &unit.1, elem_id, old, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -28,6 +28,8 @@ impl ItwinModel {
         self.common_ctl
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+
         Ok(())
     }
 }
@@ -59,12 +61,12 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
             })?;
-        self.ch_strip_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|(notified_elem_id_list, measured_elem_id_list)| {
+        self.ch_strip_ctl.load(card_cntr).map(
+            |(notified_elem_id_list, measured_elem_id_list)| {
                 self.ch_strip_ctl.2 = notified_elem_id_list;
                 self.ch_strip_ctl.3 = measured_elem_id_list;
-            })?;
+            },
+        )?;
 
         Ok(())
     }
@@ -138,7 +140,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
             Ok(true)
         } else if self
             .ch_strip_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -181,7 +183,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
         self.reverb_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -227,7 +229,7 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
         self.reverb_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -914,12 +916,12 @@ impl ChStripCtlOperation<ItwinChStripStates, ItwinChStripMeters, ItwinProtocol> 
         &mut self.1
     }
 
-    fn states(&self) -> &[ChStripState] {
-        &self.0.data.0
+    fn states(params: &ItwinChStripStates) -> &[ChStripState] {
+        &params.0
     }
 
-    fn states_mut(&mut self) -> &mut [ChStripState] {
-        &mut self.0.data.0
+    fn states_mut(params: &mut ItwinChStripStates) -> &mut [ChStripState] {
+        &mut params.0
     }
 
     fn meters(&self) -> &[ChStripMeter] {

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -389,16 +389,20 @@ impl ShellMixerStreamSrcCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
 }
 
 impl StandaloneCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
+    fn segment(&self) -> &ItwinConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut ItwinConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &ItwinConfig) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut ItwinConfig) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -29,6 +29,7 @@ impl ItwinModel {
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.reverb_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -56,7 +57,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         self.hw_state_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
         self.reverb_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
+            .load(card_cntr)
             .map(|(notified_elem_id_list, measured_elem_id_list)| {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
@@ -135,7 +136,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
             Ok(true)
         } else if self
             .reverb_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -181,7 +182,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
         self.hw_state_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.reverb_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
             .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         Ok(())
@@ -227,7 +228,7 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
         self.mixer_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.reverb_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         self.ch_strip_ctl
             .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
@@ -861,7 +862,7 @@ impl HwStateCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ReverbCtl(
     ItwinReverbStateSegment,
     ItwinReverbMeterSegment,
@@ -878,20 +879,24 @@ impl ReverbCtlOperation<ItwinReverbState, ItwinReverbMeter, ItwinProtocol> for R
         &mut self.0
     }
 
+    fn meter_segment(&self) -> &ItwinReverbMeterSegment {
+        &self.1
+    }
+
     fn meter_segment_mut(&mut self) -> &mut ItwinReverbMeterSegment {
         &mut self.1
     }
 
-    fn state(&self) -> &ReverbState {
-        &self.0.data.0
+    fn state(params: &ItwinReverbState) -> &ReverbState {
+        &params.0
     }
 
-    fn state_mut(&mut self) -> &mut ReverbState {
-        &mut self.0.data.0
+    fn state_mut(params: &mut ItwinReverbState) -> &mut ReverbState {
+        &mut params.0
     }
 
-    fn meter(&self) -> &ReverbMeter {
-        &self.1.data.0
+    fn meter(params: &ItwinReverbMeter) -> &ReverbMeter {
+        &params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -733,16 +733,20 @@ impl MixerCtl {
 struct HwStateCtl(ItwinHwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<ItwinHwState, ItwinProtocol> for HwStateCtl {
+    fn segment(&self) -> &ItwinHwStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut ItwinHwStateSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.hw_state.firewire_led
+    fn firewire_led(params: &ItwinHwState) -> &FireWireLedState {
+        &params.hw_state.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.hw_state.firewire_led
+    fn firewire_led_mut(params: &mut ItwinHwState) -> &mut FireWireLedState {
+        &mut params.hw_state.firewire_led
     }
 }
 
@@ -824,7 +828,7 @@ impl HwStateCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_hw_state(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_hw_state(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -28,6 +28,8 @@ impl K24dModel {
         self.common_ctl
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+
         Ok(())
     }
 }
@@ -59,12 +61,12 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
             })?;
-        self.ch_strip_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|(notified_elem_id_list, measured_elem_id_list)| {
+        self.ch_strip_ctl.load(card_cntr).map(
+            |(notified_elem_id_list, measured_elem_id_list)| {
                 self.ch_strip_ctl.2 = notified_elem_id_list;
                 self.ch_strip_ctl.3 = measured_elem_id_list;
-            })?;
+            },
+        )?;
 
         Ok(())
     }
@@ -138,7 +140,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
             Ok(true)
         } else if self
             .ch_strip_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -182,7 +184,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         self.reverb_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -228,7 +230,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         self.reverb_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -918,12 +920,12 @@ impl ChStripCtlOperation<K24dChStripStates, K24dChStripMeters, K24dProtocol> for
         &mut self.1
     }
 
-    fn states(&self) -> &[ChStripState] {
-        &self.0.data.0
+    fn states(params: &K24dChStripStates) -> &[ChStripState] {
+        &params.0
     }
 
-    fn states_mut(&mut self) -> &mut [ChStripState] {
-        &mut self.0.data.0
+    fn states_mut(params: &mut K24dChStripStates) -> &mut [ChStripState] {
+        &mut params.0
     }
 
     fn meters(&self) -> &[ChStripMeter] {

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -439,16 +439,20 @@ impl ShellOptIfaceCtl<K24dConfig, K24dProtocol> for ConfigCtl {
 }
 
 impl StandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
+    fn segment(&self) -> &K24dConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &K24dConfig) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut K24dConfig) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -29,6 +29,7 @@ impl K24dModel {
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.reverb_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -56,7 +57,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         self.hw_state_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
         self.reverb_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
+            .load(card_cntr)
             .map(|(notified_elem_id_list, measured_elem_id_list)| {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
@@ -135,7 +136,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
             Ok(true)
         } else if self
             .reverb_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -182,7 +183,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         self.hw_state_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.reverb_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
             .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         Ok(())
@@ -228,7 +229,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         self.mixer_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.reverb_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         self.ch_strip_ctl
             .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
@@ -865,7 +866,7 @@ impl HwStateCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ReverbCtl(
     K24dReverbStateSegment,
     K24dReverbMeterSegment,
@@ -882,20 +883,24 @@ impl ReverbCtlOperation<K24dReverbState, K24dReverbMeter, K24dProtocol> for Reve
         &mut self.0
     }
 
+    fn meter_segment(&self) -> &K24dReverbMeterSegment {
+        &self.1
+    }
+
     fn meter_segment_mut(&mut self) -> &mut K24dReverbMeterSegment {
         &mut self.1
     }
 
-    fn state(&self) -> &ReverbState {
-        &self.0.data.0
+    fn state(params: &K24dReverbState) -> &ReverbState {
+        &params.0
     }
 
-    fn state_mut(&mut self) -> &mut ReverbState {
-        &mut self.0.data.0
+    fn state_mut(params: &mut K24dReverbState) -> &mut ReverbState {
+        &mut params.0
     }
 
-    fn meter(&self) -> &ReverbMeter {
-        &self.1.data.0
+    fn meter(params: &K24dReverbMeter) -> &ReverbMeter {
+        &params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -131,7 +131,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -788,16 +788,20 @@ impl MixerCtl {
 struct HwStateCtl(K24dHwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<K24dHwState, K24dProtocol> for HwStateCtl {
+    fn segment(&self) -> &K24dHwStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dHwStateSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.0.firewire_led
+    fn firewire_led(params: &K24dHwState) -> &FireWireLedState {
+        &params.0.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.0.firewire_led
+    fn firewire_led_mut(params: &mut K24dHwState) -> &mut FireWireLedState {
+        &mut params.0.firewire_led
     }
 }
 
@@ -837,14 +841,14 @@ impl HwStateCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         _: &ElemValue,
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_hw_state(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_hw_state(req, node, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -305,16 +305,20 @@ impl ShellKnob2CtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
 }
 
 impl ProgramCtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
+    fn segment(&self) -> &K24dKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dKnobSegment {
         &mut self.0
     }
 
-    fn prog(&self) -> &TcKonnektLoadedProgram {
-        &self.0.data.prog
+    fn prog(params: &K24dKnob) -> &TcKonnektLoadedProgram {
+        &params.prog
     }
 
-    fn prog_mut(&mut self) -> &mut TcKonnektLoadedProgram {
-        &mut self.0.data.prog
+    fn prog_mut(params: &mut K24dKnob) -> &mut TcKonnektLoadedProgram {
+        &mut params.prog
     }
 }
 
@@ -365,7 +369,7 @@ impl KnobCtl {
             Ok(true)
         } else if self.write_knob2_target(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_prog(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_prog(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -6,7 +6,7 @@ use {
     protocols::tcelectronic::shell::{k24d::*, *},
 };
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct K24dModel {
     req: FwReq,
     sections: GeneralSections,
@@ -28,6 +28,10 @@ impl K24dModel {
         self.common_ctl
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.mixer_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.reverb_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
 
@@ -36,11 +40,7 @@ impl K24dModel {
 }
 
 impl CtlModel<(SndDice, FwNode)> for K24dModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections).map(
             |(measured_elem_id_list, notified_elem_id_list)| {
                 self.common_ctl.0 = measured_elem_id_list;
@@ -48,14 +48,10 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
             },
         )?;
 
-        self.knob_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.config_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.mixer_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.hw_state_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
+        self.knob_ctl.load(card_cntr)?;
+        self.config_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
+        self.hw_state_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
             .map(|(notified_elem_id_list, measured_elem_id_list)| {
@@ -116,22 +112,22 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
             Ok(true)
         } else if self
             .knob_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -175,13 +171,13 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         )?;
 
         self.knob_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.mixer_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.reverb_ctl
             .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
@@ -227,7 +223,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         self.common_ctl
             .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.mixer_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         self.reverb_ctl
             .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         self.ch_strip_ctl
@@ -331,15 +327,11 @@ impl ProgramCtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
 }
 
 impl KnobCtl {
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)?;
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_knob_target(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
@@ -366,18 +358,17 @@ impl KnobCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob_target(req, &unit.1, elem_id, new, timeout_ms)? {
+        if self.write_knob_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_knob2_target(req, &unit.1, elem_id, new, timeout_ms)? {
+        } else if self.write_knob2_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_prog(req, &unit.1, elem_id, new, timeout_ms)? {
+        } else if self.write_prog(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)
@@ -386,13 +377,13 @@ impl KnobCtl {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if self.0.has_segment_change(msg) {
-            K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)
+        if K24dProtocol::is_notified_segment(&self.0, msg) {
+            K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
         } else {
             Ok(())
         }
@@ -415,7 +406,7 @@ impl KnobCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ConfigCtl(K24dConfigSegment, Vec<ElemId>);
 
 impl ShellCoaxIfaceCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
@@ -485,15 +476,11 @@ impl ShellStandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
 const OUT_23_SRC_NAME: &str = "output-3/4-source";
 
 impl ConfigCtl {
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)?;
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_coax_out_src(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
         self.load_standalone(card_cntr)?;
@@ -532,34 +519,39 @@ impl ConfigCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_coax_out_src(req, &unit.1, elem_id, new, timeout_ms)? {
+        if self.write_coax_out_src(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_opt_iface_config(req, &unit.1, elem_id, new, timeout_ms)? {
+        } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(req, &unit.1, elem_id, new, timeout_ms)? {
+        } else if self.write_standalone(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
                 OUT_23_SRC_NAME => {
-                    ElemValueAccessor::<u32>::get_val(new, |val| {
-                        PHYS_OUT_SRCS
-                            .iter()
-                            .nth(val as usize)
-                            .ok_or_else(|| {
-                                let msg = format!("Invalid index of output source: {}", val);
-                                Error::new(FileError::Inval, &msg)
-                            })
-                            .map(|&s| self.0.data.out_23_src = s)
-                    })?;
-                    K24dProtocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
-                        .map(|_| true)
+                    let mut params = self.0.data.clone();
+                    let pos = elem_value.enumerated()[0] as usize;
+                    PHYS_OUT_SRCS
+                        .iter()
+                        .nth(pos)
+                        .ok_or_else(|| {
+                            let msg = format!("Invalid index of output source: {}", pos);
+                            Error::new(FileError::Inval, &msg)
+                        })
+                        .map(|&s| params.out_23_src = s)?;
+                    K24dProtocol::update_partial_segment(
+                        req,
+                        node,
+                        &params,
+                        &mut self.0,
+                        timeout_ms,
+                    )
+                    .map(|_| true)
                 }
                 _ => Ok(false),
             }
@@ -568,13 +560,13 @@ impl ConfigCtl {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if self.0.has_segment_change(msg) {
-            K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)
+        if K24dProtocol::is_notified_segment(&self.0, msg) {
+            K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
         } else {
             Ok(())
         }
@@ -595,7 +587,7 @@ impl ConfigCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct MixerCtl(
     K24dMixerStateSegment,
     K24dMixerMeterSegment,
@@ -660,16 +652,13 @@ const USE_CH_STRIP_AS_PLUGIN_NAME: &str = "use-channel-strip-as-plugin";
 const USE_REVERB_AT_MID_RATE: &str = "use-reverb-at-mid-rate";
 
 impl MixerCtl {
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)?;
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.1, timeout_ms)?;
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)?;
+        K24dProtocol::cache_whole_segment(req, node, &mut self.1, timeout_ms)?;
+        Ok(())
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_mixer(card_cntr)
             .map(|(notified_elem_id_list, measured_elem_id_list)| {
                 self.2 = notified_elem_id_list;
@@ -720,42 +709,54 @@ impl MixerCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         old: &ElemValue,
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer(req, &unit.1, elem_id, old, new, timeout_ms)? {
+        if self.write_mixer(req, node, elem_id, old, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_reverb_return(req, &unit.1, elem_id, new, timeout_ms)? {
+        } else if self.write_reverb_return(req, node, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
                 MIXER_ENABLE_NAME => {
-                    ElemValueAccessor::<bool>::get_val(new, |val| {
-                        self.0.data.enabled = val;
-                        Ok(())
-                    })?;
-                    K24dProtocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
-                        .map(|_| true)
+                    let mut params = self.0.data.clone();
+                    params.enabled = new.boolean()[0];
+                    K24dProtocol::update_partial_segment(
+                        req,
+                        node,
+                        &params,
+                        &mut self.0,
+                        timeout_ms,
+                    )
+                    .map(|_| true)
                 }
                 USE_CH_STRIP_AS_PLUGIN_NAME => {
-                    ElemValueAccessor::<bool>::get_val(new, |val| {
-                        self.0.data.use_ch_strip_as_plugin = val;
-                        Ok(())
-                    })?;
-                    K24dProtocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
-                        .map(|_| true)
+                    let mut params = self.0.data.clone();
+                    params.use_ch_strip_as_plugin = new.boolean()[0];
+                    K24dProtocol::update_partial_segment(
+                        req,
+                        node,
+                        &params,
+                        &mut self.0,
+                        timeout_ms,
+                    )
+                    .map(|_| true)
                 }
                 USE_REVERB_AT_MID_RATE => {
-                    ElemValueAccessor::<bool>::get_val(new, |val| {
-                        self.0.data.use_reverb_at_mid_rate = val;
-                        Ok(())
-                    })?;
-                    K24dProtocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
-                        .map(|_| true)
+                    let mut params = self.0.data.clone();
+                    params.use_reverb_at_mid_rate = new.boolean()[0];
+                    K24dProtocol::update_partial_segment(
+                        req,
+                        node,
+                        &params,
+                        &mut self.0,
+                        timeout_ms,
+                    )
+                    .map(|_| true)
                 }
                 _ => Ok(false),
             }
@@ -764,13 +765,13 @@ impl MixerCtl {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if self.0.has_segment_change(msg) {
-            K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)
+        if K24dProtocol::is_notified_segment(&self.0, msg) {
+            K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
         } else {
             Ok(())
         }
@@ -790,13 +791,8 @@ impl MixerCtl {
         }
     }
 
-    fn measure_states(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.1, timeout_ms)
+    fn measure_states(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        K24dProtocol::cache_whole_segment(req, node, &mut self.1, timeout_ms)
     }
 
     fn read_measured_elem(
@@ -812,7 +808,7 @@ impl MixerCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct HwStateCtl(K24dHwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<K24dHwState, K24dProtocol> for HwStateCtl {
@@ -844,15 +840,11 @@ impl ShellHwStateCtlOperation<K24dHwState, K24dProtocol> for HwStateCtl {
 }
 
 impl HwStateCtl {
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)?;
+    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_hw_state(card_cntr)
             .map(|mut notified_elem_id_list| self.1.append(&mut notified_elem_id_list))?;
 
@@ -872,11 +864,10 @@ impl HwStateCtl {
         req: &FwReq,
         node: &FwNode,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_hw_state(req, node, elem_id, new, timeout_ms)? {
+        if self.write_hw_state(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)
@@ -885,13 +876,13 @@ impl HwStateCtl {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if self.0.has_segment_change(msg) {
-            K24dProtocol::read_segment(req, &mut unit.1, &mut self.0, timeout_ms)
+        if K24dProtocol::is_notified_segment(&self.0, msg) {
+            K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms)
         } else {
             Ok(())
         }
@@ -936,7 +927,7 @@ impl ReverbCtlOperation<K24dReverbState, K24dReverbMeter, K24dProtocol> for Reve
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ChStripCtl(
     K24dChStripStatesSegment,
     K24dChStripMetersSegment,

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -260,22 +260,26 @@ struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
 
 impl CommonCtlOperation<K24dProtocol> for CommonCtl {}
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct KnobCtl(K24dKnobSegment, Vec<ElemId>);
 
 impl ShellKnobCtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
     const TARGETS: [&'static str; 4] = ["Analog-1", "Analog-2", "Analog-3/4", "Configurable"];
 
+    fn segment(&self) -> &K24dKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dKnobSegment {
         &mut self.0
     }
 
-    fn knob_target(&self) -> &ShellKnobTarget {
-        &self.0.data.target
+    fn knob_target(params: &K24dKnob) -> &ShellKnobTarget {
+        &params.target
     }
 
-    fn knob_target_mut(&mut self) -> &mut ShellKnobTarget {
-        &mut self.0.data.target
+    fn knob_target_mut(params: &mut K24dKnob) -> &mut ShellKnobTarget {
+        &mut params.target
     }
 }
 
@@ -291,16 +295,20 @@ impl ShellKnob2CtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
         "Tune-pitch-tone",
     ];
 
+    fn segment(&self) -> &K24dKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dKnobSegment {
         &mut self.0
     }
 
-    fn knob2_target(&self) -> &ShellKnob2Target {
-        &self.0.data.knob2_target
+    fn knob2_target(params: &K24dKnob) -> &ShellKnob2Target {
+        &params.knob2_target
     }
 
-    fn knob2_target_mut(&mut self) -> &mut ShellKnob2Target {
-        &mut self.0.data.knob2_target
+    fn knob2_target_mut(params: &mut K24dKnob) -> &mut ShellKnob2Target {
+        &mut params.knob2_target
     }
 }
 
@@ -365,9 +373,9 @@ impl KnobCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob_target(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_knob_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_knob2_target(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_knob2_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else if self.write_prog(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
@@ -411,30 +419,38 @@ impl KnobCtl {
 struct ConfigCtl(K24dConfigSegment, Vec<ElemId>);
 
 impl ShellCoaxIfaceCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
+    fn segment(&self) -> &K24dConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dConfigSegment {
         &mut self.0
     }
 
-    fn coax_out_src(&self) -> &ShellCoaxOutPairSrc {
-        &self.0.data.coax_out_src
+    fn coax_out_src(params: &K24dConfig) -> &ShellCoaxOutPairSrc {
+        &params.coax_out_src
     }
 
-    fn coax_out_src_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
-        &mut self.0.data.coax_out_src
+    fn coax_out_src_mut(params: &mut K24dConfig) -> &mut ShellCoaxOutPairSrc {
+        &mut params.coax_out_src
     }
 }
 
 impl ShellOptIfaceCtl<K24dConfig, K24dProtocol> for ConfigCtl {
+    fn segment(&self) -> &K24dConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dConfigSegment {
         &mut self.0
     }
 
-    fn opt_iface_config(&self) -> &ShellOptIfaceConfig {
-        &self.0.data.opt
+    fn opt_iface_config(params: &K24dConfig) -> &ShellOptIfaceConfig {
+        &params.opt
     }
 
-    fn opt_iface_config_mut(&mut self) -> &mut ShellOptIfaceConfig {
-        &mut self.0.data.opt
+    fn opt_iface_config_mut(params: &mut K24dConfig) -> &mut ShellOptIfaceConfig {
+        &mut params.opt
     }
 }
 
@@ -457,12 +473,12 @@ impl StandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
 }
 
 impl ShellStandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
-    fn standalone_src(&self) -> &ShellStandaloneClkSrc {
-        &self.0.data.standalone_src
+    fn standalone_src(params: &K24dConfig) -> &ShellStandaloneClkSrc {
+        &params.standalone_src
     }
 
-    fn standalone_src_mut(&mut self) -> &mut ShellStandaloneClkSrc {
-        &mut self.0.data.standalone_src
+    fn standalone_src_mut(params: &mut K24dConfig) -> &mut ShellStandaloneClkSrc {
+        &mut params.standalone_src
     }
 }
 
@@ -523,11 +539,11 @@ impl ConfigCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_coax_out_src(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_coax_out_src(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_opt_iface_config(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_opt_iface_config(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_standalone(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -600,12 +616,12 @@ impl ShellMixerCtlOperation<K24dMixerState, K24dMixerMeter, K24dProtocol> for Mi
         &mut self.1
     }
 
-    fn state(&self) -> &ShellMixerState {
-        &self.0.data.mixer
+    fn state(params: &K24dMixerState) -> &ShellMixerState {
+        &params.mixer
     }
 
-    fn state_mut(&mut self) -> &mut ShellMixerState {
-        &mut self.0.data.mixer
+    fn state_mut(params: &mut K24dMixerState) -> &mut ShellMixerState {
+        &mut params.mixer
     }
 
     fn meter(&self) -> &ShellMixerMeter {
@@ -622,16 +638,20 @@ impl ShellMixerCtlOperation<K24dMixerState, K24dMixerMeter, K24dProtocol> for Mi
 }
 
 impl ShellReverbReturnCtlOperation<K24dMixerState, K24dProtocol> for MixerCtl {
+    fn segment(&self) -> &K24dMixerStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K24dMixerStateSegment {
         &mut self.0
     }
 
-    fn reverb_return(&self) -> &ShellReverbReturn {
-        &self.0.data.reverb_return
+    fn reverb_return(params: &K24dMixerState) -> &ShellReverbReturn {
+        &params.reverb_return
     }
 
-    fn reverb_return_mut(&mut self) -> &mut ShellReverbReturn {
-        &mut self.0.data.reverb_return
+    fn reverb_return_mut(params: &mut K24dMixerState) -> &mut ShellReverbReturn {
+        &mut params.reverb_return
     }
 }
 
@@ -707,9 +727,9 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
+        if self.write_mixer(req, &unit.1, elem_id, old, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_reverb_return(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_reverb_return(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -208,38 +208,46 @@ struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
 
 impl CommonCtlOperation<K8Protocol> for CommonCtl {}
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct KnobCtl(K8KnobSegment, Vec<ElemId>);
 
 impl ShellKnobCtlOperation<K8Knob, K8Protocol> for KnobCtl {
     const TARGETS: [&'static str; 4] = ["Analog-1", "Analog-2", "S/PDIF-1/2", "Configurable"];
 
+    fn segment(&self) -> &K8KnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K8KnobSegment {
         &mut self.0
     }
 
-    fn knob_target(&self) -> &ShellKnobTarget {
-        &self.0.data.target
+    fn knob_target(params: &K8Knob) -> &ShellKnobTarget {
+        &params.target
     }
 
-    fn knob_target_mut(&mut self) -> &mut ShellKnobTarget {
-        &mut self.0.data.target
+    fn knob_target_mut(params: &mut K8Knob) -> &mut ShellKnobTarget {
+        &mut params.target
     }
 }
 
 impl ShellKnob2CtlOperation<K8Knob, K8Protocol> for KnobCtl {
     const TARGETS: &'static [&'static str] = &["Stream-input-1/2", "Mixer-1/2"];
 
+    fn segment(&self) -> &K8KnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K8KnobSegment {
         &mut self.0
     }
 
-    fn knob2_target(&self) -> &ShellKnob2Target {
-        &self.0.data.knob2_target
+    fn knob2_target(params: &K8Knob) -> &ShellKnob2Target {
+        &params.knob2_target
     }
 
-    fn knob2_target_mut(&mut self) -> &mut ShellKnob2Target {
-        &mut self.0.data.knob2_target
+    fn knob2_target_mut(params: &mut K8Knob) -> &mut ShellKnob2Target {
+        &mut params.knob2_target
     }
 }
 
@@ -280,9 +288,9 @@ impl KnobCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob_target(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_knob_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_knob2_target(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_knob2_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)
@@ -322,16 +330,20 @@ impl KnobCtl {
 struct ConfigCtl(K8ConfigSegment, Vec<ElemId>);
 
 impl ShellCoaxIfaceCtlOperation<K8Config, K8Protocol> for ConfigCtl {
+    fn segment(&self) -> &K8ConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K8ConfigSegment {
         &mut self.0
     }
 
-    fn coax_out_src(&self) -> &ShellCoaxOutPairSrc {
-        &self.0.data.coax_out_src
+    fn coax_out_src(params: &K8Config) -> &ShellCoaxOutPairSrc {
+        &params.coax_out_src
     }
 
-    fn coax_out_src_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
-        &mut self.0.data.coax_out_src
+    fn coax_out_src_mut(params: &mut K8Config) -> &mut ShellCoaxOutPairSrc {
+        &mut params.coax_out_src
     }
 }
 
@@ -354,12 +366,12 @@ impl StandaloneCtlOperation<K8Config, K8Protocol> for ConfigCtl {
 }
 
 impl ShellStandaloneCtlOperation<K8Config, K8Protocol> for ConfigCtl {
-    fn standalone_src(&self) -> &ShellStandaloneClkSrc {
-        &self.0.data.standalone_src
+    fn standalone_src(params: &K8Config) -> &ShellStandaloneClkSrc {
+        &params.standalone_src
     }
 
-    fn standalone_src_mut(&mut self) -> &mut ShellStandaloneClkSrc {
-        &mut self.0.data.standalone_src
+    fn standalone_src_mut(params: &mut K8Config) -> &mut ShellStandaloneClkSrc {
+        &mut params.standalone_src
     }
 }
 
@@ -398,9 +410,9 @@ impl ConfigCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_coax_out_src(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_coax_out_src(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_standalone(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)
@@ -455,12 +467,12 @@ impl ShellMixerCtlOperation<K8MixerState, K8MixerMeter, K8Protocol> for MixerCtl
         &mut self.1
     }
 
-    fn state(&self) -> &ShellMixerState {
-        &self.0.data.mixer
+    fn state(params: &K8MixerState) -> &ShellMixerState {
+        &params.mixer
     }
 
-    fn state_mut(&mut self) -> &mut ShellMixerState {
-        &mut self.0.data.mixer
+    fn state_mut(params: &mut K8MixerState) -> &mut ShellMixerState {
+        &mut params.mixer
     }
 
     fn meter(&self) -> &ShellMixerMeter {
@@ -524,7 +536,7 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
+        if self.write_mixer(req, &unit.1, elem_id, old, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -336,16 +336,20 @@ impl ShellCoaxIfaceCtlOperation<K8Config, K8Protocol> for ConfigCtl {
 }
 
 impl StandaloneCtlOperation<K8Config, K8Protocol> for ConfigCtl {
+    fn segment(&self) -> &K8ConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K8ConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &K8Config) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut K8Config) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -110,7 +110,7 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -589,16 +589,20 @@ impl MixerCtl {
 struct HwStateCtl(K8HwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<K8HwState, K8Protocol> for HwStateCtl {
+    fn segment(&self) -> &K8HwStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut K8HwStateSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.hw_state.firewire_led
+    fn firewire_led(params: &K8HwState) -> &FireWireLedState {
+        &params.hw_state.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.hw_state.firewire_led
+    fn firewire_led_mut(params: &mut K8HwState) -> &mut FireWireLedState {
+        &mut params.hw_state.firewire_led
     }
 }
 
@@ -651,14 +655,14 @@ impl HwStateCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         _: &ElemValue,
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_hw_state(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_hw_state(req, node, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -496,16 +496,20 @@ impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
 }
 
 impl StandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
+    fn segment(&self) -> &KliveConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &KliveConfig) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut KliveConfig) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -259,22 +259,26 @@ struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
 
 impl CommonCtlOperation<KliveProtocol> for CommonCtl {}
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct KnobCtl(KliveKnobSegment, Vec<ElemId>);
 
 impl ShellKnobCtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
     const TARGETS: [&'static str; 4] = ["Analog-1", "Analog-2", "Analog-3/4", "Configurable"];
 
+    fn segment(&self) -> &KliveKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveKnobSegment {
         &mut self.0
     }
 
-    fn knob_target(&self) -> &ShellKnobTarget {
-        &self.0.data.target
+    fn knob_target(params: &KliveKnob) -> &ShellKnobTarget {
+        &params.target
     }
 
-    fn knob_target_mut(&mut self) -> &mut ShellKnobTarget {
-        &mut self.0.data.target
+    fn knob_target_mut(params: &mut KliveKnob) -> &mut ShellKnobTarget {
+        &mut params.target
     }
 }
 
@@ -291,16 +295,20 @@ impl ShellKnob2CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
         "Midi-send",
     ];
 
+    fn segment(&self) -> &KliveKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveKnobSegment {
         &mut self.0
     }
 
-    fn knob2_target(&self) -> &ShellKnob2Target {
-        &self.0.data.knob2_target
+    fn knob2_target(params: &KliveKnob) -> &ShellKnob2Target {
+        &params.knob2_target
     }
 
-    fn knob2_target_mut(&mut self) -> &mut ShellKnob2Target {
-        &mut self.0.data.knob2_target
+    fn knob2_target_mut(params: &mut KliveKnob) -> &mut ShellKnob2Target {
+        &mut params.knob2_target
     }
 }
 
@@ -392,9 +400,9 @@ impl KnobCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob_target(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_knob_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_knob2_target(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_knob2_target(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else if self.write_prog(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
@@ -450,48 +458,60 @@ impl KnobCtl {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Debug)]
 struct ConfigCtl(KliveConfigSegment, Vec<ElemId>);
 
 impl ShellMixerStreamSrcCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
+    fn segment(&self) -> &KliveConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveConfigSegment {
         &mut self.0
     }
 
-    fn mixer_stream_src(&self) -> &ShellMixerStreamSrcPair {
-        &self.0.data.mixer_stream_src_pair
+    fn mixer_stream_src(params: &KliveConfig) -> &ShellMixerStreamSrcPair {
+        &params.mixer_stream_src_pair
     }
 
-    fn mixer_stream_src_mut(&mut self) -> &mut ShellMixerStreamSrcPair {
-        &mut self.0.data.mixer_stream_src_pair
+    fn mixer_stream_src_mut(params: &mut KliveConfig) -> &mut ShellMixerStreamSrcPair {
+        &mut params.mixer_stream_src_pair
     }
 }
 
 impl ShellCoaxIfaceCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
+    fn segment(&self) -> &KliveConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveConfigSegment {
         &mut self.0
     }
 
-    fn coax_out_src(&self) -> &ShellCoaxOutPairSrc {
-        &self.0.data.coax_out_src
+    fn coax_out_src(params: &KliveConfig) -> &ShellCoaxOutPairSrc {
+        &params.coax_out_src
     }
 
-    fn coax_out_src_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
-        &mut self.0.data.coax_out_src
+    fn coax_out_src_mut(params: &mut KliveConfig) -> &mut ShellCoaxOutPairSrc {
+        &mut params.coax_out_src
     }
 }
 
 impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
+    fn segment(&self) -> &KliveConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveConfigSegment {
         &mut self.0
     }
 
-    fn opt_iface_config(&self) -> &ShellOptIfaceConfig {
-        &self.0.data.opt
+    fn opt_iface_config(params: &KliveConfig) -> &ShellOptIfaceConfig {
+        &params.opt
     }
 
-    fn opt_iface_config_mut(&mut self) -> &mut ShellOptIfaceConfig {
-        &mut self.0.data.opt
+    fn opt_iface_config_mut(params: &mut KliveConfig) -> &mut ShellOptIfaceConfig {
+        &mut params.opt
     }
 }
 
@@ -514,12 +534,12 @@ impl StandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
 }
 
 impl ShellStandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn standalone_src(&self) -> &ShellStandaloneClkSrc {
-        &self.0.data.standalone_src
+    fn standalone_src(params: &KliveConfig) -> &ShellStandaloneClkSrc {
+        &params.standalone_src
     }
 
-    fn standalone_src_mut(&mut self) -> &mut ShellStandaloneClkSrc {
-        &mut self.0.data.standalone_src
+    fn standalone_src_mut(params: &mut KliveConfig) -> &mut ShellStandaloneClkSrc {
+        &mut params.standalone_src
     }
 }
 
@@ -598,13 +618,13 @@ impl ConfigCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer_stream_src(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_mixer_stream_src(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_coax_out_src(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_coax_out_src(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_opt_iface_config(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_opt_iface_config(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_standalone(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else if self.write_midi_sender(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
@@ -697,12 +717,12 @@ impl ShellMixerCtlOperation<KliveMixerState, KliveMixerMeter, KliveProtocol> for
         &mut self.1
     }
 
-    fn state(&self) -> &ShellMixerState {
-        &self.0.data.mixer
+    fn state(params: &KliveMixerState) -> &ShellMixerState {
+        &params.mixer
     }
 
-    fn state_mut(&mut self) -> &mut ShellMixerState {
-        &mut self.0.data.mixer
+    fn state_mut(params: &mut KliveMixerState) -> &mut ShellMixerState {
+        &mut params.mixer
     }
 
     fn meter(&self) -> &ShellMixerMeter {
@@ -719,16 +739,20 @@ impl ShellMixerCtlOperation<KliveMixerState, KliveMixerMeter, KliveProtocol> for
 }
 
 impl ShellReverbReturnCtlOperation<KliveMixerState, KliveProtocol> for MixerCtl {
+    fn segment(&self) -> &KliveMixerStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveMixerStateSegment {
         &mut self.0
     }
 
-    fn reverb_return(&self) -> &ShellReverbReturn {
-        &self.0.data.reverb_return
+    fn reverb_return(params: &KliveMixerState) -> &ShellReverbReturn {
+        &params.reverb_return
     }
 
-    fn reverb_return_mut(&mut self) -> &mut ShellReverbReturn {
-        &mut self.0.data.reverb_return
+    fn reverb_return_mut(params: &mut KliveMixerState) -> &mut ShellReverbReturn {
+        &mut params.reverb_return
     }
 }
 
@@ -874,9 +898,9 @@ impl MixerCtl {
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer(unit, req, elem_id, old, new, timeout_ms)? {
+        if self.write_mixer(req, &unit.1, elem_id, old, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_reverb_return(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_reverb_return(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -28,6 +28,8 @@ impl KliveModel {
         self.common_ctl
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+
         Ok(())
     }
 }
@@ -59,12 +61,12 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
             })?;
-        self.ch_strip_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|(notified_elem_id_list, measured_elem_id_list)| {
+        self.ch_strip_ctl.load(card_cntr).map(
+            |(notified_elem_id_list, measured_elem_id_list)| {
                 self.ch_strip_ctl.2 = notified_elem_id_list;
                 self.ch_strip_ctl.3 = measured_elem_id_list;
-            })?;
+            },
+        )?;
 
         Ok(())
     }
@@ -133,7 +135,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
             Ok(true)
         } else if self
             .ch_strip_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -181,7 +183,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
         self.reverb_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -227,7 +229,7 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
         self.reverb_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -1111,12 +1113,12 @@ impl ChStripCtlOperation<KliveChStripStates, KliveChStripMeters, KliveProtocol> 
         &mut self.1
     }
 
-    fn states(&self) -> &[ChStripState] {
-        &self.0.data.0
+    fn states(params: &KliveChStripStates) -> &[ChStripState] {
+        &params.0
     }
 
-    fn states_mut(&mut self) -> &mut [ChStripState] {
-        &mut self.0.data.0
+    fn states_mut(params: &mut KliveChStripStates) -> &mut [ChStripState] {
+        &mut params.0
     }
 
     fn meters(&self) -> &[ChStripMeter] {

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -305,16 +305,20 @@ impl ShellKnob2CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
 }
 
 impl ProgramCtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
+    fn segment(&self) -> &KliveKnobSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveKnobSegment {
         &mut self.0
     }
 
-    fn prog(&self) -> &TcKonnektLoadedProgram {
-        &self.0.data.prog
+    fn prog(params: &KliveKnob) -> &TcKonnektLoadedProgram {
+        &params.prog
     }
 
-    fn prog_mut(&mut self) -> &mut TcKonnektLoadedProgram {
-        &mut self.0.data.prog
+    fn prog_mut(params: &mut KliveKnob) -> &mut TcKonnektLoadedProgram {
+        &mut params.prog
     }
 }
 
@@ -392,7 +396,7 @@ impl KnobCtl {
             Ok(true)
         } else if self.write_knob2_target(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_prog(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_prog(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -141,7 +141,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -981,16 +981,20 @@ impl MixerCtl {
 struct HwStateCtl(KliveHwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<KliveHwState, KliveProtocol> for HwStateCtl {
+    fn segment(&self) -> &KliveHwStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveHwStateSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.0.firewire_led
+    fn firewire_led(params: &KliveHwState) -> &FireWireLedState {
+        &params.0.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.0.firewire_led
+    fn firewire_led_mut(params: &mut KliveHwState) -> &mut FireWireLedState {
+        &mut params.0.firewire_led
     }
 }
 
@@ -1030,14 +1034,14 @@ impl HwStateCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         _: &ElemValue,
         new: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_hw_state(unit, req, elem_id, new, timeout_ms)? {
+        if self.write_hw_state(req, node, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -516,16 +516,20 @@ impl ShellStandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
 }
 
 impl MidiSendCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
+    fn segment(&self) -> &KliveConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut KliveConfigSegment {
         &mut self.0
     }
 
-    fn midi_sender(&self) -> &TcKonnektMidiSender {
-        &self.0.data.midi_sender
+    fn midi_sender(params: &KliveConfig) -> &TcKonnektMidiSender {
+        &params.midi_sender
     }
 
-    fn midi_sender_mut(&mut self) -> &mut TcKonnektMidiSender {
-        &mut self.0.data.midi_sender
+    fn midi_sender_mut(params: &mut KliveConfig) -> &mut TcKonnektMidiSender {
+        &mut params.midi_sender
     }
 }
 
@@ -594,7 +598,7 @@ impl ConfigCtl {
             Ok(true)
         } else if self.write_standalone(unit, req, elem_id, new, timeout_ms)? {
             Ok(true)
-        } else if self.write_midi_sender(unit, req, elem_id, new, timeout_ms)? {
+        } else if self.write_midi_sender(req, &unit.1, elem_id, new, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/midi_send_ctl.rs
+++ b/runtime/dice/src/tcelectronic/midi_send_ctl.rs
@@ -12,15 +12,16 @@ const EVENT_TO_STREAM_NAME: &str = "midi-event-to-stream";
 
 pub trait MidiSendCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData,
-    TcKonnektSegment<S>: TcKonnektSegmentSpec + TcKonnektNotifiedSegmentSpec,
-    T: SegmentOperation<S>,
+    S: TcKonnektSegmentData + Clone,
+    T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
+    fn segment(&self) -> &TcKonnektSegment<S>;
     fn segment_mut(&mut self) -> &mut TcKonnektSegment<S>;
-    fn midi_sender(&self) -> &TcKonnektMidiSender;
-    fn midi_sender_mut(&mut self) -> &mut TcKonnektMidiSender;
 
-    fn load_midi_sender(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn midi_sender(params: &S) -> &TcKonnektMidiSender;
+    fn midi_sender_mut(params: &mut S) -> &mut TcKonnektMidiSender;
+
+    fn load_midi_sender(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Rawmidi, 0, 0, NORMAL_EVENT_CH_NAME, 0);
         let _ = card_cntr.add_bytes_elems(&elem_id, 1, 1, None, true)?;
 
@@ -49,93 +50,97 @@ where
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             NORMAL_EVENT_CH_NAME => {
-                ElemValueAccessor::<u8>::set_val(elem_value, || Ok(self.midi_sender().normal.ch))
-                    .map(|_| true)
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bytes(&[sender.normal.ch]);
+                Ok(true)
             }
             NORMAL_EVENT_CC_NAME => {
-                ElemValueAccessor::<u8>::set_val(elem_value, || Ok(self.midi_sender().normal.cc))
-                    .map(|_| true)
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bytes(&[sender.normal.cc]);
+                Ok(true)
             }
             PUSHED_EVENT_CH_NAME => {
-                ElemValueAccessor::<u8>::set_val(elem_value, || Ok(self.midi_sender().pushed.ch))
-                    .map(|_| true)
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bytes(&[sender.pushed.ch]);
+                Ok(true)
             }
             PUSHED_EVENT_CC_NAME => {
-                ElemValueAccessor::<u8>::set_val(elem_value, || Ok(self.midi_sender().pushed.cc))
-                    .map(|_| true)
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bytes(&[sender.pushed.cc]);
+                Ok(true)
             }
-            EVENT_TO_PORT_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
-                Ok(self.midi_sender().send_to_port)
-            })
-            .map(|_| true),
-            EVENT_TO_STREAM_NAME => ElemValueAccessor::<bool>::set_val(elem_value, || {
-                Ok(self.midi_sender().send_to_stream)
-            })
-            .map(|_| true),
+            EVENT_TO_PORT_NAME => {
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bool(&[sender.send_to_port]);
+                Ok(true)
+            }
+            EVENT_TO_STREAM_NAME => {
+                let params = &self.segment().data;
+                let sender = Self::midi_sender(&params);
+                elem_value.set_bool(&[sender.send_to_stream]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
     fn write_midi_sender(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            NORMAL_EVENT_CH_NAME => ElemValueAccessor::<u8>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.normal.ch = val;
-                })
-            })
-            .map(|_| true),
-            NORMAL_EVENT_CC_NAME => ElemValueAccessor::<u8>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.normal.cc = val;
-                })
-            })
-            .map(|_| true),
-            PUSHED_EVENT_CH_NAME => ElemValueAccessor::<u8>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.pushed.ch = val;
-                })
-            })
-            .map(|_| true),
-            PUSHED_EVENT_CC_NAME => ElemValueAccessor::<u8>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.pushed.cc = val;
-                })
-            })
-            .map(|_| true),
-            EVENT_TO_PORT_NAME => ElemValueAccessor::<bool>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.send_to_port = val;
-                })
-            })
-            .map(|_| true),
-            EVENT_TO_STREAM_NAME => ElemValueAccessor::<bool>::get_val(elem_value, |val| {
-                self.state_write(unit, req, timeout_ms, |state| {
-                    state.send_to_stream = val;
-                })
-            })
-            .map(|_| true),
+            NORMAL_EVENT_CH_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.normal.ch = elem_value.bytes()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
+            NORMAL_EVENT_CC_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.normal.cc = elem_value.bytes()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
+            PUSHED_EVENT_CH_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.pushed.ch = elem_value.bytes()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
+            PUSHED_EVENT_CC_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.pushed.cc = elem_value.bytes()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
+            EVENT_TO_PORT_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.send_to_port = elem_value.boolean()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
+            EVENT_TO_STREAM_NAME => {
+                let mut params = self.segment().data.clone();
+                let mut sender = Self::midi_sender_mut(&mut params);
+                sender.send_to_stream = elem_value.boolean()[0];
+                T::update_partial_segment(req, &node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
+            }
             _ => Ok(false),
         }
-    }
-
-    fn state_write<F>(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        cb: F,
-    ) -> Result<(), Error>
-    where
-        F: Fn(&mut TcKonnektMidiSender),
-    {
-        cb(&mut self.midi_sender_mut());
-        T::write_segment(req, &mut unit.1, self.segment_mut(), timeout_ms)
     }
 }

--- a/runtime/dice/src/tcelectronic/midi_send_ctl.rs
+++ b/runtime/dice/src/tcelectronic/midi_send_ctl.rs
@@ -12,7 +12,7 @@ const EVENT_TO_STREAM_NAME: &str = "midi-event-to-stream";
 
 pub trait MidiSendCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;

--- a/runtime/dice/src/tcelectronic/prog_ctl.rs
+++ b/runtime/dice/src/tcelectronic/prog_ctl.rs
@@ -7,7 +7,7 @@ const LOADED_NAME: &str = "loaded-program";
 
 pub trait ProgramCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     const PROG_LABELS: [&'static str; 3] = ["P1", "P2", "P3"];

--- a/runtime/dice/src/tcelectronic/prog_ctl.rs
+++ b/runtime/dice/src/tcelectronic/prog_ctl.rs
@@ -7,57 +7,58 @@ const LOADED_NAME: &str = "loaded-program";
 
 pub trait ProgramCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData,
-    TcKonnektSegment<S>: TcKonnektSegmentSpec + TcKonnektNotifiedSegmentSpec,
-    T: SegmentOperation<S>,
+    S: TcKonnektSegmentData + Clone,
+    T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     const PROG_LABELS: [&'static str; 3] = ["P1", "P2", "P3"];
 
+    fn segment(&self) -> &TcKonnektSegment<S>;
     fn segment_mut(&mut self) -> &mut TcKonnektSegment<S>;
-    fn prog(&self) -> &TcKonnektLoadedProgram;
-    fn prog_mut(&mut self) -> &mut TcKonnektLoadedProgram;
 
-    fn load_prog(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
+    fn prog(params: &S) -> &TcKonnektLoadedProgram;
+    fn prog_mut(params: &mut S) -> &mut TcKonnektLoadedProgram;
+
+    fn load_prog(&self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
         let labels: Vec<String> = Self::PROG_LABELS.iter().map(|l| l.to_string()).collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LOADED_NAME, 0);
         card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)
     }
 
-    fn read_prog(&mut self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+    fn read_prog(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            LOADED_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                if self.prog().0 >= Self::PROG_LABELS.len() as u32 {
-                    let msg = format!("Unexpected index of program: {}", self.prog().0);
-                    Err(Error::new(FileError::Io, &msg))
-                } else {
-                    Ok(self.prog().0)
+            LOADED_NAME => {
+                let params = &self.segment().data;
+                let prog = Self::prog(&params);
+                if prog.0 >= Self::PROG_LABELS.len() as u32 {
+                    let msg = format!("Unexpected index of program: {}", prog.0);
+                    Err(Error::new(FileError::Io, &msg))?;
                 }
-            })
-            .map(|_| true),
+                elem_value.set_enum(&[prog.0]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
     fn write_prog(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             LOADED_NAME => {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    if val >= Self::PROG_LABELS.len() as u32 {
-                        let msg = format!("Invalid value for index of program: {}", val);
-                        Err(Error::new(FileError::Io, &msg))
-                    } else {
-                        self.prog_mut().0 = val;
-                        Ok(())
-                    }
-                })?;
-                T::write_segment(req, &mut unit.1, self.segment_mut(), timeout_ms).map(|_| true)
+                let val = elem_value.enumerated()[0];
+                if val >= Self::PROG_LABELS.len() as u32 {
+                    let msg = format!("Invalid value for index of program: {}", val);
+                    Err(Error::new(FileError::Io, &msg))?;
+                }
+                let mut params = self.segment().data.clone();
+                Self::prog_mut(&mut params).0 = val;
+                T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms)
+                    .map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/dice/src/tcelectronic/reverb_ctl.rs
+++ b/runtime/dice/src/tcelectronic/reverb_ctl.rs
@@ -44,8 +44,7 @@ fn reverb_algorithm_to_str(algo: &ReverbAlgorithm) -> &'static str {
 
 pub trait ReverbCtlOperation<S, T, U>
 where
-    S: TcKonnektSegmentData + Clone,
-    T: TcKonnektSegmentData,
+    S: Clone,
     U: TcKonnektSegmentOperation<S>
         + TcKonnektSegmentOperation<T>
         + TcKonnektMutableSegmentOperation<S>

--- a/runtime/dice/src/tcelectronic/shell_ctl.rs
+++ b/runtime/dice/src/tcelectronic/shell_ctl.rs
@@ -18,7 +18,7 @@ const ANALOG_JACK_STATE_NAME: &str = "analog-jack-state";
 
 pub trait ShellHwStateCtlOperation<S, T>: FirewireLedCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn hw_state(&self) -> &ShellHwState;
@@ -118,8 +118,7 @@ const MIXER_OUT_METER_NAME: &str = "mixer-output-meters";
 
 pub trait ShellMixerCtlOperation<S, T, U>
 where
-    S: TcKonnektSegmentData + Clone,
-    T: TcKonnektSegmentData,
+    S: Clone,
     U: TcKonnektSegmentOperation<S>
         + TcKonnektSegmentOperation<T>
         + TcKonnektMutableSegmentOperation<S>
@@ -674,7 +673,7 @@ const MUTE_NAME: &str = "reverb-return-mute";
 
 pub trait ShellReverbReturnCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;
@@ -806,9 +805,8 @@ const SRC_NAME: &str = "standalone-clock-source";
 
 pub trait ShellStandaloneCtlOperation<S, T>: StandaloneCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + ShellStandaloneClkSpec + Clone,
-    TcKonnektSegment<S>: TcKonnektSegmentSpec,
-    T: SegmentOperation<S> + TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
+    S: ShellStandaloneClkSpec + Clone,
+    T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn standalone_src(params: &S) -> &ShellStandaloneClkSrc;
     fn standalone_src_mut(params: &mut S) -> &mut ShellStandaloneClkSrc;
@@ -887,7 +885,7 @@ const MIXER_STREAM_SRC_NAME: &str = "mixer-stream-soruce";
 
 pub trait ShellMixerStreamSrcCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + ShellMixerStreamSrcPairSpec + Clone,
+    S: ShellMixerStreamSrcPairSpec + Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;
@@ -989,7 +987,7 @@ const COAX_OUT_SRC_NAME: &str = "coaxial-output-source";
 
 pub trait ShellCoaxIfaceCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;
@@ -1075,7 +1073,7 @@ const OPT_OUT_SRC_NAME: &str = "optical-output-source";
 
 pub trait ShellOptIfaceCtl<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     const IN_FMTS: [ShellOptInputIfaceFormat; 3] = [
@@ -1220,7 +1218,7 @@ const TARGET_NAME: &str = "knob-target";
 
 pub trait ShellKnobCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     const TARGETS: [&'static str; 4];
@@ -1286,7 +1284,7 @@ const KNOB2_NAME: &str = "configurable-knob-target";
 
 pub trait ShellKnob2CtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S>
         + TcKonnektMutableSegmentOperation<S>
         + TcKonnektNotifiedSegmentOperation<S>,

--- a/runtime/dice/src/tcelectronic/shell_ctl.rs
+++ b/runtime/dice/src/tcelectronic/shell_ctl.rs
@@ -766,9 +766,9 @@ const SRC_NAME: &str = "standalone-clock-source";
 
 pub trait ShellStandaloneCtlOperation<S, T>: StandaloneCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + ShellStandaloneClkSpec,
+    S: TcKonnektSegmentData + ShellStandaloneClkSpec + Clone,
     TcKonnektSegment<S>: TcKonnektSegmentSpec,
-    T: SegmentOperation<S>,
+    T: SegmentOperation<S> + TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn standalone_src(&self) -> &ShellStandaloneClkSrc;
     fn standalone_src_mut(&mut self) -> &mut ShellStandaloneClkSrc;
@@ -822,7 +822,7 @@ where
                 })?;
                 T::write_segment(req, &mut unit.1, self.segment_mut(), timeout_ms).map(|_| true)
             }
-            _ => self.write_standalone_rate(unit, req, elem_id, elem_value, timeout_ms),
+            _ => self.write_standalone_rate(req, &unit.1, elem_id, elem_value, timeout_ms),
         }
     }
 }

--- a/runtime/dice/src/tcelectronic/shell_ctl.rs
+++ b/runtime/dice/src/tcelectronic/shell_ctl.rs
@@ -18,9 +18,9 @@ const ANALOG_JACK_STATE_NAME: &str = "analog-jack-state";
 
 pub trait ShellHwStateCtlOperation<S, T>: FirewireLedCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData,
+    S: TcKonnektSegmentData + Clone,
     TcKonnektSegment<S>: TcKonnektSegmentSpec + TcKonnektNotifiedSegmentSpec,
-    T: SegmentOperation<S>,
+    T: SegmentOperation<S> + TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn hw_state(&self) -> &ShellHwState;
     fn hw_state_mut(&mut self) -> &mut ShellHwState;
@@ -86,13 +86,13 @@ where
 
     fn write_hw_state(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        self.write_firewire_led(unit, req, elem_id, elem_value, timeout_ms)
+        self.write_firewire_led(req, node, elem_id, elem_value, timeout_ms)
     }
 }
 

--- a/runtime/dice/src/tcelectronic/standalone_ctl.rs
+++ b/runtime/dice/src/tcelectronic/standalone_ctl.rs
@@ -16,7 +16,7 @@ const RATE_NAME: &str = "standalone-clock-rate";
 
 pub trait StandaloneCtlOperation<S, T>
 where
-    S: TcKonnektSegmentData + Clone,
+    S: Clone,
     T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
 {
     fn segment(&self) -> &TcKonnektSegment<S>;

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -755,16 +755,20 @@ fn knob_push_mode_to_str(mode: &KnobPushMode) -> &'static str {
 }
 
 impl StandaloneCtlOperation<StudioConfig, Studiok48Protocol> for ConfigCtl {
+    fn segment(&self) -> &Studiok48ConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Studiok48ConfigSegment {
         &mut self.0
     }
 
-    fn standalone_rate(&self) -> &TcKonnektStandaloneClkRate {
-        &self.0.data.standalone_rate
+    fn standalone_rate(params: &StudioConfig) -> &TcKonnektStandaloneClkRate {
+        &params.standalone_rate
     }
 
-    fn standalone_rate_mut(&mut self) -> &mut TcKonnektStandaloneClkRate {
-        &mut self.0.data.standalone_rate
+    fn standalone_rate_mut(params: &mut StudioConfig) -> &mut TcKonnektStandaloneClkRate {
+        &mut params.standalone_rate
     }
 }
 
@@ -874,7 +878,7 @@ impl ConfigCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_standalone_rate(unit, req, elem_id, elem_value, timeout_ms)? {
+        if self.write_standalone_rate(req, &unit.1, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else if self.write_midi_sender(req, &unit.1, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -449,16 +449,20 @@ impl LineoutCtl {
 struct RemoteCtl(Studiok48RemoteSegment, Vec<ElemId>);
 
 impl ProgramCtlOperation<StudioRemote, Studiok48Protocol> for RemoteCtl {
+    fn segment(&self) -> &Studiok48RemoteSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Studiok48RemoteSegment {
         &mut self.0
     }
 
-    fn prog(&self) -> &TcKonnektLoadedProgram {
-        &self.0.data.prog
+    fn prog(params: &StudioRemote) -> &TcKonnektLoadedProgram {
+        &params.prog
     }
 
-    fn prog_mut(&mut self) -> &mut TcKonnektLoadedProgram {
-        &mut self.0.data.prog
+    fn prog_mut(params: &mut StudioRemote) -> &mut TcKonnektLoadedProgram {
+        &mut params.prog
     }
 }
 
@@ -694,7 +698,7 @@ impl RemoteCtl {
                 Studiok48Protocol::write_segment(req, &mut unit.1, &mut self.0, timeout_ms)
                     .map(|_| true)
             }
-            _ => self.write_prog(unit, req, elem_id, new, timeout_ms),
+            _ => self.write_prog(req, &unit.1, elem_id, new, timeout_ms),
         }
     }
 

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -32,6 +32,8 @@ impl Studiok48Model {
         self.common_ctl
             .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.ch_strip_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+
         Ok(())
     }
 }
@@ -66,12 +68,12 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
                 self.reverb_ctl.2 = notified_elem_id_list;
                 self.reverb_ctl.3 = measured_elem_id_list;
             })?;
-        self.ch_strip_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|(notified_elem_id_list, measured_elem_id_list)| {
+        self.ch_strip_ctl.load(card_cntr).map(
+            |(notified_elem_id_list, measured_elem_id_list)| {
                 self.ch_strip_ctl.2 = notified_elem_id_list;
                 self.ch_strip_ctl.3 = measured_elem_id_list;
-            })?;
+            },
+        )?;
 
         self.hw_state_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
@@ -157,7 +159,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
             Ok(true)
         } else if self
             .ch_strip_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -209,7 +211,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
         self.reverb_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
             .parse_notification(unit, &mut self.req, msg, TIMEOUT_MS)?;
 
@@ -262,7 +264,7 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
         self.reverb_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.ch_strip_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .measure_states(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -2402,12 +2404,12 @@ impl ChStripCtlOperation<StudioChStripStates, StudioChStripMeters, Studiok48Prot
         &mut self.1
     }
 
-    fn states(&self) -> &[ChStripState] {
-        &self.0.data.0
+    fn states(params: &StudioChStripStates) -> &[ChStripState] {
+        &params.0
     }
 
-    fn states_mut(&mut self) -> &mut [ChStripState] {
-        &mut self.0.data.0
+    fn states_mut(params: &mut StudioChStripStates) -> &mut [ChStripState] {
+        &mut params.0
     }
 
     fn meters(&self) -> &[ChStripMeter] {

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -765,16 +765,20 @@ impl StandaloneCtlOperation<StudioConfig, Studiok48Protocol> for ConfigCtl {
 }
 
 impl MidiSendCtlOperation<StudioConfig, Studiok48Protocol> for ConfigCtl {
+    fn segment(&self) -> &Studiok48ConfigSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Studiok48ConfigSegment {
         &mut self.0
     }
 
-    fn midi_sender(&self) -> &TcKonnektMidiSender {
-        &self.0.data.midi_send
+    fn midi_sender(params: &StudioConfig) -> &TcKonnektMidiSender {
+        &params.midi_send
     }
 
-    fn midi_sender_mut(&mut self) -> &mut TcKonnektMidiSender {
-        &mut self.0.data.midi_send
+    fn midi_sender_mut(params: &mut StudioConfig) -> &mut TcKonnektMidiSender {
+        &mut params.midi_send
     }
 }
 
@@ -868,7 +872,7 @@ impl ConfigCtl {
     ) -> Result<bool, Error> {
         if self.write_standalone_rate(unit, req, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_midi_sender(unit, req, elem_id, elem_value, timeout_ms)? {
+        } else if self.write_midi_sender(req, &unit.1, elem_id, elem_value, timeout_ms)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -165,7 +165,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -2469,16 +2469,20 @@ fn analog_jack_state_to_str(state: &StudioAnalogJackState) -> &'static str {
 struct HwStateCtl(Studiok48HwStateSegment, Vec<ElemId>);
 
 impl FirewireLedCtlOperation<StudioHwState, Studiok48Protocol> for HwStateCtl {
+    fn segment(&self) -> &Studiok48HwStateSegment {
+        &self.0
+    }
+
     fn segment_mut(&mut self) -> &mut Studiok48HwStateSegment {
         &mut self.0
     }
 
-    fn firewire_led(&self) -> &FireWireLedState {
-        &self.0.data.firewire_led
+    fn firewire_led(params: &StudioHwState) -> &FireWireLedState {
+        &params.firewire_led
     }
 
-    fn firewire_led_mut(&mut self) -> &mut FireWireLedState {
-        &mut self.0.data.firewire_led
+    fn firewire_led_mut(params: &mut StudioHwState) -> &mut FireWireLedState {
+        &mut params.firewire_led
     }
 }
 
@@ -2547,13 +2551,13 @@ impl HwStateCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
+        req: &FwReq,
+        node: &FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        self.write_firewire_led(unit, req, elem_id, elem_value, timeout_ms)
+        self.write_firewire_led(req, node, elem_id, elem_value, timeout_ms)
     }
 
     fn read_notified_elem(


### PR DESCRIPTION
Current implementation for protocol specific to TC Electronic has issue that
intermediate data expression has parameters to operate protocol. It's preferable
to move these parameters to protocol implementations.

This patchset is for the purpose.

```
Takashi Sakamoto (23):
  protocols/dice: tcat: expand error domain for vendor dependent protocols
  protocols/dice: tcelectronic: tcelectronic: add trait to revise current implementation
  protocols/dice: tcelectronic: use renewed trait for Desktop Konnekt 6
  protocols/dice: tcelectronic: implement renewed trait for Studio Konnekt 48
  protocols/dice: tcelectronic: implement renewed trait for Konnekt 8
  protocols/dice: tcelectronic: implement renewed trait for Konnekt 24
  protocols/dice: tcelectronic: implement renewed trait for Konnekt Live
  protocols/dice: tcelectronic: implement renewed trait for Impact twin
  runtime/dice: tcelectronic: use renewed trait implementation for channel strip effect controls
  runtime/dice: tcelectronic: use renewed trait implementation for reverb effect controls
  runtime/dice: tcelectronic: use renewed trait implementation for firewire LED control
  runtime/dice: tcelectronic: use renewed trait implementation for MIDI sender control
  runtime/dice: tcelectronic: use renewed trait implementation for loaded program control
  runtime/dice: tcelectronic: use renewed trait implementation for standalone rate control
  runtime/dice: tcelectronic: use renewed trait implementation for shell controls
  runtime/dice: tcelectronic: use renewed trait implementation for Desktop Konnekt 6
  runtime/dice: tcelectronic: use renewed trait implementation for Studio Konnekt 48
  runtime/dice: tcelectronic: use renewed trait implementation for Konnekt 8 controls
  runtime/dice: tcelectronic: use renewed trait implementation for K24d controls
  runtime/dice: tcelectronic: use renewed trait implementation for Konnekt Live controls
  runtime/dice: tcelectronic: use renewed trait implementation for Impact Twin
  protocols/dice: tcelectronic: implement default trait for parameterized segment
  protocols/dice: tcelectronic: delete unused trait and its implementations

 protocols/dice/src/tcat.rs                    |    5 +
 protocols/dice/src/tcelectronic.rs            |  164 ++-
 protocols/dice/src/tcelectronic/ch_strip.rs   |   14 +-
 protocols/dice/src/tcelectronic/desktop.rs    |  309 ++---
 protocols/dice/src/tcelectronic/fw_led.rs     |    2 +-
 protocols/dice/src/tcelectronic/midi_send.rs  |    4 +-
 protocols/dice/src/tcelectronic/prog.rs       |    2 +-
 protocols/dice/src/tcelectronic/reverb.rs     |    6 +-
 protocols/dice/src/tcelectronic/shell.rs      |   40 +-
 .../dice/src/tcelectronic/shell/itwin.rs      |  288 +++--
 protocols/dice/src/tcelectronic/shell/k24d.rs |  291 +++--
 protocols/dice/src/tcelectronic/shell/k8.rs   |  167 +--
 .../dice/src/tcelectronic/shell/klive.rs      |  330 ++---
 protocols/dice/src/tcelectronic/standalone.rs |    2 +-
 protocols/dice/src/tcelectronic/studio.rs     |  508 ++++----
 runtime/dice/src/tcelectronic/ch_strip_ctl.rs |  102 +-
 .../dice/src/tcelectronic/desktopk6_model.rs  |  813 ++++++------
 runtime/dice/src/tcelectronic/fw_led_ctl.rs   |   49 +-
 runtime/dice/src/tcelectronic/itwin_model.rs  |  387 +++---
 runtime/dice/src/tcelectronic/k24d_model.rs   |  428 ++++---
 runtime/dice/src/tcelectronic/k8_model.rs     |  264 ++--
 runtime/dice/src/tcelectronic/klive_model.rs  |  584 +++++----
 .../dice/src/tcelectronic/midi_send_ctl.rs    |  153 +--
 runtime/dice/src/tcelectronic/prog_ctl.rs     |   55 +-
 runtime/dice/src/tcelectronic/reverb_ctl.rs   |  109 +-
 runtime/dice/src/tcelectronic/shell_ctl.rs    |  595 +++++----
 .../dice/src/tcelectronic/standalone_ctl.rs   |   56 +-
 .../dice/src/tcelectronic/studiok48_model.rs  | 1136 ++++++++++-------
 28 files changed, 3763 insertions(+), 3100 deletions(-)
```