### PR TITLE
runtime/oxfw: support logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2022/09/04
+2022/11/07
 Takashi Sakamoto
 
 Introduction
@@ -279,6 +279,7 @@ Currently this function is available for below executables:
 
 * snd-bebob-ctl-service
 * snd-dice-ctl-service
+* snd-oxfw-ctl-service
 
 This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
 `tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.

--- a/runtime/oxfw/Cargo.toml
+++ b/runtime/oxfw/Cargo.toml
@@ -22,3 +22,5 @@ ta1394-avc-stream-format = "0.1"
 firewire-oxfw-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/oxfw/src/apogee_model.rs
+++ b/runtime/oxfw/src/apogee_model.rs
@@ -194,8 +194,12 @@ impl MeterCtl {
     const MIXER_OUTPUT_LABELS: [&'static str; 2] = ["mixer-output-1", "mixer-output-2"];
 
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache_meter(req, node, &mut self.0, timeout_ms)?;
-        DuetFwProtocol::cache_meter(req, node, &mut self.1, timeout_ms)?;
+        let res = DuetFwProtocol::cache_meter(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res?;
+        let res = DuetFwProtocol::cache_meter(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res?;
         Ok(())
     }
 
@@ -288,7 +292,9 @@ impl KnobCtl {
     ];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = DuetFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -367,7 +373,9 @@ impl OutputCtl {
     ];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = DuetFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -480,12 +488,16 @@ impl OutputCtl {
             OUTPUT_MUTE_NAME => {
                 let mut params = self.0.clone();
                 params.mute = elem_value.boolean()[0];
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_VOLUME_NAME => {
                 let mut params = self.0.clone();
                 params.volume = elem_value.int()[0] as u8;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_SRC_NAME => {
                 let mut params = self.0.clone();
@@ -498,7 +510,9 @@ impl OutputCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_NOMINAL_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -511,7 +525,9 @@ impl OutputCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_MUTE_FOR_LINE_OUT => {
                 let mut params = self.0.clone();
@@ -524,7 +540,9 @@ impl OutputCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             OUTPUT_MUTE_FOR_HP_OUT => {
                 let mut params = self.0.clone();
@@ -537,7 +555,9 @@ impl OutputCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -582,7 +602,9 @@ impl InputCtl {
     ];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = DuetFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -699,7 +721,9 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as u8);
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_POLARITY_NAME => {
                 let mut params = self.0.clone();
@@ -708,7 +732,9 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(polarity, val)| *polarity = val);
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_XLR_NOMINAL_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -728,7 +754,9 @@ impl InputCtl {
                             })
                             .map(|&level| *xlr_nominal_level = level)
                     })?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_PHANTOM_NAME => {
                 let mut params = self.0.clone();
@@ -737,7 +765,9 @@ impl InputCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_SOURCE_NAME => {
                 let mut params = self.0.clone();
@@ -756,12 +786,16 @@ impl InputCtl {
                             })
                             .map(|&s| *src = s)
                     })?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_CLICKLESS_NAME => {
                 let mut params = self.0.clone();
                 params.clickless = elem_value.boolean()[0];
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -783,7 +817,9 @@ impl MixerCtl {
     ];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = DuetFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -844,7 +880,9 @@ impl MixerCtl {
                     .chain(&mut mixer.analog_inputs)
                     .zip(elem_value.int())
                     .for_each(|(coef, &val)| *coef = val as u16);
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -894,7 +932,9 @@ impl DisplayCtl {
     ];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        DuetFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = DuetFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -968,7 +1008,9 @@ impl DisplayCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&t| params.target = t)?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             DISPLAY_MODE_NAME => {
                 let mut params = self.0.clone();
@@ -981,7 +1023,9 @@ impl DisplayCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&m| params.mode = m)?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             DISPLAY_OVERHOLDS_NAME => {
                 let mut params = self.0.clone();
@@ -994,7 +1038,9 @@ impl DisplayCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&o| params.overhold = o)?;
-                DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = DuetFwProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/oxfw/src/apogee_model.rs
+++ b/runtime/oxfw/src/apogee_model.rs
@@ -20,12 +20,8 @@ const TIMEOUT_MS: u32 = 50;
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl ApogeeModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
@@ -38,6 +34,12 @@ impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
         self.mixer_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
         self.display_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         self.knob_ctl.load(card_cntr)?;

--- a/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
+++ b/runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs
@@ -14,11 +14,15 @@ struct OxfwServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, OxfwRuntime> for OxfwServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/oxfw/src/common_model.rs
+++ b/runtime/oxfw/src/common_model.rs
@@ -11,17 +11,20 @@ pub struct CommonModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for CommonModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommonModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
 
         self.common_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
+
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for CommonModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
 
         Ok(())

--- a/runtime/oxfw/src/griffin_model.rs
+++ b/runtime/oxfw/src/griffin_model.rs
@@ -12,12 +12,8 @@ pub struct GriffinModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl GriffinModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
@@ -25,6 +21,12 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         self.common_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
 

--- a/runtime/oxfw/src/lacie_model.rs
+++ b/runtime/oxfw/src/lacie_model.rs
@@ -12,12 +12,8 @@ pub struct LacieModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for LacieModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl LacieModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
@@ -25,6 +21,12 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         self.common_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for LacieModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
 

--- a/runtime/oxfw/src/lib.rs
+++ b/runtime/oxfw/src/lib.rs
@@ -115,6 +115,8 @@ impl RuntimeOperation<u32> for OxfwRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
+        self.model.cache(&mut self.unit)?;
+
         self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measure_elem_list.len() > 0 {

--- a/runtime/oxfw/src/loud_model.rs
+++ b/runtime/oxfw/src/loud_model.rs
@@ -12,12 +12,8 @@ pub struct LinkFwModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl LinkFwModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
@@ -25,6 +21,12 @@ impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
         self.common_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
         self.specific_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
         self.specific_ctl.load(card_cntr)?;
 

--- a/runtime/oxfw/src/loud_model.rs
+++ b/runtime/oxfw/src/loud_model.rs
@@ -113,7 +113,9 @@ impl SpecificCtl {
     const SRCS: [LinkFwInputSource; 2] = [LinkFwInputSource::Analog, LinkFwInputSource::Digital];
 
     fn cache(&mut self, avc: &mut OxfwAvc, timeout_ms: u32) -> Result<(), Error> {
-        LinkFwProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = LinkFwProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -153,7 +155,9 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                LinkFwProtocol::update(avc, &src, &mut self.0, timeout_ms).map(|_| true)
+                let res = LinkFwProtocol::update(avc, &src, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/oxfw/src/model.rs
+++ b/runtime/oxfw/src/model.rs
@@ -42,6 +42,17 @@ impl OxfwModel {
         Ok(model)
     }
 
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
+        match &mut self.ctl_model {
+            OxfwCtlModel::Fireone(m) => m.cache(unit),
+            OxfwCtlModel::Duet(m) => m.cache(unit),
+            OxfwCtlModel::Firewave(m) => m.cache(unit),
+            OxfwCtlModel::Speaker(m) => m.cache(unit),
+            OxfwCtlModel::TapcoLinkFw(m) => m.cache(unit),
+            OxfwCtlModel::Common(m) => m.cache(unit),
+        }
+    }
+
     pub fn load(
         &mut self,
         unit: &mut (SndUnit, FwNode),

--- a/runtime/oxfw/src/tascam_model.rs
+++ b/runtime/oxfw/src/tascam_model.rs
@@ -12,12 +12,8 @@ pub struct TascamModel {
 
 const FCP_TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for TascamModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl TascamModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.avc.bind(&unit.1)?;
 
         self.common_ctl.detect(&mut self.avc, FCP_TIMEOUT_MS)?;
@@ -25,6 +21,12 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         self.common_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
         self.specific_ctl.cache(&mut self.avc, FCP_TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for TascamModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
         self.specific_ctl.load(card_cntr)?;
 

--- a/runtime/oxfw/src/tascam_model.rs
+++ b/runtime/oxfw/src/tascam_model.rs
@@ -153,7 +153,9 @@ impl SpecificCtl {
         [FireoneInputMode::Stereo, FireoneInputMode::Monaural];
 
     fn cache(&mut self, avc: &mut TascamAvc, timeout_ms: u32) -> Result<(), Error> {
-        FireoneProtocol::cache(avc, &mut self.0, timeout_ms)
+        let res = FireoneProtocol::cache(avc, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -241,7 +243,9 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIDI_MESSAGE_MODE_NAME => {
                 let mut params = self.0.clone();
@@ -254,7 +258,9 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_MODE_NAME => {
                 let mut params = self.0.clone();
@@ -267,7 +273,9 @@ impl SpecificCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms).map(|_| true)
+                let res = FireoneProtocol::update(avc, &params, &mut self.0, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }


### PR DESCRIPTION
Like either `snd-bebob-ctl-service` or `snd-dice-ctl-service`, this patchset adds an
option to `snd-oxfw-ctl-service` for logging. The `tracing` and `tracing-subscriber`
crates are used for the function.

```
Takashi Sakamoto (6):
  runtime/oxfw: add cache function in model level
  runtime/oxfw: add logging by tracing crate
  runtime/oxfw: common_ctl: add logging to common controls
  runtime/oxfw: apogee: add logging for specific controls
  runtime/oxfw: loud: add logging for specific controls
  runtime/oxfw: tascam: add logging for specific controls

 README.rst                                   |   3 +-
 runtime/oxfw/Cargo.toml                      |   2 +
 runtime/oxfw/src/apogee_model.rs             | 106 ++++++++++++++-----
 runtime/oxfw/src/bin/snd-oxfw-ctl-service.rs |   6 +-
 runtime/oxfw/src/common_ctl.rs               |  47 +++++---
 runtime/oxfw/src/common_model.rs             |  15 +--
 runtime/oxfw/src/griffin_model.rs            |  14 +--
 runtime/oxfw/src/lacie_model.rs              |  14 +--
 runtime/oxfw/src/lib.rs                      |  35 +++++-
 runtime/oxfw/src/loud_model.rs               |  22 ++--
 runtime/oxfw/src/model.rs                    |  11 ++
 runtime/oxfw/src/tascam_model.rs             |  30 ++++--
 12 files changed, 224 insertions(+), 81 deletions(-)
```