### PR TITLE
[PATCH 0/7] protocols/dice: tcat: some arrangements for TCD22xx implementation

### DIFF
--- a/protocols/dice/src/tcat/tcd22xx_spec.rs
+++ b/protocols/dice/src/tcat/tcd22xx_spec.rs
@@ -308,8 +308,8 @@ pub trait Tcd22xxOperation: Tcd22xxSpecification {
 
     /// Update router entries.
     fn update_router_entries(
-        node: &mut FwNode,
         req: &mut FwReq,
+        node: &mut FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         rate_mode: RateMode,

--- a/protocols/dice/src/tcat/tcd22xx_spec.rs
+++ b/protocols/dice/src/tcat/tcd22xx_spec.rs
@@ -164,59 +164,6 @@ pub trait Tcd22xxSpecification {
         (src_blk_list, dst_blk_list)
     }
 
-    /// Label for source block.
-    fn src_blk_label(src_blk: &SrcBlk) -> String {
-        Self::INPUTS
-            .iter()
-            .find(|entry| {
-                entry.id == src_blk.id
-                    && src_blk.ch >= entry.offset
-                    && src_blk.ch < entry.offset + entry.count
-                    && entry.label.is_some()
-            })
-            .map(|entry| format!("{}-{}", entry.label.unwrap(), src_blk.ch - entry.offset))
-            .unwrap_or_else(|| {
-                let name = match src_blk.id {
-                    SrcBlkId::Aes => "S/PDIF",
-                    SrcBlkId::Adat => "ADAT",
-                    SrcBlkId::Mixer => "Mixer",
-                    SrcBlkId::Ins0 => "Analog-A",
-                    SrcBlkId::Ins1 => "Analog-B",
-                    SrcBlkId::Avs0 => "Stream-A",
-                    SrcBlkId::Avs1 => "Stream-B",
-                    _ => "Unknown",
-                };
-                format!("{}-{}", name, src_blk.ch)
-            })
-    }
-
-    /// Label for destination block.
-    fn dst_blk_label(dst_blk: DstBlk) -> String {
-        Self::OUTPUTS
-            .iter()
-            .find(|entry| {
-                entry.id == dst_blk.id
-                    && dst_blk.ch >= entry.offset
-                    && dst_blk.ch < entry.offset + entry.count
-                    && entry.label.is_some()
-            })
-            .map(|entry| format!("{}-{}", entry.label.unwrap(), dst_blk.ch - entry.offset))
-            .unwrap_or_else(|| {
-                let name = match dst_blk.id {
-                    DstBlkId::Aes => "S/PDIF",
-                    DstBlkId::Adat => "ADAT",
-                    DstBlkId::MixerTx0 => "Mixer-A",
-                    DstBlkId::MixerTx1 => "Mixer-B",
-                    DstBlkId::Ins0 => "Analog-A",
-                    DstBlkId::Ins1 => "Analog-B",
-                    DstBlkId::Avs0 => "Stream-A",
-                    DstBlkId::Avs1 => "Stream-B",
-                    _ => "Unknown",
-                };
-                format!("{}-{}", name, dst_blk.ch)
-            })
-    }
-
     /// Refine router entries by defined descriptors.
     fn refine_router_entries(
         entries: &mut Vec<RouterEntry>,

--- a/protocols/dice/src/tcat/tcd22xx_spec.rs
+++ b/protocols/dice/src/tcat/tcd22xx_spec.rs
@@ -46,7 +46,7 @@ pub trait Tcd22xxSpecification {
     /// Physical output ports.
     const OUTPUTS: &'static [Output];
 
-    /// Ports with fixed position in router entries.
+    /// Ports with fixed position in router entries; e.g. target ports for meter display.
     const FIXED: &'static [SrcBlk];
 
     /// The number of mixer outputs at specification of TCD22xx.
@@ -289,7 +289,7 @@ pub trait Tcd22xxOperation: Tcd22xxSpecification {
         Ok(())
     }
 
-    /// Load configuration from on-board flash memory.
+    /// Load configuration from on-board flash memory, including parameters in application section.
     fn load_configuration(
         req: &mut FwReq,
         node: &mut FwNode,
@@ -308,7 +308,7 @@ pub trait Tcd22xxOperation: Tcd22xxSpecification {
         .map(|_| ())
     }
 
-    /// Store configuration to on-board flash memory.
+    /// Store configuration to on-board flash memory, including parameters in application section.
     fn store_configuration(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -45,6 +45,15 @@ impl BlackbirdModel {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -46,6 +46,15 @@ impl ExtensionModel {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for ExtensionModel {

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -67,6 +67,15 @@ impl LiquidS56Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -54,6 +54,15 @@ impl SPro14Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for SPro14Model {

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -54,6 +54,15 @@ impl SPro24Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for SPro24Model {

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -91,6 +91,15 @@ impl SPro24DspModel {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -46,6 +46,15 @@ impl SPro26Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for SPro26Model {

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -54,6 +54,15 @@ impl SPro40Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for SPro40Model {

--- a/runtime/dice/src/lib.rs
+++ b/runtime/dice/src/lib.rs
@@ -123,7 +123,11 @@ impl RuntimeOperation<u32> for DiceRuntime {
             };
 
             match ev {
-                Event::Shutdown => break,
+                Event::Shutdown => {
+                    let _enter = debug_span!("shutdown").entered();
+                    self.model.store_configuration(&mut self.unit.1)?;
+                    break;
+                }
                 Event::Disconnected => break,
                 Event::BusReset(generation) => {
                     debug!("IEEE 1394 bus is updated: {}", generation);

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -52,6 +52,15 @@ impl Mbox3Model {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for Mbox3Model {

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -418,4 +418,23 @@ impl DiceModel {
             }
         }
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        match &mut self.model {
+            Model::Extension(m) => m.store_configuration(node),
+            Model::MaudioPfire2626(m) => m.store_configuration(node),
+            Model::MaudioPfire610(m) => m.store_configuration(node),
+            Model::AvidMbox3(m) => m.store_configuration(node),
+            Model::LoudBlackbird(m) => m.store_configuration(node),
+            Model::FocusriteSPro40(m) => m.store_configuration(node),
+            Model::FocusriteLiquidS56(m) => m.store_configuration(node),
+            Model::FocusriteSPro24(m) => m.store_configuration(node),
+            Model::FocusriteSPro24Dsp(m) => m.store_configuration(node),
+            Model::FocusriteSPro14(m) => m.store_configuration(node),
+            Model::FocusriteSPro26(m) => m.store_configuration(node),
+            Model::PresonusFStudioProject(m) => m.store_configuration(node),
+            Model::PresonusFStudioMobile(m) => m.store_configuration(node),
+            _ => Ok(()),
+        }
+    }
 }

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -82,6 +82,15 @@ where
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl<T> CtlModel<(SndDice, FwNode)> for PfireModel<T>

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -46,6 +46,15 @@ impl FStudioMobileModel {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -46,6 +46,15 @@ impl FStudioProjectModel {
 
         Ok(())
     }
+
+    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
 }
 
 impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -756,7 +756,7 @@ where
 }
 
 #[derive(Default, Debug)]
-struct RouterCtls<T>(Vec<RouterEntry>, Tcd22xxState, PhantomData<T>)
+struct RouterCtls<T>(Vec<RouterEntry>, Tcd22xxAvailableBlocks, PhantomData<T>)
 where
     T: Tcd22xxSpecification + Tcd22xxOperation;
 
@@ -775,7 +775,7 @@ where
         rate_mode: RateMode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::cache_tcd22xx_state(
+        let res = T::detect_available_blocks(
             req,
             node,
             sections,

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -282,6 +282,18 @@ where
         }
         Ok(())
     }
+
+    pub fn store_configuration(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        sections: &ExtensionSections,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let res = T::store_configuration(req, node, sections, &self.caps, timeout_ms);
+        debug!(?res);
+        res
+    }
 }
 
 #[derive(Default, Debug)]

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -798,8 +798,8 @@ where
         debug!(params = ?self.0, ?res);
         res?;
         let res = T::update_router_entries(
-            node,
             req,
+            node,
             sections,
             caps,
             rate_mode,
@@ -1018,8 +1018,8 @@ where
         let rate_mode = RateMode::try_from(current_rate).unwrap();
 
         let res = T::update_router_entries(
-            node,
             req,
+            node,
             sections,
             caps,
             rate_mode,

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -849,7 +849,7 @@ where
 
     /// Label for source block.
     fn src_blk_label(src_blk: &SrcBlk) -> String {
-        T::INPUTS
+        let (name, ch) = T::INPUTS
             .iter()
             .find(|entry| {
                 entry.id == src_blk.id
@@ -857,7 +857,7 @@ where
                     && src_blk.ch < entry.offset + entry.count
                     && entry.label.is_some()
             })
-            .map(|entry| format!("{}-{}", entry.label.unwrap(), src_blk.ch - entry.offset))
+            .map(|entry| (entry.label.unwrap(), src_blk.ch - entry.offset))
             .unwrap_or_else(|| {
                 let name = match src_blk.id {
                     SrcBlkId::Aes => "S/PDIF",
@@ -869,13 +869,14 @@ where
                     SrcBlkId::Avs1 => "Stream-B",
                     _ => "Unknown",
                 };
-                format!("{}-{}", name, src_blk.ch)
-            })
+                (name, src_blk.ch)
+            });
+        format!("{}-{}", name, ch + 1)
     }
 
     /// Label for destination block.
     fn dst_blk_label(dst_blk: DstBlk) -> String {
-        T::OUTPUTS
+        let (name, ch) = T::OUTPUTS
             .iter()
             .find(|entry| {
                 entry.id == dst_blk.id
@@ -883,7 +884,7 @@ where
                     && dst_blk.ch < entry.offset + entry.count
                     && entry.label.is_some()
             })
-            .map(|entry| format!("{}-{}", entry.label.unwrap(), dst_blk.ch - entry.offset))
+            .map(|entry| (entry.label.unwrap(), dst_blk.ch - entry.offset))
             .unwrap_or_else(|| {
                 let name = match dst_blk.id {
                     DstBlkId::Aes => "S/PDIF",
@@ -896,8 +897,9 @@ where
                     DstBlkId::Avs1 => "Stream-B",
                     _ => "Unknown",
                 };
-                format!("{}-{}", name, dst_blk.ch)
-            })
+                (name, dst_blk.ch)
+            });
+        format!("{}-{}", name, ch + 1)
     }
 
     fn add_an_elem_for_src(

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -847,18 +847,71 @@ where
         Ok(notified_elem_id_list)
     }
 
+    /// Label for source block.
+    fn src_blk_label(src_blk: &SrcBlk) -> String {
+        T::INPUTS
+            .iter()
+            .find(|entry| {
+                entry.id == src_blk.id
+                    && src_blk.ch >= entry.offset
+                    && src_blk.ch < entry.offset + entry.count
+                    && entry.label.is_some()
+            })
+            .map(|entry| format!("{}-{}", entry.label.unwrap(), src_blk.ch - entry.offset))
+            .unwrap_or_else(|| {
+                let name = match src_blk.id {
+                    SrcBlkId::Aes => "S/PDIF",
+                    SrcBlkId::Adat => "ADAT",
+                    SrcBlkId::Mixer => "Mixer",
+                    SrcBlkId::Ins0 => "Analog-A",
+                    SrcBlkId::Ins1 => "Analog-B",
+                    SrcBlkId::Avs0 => "Stream-A",
+                    SrcBlkId::Avs1 => "Stream-B",
+                    _ => "Unknown",
+                };
+                format!("{}-{}", name, src_blk.ch)
+            })
+    }
+
+    /// Label for destination block.
+    fn dst_blk_label(dst_blk: DstBlk) -> String {
+        T::OUTPUTS
+            .iter()
+            .find(|entry| {
+                entry.id == dst_blk.id
+                    && dst_blk.ch >= entry.offset
+                    && dst_blk.ch < entry.offset + entry.count
+                    && entry.label.is_some()
+            })
+            .map(|entry| format!("{}-{}", entry.label.unwrap(), dst_blk.ch - entry.offset))
+            .unwrap_or_else(|| {
+                let name = match dst_blk.id {
+                    DstBlkId::Aes => "S/PDIF",
+                    DstBlkId::Adat => "ADAT",
+                    DstBlkId::MixerTx0 => "Mixer-A",
+                    DstBlkId::MixerTx1 => "Mixer-B",
+                    DstBlkId::Ins0 => "Analog-A",
+                    DstBlkId::Ins1 => "Analog-B",
+                    DstBlkId::Avs0 => "Stream-A",
+                    DstBlkId::Avs1 => "Stream-B",
+                    _ => "Unknown",
+                };
+                format!("{}-{}", name, dst_blk.ch)
+            })
+    }
+
     fn add_an_elem_for_src(
         card_cntr: &mut CardCntr,
         label: &str,
         dsts: &[DstBlk],
         srcs: &[&[SrcBlk]],
     ) -> Result<Vec<ElemId>, Error> {
-        let targets: Vec<String> = dsts.iter().map(|&dst| T::dst_blk_label(dst)).collect();
+        let targets: Vec<String> = dsts.iter().map(|&dst| Self::dst_blk_label(dst)).collect();
 
         let mut sources: Vec<String> = srcs
             .iter()
             .flat_map(|srcs| *srcs)
-            .map(|src| T::src_blk_label(src))
+            .map(|src| Self::src_blk_label(src))
             .collect();
         sources.insert(0, Self::NONE_SRC_LABEL.to_string());
 


### PR DESCRIPTION
Current implementation of TCD22xx operation includes some inconvenience.
This patchset is to arrange the implementation.

```
Takashi Sakamoto (7):
  protocols/dice: tcat: arrangement to detect available source and destination blocks of TCD22xx
  protocols/dice: tcat: arrangement for argument order
  protocols/dice: tcat: move string generator for source and destination blocks of TCD22xx
  runtime/dice: tcd22xx_ctl: start channel index at 1 instead of 0
  runtime/dice: tcd22xx_ctl: use stream label "Stream" if single stream is just supported
  protocols/dice: tcat: fulfill doc comment for operation specific to TCD22xx
  runtime/dice: tcd22xx_ctl: store configuration to on-board flash memory when terminated

 protocols/dice/src/tcat/tcd22xx_spec.rs       | 137 ++++++------------
 runtime/dice/src/blackbird_model.rs           |   9 ++
 runtime/dice/src/extension_model.rs           |   9 ++
 runtime/dice/src/focusrite/liquids56_model.rs |   9 ++
 runtime/dice/src/focusrite/spro14_model.rs    |   9 ++
 runtime/dice/src/focusrite/spro24_model.rs    |   9 ++
 runtime/dice/src/focusrite/spro24dsp_model.rs |   9 ++
 runtime/dice/src/focusrite/spro26_model.rs    |   9 ++
 runtime/dice/src/focusrite/spro40_model.rs    |   9 ++
 runtime/dice/src/lib.rs                       |   6 +-
 runtime/dice/src/mbox3_model.rs               |   9 ++
 runtime/dice/src/model.rs                     |  19 +++
 runtime/dice/src/pfire_model.rs               |   9 ++
 .../dice/src/presonus/fstudiomobile_model.rs  |   9 ++
 .../dice/src/presonus/fstudioproject_model.rs |   9 ++
 runtime/dice/src/tcd22xx_ctl.rs               |  94 +++++++++++-
 16 files changed, 268 insertions(+), 96 deletions(-)
```