### PR TITLE
[PATCH 00/14] runtime/dice: rework for controls of TCD22xx

### DIFF
--- a/protocols/dice/src/bin/tcat-extension-parser.rs
+++ b/protocols/dice/src/bin/tcat-extension-parser.rs
@@ -241,25 +241,30 @@ fn print_standalone_config(
     sections: &ExtensionSections,
 ) -> Result<(), Error> {
     println!("Standalone configurations:");
-    let src =
-        StandaloneSectionProtocol::read_standalone_clock_source(req, node, sections, TIMEOUT_MS)?;
-    println!("  clock source: {}", clock_source_to_string(&src));
-    let mode =
-        StandaloneSectionProtocol::read_standalone_aes_high_rate(req, node, sections, TIMEOUT_MS)?;
-    println!("  AES high rate: {}", mode);
-    let mode =
-        StandaloneSectionProtocol::read_standalone_adat_mode(req, node, sections, TIMEOUT_MS)?;
-    println!("  ADAT mode: {}", mode);
-    let params = StandaloneSectionProtocol::read_standalone_word_clock_param(
-        req, node, sections, TIMEOUT_MS,
+    let mut params = StandaloneParameters::default();
+    StandaloneSectionProtocol::cache_standalone_params(
+        req,
+        node,
+        sections,
+        &mut params,
+        TIMEOUT_MS,
     )?;
     println!(
-        "  Word clock params: {}, {} / {}",
-        params.mode, params.rate.numerator, params.rate.denominator
+        "  clock source: {}",
+        clock_source_to_string(&params.clock_source)
     );
-    let rate =
-        StandaloneSectionProtocol::read_standalone_internal_rate(req, node, sections, TIMEOUT_MS)?;
-    println!("  Internal rate: {}", clock_rate_to_string(&rate));
+    println!("  AES high rate: {}", params.aes_high_rate);
+    println!("  ADAT mode: {}", params.adat_mode);
+    println!(
+        "  Word clock params: {}, {} / {}",
+        params.word_clock_param.mode,
+        params.word_clock_param.rate.numerator,
+        params.word_clock_param.rate.denominator
+    );
+    println!(
+        "  Internal rate: {}",
+        clock_rate_to_string(&params.internal_rate)
+    );
     Ok(())
 }
 

--- a/protocols/dice/src/tcat/extension/standalone_section.rs
+++ b/protocols/dice/src/tcat/extension/standalone_section.rs
@@ -137,9 +137,98 @@ impl From<WordClockParam> for [u8; 4] {
     }
 }
 
+/// Parameters in standalone configuration section.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct StandaloneParameters {
+    /// Source of sampling clock.
+    pub clock_source: ClockSource,
+    /// Mode of AES input at high rate.
+    pub aes_high_rate: bool,
+    /// Mode of ADAT input for supported rates.
+    pub adat_mode: AdatParam,
+    /// Mode of word clock input.
+    pub word_clock_param: WordClockParam,
+    /// Internally generated sampling clock.
+    pub internal_rate: ClockRate,
+}
+
 /// Protocol implementation of standalone section.
 #[derive(Default)]
 pub struct StandaloneSectionProtocol;
+
+const MIN_SIZE: usize = 20;
+
+fn serialize(params: &StandaloneParameters, raw: &mut [u8]) -> Result<(), String> {
+    assert!(raw.len() >= MIN_SIZE);
+
+    (u8::from(params.clock_source) as u32).build_quadlet(&mut raw[..4]);
+
+    (params.aes_high_rate as u32).build_quadlet(&mut raw[4..8]);
+
+    (match params.adat_mode {
+        AdatParam::Normal => 0x00u32,
+        AdatParam::SMUX2 => 0x01,
+        AdatParam::SMUX4 => 0x02,
+        AdatParam::Auto => 0x03,
+    })
+    .build_quadlet(&mut raw[8..12]);
+
+    let mut val = match params.word_clock_param.mode {
+        WordClockMode::Normal => 0x00u32,
+        WordClockMode::Low => 0x01,
+        WordClockMode::Middle => 0x02,
+        WordClockMode::High => 0x03,
+    };
+    if params.word_clock_param.rate.numerator < 1 || params.word_clock_param.rate.denominator < 1 {
+        let msg = format!(
+            "Invalid parameters for rate of word clock: {} / {}",
+            params.word_clock_param.rate.numerator, params.word_clock_param.rate.denominator
+        );
+        Err(msg)?;
+    }
+    val |= ((params.word_clock_param.rate.numerator as u32) - 1) << 4;
+    val |= ((params.word_clock_param.rate.denominator as u32) - 1) << 16;
+    val.build_quadlet(&mut raw[12..16]);
+
+    (u8::from(params.internal_rate) as u32).build_quadlet(&mut raw[16..20]);
+
+    Ok(())
+}
+
+fn deserialize(params: &mut StandaloneParameters, raw: &[u8]) -> Result<(), String> {
+    assert!(raw.len() >= MIN_SIZE);
+
+    let mut val = 0u32;
+
+    val.parse_quadlet(&raw[..4]);
+    params.clock_source = ClockSource::from(val as u8);
+
+    val.parse_quadlet(&raw[4..8]);
+    params.aes_high_rate = val > 0;
+
+    val.parse_quadlet(&raw[8..12]);
+    params.adat_mode = match val {
+        0x01 => AdatParam::SMUX2,
+        0x02 => AdatParam::SMUX4,
+        0x03 => AdatParam::Auto,
+        _ => AdatParam::Normal,
+    };
+
+    val.parse_quadlet(&raw[12..16]);
+    params.word_clock_param.mode = match val & 0x03 {
+        0x01 => WordClockMode::Low,
+        0x02 => WordClockMode::Middle,
+        0x03 => WordClockMode::High,
+        _ => WordClockMode::Normal,
+    };
+    params.word_clock_param.rate.numerator = 1 + ((val >> 4) & 0x0fff) as u16;
+    params.word_clock_param.rate.denominator = 1 + ((val >> 16) & 0xffff) as u16;
+
+    val.parse_quadlet(&raw[16..20]);
+    params.internal_rate = ClockRate::from(val as u8);
+
+    Ok(())
+}
 
 impl StandaloneSectionProtocol {
     const CLK_SRC_OFFSET: usize = 0x00;
@@ -147,6 +236,57 @@ impl StandaloneSectionProtocol {
     const ADAT_CFG_OFFSET: usize = 0x08;
     const WC_CFG_OFFSET: usize = 0x0c;
     const INTERNAL_CFG_OFFSET: usize = 0x10;
+
+    pub fn cache_standalone_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        params: &mut StandaloneParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut raw = vec![0; sections.standalone.size];
+        extension_read(req, node, sections.standalone.offset, &mut raw, timeout_ms)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))?;
+
+        deserialize(params, &raw)
+            .map_err(|msg| Error::new(ProtocolExtensionError::Standalone, &msg))
+    }
+
+    pub fn update_standalone_params(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        params: &StandaloneParameters,
+        prev: &mut StandaloneParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut new = vec![0; sections.standalone.size];
+        serialize(params, &mut new)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))?;
+
+        let mut old = vec![0; sections.standalone.size];
+        serialize(params, &mut old)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))?;
+
+        (0..sections.standalone.size)
+            .step_by(4)
+            .try_for_each(|pos| {
+                if new[pos] != old[pos] {
+                    extension_read(
+                        req,
+                        node,
+                        sections.standalone.offset + pos,
+                        &mut new[pos..(pos + 4)],
+                        timeout_ms,
+                    )
+                } else {
+                    Ok(())
+                }
+            })?;
+
+        deserialize(prev, &new)
+            .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
 
     pub fn read_standalone_clock_source(
         req: &mut FwReq,
@@ -329,5 +469,35 @@ impl StandaloneSectionProtocol {
             timeout_ms,
         )
         .map_err(|e| Error::new(ProtocolExtensionError::Standalone, &e.to_string()))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn standalone_params_serdes() {
+        let params = StandaloneParameters {
+            clock_source: ClockSource::Tdif,
+            aes_high_rate: true,
+            adat_mode: AdatParam::SMUX4,
+            word_clock_param: WordClockParam {
+                mode: WordClockMode::Middle,
+                rate: WordClockRate {
+                    numerator: 12,
+                    denominator: 7,
+                },
+            },
+            internal_rate: ClockRate::R88200,
+        };
+
+        let mut raw = [0u8; MIN_SIZE];
+        assert!(serialize(&params, &mut raw).is_ok());
+
+        let mut p = StandaloneParameters::default();
+        assert!(deserialize(&mut p, &raw).is_ok());
+
+        assert_eq!(params, p);
     }
 }

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -46,9 +46,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -134,7 +134,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -168,7 +168,7 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -12,7 +12,6 @@ pub struct BlackbirdModel {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<BlackbirdProtocol>,
     tcd22xx_ctls: Tcd22xxCtls<BlackbirdProtocol>,
-    tcd22xx_ctl: BlackbirdTcd22xxCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -40,14 +39,6 @@ impl BlackbirdModel {
             TIMEOUT_MS,
         )?;
 
-        self.tcd22xx_ctl.cache(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-        )?;
-
         Ok(())
     }
 }
@@ -57,9 +48,6 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
-
-        self.tcd22xx_ctl
-            .load(card_cntr, &self.sections.global.params)?;
 
         Ok(())
     }
@@ -74,8 +62,6 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -85,7 +71,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
@@ -107,16 +93,6 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.tcd22xx_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -127,7 +103,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
-        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -139,14 +114,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctls.parse_notification(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            *msg,
-        )?;
-        self.tcd22xx_ctl.parse_notification(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -167,8 +134,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -179,7 +144,6 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
-        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -188,12 +152,6 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
         self.tcd22xx_ctls.cache_partial_params(
             &mut self.req,
             &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-        self.tcd22xx_ctl.measure_states(
-            unit,
-            &mut self.req,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -210,23 +168,8 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default)]
-struct BlackbirdTcd22xxCtl(Tcd22xxCtl);
-
-impl Tcd22xxCtlOperation<BlackbirdProtocol> for BlackbirdTcd22xxCtl {
-    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
-        &self.0
-    }
-
-    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
-        &mut self.0
     }
 }

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -10,7 +10,7 @@ pub struct BlackbirdModel {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<BlackbirdProtocol>,
     tcd22xx_ctl: BlackbirdTcd22xxCtl,
 }
 
@@ -26,7 +26,7 @@ impl BlackbirdModel {
         )?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -38,12 +38,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -173,7 +168,7 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -198,11 +193,6 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<BlackbirdProtocol> for CommonCtl {}
 
 #[derive(Default)]
 struct BlackbirdTcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -28,36 +28,27 @@ impl BlackbirdModel {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.extension_sections =
+            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
+
         Ok(())
     }
 }
 
 impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
-        self.extension_sections =
-            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
-
-        self.tcd22xx_ctl.cache(
-            unit,
-            &mut self.req,
-            &self.sections,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         Ok(())
     }
@@ -125,10 +116,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -64,20 +64,13 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -47,9 +47,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -64,20 +64,13 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -29,35 +29,26 @@ impl ExtensionModel {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.extension_sections =
+            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
         Ok(())
     }
 }
 
 impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
-        self.extension_sections =
-            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
-        self.tcd22xx_ctl.cache(
-            unit,
-            &mut self.req,
-            &self.sections,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         Ok(())
     }
@@ -125,10 +116,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -13,7 +13,6 @@ pub struct ExtensionModel {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<ExtensionProtocol>,
     tcd22xx_ctls: Tcd22xxCtls<ExtensionProtocol>,
-    tcd22xx_ctl: ExtensionTcd22xxCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -41,13 +40,6 @@ impl ExtensionModel {
             TIMEOUT_MS,
         )?;
 
-        self.tcd22xx_ctl.cache(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-        )?;
         Ok(())
     }
 }
@@ -57,9 +49,6 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
-
-        self.tcd22xx_ctl
-            .load(card_cntr, &self.sections.global.params)?;
 
         Ok(())
     }
@@ -74,8 +63,6 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -85,7 +72,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
@@ -107,16 +94,6 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.tcd22xx_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -127,7 +104,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
-        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -139,14 +115,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctls.parse_notification(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            *msg,
-        )?;
-        self.tcd22xx_ctl.parse_notification(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -167,8 +135,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -179,7 +145,6 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
-        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -188,12 +153,6 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
         self.tcd22xx_ctls.cache_partial_params(
             &mut self.req,
             &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-        self.tcd22xx_ctl.measure_states(
-            unit,
-            &mut self.req,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -209,8 +168,6 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -360,19 +317,6 @@ impl Tcd22xxSpecOperation for ExtensionProtocol {
             ch: 3,
         },
     ];
-}
-
-#[derive(Default)]
-struct ExtensionTcd22xxCtl(Tcd22xxCtl);
-
-impl Tcd22xxCtlOperation<ExtensionProtocol> for ExtensionTcd22xxCtl {
-    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
-        &self.0
-    }
-
-    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
-        &mut self.0
-    }
 }
 
 pub fn detect_extended_model(node: &mut FwNode) -> bool {

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -12,6 +12,7 @@ pub struct ExtensionModel {
     sections: GeneralSections,
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<ExtensionProtocol>,
+    tcd22xx_ctls: Tcd22xxCtls<ExtensionProtocol>,
     tcd22xx_ctl: ExtensionTcd22xxCtl,
 }
 
@@ -32,6 +33,14 @@ impl ExtensionModel {
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
+
         self.tcd22xx_ctl.cache(
             &mut self.req,
             &mut unit.1,
@@ -47,6 +56,8 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
+        self.tcd22xx_ctls.load(card_cntr)?;
+
         self.tcd22xx_ctl
             .load(card_cntr, &self.sections.global.params)?;
 
@@ -60,6 +71,8 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -85,6 +98,15 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
         } else if self.tcd22xx_ctl.write(
             unit,
             &mut self.req,
@@ -104,6 +126,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
 impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
@@ -114,6 +137,14 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
             &mut self.sections,
             *msg,
             TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+            *msg,
         )?;
         self.tcd22xx_ctl.parse_notification(
             &mut self.req,
@@ -134,6 +165,8 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -145,12 +178,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
 impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -167,6 +207,8 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -11,7 +11,7 @@ pub struct ExtensionModel {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<ExtensionProtocol>,
     tcd22xx_ctl: ExtensionTcd22xxCtl,
 }
 
@@ -27,7 +27,7 @@ impl ExtensionModel {
         )?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -39,12 +39,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -173,7 +168,7 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -342,11 +337,6 @@ impl Tcd22xxSpecOperation for ExtensionProtocol {
         },
     ];
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<ExtensionProtocol> for CommonCtl {}
 
 #[derive(Default)]
 struct ExtensionTcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -134,7 +134,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -168,7 +168,7 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -201,7 +201,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -237,7 +237,7 @@ impl MeasureModel<(SndDice, FwNode)> for LiquidS56Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -47,9 +47,7 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -90,20 +90,13 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -29,34 +29,14 @@ impl LiquidS56Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -80,6 +60,17 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
         self.io_params_ctl.load(card_cntr)?;
@@ -185,10 +176,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -23,34 +23,14 @@ impl SPro14Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for SPro14Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -67,6 +47,17 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for SPro14Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
@@ -159,10 +150,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -76,20 +76,13 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -41,9 +41,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -9,6 +9,7 @@ pub struct SPro14Model {
     sections: GeneralSections,
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro14Protocol>,
+    tcd22xx_ctls: Tcd22xxCtls<SPro14Protocol>,
     tcd22xx_ctl: SPro14Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro14Protocol>,
     input_ctl: SaffireproInputCtl<SPro14Protocol>,
@@ -25,6 +26,14 @@ impl SPro14Model {
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
 
         self.tcd22xx_ctl.cache(
             &mut self.req,
@@ -56,6 +65,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
+        self.tcd22xx_ctls.load(card_cntr)?;
+
         self.tcd22xx_ctl
             .load(card_cntr, &self.sections.global.params)?;
 
@@ -72,6 +83,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -96,6 +109,15 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
             &self.req,
             &unit.1,
             &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -138,6 +160,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
 impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
@@ -148,6 +171,14 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
             &mut self.sections,
             *msg,
             TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+            *msg,
         )?;
         self.tcd22xx_ctl.parse_notification(
             &mut self.req,
@@ -168,6 +199,8 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -179,12 +212,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
 impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -201,6 +241,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -10,7 +10,6 @@ pub struct SPro14Model {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro14Protocol>,
     tcd22xx_ctls: Tcd22xxCtls<SPro14Protocol>,
-    tcd22xx_ctl: SPro14Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro14Protocol>,
     input_ctl: SaffireproInputCtl<SPro14Protocol>,
 }
@@ -28,14 +27,6 @@ impl SPro14Model {
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.tcd22xx_ctls.cache_whole_params(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-        )?;
-
-        self.tcd22xx_ctl.cache(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -67,9 +58,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
-        self.tcd22xx_ctl
-            .load(card_cntr, &self.sections.global.params)?;
-
         self.out_grp_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
 
@@ -86,8 +74,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
@@ -101,7 +87,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
@@ -119,16 +105,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
             &mut unit.1,
             &self.extension_sections,
             elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.tcd22xx_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
             new,
             TIMEOUT_MS,
         )? {
@@ -161,7 +137,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
-        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -173,14 +148,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctls.parse_notification(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            *msg,
-        )?;
-        self.tcd22xx_ctl.parse_notification(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -201,8 +168,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
@@ -213,7 +178,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
-        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -222,12 +186,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
         self.tcd22xx_ctls.cache_partial_params(
             &mut self.req,
             &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-        self.tcd22xx_ctl.measure_states(
-            unit,
-            &mut self.req,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -244,23 +202,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default)]
-struct SPro14Tcd22xxCtl(Tcd22xxCtl);
-
-impl Tcd22xxCtlOperation<SPro14Protocol> for SPro14Tcd22xxCtl {
-    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
-        &self.0
-    }
-
-    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
-        &mut self.0
     }
 }

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -168,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -202,7 +202,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -76,20 +76,13 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -8,7 +8,7 @@ pub struct SPro24Model {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<SPro24Protocol>,
     tcd22xx_ctl: SPro24Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro24Protocol>,
     input_ctl: SaffireproInputCtl<SPro24Protocol>,
@@ -21,7 +21,7 @@ impl SPro24Model {
         SPro24Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -33,12 +33,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -217,7 +212,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -242,11 +237,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<SPro24Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct SPro24Tcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -23,34 +23,14 @@ impl SPro24Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for SPro24Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -67,6 +47,17 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for SPro24Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
@@ -160,10 +151,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -41,9 +41,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -176,7 +176,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -212,7 +212,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -10,7 +10,6 @@ pub struct SPro24Model {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro24Protocol>,
     tcd22xx_ctls: Tcd22xxCtls<SPro24Protocol>,
-    tcd22xx_ctl: SPro24Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro24Protocol>,
     input_ctl: SaffireproInputCtl<SPro24Protocol>,
 }
@@ -28,14 +27,6 @@ impl SPro24Model {
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.tcd22xx_ctls.cache_whole_params(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-        )?;
-
-        self.tcd22xx_ctl.cache(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -67,9 +58,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
-        self.tcd22xx_ctl
-            .load(card_cntr, &self.sections.global.params)?;
-
         self.out_grp_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
 
@@ -86,8 +74,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
@@ -101,7 +87,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
@@ -119,16 +105,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
             &mut unit.1,
             &self.extension_sections,
             elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.tcd22xx_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
             new,
             TIMEOUT_MS,
         )? {
@@ -161,7 +137,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
-        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
 
@@ -174,14 +149,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctls.parse_notification(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            *msg,
-        )?;
-        self.tcd22xx_ctl.parse_notification(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -209,8 +176,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -223,7 +188,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
-        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -232,12 +196,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
         self.tcd22xx_ctls.cache_partial_params(
             &mut self.req,
             &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-        self.tcd22xx_ctl.measure_states(
-            unit,
-            &mut self.req,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -254,23 +212,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default)]
-struct SPro24Tcd22xxCtl(Tcd22xxCtl);
-
-impl Tcd22xxCtlOperation<SPro24Protocol> for SPro24Tcd22xxCtl {
-    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
-        &self.0
-    }
-
-    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
-        &mut self.0
     }
 }

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -50,9 +50,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -117,20 +117,13 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -32,34 +32,14 @@ impl SPro24DspModel {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -104,6 +84,17 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
@@ -245,10 +236,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -8,7 +8,7 @@ pub struct SPro24DspModel {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<SPro24DspProtocol>,
     tcd22xx_ctl: SPro24DspTcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro24DspProtocol>,
     input_ctl: SaffireproInputCtl<SPro24DspProtocol>,
@@ -30,7 +30,7 @@ impl SPro24DspModel {
         )?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -42,12 +42,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -302,7 +297,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24DspModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -327,11 +322,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24DspModel {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<SPro24DspProtocol> for CommonCtl {}
 
 #[derive(Default)]
 struct SPro24DspTcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -261,7 +261,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -297,7 +297,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24DspModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -22,34 +22,14 @@ impl SPro26Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for SPro26Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -59,6 +39,17 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for SPro26Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
 
@@ -140,10 +131,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -156,7 +156,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -192,7 +192,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro26Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -9,6 +9,7 @@ pub struct SPro26Model {
     sections: GeneralSections,
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro26Protocol>,
+    tcd22xx_ctls: Tcd22xxCtls<SPro26Protocol>,
     tcd22xx_ctl: SPro26Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro26Protocol>,
 }
@@ -24,6 +25,14 @@ impl SPro26Model {
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
 
         self.tcd22xx_ctl.cache(
             &mut self.req,
@@ -48,6 +57,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
+        self.tcd22xx_ctls.load(card_cntr)?;
+
         self.tcd22xx_ctl
             .load(card_cntr, &self.sections.global.params)?;
 
@@ -63,6 +74,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -85,6 +98,15 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
             &self.req,
             &unit.1,
             &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -118,6 +140,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
 impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -129,6 +152,14 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
             &mut self.sections,
             *msg,
             TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+            *msg,
         )?;
         self.tcd22xx_ctl.parse_notification(
             &mut self.req,
@@ -156,6 +187,8 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
@@ -169,12 +202,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
 impl MeasureModel<(SndDice, FwNode)> for SPro26Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -191,6 +231,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro26Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -67,20 +67,13 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -40,9 +40,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -8,7 +8,7 @@ pub struct SPro40Model {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<SPro40Protocol>,
     tcd22xx_ctl: SPro40Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro40Protocol>,
     io_params_ctl: IoParamsCtl<SPro40Protocol>,
@@ -21,7 +21,7 @@ impl SPro40Model {
         SPro40Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -33,12 +33,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -217,7 +212,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -242,11 +237,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<SPro40Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct SPro40Tcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -23,34 +23,14 @@ impl SPro40Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for SPro40Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -67,6 +47,17 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for SPro40Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         self.out_grp_ctl.load(card_cntr)?;
         self.io_params_ctl.load(card_cntr)?;
@@ -160,10 +151,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -76,20 +76,13 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -176,7 +176,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -212,7 +212,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -41,9 +41,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -10,7 +10,6 @@ pub struct SPro40Model {
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro40Protocol>,
     tcd22xx_ctls: Tcd22xxCtls<SPro40Protocol>,
-    tcd22xx_ctl: SPro40Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro40Protocol>,
     io_params_ctl: IoParamsCtl<SPro40Protocol>,
 }
@@ -28,14 +27,6 @@ impl SPro40Model {
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.tcd22xx_ctls.cache_whole_params(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-        )?;
-
-        self.tcd22xx_ctl.cache(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -67,9 +58,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
-        self.tcd22xx_ctl
-            .load(card_cntr, &self.sections.global.params)?;
-
         self.out_grp_ctl.load(card_cntr)?;
         self.io_params_ctl.load(card_cntr)?;
 
@@ -86,8 +74,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.io_params_ctl.read(elem_id, elem_value)? {
@@ -101,7 +87,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
@@ -119,16 +105,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
             &mut unit.1,
             &self.extension_sections,
             elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.tcd22xx_ctl.write(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            old,
             new,
             TIMEOUT_MS,
         )? {
@@ -161,7 +137,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
-        self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
 
@@ -174,14 +149,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctls.parse_notification(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            *msg,
-        )?;
-        self.tcd22xx_ctl.parse_notification(
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
@@ -209,8 +176,6 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -223,7 +188,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
-        self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -232,12 +196,6 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
         self.tcd22xx_ctls.cache_partial_params(
             &mut self.req,
             &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-        self.tcd22xx_ctl.measure_states(
-            unit,
-            &mut self.req,
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
@@ -254,23 +212,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default)]
-struct SPro40Tcd22xxCtl(Tcd22xxCtl);
-
-impl Tcd22xxCtlOperation<SPro40Protocol> for SPro40Tcd22xxCtl {
-    fn tcd22xx_ctl(&self) -> &Tcd22xxCtl {
-        &self.0
-    }
-
-    fn tcd22xx_ctl_mut(&mut self) -> &mut Tcd22xxCtl {
-        &mut self.0
     }
 }

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -9,6 +9,7 @@ pub struct SPro40Model {
     sections: GeneralSections,
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<SPro40Protocol>,
+    tcd22xx_ctls: Tcd22xxCtls<SPro40Protocol>,
     tcd22xx_ctl: SPro40Tcd22xxCtl,
     out_grp_ctl: OutGroupCtl<SPro40Protocol>,
     io_params_ctl: IoParamsCtl<SPro40Protocol>,
@@ -25,6 +26,14 @@ impl SPro40Model {
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
 
         self.tcd22xx_ctl.cache(
             &mut self.req,
@@ -56,6 +65,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
+        self.tcd22xx_ctls.load(card_cntr)?;
+
         self.tcd22xx_ctl
             .load(card_cntr, &self.sections.global.params)?;
 
@@ -72,6 +83,8 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -96,6 +109,15 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
             &self.req,
             &unit.1,
             &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -138,6 +160,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
 impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -149,6 +172,14 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
             &mut self.sections,
             *msg,
             TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+            *msg,
         )?;
         self.tcd22xx_ctl.parse_notification(
             &mut self.req,
@@ -176,6 +207,8 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_grp_ctl.read(elem_id, elem_value)? {
@@ -189,12 +222,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
 impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -211,6 +251,8 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/io_fw_model.rs
+++ b/runtime/dice/src/io_fw_model.rs
@@ -59,7 +59,7 @@ where
         T::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.output_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
@@ -89,12 +89,7 @@ where
         + TcatSectionOperation<ExtendedSyncParameters>,
 {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
@@ -220,7 +215,7 @@ where
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.mixer_ctl
             .partial_cache(&self.req, &unit.1, TIMEOUT_MS)?;
@@ -243,46 +238,6 @@ where
             Ok(false)
         }
     }
-}
-
-#[derive(Default, Debug)]
-pub struct CommonCtl<T>(Vec<ElemId>, Vec<ElemId>, PhantomData<T>)
-where
-    T: IofwMeterSpecification
-        + AlesisParametersOperation<IofwMeterParams>
-        + IofwOutputSpecification
-        + AlesisParametersOperation<IofwOutputParams>
-        + AlesisMutableParametersOperation<IofwOutputParams>
-        + AlesisParametersOperation<IofwOutputParams>
-        + AlesisMutableParametersOperation<IofwOutputParams>
-        + IofwMixerSpecification
-        + AlesisParametersOperation<IofwMixerParams>
-        + AlesisMutableParametersOperation<IofwMixerParams>
-        + TcatNotifiedSectionOperation<GlobalParameters>
-        + TcatFluctuatedSectionOperation<GlobalParameters>
-        + TcatMutableSectionOperation<GlobalParameters>
-        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
-        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
-        + TcatSectionOperation<ExtendedSyncParameters>;
-
-impl<T> CommonCtlOperation<T> for CommonCtl<T> where
-    T: IofwMeterSpecification
-        + AlesisParametersOperation<IofwMeterParams>
-        + IofwOutputSpecification
-        + AlesisParametersOperation<IofwOutputParams>
-        + AlesisMutableParametersOperation<IofwOutputParams>
-        + AlesisParametersOperation<IofwOutputParams>
-        + AlesisMutableParametersOperation<IofwOutputParams>
-        + IofwMixerSpecification
-        + AlesisParametersOperation<IofwMixerParams>
-        + AlesisMutableParametersOperation<IofwMixerParams>
-        + TcatNotifiedSectionOperation<GlobalParameters>
-        + TcatFluctuatedSectionOperation<GlobalParameters>
-        + TcatMutableSectionOperation<GlobalParameters>
-        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
-        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
-        + TcatSectionOperation<ExtendedSyncParameters>
-{
 }
 
 #[derive(Debug)]

--- a/runtime/dice/src/lib.rs
+++ b/runtime/dice/src/lib.rs
@@ -20,7 +20,7 @@ use {
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
     common_ctl::*,
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
+    core::{card_cntr::*, dispatcher::*, *},
     firewire_dice_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -159,7 +159,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.specific_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -195,7 +195,7 @@ impl MeasureModel<(SndDice, FwNode)> for Mbox3Model {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -25,36 +25,14 @@ impl Mbox3Model {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
-        Ok(())
-    }
-}
-
-impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
-
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
-
-        self.specific_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctl.cache(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
         )?;
 
@@ -64,6 +42,19 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
             &self.extension_sections,
             TIMEOUT_MS,
         )?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr, &self.sections)?;
+
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
+
+        self.specific_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -143,10 +134,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -70,20 +70,13 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.specific_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -43,9 +43,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -11,7 +11,7 @@ pub struct Mbox3Model {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<Mbox3Protocol>,
     tcd22xx_ctl: Mbox3Tcd22xxCtl,
     specific_ctl: SpecificCtl,
 }
@@ -23,7 +23,7 @@ impl Mbox3Model {
         Mbox3Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -35,12 +35,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -200,7 +195,7 @@ impl MeasureModel<(SndDice, FwNode)> for Mbox3Model {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -225,11 +220,6 @@ impl MeasureModel<(SndDice, FwNode)> for Mbox3Model {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<Mbox3Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct Mbox3Tcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -86,9 +86,7 @@ where
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -112,20 +112,13 @@ where
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.specific_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -206,7 +206,7 @@ where
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -252,7 +252,7 @@ where
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -56,6 +56,24 @@ where
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.extension_sections =
+            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
+
+        self.specific_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
+
         Ok(())
     }
 }
@@ -73,39 +91,13 @@ where
         + TcatNotifiedSectionOperation<RxStreamFormatParameters>
         + TcatSectionOperation<ExtendedSyncParameters>,
 {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
-        self.extension_sections =
-            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
+
         self.specific_ctl.load(card_cntr)?;
-
-        self.tcd22xx_ctl.cache(
-            unit,
-            &mut self.req,
-            &self.sections,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
-
-        self.specific_ctl.cache(
-            &mut self.req,
-            &mut unit.1,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
 
         Ok(())
     }
@@ -196,10 +188,10 @@ where
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -65,20 +65,13 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -47,9 +47,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -29,36 +29,27 @@ impl FStudioMobileModel {
         self.common_ctl
             .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
+        self.extension_sections =
+            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.tcd22xx_ctl.cache(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
+
         Ok(())
     }
 }
 
 impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndDice, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
-        self.extension_sections =
-            ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.tcd22xx_ctl.load(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            &self.sections.global.params,
-            TIMEOUT_MS,
-            card_cntr,
-        )?;
-
-        self.tcd22xx_ctl.cache(
-            unit,
-            &mut self.req,
-            &self.sections,
-            &self.extension_sections,
-            TIMEOUT_MS,
-        )?;
+        self.tcd22xx_ctl
+            .load(card_cntr, &self.sections.global.params)?;
 
         Ok(())
     }
@@ -126,10 +117,10 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
             TIMEOUT_MS,
         )?;
         self.tcd22xx_ctl.parse_notification(
-            unit,
             &mut self.req,
-            &self.sections,
+            &mut unit.1,
             &self.extension_sections,
+            &self.sections.global.params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -135,7 +135,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -169,7 +169,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioMobileModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -12,6 +12,7 @@ pub struct FStudioProjectModel {
     sections: GeneralSections,
     extension_sections: ExtensionSections,
     common_ctl: CommonCtl<FStudioProjectProtocol>,
+    tcd22xx_ctls: Tcd22xxCtls<FStudioProjectProtocol>,
     tcd22xx_ctl: FStudioProjectTcd22xxCtl,
 }
 
@@ -32,6 +33,14 @@ impl FStudioProjectModel {
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+        )?;
+
         self.tcd22xx_ctl.cache(
             &mut self.req,
             &mut unit.1,
@@ -48,6 +57,8 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr, &self.sections)?;
 
+        self.tcd22xx_ctls.load(card_cntr)?;
+
         self.tcd22xx_ctl
             .load(card_cntr, &self.sections.global.params)?;
 
@@ -61,6 +72,8 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -86,6 +99,15 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
         } else if self.tcd22xx_ctl.write(
             unit,
             &mut self.req,
@@ -105,6 +127,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
 impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         self.tcd22xx_ctl.get_notified_elem_list(elem_id_list);
     }
 
@@ -119,6 +142,14 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
             &mut self.sections,
             msg,
             TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.sections.global.params,
+            TIMEOUT_MS,
+            msg,
         )?;
         self.tcd22xx_ctl.parse_notification(
             &mut self.req,
@@ -139,6 +170,8 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -150,12 +183,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
 impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
         self.tcd22xx_ctl.get_measured_elem_list(elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -172,6 +212,8 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -11,7 +11,7 @@ pub struct FStudioProjectModel {
     req: FwReq,
     sections: GeneralSections,
     extension_sections: ExtensionSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<FStudioProjectProtocol>,
     tcd22xx_ctl: FStudioProjectTcd22xxCtl,
 }
 
@@ -27,7 +27,7 @@ impl FStudioProjectModel {
         )?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -39,12 +39,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
         unit: &mut (SndDice, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.extension_sections =
             ProtocolExtension::read_extension_sections(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -178,7 +173,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.tcd22xx_ctl.measure_states(
             unit,
             &mut self.req,
@@ -203,11 +198,6 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<FStudioProjectProtocol> for CommonCtl {}
 
 #[derive(Default)]
 struct FStudioProjectTcd22xxCtl(Tcd22xxCtl);

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -47,9 +47,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
             unit,
             &mut self.req,
             &self.extension_sections,
-            &self.sections.global.params.avail_rates,
-            &self.sections.global.params.avail_sources,
-            &self.sections.global.params.clock_source_labels,
+            &self.sections.global.params,
             TIMEOUT_MS,
             card_cntr,
         )?;

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -65,20 +65,13 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
 
     fn read(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        _: &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read(
-            unit,
-            &mut self.req,
-            &self.extension_sections,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -139,7 +139,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -173,7 +173,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
     ) -> Result<bool, Error> {
         if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
             Ok(true)
-        } else if self.tcd22xx_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.tcd22xx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -170,7 +170,7 @@ where
         Ok(())
     }
 
-    fn measure_elem_meter(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+    fn read_meter(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUT_METER_NAME => {
                 elem_value.set_int(&self.tcd22xx_ctl().meter_ctl.real_meter);
@@ -1114,7 +1114,9 @@ where
     }
 
     fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_router(elem_id, elem_value)? {
+        if self.read_meter(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.read_router(elem_id, elem_value)? {
             Ok(true)
         } else if self.read_mixer(elem_id, elem_value)? {
             Ok(true)
@@ -1160,10 +1162,6 @@ where
         self.measure_states_meter(&mut unit.1, req, sections, timeout_ms)
     }
 
-    fn measure_elem(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        self.measure_elem_meter(elem_id, elem_value)
-    }
-
     fn get_notified_elem_list(&self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.tcd22xx_ctl().router_ctl.notified_elem_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctl().mixer_ctl.notified_elem_list);
@@ -1188,20 +1186,6 @@ where
             RateMode::from(global_params.clock_config.rate),
             timeout_ms,
         )
-    }
-
-    fn read_notified_elem(
-        &self,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
-        if self.read_router(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.read_mixer(elem_id, elem_value)? {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
     }
 }
 

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -11,7 +11,77 @@ use {
         },
         tcd22xx_spec::*,
     },
+    std::marker::PhantomData,
 };
+
+#[derive(Default, Debug)]
+pub struct Tcd22xxCtls<T>
+where
+    T: Tcd22xxSpecOperation + Tcd22xxRouterOperation + Tcd22xxMixerOperation,
+{
+    pub measured_elem_id_list: Vec<ElemId>,
+    pub notified_elem_id_list: Vec<ElemId>,
+
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Tcd22xxCtls<T>
+where
+    T: Tcd22xxSpecOperation + Tcd22xxRouterOperation + Tcd22xxMixerOperation,
+{
+    pub fn cache_whole_params(
+        &mut self,
+        _: &mut FwReq,
+        _: &mut FwNode,
+        _: &ExtensionSections,
+        _: &GlobalParameters,
+        _: u32,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn load(&mut self, _: &mut CardCntr) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn read(&self, _: &ElemId, _: &ElemValue) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    pub fn write(
+        &mut self,
+        _: &mut FwReq,
+        _: &mut FwNode,
+        _: &ExtensionSections,
+        _: &ElemId,
+        _: &ElemValue,
+        _: u32,
+    ) -> Result<bool, Error> {
+        Ok(false)
+    }
+
+    pub fn cache_partial_params(
+        &mut self,
+        _: &mut FwReq,
+        _: &mut FwNode,
+        _: &ExtensionSections,
+        _: u32,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+
+    pub fn parse_notification(
+        &mut self,
+        _: &mut FwReq,
+        _: &mut FwNode,
+        _: &ExtensionSections,
+        _: &GlobalParameters,
+        _: u32,
+        _: u32,
+    ) -> Result<(), Error> {
+        Ok(())
+    }
+}
 
 #[derive(Default, Debug)]
 pub struct Tcd22xxCtl {

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -10,7 +10,7 @@ use {
 pub struct ItwinModel {
     req: FwReq,
     sections: GeneralSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<ItwinProtocol>,
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
@@ -29,7 +29,7 @@ impl ItwinModel {
         ItwinProtocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
@@ -51,12 +51,7 @@ impl ItwinModel {
 
 impl CtlModel<(SndDice, FwNode)> for ItwinModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -239,7 +234,7 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         if !self.reverb_state_ctl.is_bypassed() {
             self.reverb_meter_ctl
@@ -271,11 +266,6 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<ItwinProtocol> for CommonCtl {}
 
 #[derive(Default, Debug)]
 struct KnobCtl(ItwinKnobSegment, Vec<ElemId>);

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -10,7 +10,7 @@ use {
 pub struct K24dModel {
     req: FwReq,
     sections: GeneralSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<K24dProtocol>,
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
@@ -29,7 +29,7 @@ impl K24dModel {
         K24dProtocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
@@ -51,12 +51,7 @@ impl K24dModel {
 
 impl CtlModel<(SndDice, FwNode)> for K24dModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -240,7 +235,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         if !self.reverb_state_ctl.is_bypassed() {
             self.reverb_meter_ctl
@@ -272,11 +267,6 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<K24dProtocol> for CommonCtl {}
 
 #[derive(Default, Debug)]
 struct KnobCtl(K24dKnobSegment, Vec<ElemId>);

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -10,7 +10,7 @@ use {
 pub struct K8Model {
     req: FwReq,
     sections: GeneralSections,
-    common_ctl: CommonCtl,
+    common_ctl: CommonCtl<K8Protocol>,
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
@@ -25,7 +25,7 @@ impl K8Model {
         K8Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .whole_cache(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
 
         self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
@@ -39,12 +39,7 @@ impl K8Model {
 
 impl CtlModel<(SndDice, FwNode)> for K8Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections).map(
-            |(measured_elem_id_list, notified_elem_id_list)| {
-                self.common_ctl.0 = measured_elem_id_list;
-                self.common_ctl.1 = notified_elem_id_list;
-            },
-        )?;
+        self.common_ctl.load(card_cntr, &self.sections)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -183,7 +178,7 @@ impl MeasureModel<(SndDice, FwNode)> for K8Model {
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .measure(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
         self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
         Ok(())
     }
@@ -203,11 +198,6 @@ impl MeasureModel<(SndDice, FwNode)> for K8Model {
         }
     }
 }
-
-#[derive(Default, Debug)]
-struct CommonCtl(Vec<ElemId>, Vec<ElemId>);
-
-impl CommonCtlOperation<K8Protocol> for CommonCtl {}
 
 #[derive(Default, Debug)]
 struct KnobCtl(K8KnobSegment, Vec<ElemId>);


### PR DESCRIPTION
Current implementation of controls related to TCD22xx includes duplicated hardware data.
This patchset cleans up the redundancy as well as adding intermediate structure expression
for some parameters.

```
Takashi Sakamoto (14):
  runtime/dice: common_ctl: use generic structure for common controls
  runtime/dice: tcd22xx_ctl: code refactoring to receive global parameters
  runtime/dice: tcd22xx_ctl: code refactoring for ADAT and Word Clock modes
  protocols/dice: tcat: add intermediate structure expression for standalone configuration parameters
  runtime/dice: tcd22xx_ctls: use cached parameter for standalone configuration
  protocols/dice: tcat: remove unused functions for extension protocol
  runtime/dice: tcd22xx_ctl: code refactoring to split cache function
  runtime/dice: tcd22xx_ctl: unify element read operation
  runtime/dice: tcd22xx_ctl: add generic structure for controls specific to TCD22xx
  runtime/dice: tcd22xx_ctl: clean up for standalone controls
  runtime/dice: tcd22xx_ctl: clean up for mixer controls
  runtime/dice: tcd22xx_ctl: clean up for router controls
  runtime/dice: tcd22xx_ctl: clean up for meter controls
  runtime/dice: tcd22xx_ctl: remove unused traits and their implementations

 .../dice/src/bin/tcat-extension-parser.rs     |   35 +-
 .../src/tcat/extension/standalone_section.rs  |  317 ++-
 runtime/dice/src/blackbird_model.rs           |  105 +-
 runtime/dice/src/common_ctl.rs                |   58 +-
 runtime/dice/src/extension_model.rs           |  106 +-
 runtime/dice/src/focusrite/liquids56_model.rs |  105 +-
 runtime/dice/src/focusrite/spro14_model.rs    |  105 +-
 runtime/dice/src/focusrite/spro24_model.rs    |  105 +-
 runtime/dice/src/focusrite/spro24dsp_model.rs |  105 +-
 runtime/dice/src/focusrite/spro26_model.rs    |  105 +-
 runtime/dice/src/focusrite/spro40_model.rs    |  105 +-
 runtime/dice/src/io_fw_model.rs               |   51 +-
 runtime/dice/src/ionix_model.rs               |   18 +-
 runtime/dice/src/lib.rs                       |    2 +-
 runtime/dice/src/mbox3_model.rs               |  109 +-
 runtime/dice/src/minimal_model.rs             |   18 +-
 runtime/dice/src/pfire_model.rs               |  175 +-
 runtime/dice/src/presonus/fstudio_model.rs    |   18 +-
 .../dice/src/presonus/fstudiomobile_model.rs  |  105 +-
 .../dice/src/presonus/fstudioproject_model.rs |  105 +-
 runtime/dice/src/tcd22xx_ctl.rs               | 1718 ++++++++---------
 .../dice/src/tcelectronic/desktopk6_model.rs  |   18 +-
 runtime/dice/src/tcelectronic/itwin_model.rs  |   18 +-
 runtime/dice/src/tcelectronic/k24d_model.rs   |   18 +-
 runtime/dice/src/tcelectronic/k8_model.rs     |   18 +-
 runtime/dice/src/tcelectronic/klive_model.rs  |   18 +-
 .../dice/src/tcelectronic/studiok48_model.rs  |   18 +-
 27 files changed, 1494 insertions(+), 2184 deletions(-)
```