### PR TITLE
[PATCH 0/9] protocols/dice: lexicon: rework for protocol implementation of i-onix fw810s

### DIFF
--- a/protocols/dice/src/lexicon.rs
+++ b/protocols/dice/src/lexicon.rs
@@ -5,6 +5,35 @@
 //!
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Lexicon for I-ONIX FW810s.
+//!
+//! ## Diagram of internal signal flow
+//!
+//! ```text
+//!
+//! analog-input-0/1        -> stream-output-0/1
+//! analog-input-2/3        -> stream-output-2/3
+//! analog-input-4/5        -> stream-output-4/5
+//! analog-input-6/8        -> stream-output-6/7
+//! coaxial-input-0/1       -> stream-output-8/9
+//!
+//! stream-input-0/1        -> mixer-input-0/1
+//! stream-input-2/3        -> mixer-input-2/3
+//! stream-input-4/5        -> mixer-input-4/5
+//! stream-input-6/7        -> mixer-input-6/7
+//! analog-input-0/1        -> mixer-input-8/9
+//! analog-input-2/3        -> mixer-input-10/11
+//! analog-input-4/5        -> mixer-input-12/13
+//! analog-input-6/8        -> mixer-input-14/15
+//! coaxial-input-0/1       -> mixer-input-16/17
+//!
+//! mixer-output-0/1        -> analog-output-0/1
+//! mixer-output-2/3        -> analog-output-2/3
+//! mixer-output-4/5        -> analog-output-4/5
+//! mixer-output-6/7        -> analog-output-6/7
+//! mixer-output-8/9        -> (unused)
+//! mixer-output-10/11      -> coaxial-output-0/1
+//! mixer-output-12/13      -> main-output-0/1 (headphone-output-0/1)
+//! ```
 
 use {
     super::{

--- a/protocols/dice/src/lexicon.rs
+++ b/protocols/dice/src/lexicon.rs
@@ -6,9 +6,12 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Lexicon for I-ONIX FW810s.
 
-use super::{
-    tcat::{extension::*, *},
-    *,
+use {
+    super::{
+        tcat::{extension::*, *},
+        *,
+    },
+    std::ops::Range,
 };
 
 const BASE_OFFSET: usize = 0x00200000;
@@ -26,6 +29,143 @@ pub struct IonixProtocol;
 impl TcatOperation for IonixProtocol {}
 
 impl TcatGlobalSectionSpecification for IonixProtocol {}
+
+impl LexiconOperation for IonixProtocol {}
+
+/// Serialize and deserialize parameters.
+pub trait LexiconParametersSerdes<T> {
+    /// Name of parameters.
+    const NAME: &'static str;
+
+    /// List of offset ranges for parameters.
+    const OFFSET_RANGES: &'static [Range<usize>];
+
+    /// Serialize parameters.
+    fn serialize_params(params: &T, raw: &mut [u8]) -> Result<(), String>;
+
+    /// Deserialize parameters.
+    fn deserialize_params(params: &mut T, raw: &[u8]) -> Result<(), String>;
+}
+
+/// Common operation for Lexicon I-ONIX F810s.
+pub trait LexiconOperation: TcatOperation {
+    /// Read parameters from specific address range.
+    fn read_parameters(
+        req: &FwReq,
+        node: &FwNode,
+        offset: usize,
+        raw: &mut [u8],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Self::read(req, node, BASE_OFFSET + offset, raw, timeout_ms)
+    }
+
+    /// Write parameters to specific address range.
+    fn write_parameters(
+        req: &FwReq,
+        node: &FwNode,
+        offset: usize,
+        raw: &mut [u8],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Self::write(req, node, BASE_OFFSET + offset, raw, timeout_ms)
+    }
+}
+
+fn compute_params_size(ranges: &[Range<usize>]) -> usize {
+    ranges
+        .iter()
+        .fold(0usize, |size, range| size + range.end - range.start)
+}
+
+fn generate_err(name: &str, cause: &str, raw: &[u8]) -> Error {
+    let msg = format!("parms: {}, cause: {}, raw: {:02x?}", name, cause, raw);
+    Error::new(GeneralProtocolError::VendorDependent, &msg)
+}
+
+/// Operation to cache parameters.
+pub trait LexiconParametersOperation<T>: LexiconOperation + LexiconParametersSerdes<T> {
+    /// Cache parameters.
+    fn cache_whole_params(
+        req: &FwReq,
+        node: &FwNode,
+        params: &mut T,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let size = compute_params_size(Self::OFFSET_RANGES);
+        let mut raw = vec![0u8; size];
+
+        let mut pos = 0;
+
+        Self::OFFSET_RANGES.iter().try_for_each(|range| {
+            let size = range.end - range.start;
+            Self::read_parameters(
+                req,
+                node,
+                range.start,
+                &mut raw[pos..(pos + size)],
+                timeout_ms,
+            )
+            .map(|_| pos += size)
+        })?;
+
+        Self::deserialize_params(params, &raw)
+            .map_err(|cause| generate_err(Self::NAME, &cause, &raw))
+    }
+}
+
+impl<O: LexiconOperation + LexiconParametersSerdes<T>, T> LexiconParametersOperation<T> for O {}
+
+/// Operation for parameters to update state of hardware.
+pub trait LexiconMutableParametersOperation<T>:
+    LexiconOperation + LexiconParametersSerdes<T>
+{
+    /// Update the hardware partially for any change of parameter.
+    fn update_partial_parameters(
+        req: &FwReq,
+        node: &FwNode,
+        params: &T,
+        prev: &mut T,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let size = compute_params_size(Self::OFFSET_RANGES);
+
+        let mut new = vec![0u8; size];
+        let mut old = vec![0u8; size];
+        Self::serialize_params(params, &mut new)
+            .map_err(|cause| generate_err(Self::NAME, &cause, &new))?;
+        Self::serialize_params(prev, &mut old)
+            .map_err(|cause| generate_err(Self::NAME, &cause, &old))?;
+
+        let mut pos = 0;
+
+        Self::OFFSET_RANGES.iter().try_for_each(|range| {
+            let size = range.end - range.start;
+
+            if new[pos..(pos + size)] != old[pos..(pos + size)] {
+                (0..size).step_by(4).try_for_each(|offset| {
+                    let p = pos + offset;
+                    if new[p..(p + 4)] != old[p..(p + 4)] {
+                        Self::write_parameters(
+                            req,
+                            node,
+                            range.start + offset,
+                            &mut new[p..(p + 4)],
+                            timeout_ms,
+                        )
+                    } else {
+                        Ok(())
+                    }
+                })
+            } else {
+                Ok(())
+            }
+            .map(|_| pos += size)
+        })?;
+
+        Self::deserialize_params(prev, &new).map_err(|cause| generate_err(Self::NAME, &cause, &new))
+    }
+}
 
 fn lexicon_read(
     req: &mut FwReq,

--- a/protocols/dice/src/lexicon.rs
+++ b/protocols/dice/src/lexicon.rs
@@ -201,24 +201,33 @@ pub trait LexiconMutableParametersOperation<T>:
     }
 }
 
-fn lexicon_read(
-    req: &mut FwReq,
-    node: &mut FwNode,
-    offset: usize,
-    frame: &mut [u8],
-    timeout_ms: u32,
-) -> Result<(), Error> {
-    GeneralProtocol::read(req, node, BASE_OFFSET + offset, frame, timeout_ms)
-}
+impl IonixProtocol {
+    /// The number of analog inputs.
+    pub const ANALOG_INPUT_COUNT: usize = 8;
 
-fn lexicon_write(
-    req: &mut FwReq,
-    node: &mut FwNode,
-    offset: usize,
-    frame: &mut [u8],
-    timeout_ms: u32,
-) -> Result<(), Error> {
-    GeneralProtocol::write(req, node, BASE_OFFSET + offset, frame, timeout_ms)
+    /// The number of S/PDIF inputs.
+    pub const SPDIF_INPUT_COUNT: usize = 2;
+
+    /// The number of stream inputs.
+    pub const STREAM_INPUT_COUNT: usize = 10;
+
+    /// The number of analog inputs for mixer.
+    pub const MIXER_ANALOG_INPUT_COUNT: usize = 8;
+
+    /// The number of S/PDIF inputs for mixer.
+    pub const MIXER_SPDIF_INPUT_COUNT: usize = 2;
+
+    /// The number of stream inputs for mixer.
+    pub const MIXER_STREAM_INPUT_COUNT: usize = 8;
+
+    /// The number of channels in bus mixer.
+    pub const MIXER_BUS_COUNT: usize = 8;
+
+    /// The number of channels in main mixer.
+    pub const MIXER_MAIN_COUNT: usize = 2;
+
+    /// The number of channels in reverb mixer.
+    pub const MIXER_REVERB_COUNT: usize = 2;
 }
 
 /// Hardware meter.
@@ -234,11 +243,8 @@ pub struct IonixMeter {
 /// Entry of hardware meter.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 struct IonixMeterEntry {
-    /// The level of audio signal from the source to the destination.
     level: i16,
-    /// The source of audio signal.
     src: SrcBlk,
-    /// The destination of audio signal.
     dst: DstBlk,
 }
 
@@ -448,86 +454,6 @@ impl<O: LexiconOperation> LexiconParametersSerdes<IonixMeter> for O {
     }
 }
 
-impl From<u32> for IonixMeterEntry {
-    fn from(val: u32) -> Self {
-        IonixMeterEntry {
-            level: ((val & 0xffff0000) >> 16) as i16,
-            src: SrcBlk::from(((val & 0x0000ff00) >> 8) as u8),
-            dst: DstBlk::from(((val & 0x000000ff) >> 0) as u8),
-        }
-    }
-}
-
-impl From<IonixMeterEntry> for u32 {
-    fn from(entry: IonixMeterEntry) -> Self {
-        ((entry.level as u32) << 16)
-            | ((u8::from(entry.src) as u32) << 8)
-            | (u8::from(entry.dst) as u32)
-    }
-}
-
-impl IonixProtocol {
-    // NOTE: 90 entries are valid at all of supported sampling rate.
-    const ENTRY_COUNT: usize = 90;
-
-    pub const ANALOG_INPUT_COUNT: usize = 8;
-    pub const SPDIF_INPUT_COUNT: usize = 2;
-    pub const STREAM_INPUT_COUNT: usize = 10;
-
-    pub fn read_meters(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        meters: &mut IonixMeter,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut raw = vec![0; Self::ENTRY_COUNT * 4];
-        lexicon_read(req, node, METER_OFFSET, &mut raw, timeout_ms)?;
-        let mut entries = vec![IonixMeterEntry::default(); Self::ENTRY_COUNT];
-        entries.parse_quadlet_block(&raw);
-
-        entries
-            .iter()
-            .filter(|entry| entry.src.id == SrcBlkId::Avs0 && entry.dst.id == DstBlkId::MixerTx0)
-            .take(meters.stream_inputs.len())
-            .enumerate()
-            .for_each(|(i, entry)| meters.stream_inputs[i] = entry.level as i32);
-
-        entries
-            .iter()
-            .filter(|entry| entry.src.id == SrcBlkId::Ins0 && entry.dst.id == DstBlkId::MixerTx0)
-            .take(meters.analog_inputs.len())
-            .enumerate()
-            .for_each(|(i, entry)| meters.analog_inputs[i] = entry.level as i32);
-
-        entries
-            .iter()
-            .filter(|entry| entry.src.id == SrcBlkId::Aes && entry.dst.id == DstBlkId::MixerTx0)
-            .take(meters.spdif_inputs.len())
-            .enumerate()
-            .for_each(|(i, entry)| meters.spdif_inputs[i] = entry.level as i32);
-
-        entries
-            .iter()
-            .filter(|entry| entry.src.id == SrcBlkId::Mixer && entry.dst.id == DstBlkId::Ins0)
-            .take(meters.bus_outputs.len())
-            .enumerate()
-            .for_each(|(i, entry)| meters.bus_outputs[i] = entry.level as i32);
-
-        entries
-            .iter()
-            .filter(|entry| {
-                entry.src.id == SrcBlkId::Mixer
-                    && entry.dst.id == DstBlkId::Ins1
-                    && entry.dst.ch < 2
-            })
-            .take(meters.main_outputs.len())
-            .enumerate()
-            .for_each(|(i, entry)| meters.main_outputs[i] = entry.level as i32);
-
-        Ok(())
-    }
-}
-
 /// Gains of sources for mixer.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IonixMixerSources {
@@ -622,185 +548,6 @@ impl<O: LexiconOperation> LexiconParametersSerdes<IonixMixerParameters> for O {
 impl<O: LexiconOperation + LexiconParametersSerdes<IonixMixerParameters>>
     LexiconMutableParametersOperation<IonixMixerParameters> for O
 {
-}
-
-/// Source of mixer.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum MixerSrc {
-    Stream(usize),
-    Spdif(usize),
-    Analog(usize),
-}
-
-// Followed by gains for 8 channels of stream input.
-const STREAM_SRC_OFFSET: usize = 0x00;
-
-// Followed by gains for 2 channels of spdif input.
-const SPDIF_SRC_OFFSET: usize = 0x20;
-
-// Followed by gains for 8 channels of analog input.
-const ANALOG_SRC_OFFSET: usize = 0x28;
-
-// Including gains for the above channels.
-const MIXER_SRC_SIZE: usize = STREAM_SRC_OFFSET + SPDIF_SRC_OFFSET + ANALOG_SRC_OFFSET;
-
-impl From<MixerSrc> for usize {
-    fn from(src: MixerSrc) -> Self {
-        match src {
-            MixerSrc::Stream(ch) => STREAM_SRC_OFFSET + 4 * ch,
-            MixerSrc::Spdif(ch) => SPDIF_SRC_OFFSET + 4 * ch,
-            MixerSrc::Analog(ch) => ANALOG_SRC_OFFSET + 4 * ch,
-        }
-    }
-}
-
-impl IonixProtocol {
-    /// The number of analog inputs for mixer.
-    pub const MIXER_ANALOG_INPUT_COUNT: usize = 8;
-
-    /// The number of S/PDIF inputs for mixer.
-    pub const MIXER_SPDIF_INPUT_COUNT: usize = 2;
-
-    /// The number of stream inputs for mixer except for input 8/9 to S/PDIF output 0/1.
-    pub const MIXER_STREAM_INPUT_COUNT: usize = 8;
-
-    /// The number of channels in bus mixer.
-    pub const MIXER_BUS_COUNT: usize = 8;
-
-    /// The number of channels in main mixer.
-    pub const MIXER_MAIN_COUNT: usize = 2;
-
-    /// The number of channels in reverb mixer.
-    pub const MIXER_REVERB_COUNT: usize = 2;
-
-    pub fn read_mixer_bus_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        timeout_ms: u32,
-    ) -> Result<u32, Error> {
-        assert!(dst < Self::MIXER_BUS_COUNT);
-
-        let mut raw = [0; 4];
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_read(
-            req,
-            node,
-            MIXER_BUS_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(raw))
-    }
-
-    pub fn write_mixer_bus_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        gain: u32,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        assert!(dst < Self::MIXER_BUS_COUNT);
-
-        let mut raw = [0; 4];
-        raw.copy_from_slice(&gain.to_be_bytes());
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_write(
-            req,
-            node,
-            MIXER_BUS_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_mixer_main_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        timeout_ms: u32,
-    ) -> Result<u32, Error> {
-        assert!(dst < Self::MIXER_MAIN_COUNT);
-
-        let mut raw = [0; 4];
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_read(
-            req,
-            node,
-            MIXER_MAIN_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(raw))
-    }
-
-    pub fn write_mixer_main_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        gain: u32,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        assert!(dst < Self::MIXER_MAIN_COUNT);
-
-        let mut raw = [0; 4];
-        raw.copy_from_slice(&gain.to_be_bytes());
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_write(
-            req,
-            node,
-            MIXER_MAIN_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_mixer_reverb_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        timeout_ms: u32,
-    ) -> Result<u32, Error> {
-        assert!(dst < Self::MIXER_REVERB_COUNT);
-
-        let mut raw = [0; 4];
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_read(
-            req,
-            node,
-            MIXER_REVERB_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(raw))
-    }
-
-    pub fn write_mixer_reverb_src_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: MixerSrc,
-        gain: u32,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        assert!(dst < Self::MIXER_REVERB_COUNT);
-
-        let mut raw = [0; 4];
-        raw.copy_from_slice(&gain.to_be_bytes());
-        let offset = MIXER_SRC_SIZE * dst + usize::from(src);
-        lexicon_write(
-            req,
-            node,
-            MIXER_REVERB_SRC_OFFSET + offset,
-            &mut raw,
-            timeout_ms,
-        )
-    }
 }
 
 /// Serialize and deserialize data of system exclusive message.

--- a/runtime/dice/src/ionix_model.rs
+++ b/runtime/dice/src/ionix_model.rs
@@ -160,7 +160,9 @@ impl MeterCtl {
     };
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        IonixProtocol::cache_whole_params(req, node, &mut self.0, timeout_ms)
+        let res = IonixProtocol::cache_whole_params(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -235,7 +237,9 @@ impl MixerCtl {
     };
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        IonixProtocol::cache_whole_params(req, node, &mut self.0, timeout_ms)
+        let res = IonixProtocol::cache_whole_params(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -366,14 +370,15 @@ impl MixerCtl {
                     .chain(srcs.stream_inputs.iter_mut())
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as i16);
-                IonixProtocol::update_partial_parameters(
+                let res = IonixProtocol::update_partial_parameters(
                     req,
                     node,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MAIN_SRC_GAIN_NAME => {
                 let mixer = elem_id.index() as usize;
@@ -388,14 +393,15 @@ impl MixerCtl {
                     .chain(srcs.stream_inputs.iter_mut())
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as i16);
-                IonixProtocol::update_partial_parameters(
+                let res = IonixProtocol::update_partial_parameters(
                     req,
                     node,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::REVERB_SRC_GAIN_NAME => {
                 let mixer = elem_id.index() as usize;
@@ -410,14 +416,15 @@ impl MixerCtl {
                     .chain(srcs.stream_inputs.iter_mut())
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as i16);
-                IonixProtocol::update_partial_parameters(
+                let res = IonixProtocol::update_partial_parameters(
                     req,
                     node,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }


### PR DESCRIPTION
This patchset is rework for protocol implementation of i-onix fw810s.
Some renewed traits are newly added to obsolete old implementations.

```
Takashi Sakamoto (9):
  protocols/dice: lexicon: add renewed trait for protocol of i-onix fw810s
  protocols/dice: lexicon: add renewed trait implementation for meter operation
  protocols/dice: lexicon: add renewed trait implementation for mixer operation
  protocols/dice: lexicon: add renewed trait implementation for effect operation
  protocols/dice: lexicon: fulfill doc comment for better documentation
  runtime/dice: lexicon: use renewed trait implementation for meter parameters
  runtime/dice: lexicon: use renewed trait implementation for mixer parameters
  runtime/dice: lexicon: add logging for specific controls
  protocols/dice: lexicon: remove unused traits and implementations

 protocols/dice/src/lexicon.rs   | 820 +++++++++++++++++++++-----------
 runtime/dice/src/ionix_model.rs | 287 ++++++-----
 2 files changed, 697 insertions(+), 410 deletions(-)
```