### PR TITLE
[PATCH 0/2] dice: add support for Presonus FireStudio Tube

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -234,6 +234,7 @@ your device, please contact to developer.
   * Focusrite Saffire Pro 26
   * PreSonus FireStudio
   * PreSonus FireStudio Project
+  * PreSonus FireStudio Tube
   * PreSonus FireStudio Mobile
   * For the others, common controls are available. If supported, control extension is also available.
 

--- a/protocols/dice/README.md
+++ b/protocols/dice/README.md
@@ -95,6 +95,7 @@ This is the list of models currently supported.
  * Focusrite Saffire Pro 26
  * PreSonus FireStudio
  * PreSonus FireStudio Project
+ * PreSonus FireStudio Tube
  * PreSonus FireStudio Mobile
 
 For the other models, implementation for common and extension protocol is available without any

--- a/protocols/dice/src/presonus.rs
+++ b/protocols/dice/src/presonus.rs
@@ -10,5 +10,6 @@ pub mod fstudio;
 
 pub mod fstudiomobile;
 pub mod fstudioproject;
+pub mod fstudiotube;
 
 use super::{tcat::*, *};

--- a/protocols/dice/src/presonus/fstudiotube.rs
+++ b/protocols/dice/src/presonus/fstudiotube.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+//! Protocol implementation for PreSonus FireStudio Tube.
+
+use super::{tcat::extension::*, tcat::tcd22xx_spec::*, *};
+
+/// Protocol implementation of PreSonus FireStudio Tube.
+#[derive(Default, Debug)]
+pub struct FStudioTubeProtocol;
+
+impl TcatOperation for FStudioTubeProtocol {}
+
+impl TcatGlobalSectionSpecification for FStudioTubeProtocol {}
+
+impl TcatExtensionOperation for FStudioTubeProtocol {}
+
+impl Tcd22xxSpecification for FStudioTubeProtocol {
+    const INPUTS: &'static [Input] = &[Input {
+        id: SrcBlkId::Ins0,
+        offset: 0,
+        count: 16,
+        label: None,
+    }];
+    const OUTPUTS: &'static [Output] = &[Output {
+        id: DstBlkId::Ins0,
+        offset: 0,
+        count: 8,
+        label: None,
+    }];
+    // MEMO: Analog input 14/15 for Tube amplifier is always used for display metering ignoring
+    // router entries.
+    const FIXED: &'static [SrcBlk] = &[];
+}

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -304,7 +304,15 @@ where
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::cache_extension_notified_params(req, node, sections, caps, &mut self.0, msg, timeout_ms);
+        let res = T::cache_extension_notified_params(
+            req,
+            node,
+            sections,
+            caps,
+            &mut self.0,
+            msg,
+            timeout_ms,
+        );
         debug!(params = ?self.0, ?res);
         res
     }

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -8,9 +8,9 @@ use {
         focusrite::spro26_model::*, focusrite::spro40_model::*, io_fw_model::*, ionix_model::*,
         mbox3_model::*, minimal_model::*, pfire_model::*, presonus::fstudio_model::*,
         presonus::fstudiomobile_model::*, presonus::fstudioproject_model::*,
-        tcelectronic::desktopk6_model::*, tcelectronic::itwin_model::*,
-        tcelectronic::k24d_model::*, tcelectronic::k8_model::*, tcelectronic::klive_model::*,
-        tcelectronic::studiok48_model::*, *,
+        presonus::fstudiotube_model::*, tcelectronic::desktopk6_model::*,
+        tcelectronic::itwin_model::*, tcelectronic::k24d_model::*, tcelectronic::k8_model::*,
+        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, *,
     },
     ieee1212_config_rom::*,
     protocols::tcat::config_rom::*,
@@ -41,6 +41,7 @@ enum Model {
     FocusriteSPro14(SPro14Model),
     FocusriteSPro26(SPro26Model),
     PresonusFStudioProject(FStudioProjectModel),
+    PresonusFStudioTube(FStudioTubeModel),
     PresonusFStudioMobile(FStudioMobileModel),
 }
 
@@ -96,6 +97,7 @@ impl DiceModel {
             (0x00130e, 0x000009) => Model::FocusriteSPro14(Default::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
+            (0x000a92, 0x00000c) => Model::PresonusFStudioTube(FStudioTubeModel::default()),
             (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
@@ -152,6 +154,7 @@ impl DiceModel {
             Model::FocusriteSPro14(m) => m.cache(unit),
             Model::FocusriteSPro26(m) => m.cache(unit),
             Model::PresonusFStudioProject(m) => m.cache(unit),
+            Model::PresonusFStudioTube(m) => m.cache(unit),
             Model::PresonusFStudioMobile(m) => m.cache(unit),
         }
     }
@@ -185,6 +188,7 @@ impl DiceModel {
             Model::FocusriteSPro14(m) => m.load(unit, card_cntr),
             Model::FocusriteSPro26(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioProject(m) => m.load(unit, card_cntr),
+            Model::PresonusFStudioTube(m) => m.load(unit, card_cntr),
             Model::PresonusFStudioMobile(m) => m.load(unit, card_cntr),
         }?;
 
@@ -214,6 +218,7 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => {
                 m.get_notified_elem_list(&mut self.notified_elem_list)
             }
+            Model::PresonusFStudioTube(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::PresonusFStudioMobile(m) => {
                 m.get_notified_elem_list(&mut self.notified_elem_list)
             }
@@ -245,6 +250,7 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => {
                 m.get_measure_elem_list(&mut self.measured_elem_list)
             }
+            Model::PresonusFStudioTube(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::PresonusFStudioMobile(m) => {
                 m.get_measure_elem_list(&mut self.measured_elem_list)
             }
@@ -288,6 +294,9 @@ impl DiceModel {
             Model::FocusriteSPro14(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro26(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::PresonusFStudioProject(m) => {
+                card_cntr.dispatch_elem_event(unit, &elem_id, &events, m)
+            }
+            Model::PresonusFStudioTube(m) => {
                 card_cntr.dispatch_elem_event(unit, &elem_id, &events, m)
             }
             Model::PresonusFStudioMobile(m) => {
@@ -372,6 +381,9 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
+            Model::PresonusFStudioTube(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
@@ -413,6 +425,9 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
+            Model::PresonusFStudioTube(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
@@ -433,6 +448,7 @@ impl DiceModel {
             Model::FocusriteSPro14(m) => m.store_configuration(node),
             Model::FocusriteSPro26(m) => m.store_configuration(node),
             Model::PresonusFStudioProject(m) => m.store_configuration(node),
+            Model::PresonusFStudioTube(m) => m.store_configuration(node),
             Model::PresonusFStudioMobile(m) => m.store_configuration(node),
             _ => Ok(()),
         }

--- a/runtime/dice/src/presonus.rs
+++ b/runtime/dice/src/presonus.rs
@@ -4,5 +4,6 @@ pub mod fstudio_model;
 
 pub mod fstudiomobile_model;
 pub mod fstudioproject_model;
+pub mod fstudiotube_model;
 
 use super::*;

--- a/runtime/dice/src/presonus/fstudiotube_model.rs
+++ b/runtime/dice/src/presonus/fstudiotube_model.rs
@@ -1,0 +1,189 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+use {
+    super::{tcd22xx_ctl::*, *},
+    protocols::{presonus::fstudiotube::*, tcat::extension::*},
+};
+
+#[derive(Default)]
+pub struct FStudioTubeModel {
+    req: FwReq,
+    sections: GeneralSections,
+    extension_sections: ExtensionSections,
+    common_ctl: CommonCtl<FStudioTubeProtocol>,
+    tcd22xx_ctls: Tcd22xxCtls<FStudioTubeProtocol>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl FStudioTubeModel {
+    pub fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+        FStudioTubeProtocol::read_general_sections(
+            &self.req,
+            &unit.1,
+            &mut self.sections,
+            TIMEOUT_MS,
+        )?;
+
+        self.common_ctl
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+
+        FStudioTubeProtocol::read_extension_sections(
+            &self.req,
+            &unit.1,
+            &mut self.extension_sections,
+            TIMEOUT_MS,
+        )?;
+
+        self.tcd22xx_ctls.cache_whole_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.common_ctl.global_params,
+            TIMEOUT_MS,
+        )?;
+
+        Ok(())
+    }
+
+    pub fn store_configuration(&mut self, node: &FwNode) -> Result<(), Error> {
+        self.tcd22xx_ctls.store_configuration(
+            &mut self.req,
+            node,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )
+    }
+}
+
+impl CtlModel<(SndDice, FwNode)> for FStudioTubeModel {
+    fn load(&mut self, _: &mut (SndDice, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr)?;
+
+        self.tcd22xx_ctls.load(card_cntr)?;
+
+        Ok(())
+    }
+
+    fn read(
+        &mut self,
+        _: &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        _: &ElemValue,
+        new: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.write(
+            &unit.0,
+            &self.req,
+            &unit.1,
+            &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.write(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<(SndDice, FwNode), u32> for FStudioTubeModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.notified_elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
+        self.common_ctl.parse_notification(
+            &self.req,
+            &unit.1,
+            &mut self.sections,
+            *msg,
+            TIMEOUT_MS,
+        )?;
+        self.tcd22xx_ctls.parse_notification(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            &self.common_ctl.global_params,
+            TIMEOUT_MS,
+            *msg,
+        )?;
+        Ok(())
+    }
+
+    fn read_notified_elem(
+        &mut self,
+        _: &(SndDice, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl MeasureModel<(SndDice, FwNode)> for FStudioTubeModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
+        elem_id_list.extend_from_slice(&self.tcd22xx_ctls.measured_elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+        self.common_ctl
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+        self.tcd22xx_ctls.cache_partial_params(
+            &mut self.req,
+            &mut unit.1,
+            &self.extension_sections,
+            TIMEOUT_MS,
+        )?;
+        Ok(())
+    }
+
+    fn measure_elem(
+        &mut self,
+        _: &(SndDice, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}


### PR DESCRIPTION
This patchset adds support for Presonus FireStudio Tube. It uses TCAT TCD2210 ASIC and support TCAT protocol extension.

```
Takashi Sakamoto (2):
  protocols/dice: add protocol implementation for FireStudio Tube
  runtime/dice: add support for FireStudio Tube

 README.rst                                    |   1 +
 protocols/dice/README.md                      |   1 +
 protocols/dice/src/presonus.rs                |   1 +
 protocols/dice/src/presonus/fstudiotube.rs    |  34 ++++
 runtime/dice/src/model.rs                     |  22 +-
 runtime/dice/src/presonus.rs                  |   1 +
 .../dice/src/presonus/fstudiotube_model.rs    | 189 ++++++++++++++++++
 7 files changed, 246 insertions(+), 3 deletions(-)
 create mode 100644 protocols/dice/src/presonus/fstudiotube.rs
 create mode 100644 runtime/dice/src/presonus/fstudiotube_model.rs
```