### PR TITLE
[PATCH 0/4] protocols/dice: avid: rework for protocol implementation of Mbox 3 pro

### DIFF
--- a/protocols/dice/src/avid.rs
+++ b/protocols/dice/src/avid.rs
@@ -5,6 +5,88 @@
 //!
 //! The module includes structure, enumeration, and trait and its implementation for hardware
 //! specification and application protocol specific to Avid Mbox 3 Pro.
+//!
+//! ## Diagram of internal signal flow
+//!
+//! ```text
+//!
+//! XLR input 1 -----------------+-------+-------> analog-input-1/2
+//! Phone input 1 ---------------+       |
+//!                                      |
+//! XLR input 2 -----------------+-------+
+//! Phone input 2 ---------------+
+//!
+//! XLR input 3 -----------------+-------+-------> analog-input-3/4
+//! Phone input 3 ---------------+       |
+//!                                      |
+//! XLR input 4 -----------------+-------+
+//! Phone input 4 ---------------+
+//!
+//! RCA input 5/6 ---------------or--------------> analog-input-5/6
+//! Mini Phone ------------------+
+//! coaxial input 1/2 ---------------------------> spdif-input-1/2
+//!
+//! analog-input-1/2 ----------------------------> stream-output-1/2
+//! analog-input-3/4 ----------------------------> stream-output-3/4
+//! analog-input-5/6 ----------------------------> stream-output-5/6
+//! spdif-input-1/2 -----------------------------> stream-output-7/8
+//!
+//!                          ++=============++
+//! analog-input-1/2 ------> ||             || --> analog-output-1/2
+//! analog-input-3/4 ------> ||             || --> analog-output-3/4
+//! analog-input-5/6 ------> ||             || --> analog-output-5/6
+//! spdif-input-1/2 -------> ||             || --> spdif-output-1/2
+//!                          ||             ||
+//!                          ||             || --> headphone-output-1/2
+//!                          ||             || --> headphone-output-3/4
+//!                          ||   34 x 42   ||
+//! reberb-output-1/2 -----> ||             || --> reverb-input-1/2
+//!                          ||   router    ||
+//! stream-input-1/2 ------> ||             || --> stream-output-1/2
+//! stream-input-3/4 ------> ||   up to     || --> stream-output-3/4
+//! stream-input-5/6 ------> ||             || --> stream-output-5/6
+//! stream-input-7/8 ------> || 128 entries || --> stream-output-7/8
+//!                          ||             ||
+//! mixer-output-1/2 ------> ||             || --> mixer-input-1/2
+//! mixer-output-3/4 ------> ||             || --> mixer-input-3/4
+//! mixer-output-5/6 ------> ||             || --> mixer-input-5/6
+//! mixer-output-7/8 ------> ||             || --> mixer-input-7/8
+//! mixer-output-9/10 -----> ||             || --> mixer-input-9/10
+//! mixer-output-11/12 ----> ||             || --> mixer-input-11/12
+//! mixer-output-13/14 ----> ||             || --> mixer-input-13/14
+//! mixer-output-15/16 ----> ||             || --> mixer-input-15/16
+//!                          ||             || --> mixer-input-17/18
+//!                          ||             ||
+//!                          ||             || --> control-room-output-1/2
+//!                          ++=============++
+//!
+//!                          ++=============++
+//! reverb-input-1/2 ------> ||    reverb   || --> reverb-output-1/2
+//!                          ||    effect   ||
+//!                          ++=============++
+//!
+//!                          ++=============++
+//! mixer-input-1/2 -------> ||             || --> mixer-output-1/2
+//! mixer-input-3/4 -------> ||             || --> mixer-output-3/4
+//! mixer-input-5/6 -------> ||             || --> mixer-output-5/6
+//! mixer-input-7/8 -------> ||   18 x 16   || --> mixer-output-7/8
+//! mixer-input-9/10 ------> ||             || --> mixer-output-9/10
+//! mixer-input-11/11 -----> ||    mixer    || --> mixer-output-11/12
+//! mixer-input-13/14 -----> ||             || --> mixer-output-13/14
+//! mixer-input-15/16 -----> ||             || --> mixer-output-15/16
+//! mixer-input-17/18 -----> ||             ||
+//!                          ++=============++
+//!
+//! analog-output-1/2 ---------------------------> Phone output 1/2
+//! analog-output-3/4 ---------------------------> Phone output 3/4
+//! analog-output-5/6 ---------------------------> Phone output 5/6
+//!
+//! headphone-output-1/2 ------------------------> Headphone output 1/2
+//! headphone-output-3/4 ------------------------> Headphone output 3/4
+//!
+//! spdif-output-1/2 ----------------------------> Coaxial output 1/2
+//!
+//! ```
 
 use super::{
     tcat::{

--- a/protocols/dice/src/avid.rs
+++ b/protocols/dice/src/avid.rs
@@ -114,10 +114,13 @@ impl Tcd22xxSpecOperation for Mbox3Protocol {
 }
 
 /// Usecase of standalone mode.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum StandaloneUseCase {
+    /// For microphone pre-amplifier.
     Preamp,
+    /// For A/D and D/A conversion.
     AdDa,
+    /// For signal mixing.
     Mixer,
 }
 
@@ -131,6 +134,41 @@ impl StandaloneUseCase {
     const MIXER: u32 = 0;
     const AD_DA: u32 = 1;
     const PREAMP: u32 = 2;
+}
+
+fn serialize_standalone_use_case(
+    use_case: &StandaloneUseCase,
+    raw: &mut [u8],
+) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    match use_case {
+        StandaloneUseCase::Mixer => StandaloneUseCase::MIXER,
+        StandaloneUseCase::AdDa => StandaloneUseCase::AD_DA,
+        StandaloneUseCase::Preamp => StandaloneUseCase::PREAMP,
+    }
+    .build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_standalone_use_case(
+    use_case: &mut StandaloneUseCase,
+    raw: &[u8],
+) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    *use_case = match val {
+        StandaloneUseCase::MIXER => StandaloneUseCase::Mixer,
+        StandaloneUseCase::AD_DA => StandaloneUseCase::AdDa,
+        StandaloneUseCase::PREAMP => StandaloneUseCase::Preamp,
+        _ => Err(format!("Standalone use case not found for value {}", val))?,
+    };
+
+    Ok(())
 }
 
 impl From<u32> for StandaloneUseCase {
@@ -194,11 +232,46 @@ impl Mbox3Protocol {
 /// Assignment map for master knob.
 pub type MasterKnobAssigns = [bool; 6];
 
+const MASTER_KNOB_MASK: u32 = 0x0000003f;
+
+fn serialize_master_knob_assigns(assigns: &[bool; 6], raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !MASTER_KNOB_MASK;
+
+    assigns
+        .iter()
+        .enumerate()
+        .filter(|(_, &assign)| assign)
+        .for_each(|(i, _)| val |= 1 << i);
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_master_knob_assigns(assigns: &mut [bool; 6], raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    assigns
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, assign)| *assign = val & (1 << i) > 0);
+
+    Ok(())
+}
+
 /// LED state of mute button.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MuteLedState {
+    /// Turn Off.
     Off,
+    /// Blink.
     Blink,
+    /// Turn on.
     On,
 }
 
@@ -211,6 +284,41 @@ impl Default for MuteLedState {
 impl MuteLedState {
     const LED_MASK: u32 = 0x00000003;
     const LED_BLINK_MASK: u32 = 0x00000001;
+}
+
+fn serialize_mute_led_state(state: &MuteLedState, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !MuteLedState::LED_MASK;
+
+    match state {
+        MuteLedState::Off => (),
+        MuteLedState::Blink => val |= MuteLedState::LED_BLINK_MASK,
+        MuteLedState::On => val |= MuteLedState::LED_MASK & !MuteLedState::LED_BLINK_MASK,
+    }
+
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_mute_led_state(state: &mut MuteLedState, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    *state = if val & MuteLedState::LED_MASK == 0 {
+        MuteLedState::Off
+    } else if val & MuteLedState::LED_BLINK_MASK > 0 {
+        MuteLedState::Blink
+    } else {
+        MuteLedState::On
+    };
+
+    Ok(())
 }
 
 impl From<u32> for MuteLedState {
@@ -236,9 +344,11 @@ impl From<&MuteLedState> for u32 {
 }
 
 /// LED state of mono button.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MonoLedState {
+    /// Turn off.
     Off,
+    /// Turn on.
     On,
 }
 
@@ -251,6 +361,38 @@ impl Default for MonoLedState {
 impl MonoLedState {
     const LED_MASK: u32 = 0x0000000c;
     const LED_SHIFT: usize = 2;
+}
+
+fn serialize_mono_led_state(state: &MonoLedState, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !MonoLedState::LED_MASK;
+
+    match state {
+        MonoLedState::Off => (),
+        MonoLedState::On => val |= MonoLedState::LED_MASK,
+    }
+
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_mono_led_state(state: &mut MonoLedState, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    *state = if val & MonoLedState::LED_MASK > 0 {
+        MonoLedState::On
+    } else {
+        MonoLedState::Off
+    };
+
+    Ok(())
 }
 
 impl From<u32> for MonoLedState {
@@ -273,14 +415,21 @@ impl From<&MonoLedState> for u32 {
 }
 
 /// LED state of spkr button.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SpkrLedState {
+    /// Turn off.
     Off,
+    /// Green light.
     Green,
+    /// Blinking green light.
     GreenBlink,
+    /// Red light.
     Red,
+    /// Blinking red light.
     RedBlink,
+    /// Orange light.
     Orange,
+    /// Blinking orange light.
     OrangeBlink,
 }
 
@@ -300,6 +449,71 @@ impl SpkrLedState {
     const GREEN: u32 = 1;
     const RED: u32 = 2;
     const ORANGE: u32 = 3;
+}
+
+fn serialize_spkr_led_state(state: &SpkrLedState, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !(SpkrLedState::COLOR_MASK | SpkrLedState::BLINK_MASK);
+
+    let (color, blink) = match state {
+        SpkrLedState::GreenBlink => (SpkrLedState::GREEN, true),
+        SpkrLedState::Green => (SpkrLedState::GREEN, false),
+        SpkrLedState::RedBlink => (SpkrLedState::RED, true),
+        SpkrLedState::Red => (SpkrLedState::RED, false),
+        SpkrLedState::OrangeBlink => (SpkrLedState::RED, true),
+        SpkrLedState::Orange => (SpkrLedState::ORANGE, false),
+        SpkrLedState::Off => (SpkrLedState::NONE, false),
+    };
+
+    val |= color << SpkrLedState::COLOR_SHIFT;
+    if blink {
+        val |= SpkrLedState::BLINK_MASK;
+    }
+
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_spkr_led_state(state: &mut SpkrLedState, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    let color = (val & SpkrLedState::COLOR_MASK) >> SpkrLedState::COLOR_SHIFT;
+    let blink = (val & SpkrLedState::BLINK_MASK) >> SpkrLedState::BLINK_SHIFT > 0;
+
+    *state = match color {
+        SpkrLedState::NONE => SpkrLedState::Off,
+        SpkrLedState::GREEN => {
+            if blink {
+                SpkrLedState::GreenBlink
+            } else {
+                SpkrLedState::Green
+            }
+        }
+        SpkrLedState::RED => {
+            if blink {
+                SpkrLedState::RedBlink
+            } else {
+                SpkrLedState::Red
+            }
+        }
+        SpkrLedState::ORANGE => {
+            if blink {
+                SpkrLedState::OrangeBlink
+            } else {
+                SpkrLedState::Orange
+            }
+        }
+        _ => Err(format!("Speaker LED state not found for value {}", val))?,
+    };
+
+    Ok(())
 }
 
 impl From<u32> for SpkrLedState {
@@ -357,10 +571,13 @@ impl From<&SpkrLedState> for u32 {
 }
 
 /// Status of buttons.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ButtonLedState {
+    /// State of mute LED.
     pub mute: MuteLedState,
+    /// State of mono LED.
     pub mono: MonoLedState,
+    /// State of spkr LED.
     pub spkr: SpkrLedState,
 }
 
@@ -398,6 +615,69 @@ impl From<&ButtonLedState> for [u8; ButtonLedState::SIZE] {
     }
 }
 
+const PHANTOM_POWERING_MASK: u32 = 0x00000001;
+const INPUT_HPF_ENABLES_MASK: u32 = 0x000000f0;
+const INPUT_HPF_ENABLES_SHIFT: usize = 4;
+
+fn serialize_phantom_powering(enable: &bool, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !PHANTOM_POWERING_MASK;
+
+    if *enable {
+        val |= PHANTOM_POWERING_MASK;
+    }
+
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_phantom_powering(enable: &mut bool, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    *enable = val & PHANTOM_POWERING_MASK > 0;
+
+    Ok(())
+}
+
+fn serialize_hpf_enables(enables: &[bool; 4], raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+    val &= !INPUT_HPF_ENABLES_MASK;
+
+    enables
+        .iter()
+        .enumerate()
+        .filter(|(_, &enabled)| enabled)
+        .for_each(|(i, _)| val |= 1 << (i + INPUT_HPF_ENABLES_SHIFT));
+
+    val.build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_hpf_enables(enables: &mut [bool; 4], raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    enables
+        .iter_mut()
+        .enumerate()
+        .for_each(|(i, enabled)| *enabled = val & (1 << (i + INPUT_HPF_ENABLES_SHIFT)) > 0);
+
+    Ok(())
+}
+
 const OUT_TRIM_OFFSETS: [usize; 6] = [
     OUT_0_TRIM_OFFSET,
     OUT_1_TRIM_OFFSET,
@@ -406,6 +686,30 @@ const OUT_TRIM_OFFSETS: [usize; 6] = [
     OUT_4_TRIM_OFFSET,
     OUT_5_TRIM_OFFSET,
 ];
+
+fn serialize_output_trims(trims: &[u8; 6], raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 24);
+
+    trims.iter().enumerate().for_each(|(i, &trim)| {
+        let pos = i * 4;
+        ((u8::MAX - trim) as u32).build_quadlet(&mut raw[pos..(pos + 4)]);
+    });
+
+    Ok(())
+}
+
+fn deserialize_output_trims(trims: &mut [u8; 6], raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 24);
+
+    let mut val = 0u32;
+    trims.iter_mut().enumerate().for_each(|(i, trim)| {
+        let pos = i * 4;
+        val.parse_quadlet(&raw[pos..(pos + 4)]);
+        *trim = u8::MAX - val as u8;
+    });
+
+    Ok(())
+}
 
 impl Mbox3Protocol {
     pub fn read_master_knob_assign(
@@ -656,15 +960,23 @@ impl Mbox3Protocol {
 }
 
 /// Type of reverb DSP.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ReverbType {
+    /// Room 1.
     Room1,
+    /// Room 2.
     Room2,
+    /// Room 3.
     Room3,
+    /// Hall 1.
     Hall1,
+    /// Hall 2.
     Hall2,
+    /// Plate.
     Plate,
+    /// Delay.
     Delay,
+    /// Echo.
     Echo,
 }
 
@@ -683,6 +995,45 @@ impl ReverbType {
     const PLATE: u32 = 0x0b;
     const DELAY: u32 = 0x13;
     const ECHO: u32 = 0x14;
+}
+
+fn serialize_reverb_type(reverb_type: &ReverbType, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    match reverb_type {
+        ReverbType::Room1 => ReverbType::ROOM_1,
+        ReverbType::Room2 => ReverbType::ROOM_2,
+        ReverbType::Room3 => ReverbType::ROOM_3,
+        ReverbType::Hall1 => ReverbType::HALL_1,
+        ReverbType::Hall2 => ReverbType::HALL_2,
+        ReverbType::Plate => ReverbType::PLATE,
+        ReverbType::Delay => ReverbType::DELAY,
+        ReverbType::Echo => ReverbType::ECHO,
+    }
+    .build_quadlet(raw);
+
+    Ok(())
+}
+
+fn deserialize_reverb_type(reverb_type: &mut ReverbType, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= 4);
+
+    let mut val = 0u32;
+    val.parse_quadlet(raw);
+
+    *reverb_type = match val {
+        ReverbType::ROOM_1 => ReverbType::Room1,
+        ReverbType::ROOM_2 => ReverbType::Room2,
+        ReverbType::ROOM_3 => ReverbType::Room3,
+        ReverbType::HALL_1 => ReverbType::Hall1,
+        ReverbType::HALL_2 => ReverbType::Hall2,
+        ReverbType::PLATE => ReverbType::Plate,
+        ReverbType::DELAY => ReverbType::Delay,
+        ReverbType::ECHO => ReverbType::Echo,
+        _ => Err(format!("Reverb type not found for value {}", val))?,
+    };
+
+    Ok(())
 }
 
 impl From<u32> for ReverbType {
@@ -715,7 +1066,232 @@ impl From<ReverbType> for u32 {
     }
 }
 
+/// Parameters specific to Mbox 3 pro.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct Mbox3SpecificParams {
+    /// Usecase at standalone mode.
+    pub standalone_use_case: StandaloneUseCase,
+    /// State of master knob.
+    pub master_knob_value: u8,
+    /// Assignment map for master knob.
+    pub master_knob_assigns: [bool; 6],
+    /// State of mute LED.
+    pub mute_led: MuteLedState,
+    /// State of mono LED.
+    pub mono_led: MonoLedState,
+    /// State of spkr LED.
+    pub spkr_led: SpkrLedState,
+    /// Whether to use dim LED.
+    pub dim_led: bool,
+    /// Duration till being activate by holding button.
+    pub duration_hold: u8,
+    /// Whether to supply phantom powering.
+    pub phantom_powering: bool,
+    /// Whether to enable High Pass Filter.
+    pub hpf_enables: [bool; 4],
+    /// Volume of analog outputs.
+    pub output_trims: [u8; 6],
+    /// The type of reverb.
+    pub reverb_type: ReverbType,
+    /// Volume of reverb return.
+    pub reverb_volume: u8,
+    /// Duration of reverb.
+    pub reverb_duration: u8,
+    /// Feedback of reverb.
+    pub reverb_feedback: u8,
+}
+
+const MIN_SIZE: usize = 0x50;
+
+fn serialize(params: &Mbox3SpecificParams, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= MIN_SIZE);
+
+    serialize_standalone_use_case(&params.standalone_use_case, &mut raw[..0x04])?;
+    (params.master_knob_value as u32).build_quadlet(&mut raw[0x08..0x0c]);
+    serialize_master_knob_assigns(&params.master_knob_assigns, &mut raw[0x0c..0x10])?;
+    serialize_mute_led_state(&params.mute_led, &mut raw[0x10..0x14])?;
+    serialize_mono_led_state(&params.mono_led, &mut raw[0x14..0x18])?;
+    serialize_spkr_led_state(&params.spkr_led, &mut raw[0x14..0x18])?;
+
+    params.dim_led.build_quadlet(&mut raw[0x1c..0x20]);
+
+    (params.duration_hold as u32).build_quadlet(&mut raw[0x20..0x24]);
+
+    serialize_phantom_powering(&params.phantom_powering, &mut raw[0x24..0x28])?;
+    serialize_hpf_enables(&params.hpf_enables, &mut raw[0x24..0x28])?;
+    serialize_output_trims(&params.output_trims, &mut raw[0x28..0x40])?;
+    serialize_reverb_type(&params.reverb_type, &mut raw[0x40..0x44])?;
+    (params.reverb_volume as u32).build_quadlet(&mut raw[0x44..0x48]);
+    (params.reverb_duration as u32).build_quadlet(&mut raw[0x48..0x4c]);
+    (params.reverb_feedback as u32).build_quadlet(&mut raw[0x4c..0x50]);
+
+    Ok(())
+}
+
+fn deserialize(params: &mut Mbox3SpecificParams, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= MIN_SIZE);
+
+    let mut val = 0u32;
+
+    deserialize_standalone_use_case(&mut params.standalone_use_case, &raw[..0x04])?;
+
+    val.parse_quadlet(&raw[0x08..0x0c]);
+    params.master_knob_value = val as u8;
+
+    deserialize_master_knob_assigns(&mut params.master_knob_assigns, &raw[0x0c..0x10])?;
+    deserialize_mute_led_state(&mut params.mute_led, &raw[0x10..0x14])?;
+    deserialize_mono_led_state(&mut params.mono_led, &raw[0x14..0x18])?;
+    deserialize_spkr_led_state(&mut params.spkr_led, &raw[0x14..0x18])?;
+
+    params.dim_led.parse_quadlet(&raw[0x1c..0x20]);
+
+    val.parse_quadlet(&raw[0x20..0x24]);
+    params.duration_hold = val as u8;
+
+    deserialize_phantom_powering(&mut params.phantom_powering, &raw[0x24..0x28])?;
+    deserialize_hpf_enables(&mut params.hpf_enables, &raw[0x24..0x28])?;
+    deserialize_output_trims(&mut params.output_trims, &raw[0x28..0x40])?;
+    deserialize_reverb_type(&mut params.reverb_type, &raw[0x40..0x44])?;
+
+    val.parse_quadlet(&raw[0x44..0x48]);
+    params.reverb_volume = val as u8;
+
+    val.parse_quadlet(&raw[0x48..0x4c]);
+    params.reverb_duration = val as u8;
+
+    val.parse_quadlet(&raw[0x4c..0x50]);
+    params.reverb_feedback = val as u8;
+
+    Ok(())
+}
+
+const PHANTOM_POWERING_CHANGED: u32 = 0x10000000;
+const MASTER_KNOB_CHANGED: u32 = 0x08000000;
+const SPKR_BUTTON_PUSHED: u32 = 0x04000000;
+const SPKR_BUTTON_HELD: u32 = 0x02000000;
+const MONO_BUTTON_PUSHED: u32 = 0x00800000;
+const MUTE_BUTTON_PUSHED: u32 = 0x00400000;
+const MUTE_BUTTON_HELD: u32 = 0x00200000;
+
 impl Mbox3Protocol {
+    /// Cache state of hardware for whole parameters.
+    pub fn cache_whole_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        params: &mut Mbox3SpecificParams,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut raw = vec![0u8; sections.application.size];
+        ApplSectionProtocol::read_appl_data(req, node, sections, 0, &mut raw, timeout_ms)?;
+        deserialize(params, &raw).map_err(|cause| Error::new(ProtocolExtensionError::Appl, &cause))
+    }
+
+    /// Update state of hardware for part of parameters.
+    pub fn update_partial_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        params: &Mbox3SpecificParams,
+        prev: &mut Mbox3SpecificParams,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut new = vec![0u8; sections.application.size];
+        serialize(params, &mut new)
+            .map_err(|cause| Error::new(ProtocolExtensionError::Appl, &cause))?;
+
+        let mut old = vec![0u8; sections.application.size];
+        serialize(prev, &mut old)
+            .map_err(|cause| Error::new(ProtocolExtensionError::Appl, &cause))?;
+
+        (0..sections.application.size)
+            .step_by(4)
+            .try_for_each(|pos| {
+                if new[pos..(pos + 4)] != old[pos..(pos + 4)] {
+                    ApplSectionProtocol::write_appl_data(
+                        req,
+                        node,
+                        sections,
+                        pos,
+                        &mut new[pos..(pos + 4)],
+                        timeout_ms,
+                    )
+                } else {
+                    Ok(())
+                }
+            })?;
+
+        deserialize(prev, &new).map_err(|cause| Error::new(ProtocolExtensionError::Appl, &cause))
+    }
+
+    /// Cache state of hardware for notified parameters.
+    pub fn cache_notified_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        msg: u32,
+        params: &mut Mbox3SpecificParams,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        if msg & (PHANTOM_POWERING_CHANGED | MASTER_KNOB_CHANGED) > 0 {
+            Self::cache_whole_params(req, node, sections, params, timeout_ms)?;
+        }
+
+        let mut p = params.clone();
+        if msg & SPKR_BUTTON_PUSHED > 0 {
+            p.spkr_led = match params.spkr_led {
+                SpkrLedState::Off => SpkrLedState::Green,
+                SpkrLedState::GreenBlink => SpkrLedState::Green,
+                SpkrLedState::Green => SpkrLedState::Red,
+                SpkrLedState::RedBlink => SpkrLedState::Red,
+                SpkrLedState::Red => SpkrLedState::Orange,
+                SpkrLedState::OrangeBlink => SpkrLedState::Orange,
+                SpkrLedState::Orange => SpkrLedState::Off,
+            };
+        }
+
+        if msg & SPKR_BUTTON_HELD > 0 {
+            p.spkr_led = match params.spkr_led {
+                SpkrLedState::Off => SpkrLedState::Off,
+                SpkrLedState::GreenBlink => SpkrLedState::Green,
+                SpkrLedState::Green => SpkrLedState::GreenBlink,
+                SpkrLedState::RedBlink => SpkrLedState::Red,
+                SpkrLedState::Red => SpkrLedState::RedBlink,
+                SpkrLedState::OrangeBlink => SpkrLedState::Orange,
+                SpkrLedState::Orange => SpkrLedState::OrangeBlink,
+            };
+        }
+
+        if msg & MONO_BUTTON_PUSHED > 0 {
+            p.mono_led = match params.mono_led {
+                MonoLedState::Off => MonoLedState::On,
+                MonoLedState::On => MonoLedState::Off,
+            };
+        }
+
+        if msg & MUTE_BUTTON_PUSHED > 0 {
+            p.mute_led = match params.mute_led {
+                MuteLedState::Off => MuteLedState::On,
+                MuteLedState::Blink => MuteLedState::On,
+                MuteLedState::On => MuteLedState::Off,
+            };
+        }
+
+        if msg & MUTE_BUTTON_HELD > 0 {
+            p.mute_led = match params.mute_led {
+                MuteLedState::Off => MuteLedState::Off,
+                MuteLedState::Blink => MuteLedState::On,
+                MuteLedState::On => MuteLedState::Blink,
+            };
+        }
+
+        if !p.eq(params) {
+            Self::update_partial_params(req, node, sections, &p, params, timeout_ms)?;
+        }
+
+        Ok(())
+    }
+
     pub fn read_reverb_type(
         req: &mut FwReq,
         node: &mut FwNode,
@@ -891,5 +1467,39 @@ impl Mbox3Protocol {
 
     pub fn has_mute_button_held(msg: u32) -> bool {
         msg & Self::MUTE_BUTTON_HELD > 0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn mbox3_specific_params_serdes() {
+        let params = Mbox3SpecificParams {
+            standalone_use_case: StandaloneUseCase::AdDa,
+            master_knob_value: 0xf9,
+            master_knob_assigns: [true, false, true, true, false, true],
+            mute_led: MuteLedState::Blink,
+            mono_led: MonoLedState::On,
+            spkr_led: SpkrLedState::RedBlink,
+            dim_led: false,
+            duration_hold: 10,
+            phantom_powering: true,
+            hpf_enables: [false, false, true, false],
+            output_trims: [0, 1, 2, 3, 4, 5],
+            reverb_type: ReverbType::Hall2,
+            reverb_volume: 0xb3,
+            reverb_duration: 0xa5,
+            reverb_feedback: 0x17,
+        };
+
+        let mut raw = [0; MIN_SIZE];
+        serialize(&params, &mut raw).unwrap();
+
+        let mut p = Mbox3SpecificParams::default();
+        deserialize(&mut p, &raw).unwrap();
+
+        assert_eq!(params, p);
     }
 }

--- a/protocols/dice/src/avid.rs
+++ b/protocols/dice/src/avid.rs
@@ -15,22 +15,27 @@ use super::{
     *,
 };
 
-const USE_CASE_OFFSET: usize = 0x00;
-const MASTER_KNOB_ASSIGN_OFFSET: usize = 0x0c;
-const BUTTON_LED_STATE_OFFSET: usize = 0x10;
-const DIM_LED_USAGE_OFFSET: usize = 0x1c;
-const BUTTON_HOLD_DURATION_OFFSET: usize = 0x20;
-const HPF_ENABLE_OFFSET: usize = 0x24; // High pass filter for analog inputs.
-const OUT_0_TRIM_OFFSET: usize = 0x28;
-const OUT_1_TRIM_OFFSET: usize = 0x2c;
-const OUT_2_TRIM_OFFSET: usize = 0x30;
-const OUT_3_TRIM_OFFSET: usize = 0x34;
-const OUT_4_TRIM_OFFSET: usize = 0x38;
-const OUT_5_TRIM_OFFSET: usize = 0x3c;
-const REVERB_TYPE_OFFSET: usize = 0x40;
-const REVERB_VOLUME_OFFSET: usize = 0x44;
-const REVERB_DURATION_OFFSET: usize = 0x48;
-const REVERB_FEEDBACK_OFFSET: usize = 0x4c;
+// const USE_CASE_OFFSET: usize = 0x00;
+// (0x04 is unclear)
+// const MASTER_KNOB_VALUE_OFFSET: usize = 0x08;
+// const MASTER_KNOB_ASSIGN_OFFSET: usize = 0x0c;
+// const MUTE_BUTTON_LED_OFFSET: usize = 0x10;
+// const MONO_BUTTON_LED_OFFSET: usize = 0x14;  // 0x08 enables playback routing to analog input 3/4.
+// const SPKR_BUTTON_LED_OFFSET: usize = 0x14;
+// const ALL_LEDS_BRIGHTNESS_OFFSET: usize = 0x18;   // 0x00 - 0x7f.
+// const FORCE_LEDS_BRIGHTNESS_OFFSET: usize = 0x1c;   // 0x00 - 0x7f.
+// const BUTTON_HOLD_DURATION_OFFSET: usize = 0x20;
+// const HPF_ENABLE_OFFSET: usize = 0x24; // High pass filter for analog inputs.
+// const OUT_0_TRIM_OFFSET: usize = 0x28;
+// const OUT_1_TRIM_OFFSET: usize = 0x2c;
+// const OUT_2_TRIM_OFFSET: usize = 0x30;
+// const OUT_3_TRIM_OFFSET: usize = 0x34;
+// const OUT_4_TRIM_OFFSET: usize = 0x38;
+// const OUT_5_TRIM_OFFSET: usize = 0x3c;
+// const REVERB_TYPE_OFFSET: usize = 0x40;
+// const REVERB_VOLUME_OFFSET: usize = 0x44;
+// const REVERB_DURATION_OFFSET: usize = 0x48;
+// const REVERB_FEEDBACK_OFFSET: usize = 0x4c;
 
 /// Protocol implementation of Avid Mbox 3 Pro.
 #[derive(Default, Debug)]
@@ -171,67 +176,6 @@ fn deserialize_standalone_use_case(
     Ok(())
 }
 
-impl From<u32> for StandaloneUseCase {
-    fn from(val: u32) -> Self {
-        match val {
-            StandaloneUseCase::MIXER => StandaloneUseCase::Mixer,
-            StandaloneUseCase::AD_DA => StandaloneUseCase::AdDa,
-            _ => StandaloneUseCase::Preamp,
-        }
-    }
-}
-
-impl From<StandaloneUseCase> for u32 {
-    fn from(use_case: StandaloneUseCase) -> u32 {
-        match use_case {
-            StandaloneUseCase::Mixer => StandaloneUseCase::MIXER,
-            StandaloneUseCase::AdDa => StandaloneUseCase::AD_DA,
-            StandaloneUseCase::Preamp => StandaloneUseCase::PREAMP,
-        }
-    }
-}
-
-impl Mbox3Protocol {
-    pub fn read_standalone_use_case(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<StandaloneUseCase, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            USE_CASE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data).into())
-    }
-
-    pub fn write_standalone_use_case(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        use_case: StandaloneUseCase,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = u32::from(use_case).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            USE_CASE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-}
-
-/// Assignment map for master knob.
-pub type MasterKnobAssigns = [bool; 6];
-
 const MASTER_KNOB_MASK: u32 = 0x0000003f;
 
 fn serialize_master_knob_assigns(assigns: &[bool; 6], raw: &mut [u8]) -> Result<(), String> {
@@ -321,28 +265,6 @@ fn deserialize_mute_led_state(state: &mut MuteLedState, raw: &[u8]) -> Result<()
     Ok(())
 }
 
-impl From<u32> for MuteLedState {
-    fn from(val: u32) -> Self {
-        if val & Self::LED_MASK == 0 {
-            Self::Off
-        } else if val & Self::LED_BLINK_MASK > 0 {
-            Self::Blink
-        } else {
-            Self::On
-        }
-    }
-}
-
-impl From<&MuteLedState> for u32 {
-    fn from(state: &MuteLedState) -> Self {
-        match state {
-            MuteLedState::Off => 0,
-            MuteLedState::Blink => MuteLedState::LED_BLINK_MASK,
-            MuteLedState::On => MuteLedState::LED_MASK & !MuteLedState::LED_BLINK_MASK,
-        }
-    }
-}
-
 /// LED state of mono button.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum MonoLedState {
@@ -360,7 +282,6 @@ impl Default for MonoLedState {
 
 impl MonoLedState {
     const LED_MASK: u32 = 0x0000000c;
-    const LED_SHIFT: usize = 2;
 }
 
 fn serialize_mono_led_state(state: &MonoLedState, raw: &mut [u8]) -> Result<(), String> {
@@ -393,25 +314,6 @@ fn deserialize_mono_led_state(state: &mut MonoLedState, raw: &[u8]) -> Result<()
     };
 
     Ok(())
-}
-
-impl From<u32> for MonoLedState {
-    fn from(val: u32) -> Self {
-        if (val & Self::LED_MASK) >> Self::LED_SHIFT > 0 {
-            MonoLedState::On
-        } else {
-            MonoLedState::Off
-        }
-    }
-}
-
-impl From<&MonoLedState> for u32 {
-    fn from(state: &MonoLedState) -> Self {
-        match state {
-            MonoLedState::On => MonoLedState::LED_MASK,
-            MonoLedState::Off => 0,
-        }
-    }
 }
 
 /// LED state of spkr button.
@@ -516,105 +418,6 @@ fn deserialize_spkr_led_state(state: &mut SpkrLedState, raw: &[u8]) -> Result<()
     Ok(())
 }
 
-impl From<u32> for SpkrLedState {
-    fn from(val: u32) -> Self {
-        let color = (val & Self::COLOR_MASK) >> Self::COLOR_SHIFT;
-        let blink = (val & Self::BLINK_MASK) >> Self::BLINK_SHIFT > 0;
-
-        match color {
-            Self::NONE => SpkrLedState::Off,
-            Self::GREEN => {
-                if blink {
-                    SpkrLedState::GreenBlink
-                } else {
-                    SpkrLedState::Green
-                }
-            }
-            Self::RED => {
-                if blink {
-                    SpkrLedState::RedBlink
-                } else {
-                    SpkrLedState::Red
-                }
-            }
-            Self::ORANGE => {
-                if blink {
-                    SpkrLedState::OrangeBlink
-                } else {
-                    SpkrLedState::Orange
-                }
-            }
-            _ => SpkrLedState::Off,
-        }
-    }
-}
-
-impl From<&SpkrLedState> for u32 {
-    fn from(state: &SpkrLedState) -> Self {
-        let (color, blink) = match state {
-            SpkrLedState::GreenBlink => (SpkrLedState::GREEN, true),
-            SpkrLedState::Green => (SpkrLedState::GREEN, false),
-            SpkrLedState::RedBlink => (SpkrLedState::RED, true),
-            SpkrLedState::Red => (SpkrLedState::RED, false),
-            SpkrLedState::OrangeBlink => (SpkrLedState::RED, true),
-            SpkrLedState::Orange => (SpkrLedState::ORANGE, false),
-            SpkrLedState::Off => (SpkrLedState::NONE, false),
-        };
-
-        let mut val = color << SpkrLedState::COLOR_SHIFT;
-        if blink {
-            val |= SpkrLedState::BLINK_MASK;
-        }
-
-        val
-    }
-}
-
-/// Status of buttons.
-#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
-pub struct ButtonLedState {
-    /// State of mute LED.
-    pub mute: MuteLedState,
-    /// State of mono LED.
-    pub mono: MonoLedState,
-    /// State of spkr LED.
-    pub spkr: SpkrLedState,
-}
-
-impl ButtonLedState {
-    const SIZE: usize = 8;
-}
-
-impl From<[u8; ButtonLedState::SIZE]> for ButtonLedState {
-    fn from(raw: [u8; ButtonLedState::SIZE]) -> Self {
-        let mut quadlet = [0; 4];
-        quadlet.copy_from_slice(&raw[..4]);
-        let val = u32::from_be_bytes(quadlet);
-        let mute = MuteLedState::from(val);
-
-        quadlet.copy_from_slice(&raw[4..8]);
-        let val = u32::from_be_bytes(quadlet);
-        let mono = MonoLedState::from(val);
-        let spkr = SpkrLedState::from(val);
-
-        ButtonLedState { mute, mono, spkr }
-    }
-}
-
-impl From<&ButtonLedState> for [u8; ButtonLedState::SIZE] {
-    fn from(state: &ButtonLedState) -> Self {
-        let mut data = [0; ButtonLedState::SIZE];
-
-        let val = u32::from(&state.mute);
-        data[..4].copy_from_slice(&val.to_be_bytes());
-
-        let val = u32::from(&state.mono) | u32::from(&state.spkr);
-        data[4..].copy_from_slice(&val.to_be_bytes());
-
-        data
-    }
-}
-
 const PHANTOM_POWERING_MASK: u32 = 0x00000001;
 const INPUT_HPF_ENABLES_MASK: u32 = 0x000000f0;
 const INPUT_HPF_ENABLES_SHIFT: usize = 4;
@@ -678,15 +481,6 @@ fn deserialize_hpf_enables(enables: &mut [bool; 4], raw: &[u8]) -> Result<(), St
     Ok(())
 }
 
-const OUT_TRIM_OFFSETS: [usize; 6] = [
-    OUT_0_TRIM_OFFSET,
-    OUT_1_TRIM_OFFSET,
-    OUT_2_TRIM_OFFSET,
-    OUT_3_TRIM_OFFSET,
-    OUT_4_TRIM_OFFSET,
-    OUT_5_TRIM_OFFSET,
-];
-
 fn serialize_output_trims(trims: &[u8; 6], raw: &mut [u8]) -> Result<(), String> {
     assert!(raw.len() >= 24);
 
@@ -709,254 +503,6 @@ fn deserialize_output_trims(trims: &mut [u8; 6], raw: &[u8]) -> Result<(), Strin
     });
 
     Ok(())
-}
-
-impl Mbox3Protocol {
-    pub fn read_master_knob_assign(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        assigns: &mut MasterKnobAssigns,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            MASTER_KNOB_ASSIGN_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| {
-            let val = u32::from_be_bytes(data);
-            assigns
-                .iter_mut()
-                .enumerate()
-                .for_each(|(i, assigned)| *assigned = val & (1 << i) > 0);
-            ()
-        })
-    }
-
-    pub fn write_master_knob_assign(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        assigns: &MasterKnobAssigns,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = [0; 4];
-        let val: u32 = assigns
-            .iter()
-            .enumerate()
-            .filter(|&(_, &assigned)| assigned)
-            .fold(0, |val, (i, _)| val | (1 << i));
-        data.copy_from_slice(&val.to_be_bytes());
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            MASTER_KNOB_ASSIGN_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_button_led_state(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<ButtonLedState, Error> {
-        let mut data = [0; ButtonLedState::SIZE];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            BUTTON_LED_STATE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| ButtonLedState::from(data))
-    }
-
-    pub fn write_button_led_state(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        state: &ButtonLedState,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = Into::<[u8; ButtonLedState::SIZE]>::into(state);
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            BUTTON_LED_STATE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_dim_led_usage(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            DIM_LED_USAGE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data) > 0)
-    }
-
-    pub fn write_dim_led_usage(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        usage: bool,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = (usage as u32).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            DIM_LED_USAGE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_hold_duration(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<u8, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            BUTTON_HOLD_DURATION_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data) as u8)
-    }
-
-    pub fn write_hold_duration(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        duration: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = (duration as u32).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            BUTTON_HOLD_DURATION_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_hpf_enable(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        inputs: &mut [bool; 4],
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            HPF_ENABLE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| {
-            let val = u32::from_be_bytes(data);
-            inputs
-                .iter_mut()
-                .enumerate()
-                .for_each(|(i, v)| *v = val & (1 << i) > 0);
-        })
-    }
-
-    pub fn write_hpf_enable(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        inputs: [bool; 4],
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let val = inputs
-            .iter()
-            .enumerate()
-            .filter(|(_, &v)| v)
-            .fold(0 as u32, |val, (i, _)| val | (1 << i));
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            HPF_ENABLE_OFFSET,
-            &mut val.to_be_bytes().clone(),
-            timeout_ms,
-        )
-    }
-
-    pub fn read_output_trim(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        idx: usize,
-        timeout_ms: u32,
-    ) -> Result<u8, Error> {
-        let &offset = OUT_TRIM_OFFSETS.iter().nth(idx).ok_or_else(|| {
-            let msg = format!(
-                "Invalid index of output: {} greater than {}",
-                idx,
-                OUT_TRIM_OFFSETS.len()
-            );
-            Error::new(FileError::Inval, &msg)
-        })?;
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(req, node, sections, offset, &mut data, timeout_ms)
-            .map(|_| u32::from_be_bytes(data) as u8)
-    }
-
-    pub fn write_output_trim(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        idx: usize,
-        trim: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let &offset = OUT_TRIM_OFFSETS.iter().nth(idx).ok_or_else(|| {
-            let msg = format!(
-                "Invalid index of output: {} greater than {}",
-                idx,
-                OUT_TRIM_OFFSETS.len()
-            );
-            Error::new(FileError::Inval, &msg)
-        })?;
-        let mut data = [0; 4];
-        data.copy_from_slice(&(trim as u32).to_be_bytes());
-        ApplSectionProtocol::write_appl_data(req, node, sections, offset, &mut data, timeout_ms)
-    }
 }
 
 /// Type of reverb DSP.
@@ -1034,36 +580,6 @@ fn deserialize_reverb_type(reverb_type: &mut ReverbType, raw: &[u8]) -> Result<(
     };
 
     Ok(())
-}
-
-impl From<u32> for ReverbType {
-    fn from(val: u32) -> Self {
-        match val {
-            ReverbType::ROOM_1 => ReverbType::Room1,
-            ReverbType::ROOM_2 => ReverbType::Room2,
-            ReverbType::ROOM_3 => ReverbType::Room3,
-            ReverbType::HALL_1 => ReverbType::Hall1,
-            ReverbType::HALL_2 => ReverbType::Hall2,
-            ReverbType::PLATE => ReverbType::Plate,
-            ReverbType::DELAY => ReverbType::Delay,
-            _ => ReverbType::Echo,
-        }
-    }
-}
-
-impl From<ReverbType> for u32 {
-    fn from(reverb_type: ReverbType) -> Self {
-        match reverb_type {
-            ReverbType::Room1 => ReverbType::ROOM_1,
-            ReverbType::Room2 => ReverbType::ROOM_2,
-            ReverbType::Room3 => ReverbType::ROOM_3,
-            ReverbType::Hall1 => ReverbType::HALL_1,
-            ReverbType::Hall2 => ReverbType::HALL_2,
-            ReverbType::Plate => ReverbType::PLATE,
-            ReverbType::Delay => ReverbType::DELAY,
-            ReverbType::Echo => ReverbType::ECHO,
-        }
-    }
 }
 
 /// Parameters specific to Mbox 3 pro.
@@ -1290,183 +806,6 @@ impl Mbox3Protocol {
         }
 
         Ok(())
-    }
-
-    pub fn read_reverb_type(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<ReverbType, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_TYPE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| ReverbType::from(u32::from_be_bytes(data)))
-    }
-
-    pub fn write_reverb_type(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        reverb_type: ReverbType,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = u32::from(reverb_type).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_TYPE_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_reverb_volume(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<u8, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_VOLUME_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data) as u8)
-    }
-
-    pub fn write_reverb_volume(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        volume: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = (volume as u32).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_VOLUME_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_reverb_duration(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<u8, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_DURATION_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data) as u8)
-    }
-
-    pub fn write_reverb_duration(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        duration: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = (duration as u32).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_DURATION_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-
-    pub fn read_reverb_feedback(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        timeout_ms: u32,
-    ) -> Result<u8, Error> {
-        let mut data = [0; 4];
-        ApplSectionProtocol::read_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_FEEDBACK_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-        .map(|_| u32::from_be_bytes(data) as u8)
-    }
-
-    pub fn write_reverb_feedback(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        sections: &ExtensionSections,
-        feedback: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut data = (feedback as u32).to_be_bytes().clone();
-        ApplSectionProtocol::write_appl_data(
-            req,
-            node,
-            sections,
-            REVERB_FEEDBACK_OFFSET,
-            &mut data,
-            timeout_ms,
-        )
-    }
-}
-
-impl Mbox3Protocol {
-    const PHANTOM_BUTTON_PUSHED: u32 = 0x10000000;
-    const SPKR_BUTTON_PUSHED: u32 = 0x04000000;
-    const SPKR_BUTTON_HELD: u32 = 0x02000000;
-    const MONO_BUTTON_PUSHED: u32 = 0x00800000;
-    const MUTE_BUTTON_PUSHED: u32 = 0x00400000;
-    const MUTE_BUTTON_HELD: u32 = 0x00200000;
-
-    pub fn has_phantom_button_pushed(msg: u32) -> bool {
-        msg & Self::PHANTOM_BUTTON_PUSHED > 0
-    }
-
-    pub fn has_spkr_button_pushed(msg: u32) -> bool {
-        msg & Self::SPKR_BUTTON_PUSHED > 0
-    }
-
-    pub fn has_spkr_button_held(msg: u32) -> bool {
-        msg & Self::SPKR_BUTTON_HELD > 0
-    }
-
-    pub fn has_mono_button_pushed(msg: u32) -> bool {
-        msg & Self::MONO_BUTTON_PUSHED > 0
-    }
-
-    pub fn has_mute_button_pushed(msg: u32) -> bool {
-        msg & Self::MUTE_BUTTON_PUSHED > 0
-    }
-
-    pub fn has_mute_button_held(msg: u32) -> bool {
-        msg & Self::MUTE_BUTTON_HELD > 0
     }
 }
 

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -365,7 +365,9 @@ impl SpecificCtl {
         sections: &ExtensionSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        Mbox3Protocol::cache_whole_params(req, node, sections, &mut self.0, timeout_ms)
+        let res = Mbox3Protocol::cache_whole_params(req, node, sections, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -633,15 +635,16 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&case| params.standalone_use_case = case)?;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MASTER_KNOB_ASSIGN_NAME => {
                 let mut params = self.0.clone();
@@ -650,15 +653,16 @@ impl SpecificCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(assign, val)| *assign = val);
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MUTE_BUTTON_NAME => {
                 let mut params = self.0.clone();
@@ -671,15 +675,16 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&s| params.mute_led = s)?;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::MONO_BUTTON_NAME => {
                 let mut params = self.0.clone();
@@ -692,15 +697,16 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&s| params.mono_led = s)?;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::SPKR_BUTTON_NAME => {
                 let mut params = self.0.clone();
@@ -713,54 +719,58 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&s| params.spkr_led = s)?;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::DIM_LED_USAGE_NAME => {
                 let mut params = self.0.clone();
                 params.dim_led = elem_value.boolean()[0];
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::HOLD_DURATION_NAME => {
                 let mut params = self.0.clone();
                 params.duration_hold = elem_value.int()[0] as u8;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::PHANTOM_POWERING_NAME => {
                 let mut params = self.0.clone();
                 params.phantom_powering = elem_value.boolean()[0];
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::INPUT_HPF_NAME => {
                 let mut params = self.0.clone();
@@ -769,15 +779,16 @@ impl SpecificCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::OUTPUT_TRIM_NAME => {
                 let mut params = self.0.clone();
@@ -786,15 +797,16 @@ impl SpecificCtl {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(trim, &val)| *trim = val as u8);
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::REVERB_TYPE_NAME => {
                 let mut params = self.0.clone();
@@ -807,54 +819,58 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&t| params.reverb_type = t)?;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::REVERB_VOL_NAME => {
                 let mut params = self.0.clone();
                 params.reverb_volume = elem_value.int()[0] as u8;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::REVERB_DURATION_NAME => {
                 let mut params = self.0.clone();
                 params.reverb_duration = elem_value.int()[0] as u8;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             Self::REVERB_FEEDBACK_NAME => {
                 let mut params = self.0.clone();
                 params.reverb_feedback = elem_value.int()[0] as u8;
-                Mbox3Protocol::update_partial_params(
+                let res = Mbox3Protocol::update_partial_params(
                     req,
                     node,
                     sections,
                     &params,
                     &mut self.0,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -868,6 +884,9 @@ impl SpecificCtl {
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        Mbox3Protocol::cache_notified_params(req, node, sections, msg, &mut self.0, timeout_ms)
+        let res =
+            Mbox3Protocol::cache_notified_params(req, node, sections, msg, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 }

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -13,10 +13,7 @@ pub struct Mbox3Model {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl,
     tcd22xx_ctl: Mbox3Tcd22xxCtl,
-    standalone_ctl: StandaloneCtl,
-    hw_ctl: HwCtl,
-    reverb_ctl: ReverbCtl,
-    button_ctl: ButtonCtl,
+    specific_ctl: SpecificCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -57,21 +54,20 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
             TIMEOUT_MS,
             card_cntr,
         )?;
-        self.standalone_ctl.load(card_cntr)?;
-        self.hw_ctl.load(card_cntr)?;
-        self.reverb_ctl.load(card_cntr)?;
-        self.button_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
+
+        self.specific_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctl.cache(
             unit,
             &mut self.req,
             &self.sections,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
+
+        self.specific_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -96,34 +92,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.standalone_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.hw_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.reverb_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.button_ctl.read(elem_id, elem_value)? {
+        } else if self.specific_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -157,39 +126,9 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.standalone_ctl.write(
-            unit,
+        } else if self.specific_ctl.write(
             &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.hw_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.reverb_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.button_ctl.write(
-            unit,
-            &mut self.req,
+            &mut unit.1,
             &self.extension_sections,
             elem_id,
             new,
@@ -206,7 +145,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
-        elem_id_list.extend_from_slice(&self.button_ctl.1);
+        elem_id_list.extend_from_slice(&self.specific_ctl.1);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -225,12 +164,12 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
             TIMEOUT_MS,
             *msg,
         )?;
-        self.button_ctl.parse_notification(
-            unit,
+        self.specific_ctl.parse_notification(
             &mut self.req,
+            &mut unit.1,
             &self.extension_sections,
-            TIMEOUT_MS,
             *msg,
+            TIMEOUT_MS,
         )?;
         Ok(())
     }
@@ -245,7 +184,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
             Ok(true)
         } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
             Ok(true)
-        } else if self.button_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.specific_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -305,9 +244,6 @@ impl Tcd22xxCtlOperation<Mbox3Protocol> for Mbox3Tcd22xxCtl {
     }
 }
 
-#[derive(Default)]
-struct StandaloneCtl;
-
 fn standalone_use_case_to_str(case: &StandaloneUseCase) -> &'static str {
     match case {
         StandaloneUseCase::Mixer => "Mixer",
@@ -315,258 +251,6 @@ fn standalone_use_case_to_str(case: &StandaloneUseCase) -> &'static str {
         StandaloneUseCase::Preamp => "Preamp",
     }
 }
-
-impl StandaloneCtl {
-    const USE_CASE_NAME: &'static str = "standalone-usecase";
-
-    const USE_CASES: [StandaloneUseCase; 3] = [
-        StandaloneUseCase::Mixer,
-        StandaloneUseCase::AdDa,
-        StandaloneUseCase::Preamp,
-    ];
-
-    fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels: Vec<&str> = Self::USE_CASES
-            .iter()
-            .map(|c| standalone_use_case_to_str(c))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::USE_CASE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-        Ok(())
-    }
-
-    fn read(
-        &self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::USE_CASE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                let usecase = Mbox3Protocol::read_standalone_use_case(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    timeout_ms,
-                )?;
-                let pos = Self::USE_CASES.iter().position(|c| usecase.eq(c)).unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            _ => Ok(false),
-        }
-    }
-
-    fn write(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::USE_CASE_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
-                let &usecase = Self::USE_CASES.iter().nth(val as usize).ok_or_else(|| {
-                    let msg = format!("Invalid value for standalone usecase: {}", val);
-                    Error::new(FileError::Inval, &msg)
-                })?;
-                Mbox3Protocol::write_standalone_use_case(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    usecase,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            _ => Ok(false),
-        }
-    }
-}
-
-#[derive(Default)]
-struct HwCtl;
-
-impl HwCtl {
-    const MASTER_KNOB_ASSIGN_NAME: &'static str = "master-knob-assign";
-    const DIM_LED_USAGE_NAME: &'static str = "dim-led";
-    const HOLD_DURATION_NAME: &'static str = "hold-duration";
-    const INPUT_HPF_NAME: &'static str = "input-hp-filter";
-    const OUTPUT_TRIM_NAME: &'static str = "output-trim";
-
-    const HOLD_DURATION_MAX: i32 = 1000;
-    const HOLD_DURATION_MIN: i32 = 0;
-    const HOLD_DURATION_STEP: i32 = 1;
-
-    const INPUT_COUNT: usize = 4;
-    const OUTPUT_COUNT: usize = 6;
-
-    fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let elem_id =
-            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MASTER_KNOB_ASSIGN_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::OUTPUT_COUNT, true);
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::DIM_LED_USAGE_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true);
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::HOLD_DURATION_NAME, 0);
-        let _ = card_cntr.add_int_elems(
-            &elem_id,
-            1,
-            Self::HOLD_DURATION_MIN,
-            Self::HOLD_DURATION_MAX,
-            Self::HOLD_DURATION_STEP,
-            1,
-            None,
-            true,
-        )?;
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_HPF_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::INPUT_COUNT, true);
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OUTPUT_TRIM_NAME, 0);
-        let _ = card_cntr.add_int_elems(
-            &elem_id,
-            1,
-            u8::MIN as i32,
-            u8::MAX as i32,
-            1,
-            1,
-            None,
-            true,
-        )?;
-
-        Ok(())
-    }
-
-    fn read(
-        &self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        elem_value: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::MASTER_KNOB_ASSIGN_NAME => {
-                let mut assigns = MasterKnobAssigns::default();
-                Mbox3Protocol::read_master_knob_assign(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    &mut assigns,
-                    timeout_ms,
-                )
-                .map(|_| {
-                    elem_value.set_bool(&assigns);
-                    true
-                })
-            }
-            Self::DIM_LED_USAGE_NAME => {
-                Mbox3Protocol::read_dim_led_usage(req, &mut unit.1, sections, timeout_ms).map(
-                    |usage| {
-                        elem_value.set_bool(&[usage]);
-                        true
-                    },
-                )
-            }
-            Self::HOLD_DURATION_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
-                Mbox3Protocol::read_hold_duration(req, &mut unit.1, sections, timeout_ms)
-                    .map(|duration| duration as i32)
-            })
-            .map(|_| true),
-            Self::INPUT_HPF_NAME => {
-                let mut vals = [false; Self::INPUT_COUNT];
-                Mbox3Protocol::read_hpf_enable(req, &mut unit.1, sections, &mut vals, timeout_ms)
-                    .map(|_| {
-                        elem_value.set_bool(&vals);
-                        true
-                    })
-            }
-            Self::OUTPUT_TRIM_NAME => {
-                ElemValueAccessor::<i32>::set_vals(elem_value, Self::OUTPUT_COUNT, |idx| {
-                    Mbox3Protocol::read_output_trim(req, &mut unit.1, sections, idx, timeout_ms)
-                        .map(|trim| trim as i32)
-                })
-                .map(|_| true)
-            }
-            _ => Ok(false),
-        }
-    }
-
-    fn write(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::MASTER_KNOB_ASSIGN_NAME => {
-                let mut assign = MasterKnobAssigns::default();
-                assign
-                    .iter_mut()
-                    .zip(new.boolean())
-                    .for_each(|(d, s)| *d = s);
-                Mbox3Protocol::write_master_knob_assign(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    &assign,
-                    timeout_ms,
-                )
-                .map(|_| true)
-            }
-            Self::DIM_LED_USAGE_NAME => ElemValueAccessor::<bool>::get_val(new, |val| {
-                Mbox3Protocol::write_dim_led_usage(req, &mut unit.1, sections, val, timeout_ms)
-            })
-            .map(|_| true),
-            Self::HOLD_DURATION_NAME => ElemValueAccessor::<i32>::get_val(new, |val| {
-                Mbox3Protocol::write_hold_duration(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    val as u8,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            Self::INPUT_HPF_NAME => {
-                let mut vals = [false; Self::INPUT_COUNT];
-                vals.iter_mut().zip(new.boolean()).for_each(|(d, s)| *d = s);
-                Mbox3Protocol::write_hpf_enable(req, &mut unit.1, sections, vals, timeout_ms)?;
-                Ok(true)
-            }
-            Self::OUTPUT_TRIM_NAME => {
-                ElemValueAccessor::<i32>::get_vals(new, old, Self::OUTPUT_COUNT, |idx, val| {
-                    Mbox3Protocol::write_output_trim(
-                        req,
-                        &mut unit.1,
-                        sections,
-                        idx,
-                        val as u8,
-                        timeout_ms,
-                    )
-                })
-                .map(|_| true)
-            }
-            _ => Ok(false),
-        }
-    }
-}
-
-#[derive(Default)]
-struct ReverbCtl;
 
 fn reverb_type_to_str(reverb_type: &ReverbType) -> &'static str {
     match reverb_type {
@@ -580,166 +264,6 @@ fn reverb_type_to_str(reverb_type: &ReverbType) -> &'static str {
         ReverbType::Echo => "Delay",
     }
 }
-
-impl ReverbCtl {
-    const TYPE_NAME: &'static str = "reverb-type";
-    const VOL_NAME: &'static str = "reverb-output-volume";
-    const DURATION_NAME: &'static str = "reverb-duration";
-    const FEEDBACK_NAME: &'static str = "reverb-feedback";
-
-    const TYPES: [ReverbType; 8] = [
-        ReverbType::Room1,
-        ReverbType::Room2,
-        ReverbType::Room3,
-        ReverbType::Hall1,
-        ReverbType::Hall2,
-        ReverbType::Plate,
-        ReverbType::Delay,
-        ReverbType::Echo,
-    ];
-
-    fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels: Vec<&str> = Self::TYPES.iter().map(|t| reverb_type_to_str(t)).collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::TYPE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::VOL_NAME, 0);
-        let _ = card_cntr.add_int_elems(
-            &elem_id,
-            1,
-            u8::MIN as i32,
-            u8::MAX as i32,
-            1,
-            1,
-            None,
-            true,
-        )?;
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::DURATION_NAME, 0);
-        let _ = card_cntr.add_int_elems(
-            &elem_id,
-            1,
-            u8::MIN as i32,
-            u8::MAX as i32,
-            1,
-            1,
-            None,
-            true,
-        )?;
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::FEEDBACK_NAME, 0);
-        let _ = card_cntr.add_int_elems(
-            &elem_id,
-            1,
-            u8::MIN as i32,
-            u8::MAX as i32,
-            1,
-            1,
-            None,
-            true,
-        )?;
-
-        Ok(())
-    }
-
-    fn read(
-        &self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::TYPE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                let reverb_type =
-                    Mbox3Protocol::read_reverb_type(req, &mut unit.1, sections, timeout_ms)?;
-                let pos = Self::TYPES.iter().position(|t| reverb_type.eq(t)).unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            Self::VOL_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
-                Mbox3Protocol::read_reverb_volume(req, &mut unit.1, sections, timeout_ms)
-                    .map(|vol| vol as i32)
-            })
-            .map(|_| true),
-            Self::DURATION_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
-                Mbox3Protocol::read_reverb_duration(req, &mut unit.1, sections, timeout_ms)
-                    .map(|duration| duration as i32)
-            })
-            .map(|_| true),
-            Self::FEEDBACK_NAME => ElemValueAccessor::<i32>::set_val(elem_value, || {
-                Mbox3Protocol::read_reverb_feedback(req, &mut unit.1, sections, timeout_ms)
-                    .map(|feedback| feedback as i32)
-            })
-            .map(|_| true),
-            _ => Ok(false),
-        }
-    }
-
-    fn write(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        req: &mut FwReq,
-        sections: &ExtensionSections,
-        elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            Self::TYPE_NAME => ElemValueAccessor::<u32>::get_val(new, |val| {
-                let &reverb_type = Self::TYPES.iter().nth(val as usize).ok_or_else(|| {
-                    let msg = format!("Invalid value for index of reverb type: {}", val);
-                    Error::new(FileError::Inval, &msg)
-                })?;
-                Mbox3Protocol::write_reverb_type(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    reverb_type,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            Self::VOL_NAME => ElemValueAccessor::<i32>::get_val(new, |val| {
-                Mbox3Protocol::write_reverb_volume(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    val as u8,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            Self::DURATION_NAME => ElemValueAccessor::<i32>::get_val(new, |val| {
-                Mbox3Protocol::write_reverb_duration(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    val as u8,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            Self::FEEDBACK_NAME => ElemValueAccessor::<i32>::get_val(new, |val| {
-                Mbox3Protocol::write_reverb_feedback(
-                    req,
-                    &mut unit.1,
-                    sections,
-                    val as u8,
-                    timeout_ms,
-                )
-            })
-            .map(|_| true),
-            _ => Ok(false),
-        }
-    }
-}
-
-#[derive(Default)]
-struct ButtonCtl(ButtonLedState, Vec<ElemId>);
 
 fn mute_led_state_to_str(state: &MuteLedState) -> &'static str {
     match state {
@@ -768,10 +292,56 @@ fn spkr_led_state_to_str(state: &SpkrLedState) -> &'static str {
     }
 }
 
-impl ButtonCtl {
+#[derive(Default, Debug)]
+struct SpecificCtl(Mbox3SpecificParams, Vec<ElemId>);
+
+impl SpecificCtl {
+    const USE_CASE_NAME: &'static str = "standalone-usecase";
+
+    const MASTER_KNOB_VALUE_NAME: &'static str = "master-knob-value";
+    const MASTER_KNOB_ASSIGN_NAME: &'static str = "master-knob-assign";
+    const DIM_LED_USAGE_NAME: &'static str = "dim-led";
+    const HOLD_DURATION_NAME: &'static str = "hold-duration";
+    const PHANTOM_POWERING_NAME: &'static str = "phantom-powering";
+    const INPUT_HPF_NAME: &'static str = "input-hp-filter";
+    const OUTPUT_TRIM_NAME: &'static str = "output-trim";
+
+    const REVERB_TYPE_NAME: &'static str = "reverb-type";
+    const REVERB_VOL_NAME: &'static str = "reverb-output-volume";
+    const REVERB_DURATION_NAME: &'static str = "reverb-duration";
+    const REVERB_FEEDBACK_NAME: &'static str = "reverb-feedback";
+
     const MUTE_BUTTON_NAME: &'static str = "mute-button";
     const MONO_BUTTON_NAME: &'static str = "mono-button";
     const SPKR_BUTTON_NAME: &'static str = "spkr-button";
+
+    const USE_CASES: [StandaloneUseCase; 3] = [
+        StandaloneUseCase::Mixer,
+        StandaloneUseCase::AdDa,
+        StandaloneUseCase::Preamp,
+    ];
+
+    const MASTER_KNOB_VALUE_MIN: i32 = 0x00;
+    const MASTER_KNOB_VALUE_MAX: i32 = 0xff;
+    const MASTER_KNOB_VALUE_STEP: i32 = 1;
+
+    const HOLD_DURATION_MAX: i32 = 1000;
+    const HOLD_DURATION_MIN: i32 = 0;
+    const HOLD_DURATION_STEP: i32 = 1;
+
+    const INPUT_COUNT: usize = 4;
+    const OUTPUT_COUNT: usize = 6;
+
+    const REVERB_TYPES: [ReverbType; 8] = [
+        ReverbType::Room1,
+        ReverbType::Room2,
+        ReverbType::Room3,
+        ReverbType::Hall1,
+        ReverbType::Hall2,
+        ReverbType::Plate,
+        ReverbType::Delay,
+        ReverbType::Echo,
+    ];
 
     const MUTE_LED_STATES: [MuteLedState; 3] =
         [MuteLedState::Off, MuteLedState::Blink, MuteLedState::On];
@@ -788,227 +358,516 @@ impl ButtonCtl {
         SpkrLedState::OrangeBlink,
     ];
 
-    fn load(
+    fn cache(
         &mut self,
-        unit: &mut (SndDice, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         sections: &ExtensionSections,
         timeout_ms: u32,
-        card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        Mbox3Protocol::cache_whole_params(req, node, sections, &mut self.0, timeout_ms)
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let labels: Vec<&str> = Self::USE_CASES
+            .iter()
+            .map(|c| standalone_use_case_to_str(c))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::USE_CASE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MASTER_KNOB_VALUE_NAME, 0);
+        let _ = card_cntr
+            .add_int_elems(
+                &elem_id,
+                1,
+                Self::MASTER_KNOB_VALUE_MIN,
+                Self::MASTER_KNOB_VALUE_MAX,
+                Self::MASTER_KNOB_VALUE_STEP,
+                1,
+                None,
+                false,
+            )
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MASTER_KNOB_ASSIGN_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::OUTPUT_COUNT, true);
+
         let labels: Vec<&str> = Self::MUTE_LED_STATES
             .iter()
             .map(|s| mute_led_state_to_str(s))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MUTE_BUTTON_NAME, 0);
-        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-        self.1.append(&mut elem_id_list);
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = Self::MONO_LED_STATES
             .iter()
             .map(|s| mono_led_state_to_str(s))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::MONO_BUTTON_NAME, 0);
-        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-        self.1.append(&mut elem_id_list);
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = Self::SPKR_LED_STATES
             .iter()
             .map(|s| spkr_led_state_to_str(s))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::SPKR_BUTTON_NAME, 0);
-        let mut elem_id_list = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-        self.1.append(&mut elem_id_list);
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        Mbox3Protocol::read_button_led_state(req, &mut unit.1, sections, timeout_ms)
-            .map(|state| self.0 = state)?;
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::DIM_LED_USAGE_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::HOLD_DURATION_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            Self::HOLD_DURATION_MIN,
+            Self::HOLD_DURATION_MAX,
+            Self::HOLD_DURATION_STEP,
+            1,
+            None,
+            true,
+        )?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::PHANTOM_POWERING_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::INPUT_HPF_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, Self::INPUT_COUNT, true);
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, Self::OUTPUT_TRIM_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                1,
+                u8::MIN as i32,
+                u8::MAX as i32,
+                1,
+                Self::OUTPUT_COUNT,
+                None,
+                true,
+            )
+            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+
+        let labels: Vec<&str> = Self::REVERB_TYPES
+            .iter()
+            .map(|t| reverb_type_to_str(t))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_TYPE_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_VOL_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            u8::MIN as i32,
+            u8::MAX as i32,
+            1,
+            1,
+            None,
+            true,
+        )?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_DURATION_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            u8::MIN as i32,
+            u8::MAX as i32,
+            1,
+            1,
+            None,
+            true,
+        )?;
+
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, Self::REVERB_FEEDBACK_NAME, 0);
+        let _ = card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            u8::MIN as i32,
+            u8::MAX as i32,
+            1,
+            1,
+            None,
+            true,
+        )?;
 
         Ok(())
     }
 
-    fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            Self::MUTE_BUTTON_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            Self::USE_CASE_NAME => {
+                let params = &self.0;
+                let pos = Self::USE_CASES
+                    .iter()
+                    .position(|c| params.standalone_use_case.eq(c))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::MASTER_KNOB_VALUE_NAME => {
+                let params = &self.0;
+                elem_value.set_int(&[params.master_knob_value as i32]);
+                Ok(true)
+            }
+            Self::MASTER_KNOB_ASSIGN_NAME => {
+                let params = &self.0;
+                elem_value.set_bool(&params.master_knob_assigns);
+                Ok(true)
+            }
+            Self::DIM_LED_USAGE_NAME => {
+                let params = &self.0;
+                elem_value.set_bool(&[params.dim_led]);
+                Ok(true)
+            }
+            Self::HOLD_DURATION_NAME => {
+                let params = &self.0;
+                elem_value.set_int(&[params.duration_hold as i32]);
+                Ok(true)
+            }
+            Self::PHANTOM_POWERING_NAME => {
+                let params = &self.0;
+                elem_value.set_bool(&[params.phantom_powering]);
+                Ok(true)
+            }
+            Self::INPUT_HPF_NAME => {
+                let params = &self.0;
+                elem_value.set_bool(&params.hpf_enables);
+                Ok(true)
+            }
+            Self::OUTPUT_TRIM_NAME => {
+                let params = &self.0;
+                let vals: Vec<i32> = params.output_trims.iter().map(|&val| val as i32).collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            Self::REVERB_TYPE_NAME => {
+                let params = &self.0;
+                let pos = Self::REVERB_TYPES
+                    .iter()
+                    .position(|t| params.reverb_type.eq(t))
+                    .unwrap();
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::REVERB_VOL_NAME => {
+                let params = &self.0;
+                elem_value.set_int(&[params.reverb_volume as i32]);
+                Ok(true)
+            }
+            Self::REVERB_DURATION_NAME => {
+                let params = &self.0;
+                elem_value.set_int(&[params.reverb_duration as i32]);
+                Ok(true)
+            }
+            Self::REVERB_FEEDBACK_NAME => {
+                let params = &self.0;
+                elem_value.set_int(&[params.reverb_feedback as i32]);
+                Ok(true)
+            }
+            Self::MUTE_BUTTON_NAME => {
+                let params = &self.0;
                 let pos = Self::MUTE_LED_STATES
                     .iter()
-                    .position(|s| self.0.mute.eq(s))
+                    .position(|s| params.mute_led.eq(s))
                     .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            Self::MONO_BUTTON_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::MONO_BUTTON_NAME => {
+                let params = &self.0;
                 let pos = Self::MONO_LED_STATES
                     .iter()
-                    .position(|s| self.0.mono.eq(s))
+                    .position(|s| params.mono_led.eq(s))
                     .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            Self::SPKR_BUTTON_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            Self::SPKR_BUTTON_NAME => {
+                let params = &self.0;
                 let pos = Self::SPKR_LED_STATES
                     .iter()
-                    .position(|s| self.0.spkr.eq(s))
+                    .position(|s| params.spkr_led.eq(s))
                     .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         sections: &ExtensionSections,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            Self::MUTE_BUTTON_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                let mut state = self.0.clone();
-                state.mute = Self::MUTE_LED_STATES
+            Self::USE_CASE_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::USE_CASES
                     .iter()
-                    .nth(val as usize)
-                    .map(|&s| s)
+                    .nth(pos)
                     .ok_or_else(|| {
-                        let msg = format!("Invalid value for index of mute button state: {}", val);
+                        let msg = format!("Invalid value for standalone usecase: {}", pos);
                         Error::new(FileError::Inval, &msg)
-                    })?;
-                Mbox3Protocol::write_button_led_state(
+                    })
+                    .map(|&case| params.standalone_use_case = case)?;
+                Mbox3Protocol::update_partial_params(
                     req,
-                    &mut unit.1,
+                    node,
                     sections,
-                    &state,
+                    &params,
+                    &mut self.0,
                     timeout_ms,
                 )
-                .map(|_| self.0 = state)
-            })
-            .map(|_| true),
-            Self::MONO_BUTTON_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                let mut state = self.0.clone();
-                state.mono = Self::MONO_LED_STATES
-                    .iter()
-                    .nth(val as usize)
-                    .map(|&s| s)
-                    .ok_or_else(|| {
-                        let msg = format!("Invalid value for index of mono button state: {}", val);
-                        Error::new(FileError::Inval, &msg)
-                    })?;
-                Mbox3Protocol::write_button_led_state(
+                .map(|_| true)
+            }
+            Self::MASTER_KNOB_ASSIGN_NAME => {
+                let mut params = self.0.clone();
+                params
+                    .master_knob_assigns
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(assign, val)| *assign = val);
+                Mbox3Protocol::update_partial_params(
                     req,
-                    &mut unit.1,
+                    node,
                     sections,
-                    &state,
+                    &params,
+                    &mut self.0,
                     timeout_ms,
                 )
-                .map(|_| self.0 = state)
-            })
-            .map(|_| true),
-            Self::SPKR_BUTTON_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                let mut state = self.0.clone();
-                state.spkr = Self::SPKR_LED_STATES
+                .map(|_| true)
+            }
+            Self::MUTE_BUTTON_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::MUTE_LED_STATES
                     .iter()
-                    .nth(val as usize)
-                    .map(|&s| s)
+                    .nth(pos)
                     .ok_or_else(|| {
-                        let msg = format!("Invalid value for index of mono button state: {}", val);
+                        let msg = format!("Mute LED state not found for position {}", pos);
                         Error::new(FileError::Inval, &msg)
-                    })?;
-                Mbox3Protocol::write_button_led_state(
+                    })
+                    .map(|&s| params.mute_led = s)?;
+                Mbox3Protocol::update_partial_params(
                     req,
-                    &mut unit.1,
+                    node,
                     sections,
-                    &state,
+                    &params,
+                    &mut self.0,
                     timeout_ms,
                 )
-                .map(|_| self.0 = state)
-            })
-            .map(|_| true),
+                .map(|_| true)
+            }
+            Self::MONO_BUTTON_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::MONO_LED_STATES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Mono LED state not found for position {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|&s| params.mono_led = s)?;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::SPKR_BUTTON_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::SPKR_LED_STATES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Speaker LED state not found for position {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|&s| params.spkr_led = s)?;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::DIM_LED_USAGE_NAME => {
+                let mut params = self.0.clone();
+                params.dim_led = elem_value.boolean()[0];
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::HOLD_DURATION_NAME => {
+                let mut params = self.0.clone();
+                params.duration_hold = elem_value.int()[0] as u8;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::PHANTOM_POWERING_NAME => {
+                let mut params = self.0.clone();
+                params.phantom_powering = elem_value.boolean()[0];
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::INPUT_HPF_NAME => {
+                let mut params = self.0.clone();
+                params
+                    .hpf_enables
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(enabled, val)| *enabled = val);
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::OUTPUT_TRIM_NAME => {
+                let mut params = self.0.clone();
+                params
+                    .output_trims
+                    .iter_mut()
+                    .zip(elem_value.int())
+                    .for_each(|(trim, &val)| *trim = val as u8);
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::REVERB_TYPE_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::REVERB_TYPES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Reverb type not found for position {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|&t| params.reverb_type = t)?;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::REVERB_VOL_NAME => {
+                let mut params = self.0.clone();
+                params.reverb_volume = elem_value.int()[0] as u8;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::REVERB_DURATION_NAME => {
+                let mut params = self.0.clone();
+                params.reverb_duration = elem_value.int()[0] as u8;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
+            Self::REVERB_FEEDBACK_NAME => {
+                let mut params = self.0.clone();
+                params.reverb_feedback = elem_value.int()[0] as u8;
+                Mbox3Protocol::update_partial_params(
+                    req,
+                    node,
+                    sections,
+                    &params,
+                    &mut self.0,
+                    timeout_ms,
+                )
+                .map(|_| true)
+            }
             _ => Ok(false),
         }
     }
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         sections: &ExtensionSections,
-        timeout_ms: u32,
         msg: u32,
+        timeout_ms: u32,
     ) -> Result<(), Error> {
-        let mut changed = false;
-
-        if Mbox3Protocol::has_spkr_button_pushed(msg) {
-            let state = match self.0.spkr {
-                SpkrLedState::Off => SpkrLedState::Green,
-                SpkrLedState::GreenBlink => SpkrLedState::Green,
-                SpkrLedState::Green => SpkrLedState::Red,
-                SpkrLedState::RedBlink => SpkrLedState::Red,
-                SpkrLedState::Red => SpkrLedState::Orange,
-                SpkrLedState::OrangeBlink => SpkrLedState::Orange,
-                SpkrLedState::Orange => SpkrLedState::Off,
-            };
-            self.0.spkr = state;
-            changed = true;
-        }
-
-        if Mbox3Protocol::has_spkr_button_held(msg) {
-            let state = match self.0.spkr {
-                SpkrLedState::Off => SpkrLedState::Off,
-                SpkrLedState::GreenBlink => SpkrLedState::Green,
-                SpkrLedState::Green => SpkrLedState::GreenBlink,
-                SpkrLedState::RedBlink => SpkrLedState::Red,
-                SpkrLedState::Red => SpkrLedState::RedBlink,
-                SpkrLedState::OrangeBlink => SpkrLedState::Orange,
-                SpkrLedState::Orange => SpkrLedState::OrangeBlink,
-            };
-            self.0.spkr = state;
-            changed = true;
-        }
-
-        if Mbox3Protocol::has_mono_button_pushed(msg) {
-            let state = match self.0.mono {
-                MonoLedState::Off => MonoLedState::On,
-                MonoLedState::On => MonoLedState::Off,
-            };
-            self.0.mono = state;
-            changed = true;
-        }
-
-        if Mbox3Protocol::has_mute_button_pushed(msg) {
-            let state = match self.0.mute {
-                MuteLedState::Off => MuteLedState::On,
-                MuteLedState::Blink => MuteLedState::On,
-                MuteLedState::On => MuteLedState::Off,
-            };
-            self.0.mute = state;
-            changed = true;
-        }
-
-        if Mbox3Protocol::has_mute_button_held(msg) {
-            let state = match self.0.mute {
-                MuteLedState::Off => MuteLedState::Off,
-                MuteLedState::Blink => MuteLedState::On,
-                MuteLedState::On => MuteLedState::Blink,
-            };
-            self.0.mute = state;
-            changed = true;
-        }
-
-        if changed {
-            Mbox3Protocol::write_button_led_state(req, &mut unit.1, sections, &self.0, timeout_ms)?;
-        }
-
-        Ok(())
-    }
-
-    fn read_notified_elem(
-        &self,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
-        self.read(elem_id, elem_value)
+        Mbox3Protocol::cache_notified_params(req, node, sections, msg, &mut self.0, timeout_ms)
     }
 }


### PR DESCRIPTION
This patchset is rework for protocol implementation of Mbox 3 pro so that
intermediate structure of parameters is used between protocol and runtime
implementations.

```
Takashi Sakamoto (4):
  protocols/dice: avid: add intermediate structure of parameters for runtime
  runtime/dice: avid: use intermediate structure of parameters
  protocols/dice: avid: remove unused methods from trait of protocol
  runtime/dice: avid: add logging to controls specific to Profire series

 protocols/dice/src/avid.rs      | 1143 ++++++++++++++----------------
 runtime/dice/src/mbox3_model.rs | 1180 ++++++++++++++-----------------
 2 files changed, 1075 insertions(+), 1248 deletions(-)
```