### PR TITLE
[PATCH 0/4] protocols/dice: focusrite: fix volume operation in output group parameter

### DIFF
--- a/protocols/dice/src/focusrite.rs
+++ b/protocols/dice/src/focusrite.rs
@@ -46,7 +46,7 @@ pub trait SaffireproSwNoticeOperation: TcatExtensionOperation {
 /// controlled by single software/hardware operation if enabled.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct OutGroupState {
-    /// Volume of each analog output.
+    /// Volume of each analog output, between 0x00 and 0x7f.
     pub vols: Vec<i8>,
 
     /// Whether to mute each analog output.
@@ -73,6 +73,9 @@ pub struct OutGroupState {
 }
 
 const OUT_GROUP_STATE_SIZE: usize = 0x50;
+
+const VOL_MIN: i8 = 0;
+const VOL_MAX: i8 = i8::MAX;
 
 fn serialize_out_group_state(state: &OutGroupState, raw: &mut [u8]) -> Result<(), String> {
     assert!(raw.len() >= OUT_GROUP_STATE_SIZE);
@@ -197,6 +200,12 @@ pub trait SaffireproOutGroupSpecification: SaffireproSwNoticeOperation {
 
     /// Software notification for dim and mute of output group.
     const DIM_MUTE_NOTICE: u32;
+
+    /// The minimum value of volume.
+    const VOL_MIN: i8 = VOL_MIN;
+
+    /// The maximum value of volume.
+    const VOL_MAX: i8 = VOL_MAX;
 
     /// Instantiate structure for output group state.
     fn create_out_group_state() -> OutGroupState {

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -53,8 +53,8 @@ where
         + TcatExtensionSectionPartialMutableParamsOperation<OutGroupState>
         + TcatExtensionSectionNotifiedParamsOperation<OutGroupState>,
 {
-    const LEVEL_MIN: i32 = 0x00;
-    const LEVEL_MAX: i32 = 0x7f;
+    const LEVEL_MIN: i32 = T::VOL_MIN as i32;
+    const LEVEL_MAX: i32 = T::VOL_MAX as i32;
     const LEVEL_STEP: i32 = 0x01;
 
     fn cache(

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -117,12 +117,8 @@ where
         match elem_id.name().as_str() {
             VOL_NAME => {
                 let params = &self.0;
-                let vols: Vec<i32> = params
-                    .vols
-                    .iter()
-                    .map(|&v| Self::LEVEL_MAX - (v as i32))
-                    .collect();
-                elem_value.set_int(&vols);
+                let vals: Vec<i32> = params.vols.iter().map(|&vol| vol as i32).collect();
+                elem_value.set_int(&vals);
                 Ok(true)
             }
             VOL_MUTE_NAME => {

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -15,12 +15,12 @@ use {
 };
 
 const VOL_NAME: &str = "output-group-volume";
-const VOL_HWCTL_NAME: &str = "output-group-volume-hwctl";
+const VOL_TARGET_NAME: &str = "output-group-volume-target";
 const VOL_MUTE_NAME: &str = "output-group-volume-mute";
 const MUTE_NAME: &str = "output-group-mute";
 const DIM_NAME: &str = "output-group-dim";
-const DIM_HWCTL_NAME: &str = "output-group-dim-hwctl";
-const MUTE_HWCTL_NAME: &str = "output-group-mute-hwctl";
+const DIM_TARGET_NAME: &str = "output-group-dim-target";
+const MUTE_TARGET_NAME: &str = "output-group-mute-target";
 
 #[derive(Debug)]
 pub struct OutGroupCtl<T>(OutGroupState, Vec<ElemId>, PhantomData<T>)
@@ -100,14 +100,14 @@ where
         card_cntr.add_bool_elems(&elem_id, 1, T::ENTRY_COUNT, true)?;
 
         if T::HAS_VOL_HWCTL {
-            let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, VOL_HWCTL_NAME, 0);
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, VOL_TARGET_NAME, 0);
             card_cntr.add_bool_elems(&elem_id, 1, T::ENTRY_COUNT, true)?;
         }
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, DIM_HWCTL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, DIM_TARGET_NAME, 0);
         card_cntr.add_bool_elems(&elem_id, 1, T::ENTRY_COUNT, true)?;
 
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MUTE_HWCTL_NAME, 0);
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MUTE_TARGET_NAME, 0);
         card_cntr.add_bool_elems(&elem_id, 1, T::ENTRY_COUNT, true)?;
 
         Ok(())
@@ -126,7 +126,7 @@ where
                 elem_value.set_bool(&params.vol_mutes);
                 Ok(true)
             }
-            VOL_HWCTL_NAME => {
+            VOL_TARGET_NAME => {
                 let params = &self.0;
                 elem_value.set_bool(&params.vol_hwctls);
                 Ok(true)
@@ -136,7 +136,7 @@ where
                 elem_value.set_bool(&[params.mute_enabled]);
                 Ok(true)
             }
-            MUTE_HWCTL_NAME => {
+            MUTE_TARGET_NAME => {
                 let params = &self.0;
                 elem_value.set_bool(&params.mute_hwctls);
                 Ok(true)
@@ -146,7 +146,7 @@ where
                 elem_value.set_bool(&[params.dim_enabled]);
                 Ok(true)
             }
-            DIM_HWCTL_NAME => {
+            DIM_TARGET_NAME => {
                 let params = &self.0;
                 elem_value.set_bool(&params.dim_hwctls);
                 Ok(true)
@@ -204,7 +204,7 @@ where
                 debug!(params = ?self.0, ?res);
                 res.map(|_| true)
             }
-            VOL_HWCTL_NAME => {
+            VOL_TARGET_NAME => {
                 let mut params = self.0.clone();
                 params
                     .vol_hwctls
@@ -238,7 +238,7 @@ where
                 debug!(params = ?self.0, ?res);
                 res.map(|_| true)
             }
-            MUTE_HWCTL_NAME => {
+            MUTE_TARGET_NAME => {
                 let mut params = self.0.clone();
                 params
                     .mute_hwctls
@@ -272,7 +272,7 @@ where
                 debug!(params = ?self.0, ?res);
                 res.map(|_| true)
             }
-            DIM_HWCTL_NAME => {
+            DIM_TARGET_NAME => {
                 let mut params = self.0.clone();
                 params
                     .dim_hwctls


### PR DESCRIPTION
This patchset is to fix issue reported at #91. The value of volume in output group
parameter should be inverted correctly.

```
Takashi Sakamoto (4):
  protocols/dice: focusrite: hard code minimum and maximum value of volume in output group
  protocols/dice: focusrite: invert value of volume in output group
  runtime/dice: focusrite: obsolete inversion calculation for output group control
  runtime/dice: focusrite: rename controls for output group

 protocols/dice/src/focusrite.rs | 32 ++++++++++++++++++++++++-----
 runtime/dice/src/focusrite.rs   | 36 +++++++++++++++------------------
 2 files changed, 43 insertions(+), 25 deletions(-)
```