### PR TITLE
[PATCH 00/15] protocols/dice: tcat: use simple structure for section of TCAT protocol

### DIFF
--- a/protocols/dice/src/bin/tcat-extension-parser.rs
+++ b/protocols/dice/src/bin/tcat-extension-parser.rs
@@ -143,8 +143,8 @@ fn print_caps(caps: &ExtensionCaps) {
 }
 
 fn print_mixer(
-    req: &mut FwReq,
-    node: &mut FwNode,
+    req: &FwReq,
+    node: &FwNode,
     sections: &ExtensionSections,
     caps: &ExtensionCaps,
 ) -> Result<(), Error> {
@@ -198,8 +198,8 @@ fn print_mixer(
 }
 
 fn print_peak(
-    req: &mut FwReq,
-    node: &mut FwNode,
+    req: &FwReq,
+    node: &FwNode,
     sections: &ExtensionSections,
     caps: &ExtensionCaps,
 ) -> Result<(), Error> {
@@ -217,8 +217,8 @@ fn print_peak(
 const RATE_MODES: [RateMode; 3] = [RateMode::Low, RateMode::Middle, RateMode::High];
 
 fn print_current_router_entries(
-    req: &mut FwReq,
-    node: &mut FwNode,
+    req: &FwReq,
+    node: &FwNode,
     sections: &ExtensionSections,
     caps: &ExtensionCaps,
 ) -> Result<(), Error> {
@@ -258,8 +258,8 @@ fn print_stream_format_entry(entry: &FormatEntry) {
 }
 
 fn print_current_stream_format_entries(
-    req: &mut FwReq,
-    node: &mut FwNode,
+    req: &FwReq,
+    node: &FwNode,
     sections: &ExtensionSections,
     caps: &ExtensionCaps,
 ) -> Result<(), Error> {
@@ -296,8 +296,8 @@ fn print_current_stream_format_entries(
 }
 
 fn print_standalone_config(
-    req: &mut FwReq,
-    node: &mut FwNode,
+    req: &FwReq,
+    node: &FwNode,
     sections: &ExtensionSections,
     caps: &ExtensionCaps,
 ) -> Result<(), Error> {

--- a/protocols/dice/src/bin/tcat-general-parser.rs
+++ b/protocols/dice/src/bin/tcat-general-parser.rs
@@ -79,9 +79,8 @@ fn print_global_section(
     node: &FwNode,
     sections: &mut GeneralSections,
 ) -> Result<(), Error> {
-    Protocol::whole_cache(req, node, &mut sections.global, TIMEOUT_MS)?;
-
-    let params = &sections.global.params;
+    let mut params = GlobalParameters::default();
+    Protocol::whole_cache(req, node, &sections.global, &mut params, TIMEOUT_MS)?;
 
     println!("Parameters in global section:");
     println!("  Owner:");
@@ -175,9 +174,16 @@ fn print_tx_stream_formats(
     node: &FwNode,
     sections: &mut GeneralSections,
 ) -> Result<(), Error> {
-    Protocol::whole_cache(req, node, &mut sections.tx_stream_format, TIMEOUT_MS)?;
+    let mut params = TxStreamFormatParameters::default();
+    Protocol::whole_cache(
+        req,
+        node,
+        &sections.tx_stream_format,
+        &mut params,
+        TIMEOUT_MS,
+    )?;
 
-    let entries = &sections.tx_stream_format.params.0;
+    let entries = &params.0;
 
     println!("Parameters in tx stream format section");
     println!("  Tx stream format entries:");
@@ -212,9 +218,16 @@ fn print_rx_stream_formats(
     node: &FwNode,
     sections: &mut GeneralSections,
 ) -> Result<(), Error> {
-    Protocol::whole_cache(req, node, &mut sections.rx_stream_format, TIMEOUT_MS)?;
+    let mut params = RxStreamFormatParameters::default();
+    Protocol::whole_cache(
+        req,
+        node,
+        &sections.rx_stream_format,
+        &mut params,
+        TIMEOUT_MS,
+    )?;
 
-    let entries = &sections.rx_stream_format.params.0;
+    let entries = &params.0;
     println!("Parameters in tx stream format section");
     println!("  Rx stream format entries:");
     entries.iter().enumerate().for_each(|(i, entry)| {
@@ -244,9 +257,8 @@ fn print_rx_stream_formats(
 }
 
 fn print_ext_sync(req: &FwReq, node: &FwNode, sections: &mut GeneralSections) -> Result<(), Error> {
-    Protocol::whole_cache(req, node, &mut sections.ext_sync, TIMEOUT_MS)?;
-
-    let params = &sections.ext_sync.params;
+    let mut params = ExtendedSyncParameters::default();
+    Protocol::whole_cache(req, node, &sections.ext_sync, &mut params, TIMEOUT_MS)?;
 
     println!("Parameters in external synchronization section");
     println!("  External sync:");

--- a/protocols/dice/src/lib.rs
+++ b/protocols/dice/src/lib.rs
@@ -14,7 +14,7 @@ pub mod tcat;
 pub mod tcelectronic;
 
 use {
-    glib::{Error, FileError},
+    glib::Error,
     hinawa::{FwNode, FwReq},
 };
 

--- a/protocols/dice/src/tcat.rs
+++ b/protocols/dice/src/tcat.rs
@@ -352,7 +352,7 @@ where
     const NOTIFY_FLAG: u32;
 
     /// Check message to be notified or not.
-    fn notified(_: &Section<T>, msg: u32) -> bool {
+    fn notified(_: &T, msg: u32) -> bool {
         msg & Self::NOTIFY_FLAG > 0
     }
 }

--- a/protocols/dice/src/tcat.rs
+++ b/protocols/dice/src/tcat.rs
@@ -279,13 +279,14 @@ where
     fn whole_cache(
         req: &FwReq,
         node: &FwNode,
-        section: &mut Section<T>,
+        section: &Section<T>,
+        params: &mut T,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         check_section_cache(section, Self::MIN_SIZE, Self::ERROR_TYPE)?;
-        Self::read(req, node, section.offset, &mut section.raw, timeout_ms)?;
-        Self::deserialize(&mut section.params, &section.raw)
-            .map_err(|msg| Error::new(Self::ERROR_TYPE, &msg))
+        let mut raw = vec![0u8; section.size];
+        Self::read(req, node, section.offset, &mut raw, timeout_ms)?;
+        Self::deserialize(params, &raw).map_err(|msg| Error::new(Self::ERROR_TYPE, &msg))
     }
 }
 

--- a/protocols/dice/src/tcat.rs
+++ b/protocols/dice/src/tcat.rs
@@ -406,7 +406,7 @@ where
 const BASE_ADDR: u64 = 0xffffe0000000;
 
 /// Parameter of stream format for IEC 60958.
-#[derive(Default, Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Iec60958Param {
     /// The corresponding channel supports IEC 60958 bit stream.
     pub cap: bool,

--- a/protocols/dice/src/tcat.rs
+++ b/protocols/dice/src/tcat.rs
@@ -44,11 +44,11 @@ pub struct Section {
 }
 
 impl Section {
-    const SIZE: usize = 8;
+    pub(crate) const SIZE: usize = 8;
 }
 
 #[cfg(test)]
-fn serialize_section(section: &Section, raw: &mut [u8]) -> Result<(), String> {
+pub(crate) fn serialize_section(section: &Section, raw: &mut [u8]) -> Result<(), String> {
     assert!(raw.len() >= Section::SIZE);
 
     let val = (section.offset as u32) / 4;
@@ -60,7 +60,7 @@ fn serialize_section(section: &Section, raw: &mut [u8]) -> Result<(), String> {
     Ok(())
 }
 
-fn deserialize_section(section: &mut Section, raw: &[u8]) -> Result<(), String> {
+pub(crate) fn deserialize_section(section: &mut Section, raw: &[u8]) -> Result<(), String> {
     assert!(raw.len() >= Section::SIZE);
 
     let mut val = 0u32;

--- a/protocols/dice/src/tcat/config_rom.rs
+++ b/protocols/dice/src/tcat/config_rom.rs
@@ -11,31 +11,44 @@ use ieee1212_config_rom::*;
 /// Identifier in bus information block of Configuration ROM.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct Identifier {
+    /// The numeric identifier of vendor, usually Organizationally Unique Identifier (OUI)
+    /// registered in IEEE.
     pub vendor_id: u32,
+    /// The numeric value of category.
     pub category: u8,
+    /// The numeric identifier of product.
     pub product_id: u16,
+    /// The serial number.
     pub serial: u32,
 }
 
 /// Data in root directory block of Configuration ROM.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct RootData<'a> {
+    /// The numeric identifier of vendor, usually Organizationally Unique Identifier (OUI)
+    /// registered in IEEE.
     pub vendor_id: u32,
+    /// The name of vendor.
     pub vendor_name: &'a str,
+    /// The numeric identifier of product.
     pub product_id: u32,
+    /// The name of product.
     pub product_name: &'a str,
 }
 
 /// Data in unit directory block of Configuration ROM.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct UnitData<'a> {
+    /// The numeric identifier of model.
     pub model_id: u32,
+    /// The name of model.
     pub model_name: &'a str,
+    /// The specifier identifier.
     pub specifier_id: u32,
+    /// Version.
     pub version: u32,
 }
 
-pub trait DiceConfigRom<'a> {
     const VENDOR_ID_MASK: u32 = 0xffffff00;
     const VENDOR_ID_SHIFT: usize = 8;
     const CATEGORY_MASK: u32 = 0x000000ff;
@@ -45,8 +58,13 @@ pub trait DiceConfigRom<'a> {
     const SERIAL_MASK: u32 = 0x003fffff;
     const SERIAL_SHIFT: usize = 0;
 
+/// Parser of configuration ROM which has layout specific to DICE.
+pub trait DiceConfigRom<'a> {
+    /// Get identifier.
     fn get_identifier(&self) -> Option<Identifier>;
+    /// Get data in root directory.
     fn get_root_data(&'a self) -> Option<RootData<'a>>;
+    /// Get data in unit directory.
     fn get_unit_data(&'a self) -> Option<UnitData<'a>>;
 }
 
@@ -59,13 +77,13 @@ impl<'a> DiceConfigRom<'a> for ConfigRom<'a> {
 
             quadlet.copy_from_slice(&self.bus_info[8..12]);
             let val = u32::from_be_bytes(quadlet);
-            let vendor_id = (val & Self::VENDOR_ID_MASK) >> Self::VENDOR_ID_SHIFT;
-            let category = ((val & Self::CATEGORY_MASK) >> Self::CATEGORY_SHIFT) as u8;
+            let vendor_id = (val & VENDOR_ID_MASK) >> VENDOR_ID_SHIFT;
+            let category = ((val & CATEGORY_MASK) >> CATEGORY_SHIFT) as u8;
 
             quadlet.copy_from_slice(&self.bus_info[12..16]);
             let val = u32::from_be_bytes(quadlet);
-            let product_id = ((val & Self::PRODUCT_ID_MASK) >> Self::PRODUCT_ID_SHIFT) as u16;
-            let serial = (val & Self::SERIAL_MASK) >> Self::SERIAL_SHIFT;
+            let product_id = ((val & PRODUCT_ID_MASK) >> PRODUCT_ID_SHIFT) as u16;
+            let serial = (val & SERIAL_MASK) >> SERIAL_SHIFT;
 
             Some(Identifier {
                 vendor_id,

--- a/protocols/dice/src/tcat/ext_sync_section.rs
+++ b/protocols/dice/src/tcat/ext_sync_section.rs
@@ -9,7 +9,7 @@
 use super::{global_section::*, *};
 
 /// Parameters in extended synchronization section.
-#[derive(Default, Copy, Clone, Debug, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ExtendedSyncParameters {
     /// Current clock source; read-only.
     pub clk_src: ClockSource,

--- a/protocols/dice/src/tcat/tcd22xx_spec.rs
+++ b/protocols/dice/src/tcat/tcd22xx_spec.rs
@@ -214,8 +214,8 @@ pub trait Tcd22xxOperation:
 {
     /// Detect available source and destination blocks at given rate mode.
     fn detect_available_blocks(
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         rate_mode: RateMode,
@@ -256,8 +256,8 @@ pub trait Tcd22xxOperation:
 
     /// Update router entries.
     fn update_router_entries(
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         rate_mode: RateMode,
@@ -290,8 +290,8 @@ pub trait Tcd22xxOperation:
 
     /// Load configuration from on-board flash memory, including parameters in application section.
     fn load_configuration(
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -309,8 +309,8 @@ pub trait Tcd22xxOperation:
 
     /// Store configuration to on-board flash memory, including parameters in application section.
     fn store_configuration(
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,

--- a/protocols/dice/src/tcat/tcd22xx_spec.rs
+++ b/protocols/dice/src/tcat/tcd22xx_spec.rs
@@ -272,7 +272,7 @@ pub trait Tcd22xxOperation:
                 caps.router.maximum_entry_count,
                 params.0.len()
             );
-            Err(Error::new(FileError::Inval, &msg))?
+            Err(Error::new(ProtocolExtensionError::Router, &msg))?
         }
 
         Self::update_extension_whole_params(req, node, sections, caps, params, timeout_ms)?;

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1442,7 +1442,7 @@ impl TcKonnektNotifiedSegmentOperation<StudioChStripStates> for Studiok48Protoco
     const NOTIFY_FLAG: u32 = STUDIO_CH_STRIP_NOTIFY_01_CHANGE | STUDIO_CH_STRIP_NOTIFY_23_CHANGE;
 }
 
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// State of jack sense for analog input.
 pub enum StudioAnalogJackState {
     /// Select front jack instead of rear.

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -58,7 +58,7 @@ impl BlackbirdModel {
 
 impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -71,7 +71,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -143,7 +143,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -177,7 +177,7 @@ impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -39,7 +39,7 @@ impl BlackbirdModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -130,7 +130,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -46,7 +46,7 @@ impl BlackbirdModel {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -114,7 +114,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -155,7 +155,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for BlackbirdModel {
 
 impl MeasureModel<(SndDice, FwNode)> for BlackbirdModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -243,7 +243,8 @@ where
             CLK_SRC_NAME => {
                 let pos = elem_value.enumerated()[0] as usize;
                 let mut params = self.global_params.clone();
-                let src = self.global_params
+                let src = self
+                    .global_params
                     .avail_sources
                     .iter()
                     .nth(pos)
@@ -323,19 +324,19 @@ where
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if T::notified(&sections.global, msg) {
+        if T::notified(&self.global_params, msg) {
             let res = T::whole_cache(req, node, &mut sections.global, timeout_ms);
             self.global_params = sections.global.params.clone();
             debug!(params = ?self.global_params, ?res);
             res?;
         }
-        if T::notified(&sections.tx_stream_format, msg) {
+        if T::notified(&self.tx_stream_format_params, msg) {
             let res = T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms);
             self.tx_stream_format_params = sections.tx_stream_format.params.clone();
             debug!(params = ?self.tx_stream_format_params, ?res);
             res?;
         }
-        if T::notified(&sections.rx_stream_format, msg) {
+        if T::notified(&self.rx_stream_format_params, msg) {
             let res = T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms);
             self.rx_stream_format_params = sections.rx_stream_format.params.clone();
             debug!(params = ?self.rx_stream_format_params, ?res);

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -44,25 +44,45 @@ where
         sections: &mut GeneralSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::whole_cache(req, node, &mut sections.global, timeout_ms);
-        self.global_params = sections.global.params.clone();
+        let res = T::whole_cache(
+            req,
+            node,
+            &sections.global,
+            &mut self.global_params,
+            timeout_ms,
+        );
         debug!(params = ?self.global_params, ?res);
         res?;
 
-        let res = T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms);
-        self.tx_stream_format_params = sections.tx_stream_format.params.clone();
+        let res = T::whole_cache(
+            req,
+            node,
+            &sections.tx_stream_format,
+            &mut self.tx_stream_format_params,
+            timeout_ms,
+        );
         debug!(params = ?self.tx_stream_format_params, ?res);
         res?;
 
-        let res = T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms);
-        self.rx_stream_format_params = sections.rx_stream_format.params.clone();
+        let res = T::whole_cache(
+            req,
+            node,
+            &sections.rx_stream_format,
+            &mut self.rx_stream_format_params,
+            timeout_ms,
+        );
         debug!(params = ?self.rx_stream_format_params, ?res);
         res?;
 
         // Old firmware doesn't support it.
         if sections.ext_sync.size > 0 {
-            let res = T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms);
-            self.extended_sync_params = sections.ext_sync.params.clone();
+            let res = T::whole_cache(
+                req,
+                node,
+                &mut sections.ext_sync,
+                &mut self.extended_sync_params,
+                timeout_ms,
+            );
             debug!(params = ?self.extended_sync_params, ?res);
             res?;
         }
@@ -312,8 +332,13 @@ where
 
         // Old firmware doesn't support it.
         if sections.ext_sync.size > 0 {
-            let res = T::whole_cache(req, node, &mut sections.ext_sync, timeout_ms);
-            self.extended_sync_params = sections.ext_sync.params.clone();
+            let res = T::whole_cache(
+                req,
+                node,
+                &sections.ext_sync,
+                &mut self.extended_sync_params,
+                timeout_ms,
+            );
             debug!(params = ?self.extended_sync_params, ?res);
             res?;
         }
@@ -330,20 +355,35 @@ where
         timeout_ms: u32,
     ) -> Result<(), Error> {
         if T::notified(&self.global_params, msg) {
-            let res = T::whole_cache(req, node, &mut sections.global, timeout_ms);
-            self.global_params = sections.global.params.clone();
+            let res = T::whole_cache(
+                req,
+                node,
+                &sections.global,
+                &mut self.global_params,
+                timeout_ms,
+            );
             debug!(params = ?self.global_params, ?res);
             res?;
         }
         if T::notified(&self.tx_stream_format_params, msg) {
-            let res = T::whole_cache(req, node, &mut sections.tx_stream_format, timeout_ms);
-            self.tx_stream_format_params = sections.tx_stream_format.params.clone();
+            let res = T::whole_cache(
+                req,
+                node,
+                &sections.tx_stream_format,
+                &mut self.tx_stream_format_params,
+                timeout_ms,
+            );
             debug!(params = ?self.tx_stream_format_params, ?res);
             res?;
         }
         if T::notified(&self.rx_stream_format_params, msg) {
-            let res = T::whole_cache(req, node, &mut sections.rx_stream_format, timeout_ms);
-            self.rx_stream_format_params = sections.rx_stream_format.params.clone();
+            let res = T::whole_cache(
+                req,
+                node,
+                &sections.rx_stream_format,
+                &mut self.rx_stream_format_params,
+                timeout_ms,
+            );
             debug!(params = ?self.rx_stream_format_params, ?res);
             res?;
         }

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -228,9 +228,15 @@ where
                     .copied()?;
                 params.clock_config.rate = rate;
                 unit.lock()?;
-                let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
+                let res = T::partial_update(
+                    req,
+                    node,
+                    &sections.global,
+                    &params,
+                    &mut self.global_params,
+                    timeout_ms,
+                );
                 let _ = unit.unlock();
-                self.global_params = sections.global.params.clone();
                 debug!(params = ?self.global_params, ?res);
                 res.map(|_| true)
             }
@@ -252,9 +258,15 @@ where
                     .copied()?;
                 params.clock_config.src = src;
                 unit.lock()?;
-                let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
+                let res = T::partial_update(
+                    req,
+                    node,
+                    &sections.global,
+                    &params,
+                    &mut self.global_params,
+                    timeout_ms,
+                );
                 let _ = unit.unlock();
-                self.global_params = sections.global.params.clone();
                 debug!(params = ?self.global_params, ?res);
                 res.map(|_| true)
             }
@@ -265,8 +277,14 @@ where
                     let msg = format!("Invalid bytes for string: {}", e);
                     Error::new(FileError::Inval, &msg)
                 })?;
-                let res = T::partial_update(req, node, &params, &mut sections.global, timeout_ms);
-                self.global_params = sections.global.params.clone();
+                let res = T::partial_update(
+                    req,
+                    node,
+                    &sections.global,
+                    &params,
+                    &mut self.global_params,
+                    timeout_ms,
+                );
                 debug!(params = ?self.global_params, ?res);
                 res.map(|_| true)
             }

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -15,7 +15,7 @@ where
 {
     pub measured_elem_id_list: Vec<ElemId>,
     pub notified_elem_id_list: Vec<ElemId>,
-    global_params: GlobalParameters,
+    pub global_params: GlobalParameters,
     tx_stream_format_params: TxStreamFormatParameters,
     rx_stream_format_params: RxStreamFormatParameters,
     extended_sync_params: ExtendedSyncParameters,
@@ -237,9 +237,7 @@ where
             CLK_SRC_NAME => {
                 let pos = elem_value.enumerated()[0] as usize;
                 let mut params = self.global_params.clone();
-                let src = sections
-                    .global
-                    .params
+                let src = self.global_params
                     .avail_sources
                     .iter()
                     .nth(pos)

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -4,14 +4,19 @@
 use {super::*, std::marker::PhantomData};
 
 #[derive(Default, Debug)]
-pub struct CommonCtl<T>(pub Vec<ElemId>, pub Vec<ElemId>, PhantomData<T>)
+pub struct CommonCtl<T>
 where
     T: TcatNotifiedSectionOperation<GlobalParameters>
         + TcatFluctuatedSectionOperation<GlobalParameters>
         + TcatMutableSectionOperation<GlobalParameters>
         + TcatNotifiedSectionOperation<TxStreamFormatParameters>
         + TcatNotifiedSectionOperation<RxStreamFormatParameters>
-        + TcatSectionOperation<ExtendedSyncParameters>;
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    pub measured_elem_id_list: Vec<ElemId>,
+    pub notified_elem_id_list: Vec<ElemId>,
+    _phantom: PhantomData<T>,
+}
 
 const CLK_RATE_NAME: &str = "clock-rate";
 const CLK_SRC_NAME: &str = "clock-source";
@@ -73,7 +78,7 @@ where
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, CLK_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
-            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.notified_elem_id_list.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = params
             .avail_sources
@@ -90,12 +95,12 @@ where
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, CLK_SRC_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
-            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.notified_elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, NICKNAME, 0);
         card_cntr
             .add_bytes_elems(&elem_id, 1, NICKNAME_MAX_SIZE, None, true)
-            .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.notified_elem_id_list.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = params
             .external_source_states
@@ -114,12 +119,12 @@ where
             let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LOCKED_CLK_SRC_NAME, 0);
             card_cntr
                 .add_bool_elems(&elem_id, 1, labels.len(), false)
-                .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
+                .map(|mut elem_id_list| self.measured_elem_id_list.append(&mut elem_id_list))?;
 
             let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SLIPPED_CLK_SRC_NAME, 0);
             card_cntr
                 .add_bool_elems(&elem_id, 1, labels.len(), false)
-                .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
+                .map(|mut elem_id_list| self.measured_elem_id_list.append(&mut elem_id_list))?;
         }
 
         Ok(())

--- a/runtime/dice/src/common_ctl.rs
+++ b/runtime/dice/src/common_ctl.rs
@@ -300,8 +300,13 @@ where
         sections: &mut GeneralSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::partial_cache(req, node, &mut sections.global, timeout_ms);
-        self.global_params = sections.global.params.clone();
+        let res = T::partial_cache(
+            req,
+            node,
+            &sections.global,
+            &mut self.global_params,
+            timeout_ms,
+        );
         debug!(params = ?self.global_params, ?res);
         res?;
 

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -47,7 +47,7 @@ impl ExtensionModel {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,
@@ -334,7 +334,7 @@ impl Tcd22xxSpecification for ExtensionProtocol {
     ];
 }
 
-pub fn detect_extended_model(node: &mut FwNode) -> bool {
+pub fn detect_extended_model(node: &FwNode) -> bool {
     let mut req = FwReq::default();
     let mut sections = ExtensionSections::default();
     let res = ExtensionProtocol::read_extension_sections(&req, node, &mut sections, 100);

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -115,7 +115,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -156,7 +156,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
 
 impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -40,7 +40,7 @@ impl ExtensionModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -131,7 +131,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -59,7 +59,7 @@ impl ExtensionModel {
 
 impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -72,7 +72,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -144,7 +144,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ExtensionModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -178,7 +178,7 @@ impl MeasureModel<(SndDice, FwNode)> for ExtensionModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -59,8 +59,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -161,8 +161,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -301,8 +301,8 @@ where
 
     fn parse_notification(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         msg: u32,
@@ -354,8 +354,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -418,8 +418,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -523,8 +523,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -581,8 +581,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -71,7 +71,7 @@ impl LiquidS56Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,
@@ -386,8 +386,8 @@ impl SpecificCtl {
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -533,8 +533,8 @@ impl SpecificCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -179,7 +179,7 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -231,7 +231,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
 
 impl MeasureModel<(SndDice, FwNode)> for LiquidS56Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -40,7 +40,7 @@ impl LiquidS56Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -196,7 +196,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -83,7 +83,7 @@ impl LiquidS56Model {
 
 impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -100,7 +100,7 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -217,7 +217,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for LiquidS56Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -253,7 +253,7 @@ impl MeasureModel<(SndDice, FwNode)> for LiquidS56Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -152,7 +152,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -193,7 +193,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
 
 impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -34,7 +34,7 @@ impl SPro14Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -168,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -69,7 +69,7 @@ impl SPro14Model {
 
 impl CtlModel<(SndDice, FwNode)> for SPro14Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -85,7 +85,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -181,7 +181,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro14Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -215,7 +215,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro14Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -57,7 +57,7 @@ impl SPro14Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -152,7 +152,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -204,7 +204,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
 
 impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -69,7 +69,7 @@ impl SPro24Model {
 
 impl CtlModel<(SndDice, FwNode)> for SPro24Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -85,7 +85,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -190,7 +190,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -226,7 +226,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -34,7 +34,7 @@ impl SPro24Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -169,7 +169,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -57,7 +57,7 @@ impl SPro24Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -98,7 +98,7 @@ impl SPro24DspModel {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,
@@ -358,8 +358,8 @@ const COMPRESSOR_RELEASE_NAME: &str = "compressor-release";
 impl CompressorCtl {
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -468,8 +468,8 @@ impl CompressorCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -565,8 +565,8 @@ const EQUALIZER_OUTPUT_NAME: &str = "equalizer-output-volume";
 impl EqualizerCtl {
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -612,8 +612,8 @@ impl EqualizerCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -652,8 +652,8 @@ const REVERB_PRE_FILTER_NAME: &str = "reverb-pre-filter";
 impl ReverbCtl {
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -741,8 +741,8 @@ impl ReverbCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -835,8 +835,8 @@ impl EffectGeneralCtl {
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -901,8 +901,8 @@ impl EffectGeneralCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -43,7 +43,7 @@ impl SPro24DspModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -262,7 +262,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -110,7 +110,7 @@ impl SPro24DspModel {
 
 impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -130,7 +130,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -283,7 +283,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -319,7 +319,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro24DspModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -245,7 +245,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -297,7 +297,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro24DspModel {
 
 impl MeasureModel<(SndDice, FwNode)> for SPro24DspModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -130,7 +130,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -182,7 +182,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
 
 impl MeasureModel<(SndDice, FwNode)> for SPro26Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -48,7 +48,7 @@ impl SPro26Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -60,7 +60,7 @@ impl SPro26Model {
 
 impl CtlModel<(SndDice, FwNode)> for SPro26Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -75,7 +75,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -168,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -204,7 +204,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro26Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -33,7 +33,7 @@ impl SPro26Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -147,7 +147,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro26Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -152,7 +152,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.out_grp_ctl.1);
     }
@@ -204,7 +204,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
 
 impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -57,7 +57,7 @@ impl SPro40Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -34,7 +34,7 @@ impl SPro40Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -169,7 +169,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -69,7 +69,7 @@ impl SPro40Model {
 
 impl CtlModel<(SndDice, FwNode)> for SPro40Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -85,7 +85,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -190,7 +190,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -226,7 +226,7 @@ impl MeasureModel<(SndDice, FwNode)> for SPro40Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/io_fw_model.rs
+++ b/runtime/dice/src/io_fw_model.rs
@@ -974,14 +974,21 @@ pub fn detect_io26fw_model(node: &FwNode) -> Result<bool, Error> {
     let mut sections = GeneralSections::default();
     Io14fwProtocol::read_general_sections(&req, node, &mut sections, TIMEOUT_MS)?;
 
-    Io14fwProtocol::whole_cache(&req, node, &mut sections.global, TIMEOUT_MS)?;
-    let global_params = sections.global.params.clone();
+    let mut global_params = GlobalParameters::default();
+    Io14fwProtocol::whole_cache(&req, node, &sections.global, &mut global_params, TIMEOUT_MS)?;
     let config = &global_params.clock_config;
 
     match config.rate {
         ClockRate::R32000 | ClockRate::R44100 | ClockRate::R48000 | ClockRate::AnyLow => {
-            Io14fwProtocol::whole_cache(&req, node, &mut sections.tx_stream_format, TIMEOUT_MS)?;
-            let entries = &sections.tx_stream_format.params.0;
+            let mut params = TxStreamFormatParameters::default();
+            Io14fwProtocol::whole_cache(
+                &req,
+                node,
+                &sections.tx_stream_format,
+                &mut params,
+                TIMEOUT_MS,
+            )?;
+            let entries = &params.0;
             if entries.len() == 2 && entries[0].pcm == 10 && entries[1].pcm == 16 {
                 Ok(true)
             } else if entries.len() == 2 && entries[0].pcm == 6 && entries[1].pcm == 8 {
@@ -994,8 +1001,15 @@ pub fn detect_io26fw_model(node: &FwNode) -> Result<bool, Error> {
             }
         }
         ClockRate::R88200 | ClockRate::R96000 | ClockRate::AnyMid => {
-            Io14fwProtocol::whole_cache(&req, node, &mut sections.tx_stream_format, TIMEOUT_MS)?;
-            let entries = &sections.tx_stream_format.params.0;
+            let mut params = TxStreamFormatParameters::default();
+            Io14fwProtocol::whole_cache(
+                &req,
+                node,
+                &sections.tx_stream_format,
+                &mut params,
+                TIMEOUT_MS,
+            )?;
+            let entries = &params.0;
             if entries.len() == 2 && entries[0].pcm == 10 && entries[1].pcm == 4 {
                 Ok(true)
             } else if entries.len() == 2 && entries[0].pcm == 6 && entries[1].pcm == 4 {

--- a/runtime/dice/src/io_fw_model.rs
+++ b/runtime/dice/src/io_fw_model.rs
@@ -89,7 +89,7 @@ where
         + TcatSectionOperation<ExtendedSyncParameters>,
 {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
@@ -104,7 +104,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -184,7 +184,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 }
 
@@ -228,7 +228,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -975,7 +975,8 @@ pub fn detect_io26fw_model(node: &FwNode) -> Result<bool, Error> {
     Io14fwProtocol::read_general_sections(&req, node, &mut sections, TIMEOUT_MS)?;
 
     Io14fwProtocol::whole_cache(&req, node, &mut sections.global, TIMEOUT_MS)?;
-    let config = &sections.global.params.clock_config;
+    let global_params = sections.global.params.clone();
+    let config = &global_params.clock_config;
 
     match config.rate {
         ClockRate::R32000 | ClockRate::R44100 | ClockRate::R48000 | ClockRate::AnyLow => {
@@ -1007,7 +1008,7 @@ pub fn detect_io26fw_model(node: &FwNode) -> Result<bool, Error> {
             }
         }
         ClockRate::R176400 | ClockRate::R192000 | ClockRate::AnyHigh => {
-            let nickname = &sections.global.params.nickname;
+            let nickname = &global_params.nickname;
             match nickname.as_str() {
                 "iO 26" => Ok(true),
                 "iO 14" => Ok(false),

--- a/runtime/dice/src/io_fw_model.rs
+++ b/runtime/dice/src/io_fw_model.rs
@@ -170,7 +170,7 @@ where
         + TcatSectionOperation<ExtendedSyncParameters>,
 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -208,7 +208,7 @@ where
         + TcatSectionOperation<ExtendedSyncParameters>,
 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.meter_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
     }

--- a/runtime/dice/src/ionix_model.rs
+++ b/runtime/dice/src/ionix_model.rs
@@ -82,7 +82,7 @@ impl CtlModel<(SndDice, FwNode)> for IonixModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for IonixModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -102,7 +102,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for IonixModel {
 
 impl MeasureModel<(SndDice, FwNode)> for IonixModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 

--- a/runtime/dice/src/ionix_model.rs
+++ b/runtime/dice/src/ionix_model.rs
@@ -29,7 +29,7 @@ impl IonixModel {
 
 impl CtlModel<(SndDice, FwNode)> for IonixModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
@@ -43,7 +43,7 @@ impl CtlModel<(SndDice, FwNode)> for IonixModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -96,7 +96,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for IonixModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 }
 
@@ -119,7 +119,7 @@ impl MeasureModel<(SndDice, FwNode)> for IonixModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_measured_elem(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -133,7 +133,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.specific_ctl.1);
     }
@@ -189,7 +189,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
 
 impl MeasureModel<(SndDice, FwNode)> for Mbox3Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -51,7 +51,7 @@ impl Mbox3Model {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,
@@ -337,8 +337,8 @@ impl SpecificCtl {
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -601,8 +601,8 @@ impl SpecificCtl {
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -63,7 +63,7 @@ impl Mbox3Model {
 
 impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -78,7 +78,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -175,7 +175,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -211,7 +211,7 @@ impl MeasureModel<(SndDice, FwNode)> for Mbox3Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -36,7 +36,7 @@ impl Mbox3Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -154,7 +154,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Mbox3Model {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             msg,
         )?;

--- a/runtime/dice/src/minimal_model.rs
+++ b/runtime/dice/src/minimal_model.rs
@@ -25,7 +25,7 @@ impl MinimalModel {
 
 impl CtlModel<(SndDice, FwNode)> for MinimalModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)
+        self.common_ctl.load(card_cntr)
     }
 
     fn read(
@@ -34,7 +34,7 @@ impl CtlModel<(SndDice, FwNode)> for MinimalModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 
     fn write(
@@ -72,7 +72,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for MinimalModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 }
 
@@ -92,7 +92,7 @@ impl MeasureModel<(SndDice, FwNode)> for MinimalModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 }
 

--- a/runtime/dice/src/minimal_model.rs
+++ b/runtime/dice/src/minimal_model.rs
@@ -58,7 +58,7 @@ impl CtlModel<(SndDice, FwNode)> for MinimalModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for MinimalModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
@@ -78,7 +78,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for MinimalModel {
 
 impl MeasureModel<(SndDice, FwNode)> for MinimalModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -419,7 +419,7 @@ impl DiceModel {
         }
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         match &mut self.model {
             Model::Extension(m) => m.store_configuration(node),
             Model::MaudioPfire2626(m) => m.store_configuration(node),

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -66,7 +66,7 @@ where
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -207,7 +207,7 @@ where
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -107,7 +107,7 @@ where
         + TcatExtensionSectionPartialMutableParamsOperation<PfireSpecificParams>,
 {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -122,7 +122,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -220,7 +220,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -268,7 +268,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -81,7 +81,7 @@ where
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,
@@ -324,8 +324,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -391,8 +391,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -191,7 +191,7 @@ where
         + TcatExtensionSectionPartialMutableParamsOperation<PfireSpecificParams>,
 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -246,7 +246,7 @@ where
         + TcatExtensionSectionPartialMutableParamsOperation<PfireSpecificParams>,
 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/presonus/fstudio_model.rs
+++ b/runtime/dice/src/presonus/fstudio_model.rs
@@ -32,7 +32,7 @@ impl FStudioModel {
 
 impl CtlModel<(SndDice, FwNode)> for FStudioModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.out_ctl.load(card_cntr)?;
@@ -47,7 +47,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -113,7 +113,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        self.common_ctl.read(&self.sections, elem_id, elem_value)
+        self.common_ctl.read(elem_id, elem_value)
     }
 }
 
@@ -136,7 +136,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/presonus/fstudio_model.rs
+++ b/runtime/dice/src/presonus/fstudio_model.rs
@@ -95,7 +95,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for FStudioModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
     }
 
     fn parse_notification(
@@ -119,7 +119,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioModel {
 
 impl MeasureModel<(SndDice, FwNode)> for FStudioModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -40,7 +40,7 @@ impl FStudioMobileModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -131,7 +131,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             *msg,
         )?;

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -115,7 +115,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -156,7 +156,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
 
 impl MeasureModel<(SndDice, FwNode)> for FStudioMobileModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -59,7 +59,7 @@ impl FStudioMobileModel {
 
 impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -72,7 +72,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -144,7 +144,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioMobileModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -178,7 +178,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioMobileModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -47,7 +47,7 @@ impl FStudioMobileModel {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -40,7 +40,7 @@ impl FStudioProjectModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
         )?;
 
@@ -135,7 +135,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
             &mut self.req,
             &mut unit.1,
             &self.extension_sections,
-            &self.sections.global.params,
+            &self.common_ctl.global_params,
             TIMEOUT_MS,
             msg,
         )?;

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -115,7 +115,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
     }
 
@@ -160,7 +160,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
 
 impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
     }
 

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -47,7 +47,7 @@ impl FStudioProjectModel {
         Ok(())
     }
 
-    pub fn store_configuration(&mut self, node: &mut FwNode) -> Result<(), Error> {
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
         self.tcd22xx_ctls.store_configuration(
             &mut self.req,
             node,

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -59,7 +59,7 @@ impl FStudioProjectModel {
 
 impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.tcd22xx_ctls.load(card_cntr)?;
 
@@ -72,7 +72,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -148,7 +148,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for FStudioProjectModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)
@@ -182,7 +182,7 @@ impl MeasureModel<(SndDice, FwNode)> for FStudioProjectModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcd22xx_ctl.rs
+++ b/runtime/dice/src/tcd22xx_ctl.rs
@@ -67,8 +67,8 @@ where
 {
     pub fn cache_whole_params(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         global_params: &GlobalParameters,
         timeout_ms: u32,
@@ -228,8 +228,8 @@ where
 
     pub fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         elem_id: &ElemId,
         elem_value: &ElemValue,
@@ -272,8 +272,8 @@ where
 
     pub fn cache_partial_params(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -291,8 +291,8 @@ where
 
     pub fn parse_notification(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         global_params: &GlobalParameters,
         timeout_ms: u32,
@@ -312,8 +312,8 @@ where
 
     pub fn store_configuration(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         timeout_ms: u32,
     ) -> Result<(), Error> {
@@ -350,8 +350,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -533,8 +533,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -710,8 +710,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         timeout_ms: u32,
@@ -768,8 +768,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         elem_id: &ElemId,
@@ -830,8 +830,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         rate_mode: RateMode,
@@ -1055,8 +1055,8 @@ where
 
     fn write(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         current_rate: u32,
@@ -1107,8 +1107,8 @@ where
 
     fn write_elem_src(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         current_rate: u32,
@@ -1196,8 +1196,8 @@ where
 
     fn cache(
         &mut self,
-        req: &mut FwReq,
-        node: &mut FwNode,
+        req: &FwReq,
+        node: &FwNode,
         sections: &ExtensionSections,
         caps: &ExtensionCaps,
         real_blk_dsts: &[DstBlk],

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -119,7 +119,7 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for Desktopk6Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
         elem_id_list.extend_from_slice(&self.panel_ctl.1);
     }
@@ -166,7 +166,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Desktopk6Model {
 
 impl MeasureModel<(SndDice, FwNode)> for Desktopk6Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -40,7 +40,7 @@ impl Desktopk6Model {
 
 impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.hw_state_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -57,7 +57,7 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.hw_state_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -152,7 +152,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Desktopk6Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.hw_state_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -183,7 +183,7 @@ impl MeasureModel<(SndDice, FwNode)> for Desktopk6Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -162,7 +162,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.knob_ctl.1);
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
@@ -226,7 +226,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
 
 impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -51,7 +51,7 @@ impl ItwinModel {
 
 impl CtlModel<(SndDice, FwNode)> for ItwinModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -82,7 +82,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -204,7 +204,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -253,7 +253,7 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -162,7 +162,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.knob_ctl.1);
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
@@ -227,7 +227,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
 
 impl MeasureModel<(SndDice, FwNode)> for K24dModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -51,7 +51,7 @@ impl K24dModel {
 
 impl CtlModel<(SndDice, FwNode)> for K24dModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -82,7 +82,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -205,7 +205,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -254,7 +254,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -118,7 +118,7 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for K8Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.knob_ctl.1);
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
@@ -172,7 +172,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K8Model {
 
 impl MeasureModel<(SndDice, FwNode)> for K8Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
     }
 

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -39,7 +39,7 @@ impl K8Model {
 
 impl CtlModel<(SndDice, FwNode)> for K8Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -56,7 +56,7 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -154,7 +154,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K8Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -189,7 +189,7 @@ impl MeasureModel<(SndDice, FwNode)> for K8Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -51,7 +51,7 @@ impl KliveModel {
 
 impl CtlModel<(SndDice, FwNode)> for KliveModel {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.knob_ctl.load(card_cntr)?;
         self.config_ctl.load(card_cntr)?;
@@ -82,7 +82,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -204,7 +204,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -253,7 +253,7 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -162,7 +162,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
 
 impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.knob_ctl.1);
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
@@ -226,7 +226,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
 
 impl MeasureModel<(SndDice, FwNode)> for KliveModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -57,7 +57,7 @@ impl Studiok48Model {
 
 impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
     fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr, &self.sections)?;
+        self.common_ctl.load(card_cntr)?;
 
         self.lineout_ctl.load(card_cntr)?;
         self.remote_ctl.load(card_cntr)?;
@@ -92,7 +92,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.lineout_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -235,7 +235,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.lineout_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -288,7 +288,7 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read(&self.sections, elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_meter_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -186,7 +186,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
 
 impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.1);
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
         elem_id_list.extend_from_slice(&self.lineout_ctl.1);
         elem_id_list.extend_from_slice(&self.remote_ctl.1);
         elem_id_list.extend_from_slice(&self.config_ctl.1);
@@ -261,7 +261,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
 
 impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.0);
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);


### PR DESCRIPTION
The structure for section became as generic at #119, while it's not necessarily useful,
especially for tests.

This commit redefines the structure without generics, then refactors current codes with
enough tests.

```
Takashi Sakamoto (15):
  protocols/dice: drop mutability from FwNode and FwReq
  protocols/dice: tcat: remove usage of glib::FileError
  protocols/dice: tcat: fulfill serializer of global parameters in TCAT general protocol
  runtime/dice: common_ctl: redefine as structure instead of tuple
  runtime/dice: common_ctl: add local cache of parameters in TCAT general protocol
  runtime/dice: code refactoring to use local cache of global parameters
  protocols/dice: tcat: receive instance to update whole/partial parameters in TCAT general protocol
  protocols/dice: tcat: receive instance to check notified parameters in TCAT general protocol
  protocols/dice: tcat: receive instance to cache partial parameters in TCAT general protocol
  protocols/dice: tcat: receive instance to cache whole parameters in TCAT general protocol
  protocols/dice: tcat: obsolete generic structure for section expression
  protocols/dice: tcat: code cleanup for deserialize of sections in TCAT general protocol
  protocols/dice: tcat: use common structure for section
  protocols/dice: tcat fulfill doc comment for configuration ROM parser
  protocols/dice: code cleanup for trait annotation

 .../dice/src/bin/tcat-extension-parser.rs     |  20 +-
 protocols/dice/src/bin/tcat-general-parser.rs |  34 ++-
 protocols/dice/src/lib.rs                     |   2 +-
 protocols/dice/src/tcat.rs                    | 237 ++++++++++--------
 protocols/dice/src/tcat/config_rom.rs         |  28 ++-
 protocols/dice/src/tcat/ext_sync_section.rs   |   2 +-
 protocols/dice/src/tcat/extension.rs          | 114 +++------
 protocols/dice/src/tcat/global_section.rs     | 141 ++++++++---
 protocols/dice/src/tcat/tcd22xx_spec.rs       |  18 +-
 protocols/dice/src/tcelectronic/studio.rs     |   2 +-
 runtime/dice/src/blackbird_model.rs           |  18 +-
 runtime/dice/src/common_ctl.rs                | 196 ++++++++++-----
 runtime/dice/src/extension_model.rs           |  20 +-
 runtime/dice/src/focusrite.rs                 |  28 +--
 runtime/dice/src/focusrite/liquids56_model.rs |  26 +-
 runtime/dice/src/focusrite/spro14_model.rs    |  18 +-
 runtime/dice/src/focusrite/spro24_model.rs    |  18 +-
 runtime/dice/src/focusrite/spro24dsp_model.rs |  50 ++--
 runtime/dice/src/focusrite/spro26_model.rs    |  18 +-
 runtime/dice/src/focusrite/spro40_model.rs    |  18 +-
 runtime/dice/src/io_fw_model.rs               |  41 ++-
 runtime/dice/src/ionix_model.rs               |  12 +-
 runtime/dice/src/mbox3_model.rs               |  26 +-
 runtime/dice/src/minimal_model.rs             |  12 +-
 runtime/dice/src/model.rs                     |   2 +-
 runtime/dice/src/pfire_model.rs               |  26 +-
 runtime/dice/src/presonus/fstudio_model.rs    |  12 +-
 .../dice/src/presonus/fstudiomobile_model.rs  |  18 +-
 .../dice/src/presonus/fstudioproject_model.rs |  18 +-
 runtime/dice/src/tcd22xx_ctl.rs               |  52 ++--
 .../dice/src/tcelectronic/desktopk6_model.rs  |  12 +-
 runtime/dice/src/tcelectronic/itwin_model.rs  |  12 +-
 runtime/dice/src/tcelectronic/k24d_model.rs   |  12 +-
 runtime/dice/src/tcelectronic/k8_model.rs     |  12 +-
 runtime/dice/src/tcelectronic/klive_model.rs  |  12 +-
 .../dice/src/tcelectronic/studiok48_model.rs  |  12 +-
 36 files changed, 746 insertions(+), 553 deletions(-)
```