### PR TITLE
[PATCH 0/4] protocols/fireface: fix for microphone phantom powering and instrument

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ members = [
     "protocols/oxfw",
     "protocols/bebob",
     "protocols/dice",
-#    "protocols/fireface",
+    "protocols/fireface",
 ]
 
 # For development purpose.
@@ -38,7 +38,7 @@ firewire-bebob-protocols = { path = "protocols/bebob" }
 #firewire-digi00x-protocols = { path = "protocols/digi00x" }
 firewire-dice-protocols = { path = "protocols/dice" }
 #firewire-fireworks-protocols = { path = "protocols/fireworks" }
-#firewire-fireface-protocols = { path = "protocols/fireface" }
+firewire-fireface-protocols = { path = "protocols/fireface" }
 #firewire-motu-protocols = { path = "protocols/motu" }
 firewire-oxfw-protocols = { path = "protocols/oxfw" }
 #firewire-tascam-protocols = { path = "protocols/tascam" }

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -776,6 +776,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
     const PHYS_OUTPUT_BALANCE_STEP: i32 = 1;
 
     const CH_OFFSET: u8 = Self::PHYS_INPUT_COUNT as u8;
+    const OUTPUT_PAIR_COUNT: usize = Self::OUTPUT_COUNT / 2;
 
     fn init_output(
         req: &mut FwReq,
@@ -802,16 +803,16 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
     }
 
     fn output_state_to_cmds(state: &FfLatterOutputState) -> Vec<u32> {
-        assert_eq!(state.vols.len(), Self::PHYS_INPUT_COUNT);
-        assert_eq!(state.stereo_balance.len(), Self::PHYS_INPUT_COUNT / 2);
-        assert_eq!(state.stereo_links.len(), Self::PHYS_INPUT_COUNT / 2);
-        assert_eq!(state.invert_phases.len(), Self::PHYS_INPUT_COUNT);
+        assert_eq!(state.vols.len(), Self::OUTPUT_COUNT);
+        assert_eq!(state.stereo_balance.len(), Self::OUTPUT_PAIR_COUNT);
+        assert_eq!(state.stereo_links.len(), Self::OUTPUT_PAIR_COUNT);
+        assert_eq!(state.invert_phases.len(), Self::OUTPUT_COUNT);
         assert_eq!(state.line_levels.len(), Self::LINE_OUTPUT_COUNT);
 
         let mut cmds = Vec::new();
 
         state.vols.iter().enumerate().for_each(|(i, &vol)| {
-            let ch = (Self::PHYS_INPUT_COUNT + i) as u8;
+            let ch = Self::CH_OFFSET + i as u8;
             cmds.push(create_phys_port_cmd(ch, OUTPUT_VOL_CMD, vol));
         });
 
@@ -820,7 +821,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
             .iter()
             .enumerate()
             .for_each(|(i, &balance)| {
-                let ch = (Self::PHYS_INPUT_COUNT + i * 2) as u8;
+                let ch = Self::CH_OFFSET + i as u8;
                 cmds.push(create_phys_port_cmd(ch, OUTPUT_STEREO_BALANCE_CMD, balance));
             });
 
@@ -829,7 +830,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
             .iter()
             .enumerate()
             .for_each(|(i, &link)| {
-                let ch = (Self::PHYS_INPUT_COUNT + i * 2) as u8;
+                let ch = Self::CH_OFFSET + i as u8;
                 cmds.push(create_phys_port_cmd(
                     ch,
                     OUTPUT_STEREO_LINK_CMD,
@@ -842,7 +843,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
             .iter()
             .enumerate()
             .for_each(|(i, &invert_phase)| {
-                let ch = (Self::PHYS_INPUT_COUNT + i) as u8;
+                let ch = Self::CH_OFFSET + i as u8;
                 cmds.push(create_phys_port_cmd(
                     ch,
                     OUTPUT_INVERT_PHASE_CMD,
@@ -855,7 +856,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
             .iter()
             .enumerate()
             .for_each(|(i, &line_level)| {
-                let ch = (Self::PHYS_INPUT_COUNT + i) as u8;
+                let ch = Self::CH_OFFSET + i as u8;
                 cmds.push(create_phys_port_cmd(
                     ch,
                     OUTPUT_LINE_LEVEL_CMD,

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -282,17 +282,21 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
             }
             INPUT_LINE_LEVEL_NAME => {
                 let mut state = self.state().input.clone();
-                let vals = &elem_value.enumerated()[..state.line_levels.len()];
-                vals.iter().enumerate().try_for_each(|(i, &pos)| {
-                    Self::LINE_LEVELS
-                        .iter()
-                        .nth(pos as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index of input nominal level: {}", pos);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&l| state.line_levels[i] = l)
-                })?;
+                state
+                    .line_levels
+                    .iter_mut()
+                    .zip(elem_value.enumerated())
+                    .try_for_each(|(level, &val)| {
+                        let pos = val as usize;
+                        Self::LINE_LEVELS
+                            .iter()
+                            .nth(pos)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid index of input nominal level: {}", pos);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| *level = l)
+                    })?;
                 T::write_input(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
             INPUT_MIC_POWER_NAME => {
@@ -507,17 +511,21 @@ pub trait FfLatterOutputCtlOperation<T: RmeFfLatterOutputOperation>:
             }
             LINE_LEVEL_NAME => {
                 let mut state = self.state().output.clone();
-                let vals = elem_value.enumerated();
-                vals.iter().enumerate().try_for_each(|(i, &pos)| {
-                    Self::LINE_LEVELS
-                        .iter()
-                        .nth(pos as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid for index of output nominal level: {}", pos);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&l| state.line_levels[i] = l)
-                })?;
+                state
+                    .line_levels
+                    .iter_mut()
+                    .zip(elem_value.enumerated())
+                    .try_for_each(|(level, &val)| {
+                        let pos = val as usize;
+                        Self::LINE_LEVELS
+                            .iter()
+                            .nth(pos)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid for index of output nominal level: {}", pos);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&l| *level = l)
+                    })?;
                 T::write_output(req, &mut unit.1, self.state_mut(), state, timeout_ms).map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -195,7 +195,7 @@ pub trait FfLatterInputCtlOperation<T: RmeFfLatterInputOperation>:
         let _ = card_cntr.add_enum_elems(&elem_id, 1, T::LINE_INPUT_COUNT, &labels, None, true)?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_MIC_POWER_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, T::LINE_INPUT_COUNT, true)?;
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, T::MIC_INPUT_COUNT, true)?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_MIC_INST_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, T::MIC_INPUT_COUNT, true)?;


### PR DESCRIPTION
This patchset fixes protocol implementation for microphone phantom powering and instrument. The issue was reported at #44 . Additionally, fix mic bugs as well.

```
Takashi Sakamoto (4):
  fireface/protocols: start crate development for v0.2.0
  protocols/fireface: fix invalid index of microphone inputs
  runtime/fireface: fix out-of-bounds access
  runtime/fireface: fix invalid channel count for output parameters in
    latter models

 Cargo.toml                          |  4 +--
 protocols/fireface/src/latter.rs    | 44 ++++++++++++-----------
 runtime/fireface/src/latter_ctls.rs | 54 +++++++++++++++++------------
 3 files changed, 56 insertions(+), 46 deletions(-)
```