### PR TITLE
[PATCH 0/4] protocols/dice: maudio: rework for protocol implementation of Profire series

### DIFF
--- a/protocols/dice/src/maudio.rs
+++ b/protocols/dice/src/maudio.rs
@@ -48,11 +48,18 @@ impl Tcd22xxSpecOperation for Pfire2626Protocol {
             label: None,
         },
         Input {
+            id: SrcBlkId::Aes,
+            offset: 0,
+            count: 2,
+            label: None,
+        },
+        Input {
             id: SrcBlkId::Adat,
             offset: 0,
             count: 8,
             label: None,
         },
+        // NOTE: share the same optical interface.
         Input {
             id: SrcBlkId::Adat,
             offset: 8,
@@ -61,7 +68,7 @@ impl Tcd22xxSpecOperation for Pfire2626Protocol {
         },
         Input {
             id: SrcBlkId::Aes,
-            offset: 0,
+            offset: 6,
             count: 2,
             label: None,
         },
@@ -74,11 +81,18 @@ impl Tcd22xxSpecOperation for Pfire2626Protocol {
             label: None,
         },
         Output {
+            id: DstBlkId::Aes,
+            offset: 0,
+            count: 2,
+            label: None,
+        },
+        Output {
             id: DstBlkId::Adat,
             offset: 0,
             count: 8,
             label: None,
         },
+        // NOTE: share the same optical interface.
         Output {
             id: DstBlkId::Adat,
             offset: 8,
@@ -87,7 +101,7 @@ impl Tcd22xxSpecOperation for Pfire2626Protocol {
         },
         Output {
             id: DstBlkId::Aes,
-            offset: 0,
+            offset: 6,
             count: 2,
             label: None,
         },

--- a/protocols/dice/src/maudio.rs
+++ b/protocols/dice/src/maudio.rs
@@ -5,6 +5,151 @@
 //!
 //! The modules includes structure, enumeration, and trait and its implementation for hardware
 //! specification and application protocol specific to M-Audio ProFire series.
+//!
+//! ## Diagram of internal signal flow for Profire 2626
+//!
+//! ```text
+//!
+//! XLR input 1 -------+-------+
+//! Phone input 1 -----+       |
+//!                            |
+//! XLR input 2 -------+-------+
+//! Phone input 2 -----+       |
+//!                            +----------------> analog-input-1/2
+//! XLR input 3/4 ------------------------------> analog-input-3/4
+//! XLR input 5/6 ------------------------------> analog-input-5/6
+//! XLR input 7/8 ------------------------------> analog-input-7/8
+//! Coaxial input ------------------------------> spdif-input-1/2
+//! Optical input A ----------------------------> adat-input-1..8
+//! Optical input B -----------or---------------> adat-input-8..16
+//!                             +---------------> spdif-input-3/4
+//!
+//!                          ++=============++
+//! analog-input-1/2 ------> || 70 x 68     || --> analog-output-1/2
+//! analog-input-3/4 ------> || router      || --> analog-output-3/4
+//! analog-input-5/6 ------> || up to       || --> analog-output-5/6
+//! analog-input-7/8 ------> || 128 entries || --> analog-output-7/8
+//!                          ||             ||
+//! spdif-input-1/2 -------> ||             || --> spdif-output-1/2
+//! spdif-input-3/4 -------> ||             || --> spdif-output-3/4
+//!                          ||             ||
+//! adat-input-1/2 --------> ||             || --> adat-output-1/2
+//! adat-input-3/4 --------> ||             || --> adat-output-3/4
+//! adat-input-5/6 --------> ||             || --> adat-output-5/6
+//! adat-input-7/8 --------> ||             || --> adat-output-7/8
+//!                          ||             ||
+//! adat-input-9/10 -------> ||             || --> adat-output-9/10
+//! adat-input-11/12 ------> ||             || --> adat-output-11/12
+//! adat-input-13/14 ------> ||             || --> adat-output-13/14
+//! adat-input-15/16 ------> ||             || --> adat-output-15/16
+//!                          ||             ||
+//! stream-input-A-1/2 ----> ||             || --> stream-output-A-1/2
+//! stream-input-A-3/4 ----> ||             || --> stream-output-A-3/4
+//! stream-input-A-5/6 ----> ||             || --> stream-output-A-5/6
+//! stream-input-A-7/8 ----> ||             || --> stream-output-A-7/8
+//! stream-input-A-9/10 ---> ||             || --> stream-output-A-9/10
+//!                          ||             ||
+//! stream-input-B-1/2 ----> ||             || --> stream-output-B-1/2
+//! stream-input-B-3/4 ----> ||             || --> stream-output-B-3/4
+//! stream-input-B-5/6 ----> ||             || --> stream-output-B-5/6
+//! stream-input-B-7/8 ----> ||             || --> stream-output-B-7/8
+//! stream-input-B-9/10 ---> ||             || --> stream-output-B-9/10
+//! stream-input-B-11/12 --> ||             || --> stream-output-B-11/12
+//! stream-input-B-13/14 --> ||             || --> stream-output-B-13/14
+//! stream-input-B-15/16 --> ||             || --> stream-output-B-15/16
+//!                          ||             ||
+//! mixer-output-1/2 ------> ||             || --> mixer-input-1/2
+//! mixer-output-3/4 ------> ||             || --> mixer-input-3/4
+//! mixer-output-5/6 ------> ||             || --> mixer-input-5/6
+//! mixer-output-7/8 ------> ||             || --> mixer-input-7/8
+//! mixer-output-9/10 -----> ||             || --> mixer-input-9/10
+//! mixer-output-11/12 ----> ||             || --> mixer-input-11/12
+//! mixer-output-13/14 ----> ||             || --> mixer-input-13/14
+//! mixer-output-15/16 ----> ||             || --> mixer-input-15/16
+//!                          ||             || --> mixer-input-17/18
+//!                          ++=============++
+//!
+//!                          ++============++
+//! mixer-input-1/2 ----->   ||            || --> mixer-output-1/2
+//! mixer-input-3/4 ----->   ||            || --> mixer-output-3/4
+//! mixer-input-5/6 ----->   ||            || --> mixer-output-5/6
+//! mixer-input-7/8 ----->   ||  18 x 16   || --> mixer-output-7/8
+//! mixer-input-9/10 ---->   ||            || --> mixer-output-9/10
+//! mixer-input-11/11 --->   ||   mixer    || --> mixer-output-11/12
+//! mixer-input-13/14 --->   ||            || --> mixer-output-13/14
+//! mixer-input-15/16 --->   ||            || --> mixer-output-15/16
+//! mixer-input-17/18 --->   ||            ||
+//!                          ++============++
+//!
+//! analog-output-1/2 ------------+-------------> Phone output 1/2
+//!                               +-------------> Headphone output 1/2
+//! analog-output-3/4 ------------+-------------> Phone output 1/2
+//!                               +-------------> Headphone output 3/4
+//! analog-output-5/6 --------------------------> Phone output 1/2
+//! analog-output-7/8 --------------------------> Phone output 1/2
+//!
+//! spdif-output-1/2 ---------------------------> Coaxial output
+//!
+//! adat-output-1..8 ---------------------------> Optical A output
+//!
+//! adat-output-9..16 ------------or------------> Optical B output
+//! spdif-output-3/4 -------------+
+//!
+//! ```
+//!
+//! ## Diagram of internal signal flow for Profire 610
+//!
+//! At 176.4/192.0 kHz, both stream-input-A and stream-input-B are available for
+//! analog-output-1..6 and spdif-output-1/2 per each.
+//!
+//! ```text
+//!
+//! XLR input 1/2 ------------------------------> analog-input-1/2
+//! Phone input 3/4 ----------------------------> analog-input-3/4
+//! coaxial input 1/2 --------------------------> spdif-input-1/2
+//!
+//!                          ++=============++
+//! analog-input-1/2 ------> || 32 x 30     || --> analog-output-1/2
+//! analog-input-3/4 ------> || router      || --> analog-output-3/4
+//!                          || up to       ||
+//! spdif-input-1/2 -------> || 128 entries || --> spdif-output-1/2
+//!                          ||             ||
+//! stream-input-1/2 ------> ||             || --> stream-output-1/2
+//! stream-input-3/4 ------> ||             || --> stream-output-3/4
+//! stream-input-5/6 ------> ||             || --> stream-output-5/6
+//! stream-input-7/8 ------> ||             ||
+//! stream-input-9/10 -----> ||             ||
+//!                          ||             ||
+//! mixer-output-1/2 ------> ||             || --> mixer-input-1/2
+//! mixer-output-3/4 ------> ||             || --> mixer-input-3/4
+//! mixer-output-5/6 ------> ||             || --> mixer-input-5/6
+//! mixer-output-7/8 ------> ||             || --> mixer-input-7/8
+//! mixer-output-9/10 -----> ||             || --> mixer-input-9/10
+//! mixer-output-11/12 ----> ||             || --> mixer-input-11/12
+//! mixer-output-13/14 ----> ||             || --> mixer-input-13/14
+//! mixer-output-15/16 ----> ||             || --> mixer-input-15/16
+//!                          ||             || --> mixer-input-17/18
+//!                          ++=============++
+//!
+//!                          ++============++
+//! mixer-input-1/2 ----->   ||            || --> mixer-output-1/2
+//! mixer-input-3/4 ----->   ||            || --> mixer-output-3/4
+//! mixer-input-5/6 ----->   ||            || --> mixer-output-5/6
+//! mixer-input-7/8 ----->   ||  18 x 16   || --> mixer-output-7/8
+//! mixer-input-9/10 ---->   ||            || --> mixer-output-9/10
+//! mixer-input-11/11 --->   ||   mixer    || --> mixer-output-11/12
+//! mixer-input-13/14 --->   ||            || --> mixer-output-13/14
+//! mixer-input-15/16 --->   ||            || --> mixer-output-15/16
+//! mixer-input-17/18 --->   ||            ||
+//!                          ++============++
+//!
+//! analog-output-1/2 ------------+-------------> Phone output 1/2
+//!                               +-------------> Headphone output 1/2
+//! analog-output-3/4 ------------+-------------> Phone output 3/4
+//!                               +-------------> Headphone output 1/2
+//!
+//! spdif-output-1/2 ---------------------------> Coaxial output
+//!
 
 use super::{
     tcat::{

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -370,7 +370,9 @@ impl<T: PfireSpecificOperation> PfireSpecificCtl<T> {
         sections: &ExtensionSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_whole_params(req, node, &sections, &mut self.0, timeout_ms)
+        let res = T::cache_whole_params(req, node, &sections, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -443,8 +445,10 @@ impl<T: PfireSpecificOperation> PfireSpecificCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(assign, val)| *assign = val);
-                T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OPT_IFACE_B_MODE_NAME => {
                 let mut params = self.0.clone();
@@ -458,8 +462,10 @@ impl<T: PfireSpecificOperation> PfireSpecificCtl<T> {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.opt_iface_b_mode = mode)?;
-                T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             STANDALONE_CONVERTER_MODE_NAME => {
                 let mut params = self.0.clone();
@@ -475,8 +481,10 @@ impl<T: PfireSpecificOperation> PfireSpecificCtl<T> {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.standalone_mode = mode)?;
-                T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms)
-                    .map(|_| true)
+                let res =
+                    T::update_partial_params(req, node, sections, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -378,7 +378,6 @@ impl<T: PfireSpecificOperation> PfireSpecificCtl<T> {
         let _ =
             card_cntr.add_bool_elems(&elem_id, 1, Self::MASTER_KNOB_TARGET_LABELS.len(), true)?;
 
-        // NOTE: ClockSource::Tdif is used for second optical interface as 'ADAT_AUX'.
         if T::HAS_OPT_IFACE_B {
             let labels: Vec<&str> = Self::OPT_IFACE_B_MODES
                 .iter()


### PR DESCRIPTION
This patchset is rework for protocol implementation of Profire series so that
intermediate structure of parameters is used between protocol and runtime
implementations.

```
Takashi Sakamoto (4):
  protocols/dice: maudio: add intermediate structure of parameters for runtime
  runtime/dice: maudio: use intermediate structure of parameters
  protocols/dice: maudio: remove unused methods from trait of protocol
  runtime/dice: maudio: add logging to controls specific to Profire series

 protocols/dice/src/maudio.rs    | 303 +++++++++++++++-----------------
 runtime/dice/src/pfire_model.rs | 165 ++++++++---------
 2 files changed, 214 insertions(+), 254 deletions(-)
```