### PR TITLE
[PATCH 00/18] runtime/fireface: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2022/11/07
+2023/03/05
 Takashi Sakamoto
 
 Introduction
@@ -281,6 +281,7 @@ Currently this function is available for below executables:
 * snd-bebob-ctl-service
 * snd-dice-ctl-service
 * snd-oxfw-ctl-service
+* snd-fireface-ctl-service
 
 This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
 `tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.

--- a/protocols/fireface/src/bin/ff-config-rom-parser.rs
+++ b/protocols/fireface/src/bin/ff-config-rom-parser.rs
@@ -4,7 +4,10 @@
 use {
     firewire_fireface_protocols as protocols,
     glib::FileError,
-    hinawa::{prelude::{FwNodeExt, FwNodeExtManual}, FwNode, FwNodeError},
+    hinawa::{
+        prelude::{FwNodeExt, FwNodeExtManual},
+        FwNode, FwNodeError,
+    },
     ieee1212_config_rom::*,
     protocols::*,
     std::{convert::TryFrom, io::Read},

--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -7,9 +7,9 @@ pub mod ff400;
 pub mod ff800;
 
 use {
+    super::*,
     glib::Error,
     hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-    super::*,
 };
 
 /// State of hardware meter.

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -4,13 +4,13 @@
 //! Protocol defined by RME GmbH for Fireface 400.
 
 use {
+    super::*,
     glib::Error,
     hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-    super::*,
 };
 
 /// The protocol implementation for Fireface 400.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Ff400Protocol;
 
 const MIXER_OFFSET: usize = 0x000080080000;

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -5,10 +5,9 @@
 use hinawa::{FwNode, FwReq};
 
 use super::*;
-use crate::*;
 
 /// Unique protocol for Fireface 800.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug)]
 pub struct Ff800Protocol;
 
 const MIXER_OFFSET: usize = 0x000080080000;

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -7,9 +7,9 @@ pub mod ff802;
 pub mod ucx;
 
 use {
+    super::*,
     glib::Error,
     hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-    super::*,
 };
 
 const CFG_OFFSET: usize = 0xffff00000014;

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -3,13 +3,10 @@
 
 //! Protocol defined by RME GmbH for Fireface 802.
 
-use {
-    super::*,
-    crate::*,
-};
+use super::*;
 
 /// Unique protocol for 802.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug)]
 pub struct Ff802Protocol;
 
 // For configuration register (0x'ffff'0000'0014).

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -3,13 +3,10 @@
 
 //! Protocol defined by RME GmbH for Fireface UCX.
 
-use {
-    super::*,
-    crate::*,
-};
+use super::*;
 
 /// Unique protocol for UCX.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug)]
 pub struct FfUcxProtocol;
 
 // For configuration register (0x'ffff'0000'0014).

--- a/runtime/fireface/Cargo.toml
+++ b/runtime/fireface/Cargo.toml
@@ -21,3 +21,5 @@ ieee1212-config-rom = "0.1"
 firewire-fireface-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
+++ b/runtime/fireface/src/bin/snd-fireface-ctl-service.rs
@@ -14,11 +14,15 @@ struct FfServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, FfRuntime> for FfServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -23,12 +23,8 @@ pub struct Ff400Model {
 
 const TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl Ff400Model {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.out_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -41,6 +37,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
         self.cfg_ctl
             .cache(&mut self.req, &mut unit.1, &self.status_ctl.1, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
         self.out_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -14,7 +14,7 @@ use {
 pub struct Ff400Model {
     req: FwReq,
     meter_ctl: FormerMeterCtl<Ff400Protocol>,
-    out_ctl: OutputCtl,
+    out_ctl: FormerOutputCtl<Ff400Protocol>,
     input_gain_ctl: InputGainCtl,
     mixer_ctl: MixerCtl,
     status_ctl: StatusCtl,
@@ -31,10 +31,10 @@ impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
     ) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.out_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.meter_ctl.load(card_cntr)?;
-        self.out_ctl
-            .load(unit, &mut self.req, card_cntr, TIMEOUT_MS)?;
+        self.out_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(unit, &mut self.req, card_cntr, TIMEOUT_MS)?;
         self.input_gain_ctl
@@ -81,7 +81,7 @@ impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
     ) -> Result<bool, Error> {
         if self
             .out_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -132,19 +132,6 @@ impl MeasureModel<(SndUnit, FwNode)> for Ff400Model {
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct OutputCtl(FormerOutputVolumeState);
-
-impl FormerOutputCtlOperation<Ff400Protocol> for OutputCtl {
-    fn state(&self) -> &FormerOutputVolumeState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut FormerOutputVolumeState {
-        &mut self.0
     }
 }
 

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -15,8 +15,8 @@ pub struct Ff400Model {
     req: FwReq,
     meter_ctl: FormerMeterCtl<Ff400Protocol>,
     out_ctl: FormerOutputCtl<Ff400Protocol>,
+    mixer_ctl: FormerMixerCtl<Ff400Protocol>,
     input_gain_ctl: InputGainCtl,
-    mixer_ctl: MixerCtl,
     status_ctl: StatusCtl,
     cfg_ctl: CfgCtl,
 }
@@ -32,11 +32,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.out_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.out_ctl.load(card_cntr)?;
-        self.mixer_ctl
-            .load(unit, &mut self.req, card_cntr, TIMEOUT_MS)?;
+        self.mixer_ctl.load(card_cntr)?;
         self.input_gain_ctl
             .load(unit, &mut self.req, card_cntr, TIMEOUT_MS)?;
         self.status_ctl
@@ -86,7 +87,7 @@ impl CtlModel<(SndUnit, FwNode)> for Ff400Model {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -132,19 +133,6 @@ impl MeasureModel<(SndUnit, FwNode)> for Ff400Model {
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MixerCtl(FormerMixerState);
-
-impl FormerMixerCtlOperation<Ff400Protocol> for MixerCtl {
-    fn state(&self) -> &FormerMixerState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut FormerMixerState {
-        &mut self.0
     }
 }
 

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -166,7 +166,9 @@ impl InputGainCtl {
     };
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Ff400Protocol::init_input_gains(req, node, &mut self.1, timeout_ms)
+        let res = Ff400Protocol::init_input_gains(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -233,14 +235,16 @@ impl InputGainCtl {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as i8);
-                Ff400Protocol::write_input_mic_gains(
+                let res = Ff400Protocol::write_input_mic_gains(
                     req,
                     node,
                     &mut self.1,
                     &params.mic,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(?params, ?res);
+                self.1 = params;
+                res.map(|_| true)
             }
             LINE_GAIN_NAME => {
                 let mut params = self.1.clone();
@@ -249,14 +253,16 @@ impl InputGainCtl {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as i8);
-                Ff400Protocol::write_input_line_gains(
+                let res = Ff400Protocol::write_input_line_gains(
                     req,
                     node,
                     &mut self.1,
                     &params.line,
                     timeout_ms,
-                )
-                .map(|_| true)
+                );
+                debug!(?params, ?res);
+                self.1 = params;
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -305,7 +311,9 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Ff400Protocol::read_status(req, node, &mut self.1, timeout_ms)
+        let res = Ff400Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -437,7 +445,9 @@ impl CfgCtl {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         self.0.init(&status);
-        Ff400Protocol::write_cfg(req, node, &self.0, timeout_ms)
+        let res = Ff400Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -659,9 +669,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             LINE_INPUT_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -674,9 +685,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             MIC_POWER_NAME => {
                 let mut params = self.0.clone();
@@ -686,9 +698,10 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             LINE_INST_NAME => {
                 let mut params = self.0.clone();
@@ -698,9 +711,10 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             LINE_PAD_NAME => {
                 let mut params = self.0.clone();
@@ -710,9 +724,10 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             LINE_OUTPUT_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -725,9 +740,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             HP_OUTPUT_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -741,9 +757,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_INPUT_IFACE_NAME => {
                 let mut params = self.0.clone();
@@ -756,16 +773,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_in.use_preemble = elem_value.boolean()[0];
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_FMT_NAME => {
                 let mut params = self.0.clone();
@@ -778,23 +797,26 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_EMPHASIS_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.emphasis = elem_value.boolean()[0];
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.non_audio = elem_value.boolean()[0];
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             OPT_OUTPUT_SIGNAL_NAME => {
                 let mut params = self.0.clone();
@@ -808,16 +830,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                Ff400Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -15,8 +15,8 @@ pub struct Ff800Model {
     meter_ctl: FormerMeterCtl<Ff800Protocol>,
     out_ctl: FormerOutputCtl<Ff800Protocol>,
     mixer_ctl: FormerMixerCtl<Ff800Protocol>,
-    cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
+    cfg_ctl: CfgCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -32,19 +32,16 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
         self.out_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.status_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.cfg_ctl
+            .cache(&mut self.req, &mut unit.1, &self.status_ctl.1, TIMEOUT_MS)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.out_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
-        self.status_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.cfg_ctl.load(
-            unit,
-            &mut self.req,
-            &self.status_ctl.status,
-            card_cntr,
-            TIMEOUT_MS,
-        )?;
+        self.status_ctl.load(card_cntr)?;
+        self.cfg_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -61,6 +58,8 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
+        } else if self.status_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -72,7 +71,7 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self
@@ -81,12 +80,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
         {
             Ok(true)
         } else if self
-            .cfg_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
+            .mixer_ctl
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
-            .mixer_ctl
+            .cfg_ctl
             .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
@@ -99,14 +98,14 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
 impl MeasureModel<(SndUnit, FwNode)> for Ff800Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.0);
-        elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
+        elem_id_list.extend_from_slice(&self.status_ctl.0);
     }
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.status_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -118,27 +117,12 @@ impl MeasureModel<(SndUnit, FwNode)> for Ff800Model {
     ) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.status_ctl.measure_elem(elem_id, elem_value)? {
+        } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
         }
     }
-}
-
-fn update_cfg<F>(
-    unit: &mut (SndUnit, FwNode),
-    req: &mut FwReq,
-    cfg: &mut Ff800Config,
-    timeout_ms: u32,
-    cb: F,
-) -> Result<(), Error>
-where
-    F: Fn(&mut Ff800Config) -> Result<(), Error>,
-{
-    let mut cache = cfg.clone();
-    cb(&mut cache)?;
-    Ff800Protocol::write_cfg(req, &mut unit.1, &cache, timeout_ms).map(|_| *cfg = cache)
 }
 
 fn clk_src_to_string(src: &Ff800ClkSrc) -> String {
@@ -163,10 +147,7 @@ fn line_in_jack_to_string(jack: &Ff800AnalogInputJack) -> String {
 }
 
 #[derive(Default, Debug)]
-struct StatusCtl {
-    status: Ff800Status,
-    measured_elem_list: Vec<ElemId>,
-}
+struct StatusCtl(Vec<ElemId>, Ff800Status);
 
 const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
 const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
@@ -196,15 +177,11 @@ impl StatusCtl {
         Some(ClkNominalRate::R192000),
     ];
 
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        Ff800Protocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)?;
+    fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
+        Ff800Protocol::read_status(req, node, &mut self.1, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = CfgCtl::CLK_SRCS
             .iter()
             .map(|s| clk_src_to_string(s))
@@ -218,7 +195,7 @@ impl StatusCtl {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr
                     .add_bool_elems(&elem_id, 1, Self::EXT_SRCS.len(), false)
-                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+                    .map(|mut elem_id_list| self.0.append(&mut elem_id_list))
             })?;
 
         let labels: Vec<String> = Self::EXT_SRC_RATES
@@ -228,45 +205,36 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SPDIF_SRC_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn measure_states(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        Ff800Protocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)
-    }
-
-    fn measure_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
-                    self.status.lock.spdif,
-                    self.status.lock.adat_a,
-                    self.status.lock.adat_b,
-                    self.status.lock.word_clock,
-                    self.status.lock.tco,
+                    self.1.lock.spdif,
+                    self.1.lock.adat_a,
+                    self.1.lock.adat_b,
+                    self.1.lock.word_clock,
+                    self.1.lock.tco,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EXT_SRC_SYNC_NAME => {
                 let vals = [
-                    self.status.sync.spdif,
-                    self.status.sync.adat_a,
-                    self.status.sync.adat_b,
-                    self.status.sync.word_clock,
-                    self.status.sync.tco,
+                    self.1.sync.spdif,
+                    self.1.sync.adat_a,
+                    self.1.sync.adat_b,
+                    self.1.sync.word_clock,
+                    self.1.sync.tco,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
@@ -274,7 +242,7 @@ impl StatusCtl {
             SPDIF_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES
                     .iter()
-                    .position(|r| r.eq(&self.status.spdif_rate))
+                    .position(|r| r.eq(&self.1.spdif_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
@@ -282,7 +250,7 @@ impl StatusCtl {
             EXT_SRC_RATE_NAME => {
                 let pos = Self::EXT_SRC_RATES
                     .iter()
-                    .position(|r| r.eq(&self.status.external_clk_rate))
+                    .position(|r| r.eq(&self.1.external_clk_rate))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
@@ -290,7 +258,7 @@ impl StatusCtl {
             ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS
                     .iter()
-                    .position(|s| s.eq(&self.status.active_clk_src))
+                    .position(|s| s.eq(&self.1.active_clk_src))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
@@ -359,17 +327,18 @@ impl CfgCtl {
     const OPT_OUT_SIGNALS: [OpticalOutputSignal; 2] =
         [OpticalOutputSignal::Adat, OpticalOutputSignal::Spdif];
 
-    fn load(
+    fn cache(
         &mut self,
-        unit: &mut (SndUnit, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         status: &Ff800Status,
-        card_cntr: &mut CardCntr,
         timeout_ms: u32,
     ) -> Result<(), Error> {
         self.0.init(&status);
-        Ff800Protocol::write_cfg(req, &mut unit.1, &self.0, timeout_ms)?;
+        Ff800Protocol::write_cfg(req, node, &self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = Self::CLK_SRCS
             .iter()
             .map(|s| clk_src_to_string(s))
@@ -458,22 +427,25 @@ impl CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            PRIMARY_CLK_SRC_NAME => {
                 let pos = Self::CLK_SRCS
                     .iter()
                     .position(|s| s.eq(&self.0.clk.primary_src))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            INPUT_JACK_NAME => ElemValueAccessor::<u32>::set_vals(elem_value, 3, |idx| {
-                let pos = Self::INPUT_JACKS
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            INPUT_JACK_NAME => {
+                let vals: Vec<u32> = self
+                    .0
+                    .analog_in
+                    .jacks
                     .iter()
-                    .position(|j| j.eq(&self.0.analog_in.jacks[idx]))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .map(|jack| Self::INPUT_JACKS.iter().position(|j| j.eq(jack)).unwrap() as u32)
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
+            }
             INPUT_LINE_LEVEL_NAME => {
                 let pos = Self::INPUT_LINE_LEVELS
                     .iter()
@@ -498,34 +470,34 @@ impl CfgCtl {
                 elem_value.set_bool(&[self.0.analog_in.inst.speaker_emulation]);
                 Ok(true)
             }
-            OUTPUT_LINE_LEVEL_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            OUTPUT_LINE_LEVEL_NAME => {
                 let pos = Self::OUTPUT_LINE_LEVELS
                     .iter()
                     .position(|l| l.eq(&self.0.line_out_level))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            SPDIF_INPUT_IFACE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
+            SPDIF_INPUT_IFACE_NAME => {
                 let pos = Self::SPDIF_IFACES
                     .iter()
                     .position(|i| i.eq(&self.0.spdif_in.iface))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
             SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 elem_value.set_bool(&[self.0.spdif_in.use_preemble]);
                 Ok(true)
             }
-            SPDIF_OUTPUT_FMT_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            SPDIF_OUTPUT_FMT_NAME => {
                 let pos = Self::SPDIF_FMTS
                     .iter()
                     .position(|f| f.eq(&self.0.spdif_out.format))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
             SPDIF_OUTPUT_EMPHASIS_NAME => {
                 elem_value.set_bool(&[self.0.spdif_out.emphasis]);
                 Ok(true)
@@ -534,14 +506,14 @@ impl CfgCtl {
                 elem_value.set_bool(&[self.0.spdif_out.non_audio]);
                 Ok(true)
             }
-            OPT_OUTPUT_SIGNAL_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            OPT_OUTPUT_SIGNAL_NAME => {
                 let pos = Self::OPT_OUT_SIGNALS
                     .iter()
                     .position(|f| f.eq(&self.0.opt_out_signal))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos as u32]);
+                Ok(true)
+            }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
@@ -552,166 +524,187 @@ impl CfgCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndUnit, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
-                        let msg = format!("Invalid value for index of clock source: {}", val);
+            PRIMARY_CLK_SRC_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.clk.primary_src = Self::CLK_SRCS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of clock source: {}", pos);
                         Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            INPUT_JACK_NAME => {
+                let mut params = self.0.clone();
+                params
+                    .analog_in
+                    .jacks
+                    .iter_mut()
+                    .zip(elem_value.enumerated())
+                    .try_for_each(|(jack, &val)| {
+                        let pos = val as usize;
+                        Self::INPUT_JACKS
+                            .iter()
+                            .nth(pos)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid value for index of jack: {}", pos);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|j| *jack = *j)
                     })?;
-                    cfg.clk.primary_src = *src;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            INPUT_JACK_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_vals(new, old, 3, |idx, val| {
-                    let jack = Self::INPUT_JACKS.iter().nth(val as usize).ok_or_else(|| {
-                        let msg = format!("Invalid value for index of jack: {}", val);
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            INPUT_LINE_LEVEL_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.analog_in.line_level = Self::INPUT_LINE_LEVELS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of line input level: {}", pos);
                         Error::new(FileError::Inval, &msg)
-                    })?;
-                    cfg.analog_in.jacks[idx] = *jack;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            INPUT_LINE_LEVEL_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    Self::INPUT_LINE_LEVELS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg =
-                                format!("Invalid value for index of line input level: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&l| cfg.analog_in.line_level = l)
-                })
-            })
-            .map(|_| true),
-            INPUT_POWER_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                cfg.analog_in
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            INPUT_POWER_NAME => {
+                let mut params = self.0.clone();
+                params
+                    .analog_in
                     .phantom_powering
                     .iter_mut()
-                    .zip(new.boolean())
+                    .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                Ok(())
-            })
-            .map(|_| true),
-            INPUT_INST_DRIVE_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.analog_in.inst.drive = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            INPUT_INST_LIMITTER_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.analog_in.inst.limitter = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            INPUT_INST_SPKR_EMU_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.analog_in.inst.speaker_emulation = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            OUTPUT_LINE_LEVEL_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    Self::OUTPUT_LINE_LEVELS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg =
-                                format!("Invalid value for index of line output level: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&l| cfg.line_out_level = l)
-                })
-            })
-            .map(|_| true),
-            SPDIF_INPUT_IFACE_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    Self::SPDIF_IFACES
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid value for index of S/PDIF iface: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&i| cfg.spdif_in.iface = i)
-                })
-            })
-            .map(|_| true),
-            SPDIF_INPUT_USE_PREEMBLE_NAME => {
-                update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                    ElemValueAccessor::<bool>::get_val(new, |val| {
-                        cfg.spdif_in.use_preemble = val;
-                        Ok(())
-                    })
-                })
-                .map(|_| true)
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
             }
-            SPDIF_OUTPUT_FMT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    Self::SPDIF_FMTS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid value for index of S/PDIF format: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&f| cfg.spdif_out.format = f)
-                })
-            })
-            .map(|_| true),
-            SPDIF_OUTPUT_EMPHASIS_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.spdif_out.emphasis = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            SPDIF_OUTPUT_NON_AUDIO_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.spdif_out.non_audio = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            OPT_OUTPUT_SIGNAL_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(new, |val| {
-                    Self::OPT_OUT_SIGNALS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!(
-                                "Invalid value for index of optical output signal: {}",
-                                val
-                            );
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&s| cfg.opt_out_signal = s)
-                })
-            })
-            .map(|_| true),
-            WORD_CLOCK_SINGLE_SPPED_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(new, |val| {
-                    cfg.word_out_single = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
+            INPUT_INST_DRIVE_NAME => {
+                let mut params = self.0.clone();
+                params.analog_in.inst.drive = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            INPUT_INST_LIMITTER_NAME => {
+                let mut params = self.0.clone();
+                params.analog_in.inst.limitter = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            INPUT_INST_SPKR_EMU_NAME => {
+                let mut params = self.0.clone();
+                params.analog_in.inst.speaker_emulation = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            OUTPUT_LINE_LEVEL_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.line_out_level = Self::OUTPUT_LINE_LEVELS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of line output level: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_INPUT_IFACE_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.spdif_in.iface = Self::SPDIF_IFACES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of S/PDIF iface: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_INPUT_USE_PREEMBLE_NAME => {
+                let mut params = self.0.clone();
+                params.spdif_in.use_preemble = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_OUTPUT_FMT_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.spdif_out.format = Self::SPDIF_FMTS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of S/PDIF format: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_OUTPUT_EMPHASIS_NAME => {
+                let mut params = self.0.clone();
+                params.spdif_out.emphasis = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_OUTPUT_NON_AUDIO_NAME => {
+                let mut params = self.0.clone();
+                params.spdif_out.non_audio = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            OPT_OUTPUT_SIGNAL_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.opt_out_signal = Self::OPT_OUT_SIGNALS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg =
+                            format!("Invalid value for index of optical output signal: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
+                let mut params = self.0.clone();
+                params.word_out_single = elem_value.boolean()[0];
+                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -180,7 +180,9 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Ff800Protocol::read_status(req, node, &mut self.1, timeout_ms)
+        let res = Ff800Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -337,7 +339,9 @@ impl CfgCtl {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         self.0.init(&status);
-        Ff800Protocol::write_cfg(req, node, &self.0, timeout_ms)
+        let res = Ff800Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -544,9 +548,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_JACK_NAME => {
                 let mut params = self.0.clone();
@@ -566,9 +571,10 @@ impl CfgCtl {
                             })
                             .map(|j| *jack = *j)
                     })?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_LINE_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -581,9 +587,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_POWER_NAME => {
                 let mut params = self.0.clone();
@@ -593,30 +600,34 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_INST_DRIVE_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.drive = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_INST_LIMITTER_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.limitter = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             INPUT_INST_SPKR_EMU_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.speaker_emulation = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             OUTPUT_LINE_LEVEL_NAME => {
                 let mut params = self.0.clone();
@@ -629,9 +640,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_INPUT_IFACE_NAME => {
                 let mut params = self.0.clone();
@@ -644,16 +656,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_in.use_preemble = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_FMT_NAME => {
                 let mut params = self.0.clone();
@@ -666,23 +680,26 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_EMPHASIS_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.emphasis = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.non_audio = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             OPT_OUTPUT_SIGNAL_NAME => {
                 let mut params = self.0.clone();
@@ -696,16 +713,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                Ff800Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -21,12 +21,8 @@ pub struct Ff800Model {
 
 const TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl Ff800Model {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.out_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -37,6 +33,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
         self.cfg_ctl
             .cache(&mut self.req, &mut unit.1, &self.status_ctl.1, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for Ff800Model {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
         self.out_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -172,7 +172,9 @@ impl CfgCtl {
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Ff802Protocol::write_cfg(req, node, &self.0, timeout_ms)
+        let res = Ff802Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -280,9 +282,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_INPUT_IFACE_NAME => {
                 let mut params = self.0.clone();
@@ -295,9 +298,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             OPT_OUTPUT_SIGNAL_NAME => {
                 let mut params = self.0.clone();
@@ -311,16 +315,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             EFFECT_ON_INPUT_NAME => {
                 let mut params = self.0.clone();
                 params.effect_on_inputs = elem_value.boolean()[0];
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_FMT_NAME => {
                 let mut params = self.0.clone();
@@ -333,16 +339,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -380,7 +388,9 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Ff802Protocol::read_status(req, node, &mut self.1, timeout_ms)
+        let res = Ff802Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -20,12 +20,8 @@ pub struct Ff802Model {
 
 const TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl Ff802Model {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -33,6 +29,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
         self.status_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
         self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -29,13 +29,14 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.cfg_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.status_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.dsp_ctl.load(card_cntr)?;
-        self.cfg_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.status_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.cfg_ctl.load(card_cntr)?;
+        self.status_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -51,6 +52,8 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
             Ok(true)
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
+        } else if self.status_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -61,16 +64,16 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .dsp_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .cfg_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -82,14 +85,14 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
 impl MeasureModel<(SndUnit, FwNode)> for Ff802Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.0);
-        elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
+        elem_id_list.extend_from_slice(&self.status_ctl.0);
     }
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.status_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -101,7 +104,7 @@ impl MeasureModel<(SndUnit, FwNode)> for Ff802Model {
     ) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.status_ctl.read_measured_elem(elem_id, elem_value)? {
+        } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -126,21 +129,6 @@ fn ff802_spdif_iface_to_string(iface: &Ff802SpdifIface) -> String {
         Ff802SpdifIface::Optical => "Optical",
     }
     .to_string()
-}
-
-fn update_cfg<F>(
-    unit: &mut (SndUnit, FwNode),
-    req: &mut FwReq,
-    cfg: &mut Ff802Config,
-    timeout_ms: u32,
-    cb: F,
-) -> Result<(), Error>
-where
-    F: Fn(&mut Ff802Config) -> Result<(), Error>,
-{
-    let mut cache = cfg.clone();
-    cb(&mut cache)?;
-    Ff802Protocol::write_cfg(req, &mut unit.1, &cache, timeout_ms).map(|_| *cfg = cache)
 }
 
 #[derive(Default, Debug)]
@@ -181,15 +169,11 @@ impl CfgCtl {
 
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        Ff802Protocol::write_cfg(req, &mut unit.1, &self.0, timeout_ms)?;
+    fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
+        Ff802Protocol::write_cfg(req, node, &self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = Self::CLK_SRCS
             .iter()
             .map(|s| clk_src_to_string(s))
@@ -230,42 +214,42 @@ impl CfgCtl {
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            PRIMARY_CLK_SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            PRIMARY_CLK_SRC_NAME => {
                 let pos = Self::CLK_SRCS
                     .iter()
-                    .position(|s| s.eq(&self.0.clk_src))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            SPDIF_INPUT_IFACE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    .position(|src| self.0.clk_src.eq(src))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            SPDIF_INPUT_IFACE_NAME => {
                 let pos = Self::SPDIF_IFACES
                     .iter()
-                    .position(|i| i.eq(&self.0.spdif_in_iface))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
-            OPT_OUTPUT_SIGNAL_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+                    .position(|iface| self.0.spdif_in_iface.eq(iface))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            OPT_OUTPUT_SIGNAL_NAME => {
                 let pos = Self::OPT_OUT_SIGNALS
                     .iter()
-                    .position(|f| f.eq(&self.0.opt_out_signal))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .position(|fmt| self.0.opt_out_signal.eq(fmt))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
             EFFECT_ON_INPUT_NAME => {
                 elem_value.set_bool(&[self.0.effect_on_inputs]);
                 Ok(true)
             }
-            SPDIF_OUTPUT_FMT_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
+            SPDIF_OUTPUT_FMT_NAME => {
                 let pos = Self::SPDIF_FMTS
                     .iter()
-                    .position(|f| f.eq(&self.0.spdif_out_format))
-                    .unwrap();
-                Ok(pos as u32)
-            })
-            .map(|_| true),
+                    .position(|fmt| self.0.spdif_out_format.eq(fmt))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 elem_value.set_bool(&[self.0.word_out_single]);
                 Ok(true)
@@ -276,88 +260,95 @@ impl CfgCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndUnit, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
-                        let msg = format!("Invalid value for index of clock source: {}", val);
+            PRIMARY_CLK_SRC_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.clk_src = Self::CLK_SRCS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of clock source: {}", pos);
                         Error::new(FileError::Inval, &msg)
-                    })?;
-                    cfg.clk_src = *src;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            SPDIF_INPUT_IFACE_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    Self::SPDIF_IFACES
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid value for index of S/PDIF iface: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&i| cfg.spdif_in_iface = i)
-                })
-            })
-            .map(|_| true),
-            OPT_OUTPUT_SIGNAL_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    Self::OPT_OUT_SIGNALS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!(
-                                "Invalid value for index of optical output signal: {}",
-                                val
-                            );
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&s| cfg.opt_out_signal = s)
-                })
-            })
-            .map(|_| true),
-            EFFECT_ON_INPUT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                cfg.effect_on_inputs = elem_value.boolean()[0];
-                Ok(())
-            })
-            .map(|_| true),
-            SPDIF_OUTPUT_FMT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    Self::SPDIF_FMTS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid value for index of S/PDIF format: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&f| cfg.spdif_out_format = f)
-                })
-            })
-            .map(|_| true),
-            WORD_CLOCK_SINGLE_SPPED_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(elem_value, |val| {
-                    cfg.word_out_single = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
+                    })
+                    .copied()?;
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_INPUT_IFACE_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.spdif_in_iface = Self::SPDIF_IFACES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of S/PDIF iface: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            OPT_OUTPUT_SIGNAL_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.opt_out_signal = Self::OPT_OUT_SIGNALS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg =
+                            format!("Invalid value for index of optical output signal: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            EFFECT_ON_INPUT_NAME => {
+                let mut params = self.0.clone();
+                params.effect_on_inputs = elem_value.boolean()[0];
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_OUTPUT_FMT_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.spdif_out_format = Self::SPDIF_FMTS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of S/PDIF format: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
+                let mut params = self.0.clone();
+                params.word_out_single = elem_value.boolean()[0];
+                Ff802Protocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 }
 
 #[derive(Default, Debug)]
-struct StatusCtl {
-    status: Ff802Status,
-    measured_elem_list: Vec<ElemId>,
-}
+struct StatusCtl(Vec<ElemId>, Ff802Status);
 
 const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
 const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
@@ -386,22 +377,18 @@ impl StatusCtl {
         Some(ClkNominalRate::R192000),
     ];
 
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        Ff802Protocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)?;
+    fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
+        Ff802Protocol::read_status(req, node, &mut self.1, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME]
             .iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr
                     .add_bool_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), false)
-                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+                    .map(|mut elem_id_list| self.0.append(&mut elem_id_list))
             })?;
 
         let labels: Vec<String> = Self::EXT_CLK_RATES
@@ -411,7 +398,7 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS
             .iter()
@@ -420,7 +407,7 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_RATES
             .iter()
@@ -429,48 +416,39 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn measure_states(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        Ff802Protocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)
-    }
-
-    fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
-                    self.status.ext_lock.adat_a,
-                    self.status.ext_lock.adat_b,
-                    self.status.ext_lock.spdif,
-                    self.status.ext_lock.word_clk,
+                    self.1.ext_lock.adat_a,
+                    self.1.ext_lock.adat_b,
+                    self.1.ext_lock.spdif,
+                    self.1.ext_lock.word_clk,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EXT_SRC_SYNC_NAME => {
                 let vals = [
-                    self.status.ext_sync.adat_a,
-                    self.status.ext_sync.adat_b,
-                    self.status.ext_sync.spdif,
-                    self.status.ext_sync.word_clk,
+                    self.1.ext_sync.adat_a,
+                    self.1.ext_sync.adat_b,
+                    self.1.ext_sync.spdif,
+                    self.1.ext_sync.word_clk,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EXT_SRC_RATE_NAME => {
                 let vals: Vec<u32> = [
-                    self.status.ext_rate.adat_a,
-                    self.status.ext_rate.adat_b,
-                    self.status.ext_rate.spdif,
-                    self.status.ext_rate.word_clk,
+                    self.1.ext_rate.adat_a,
+                    self.1.ext_rate.adat_b,
+                    self.1.ext_rate.spdif,
+                    self.1.ext_rate.word_clk,
                 ]
                 .iter()
                 .map(|rate| {
@@ -487,7 +465,7 @@ impl StatusCtl {
             ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS
                     .iter()
-                    .position(|r| r.eq(&self.status.active_clk_src))
+                    .position(|r| r.eq(&self.1.active_clk_src))
                     .map(|p| p as u32)
                     .unwrap();
                 elem_value.set_enum(&[pos]);
@@ -496,7 +474,7 @@ impl StatusCtl {
             ACTIVE_CLK_RATE_NAME => {
                 let pos = CfgCtl::CLK_RATES
                     .iter()
-                    .position(|r| r.eq(&self.status.active_clk_rate))
+                    .position(|r| r.eq(&self.1.active_clk_rate))
                     .map(|p| p as u32)
                     .unwrap();
                 elem_value.set_enum(&[pos]);

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -13,9 +13,9 @@ use {
 pub struct Ff802Model {
     req: FwReq,
     meter_ctl: LatterMeterCtl<Ff802Protocol>,
+    dsp_ctl: LatterDspCtl<Ff802Protocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
-    dsp_ctl: DspCtl,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -28,13 +28,13 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
     ) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.meter_ctl.load(card_cntr)?;
+        self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
+        self.meter_ctl.load(card_cntr)?;
+        self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl
             .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         self.status_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.dsp_ctl
             .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         Ok(())
     }
@@ -47,9 +47,9 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
     ) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.cfg_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.dsp_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -64,12 +64,12 @@ impl CtlModel<(SndUnit, FwNode)> for Ff802Model {
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self
-            .cfg_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .dsp_ctl
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
-            .dsp_ctl
+            .cfg_ctl
             .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
@@ -106,19 +106,6 @@ impl MeasureModel<(SndUnit, FwNode)> for Ff802Model {
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct DspCtl(FfLatterDspState);
-
-impl FfLatterDspCtlOperation<Ff802Protocol> for DspCtl {
-    fn state(&self) -> &FfLatterDspState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut FfLatterDspState {
-        &mut self.0
     }
 }
 

--- a/runtime/fireface/src/former_ctls.rs
+++ b/runtime/fireface/src/former_ctls.rs
@@ -34,7 +34,9 @@ impl<T: RmeFormerOutputOperation> FormerOutputCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_output_vols(req, node, &mut self.1, timeout_ms)
+        let res = T::init_output_vols(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -80,10 +82,10 @@ impl<T: RmeFormerOutputOperation> FormerOutputCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(vol, &val)| *vol = val);
-                T::write_output_vols(req, node, &mut self.1, &params.0, timeout_ms).map(|_| {
-                    self.1 = params;
-                    true
-                })
+                let res = T::write_output_vols(req, node, &mut self.1, &params.0, timeout_ms);
+                debug!(?params, ?res);
+                self.1 = params;
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -140,8 +142,11 @@ impl<T: RmeFormerMixerOperation> FormerMixerCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        (0..T::DST_COUNT)
-            .try_for_each(|i| T::init_mixer_src_gains(req, node, &mut self.0, i, timeout_ms))
+        (0..T::DST_COUNT).try_for_each(|i| {
+            let res = T::init_mixer_src_gains(req, node, &mut self.0, i, timeout_ms);
+            debug!(params = ?self.0, ?res);
+            res
+        })
     }
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -216,18 +221,17 @@ impl<T: RmeFormerMixerOperation> FormerMixerCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val);
-                T::write_mixer_analog_gains(
+                let res = T::write_mixer_analog_gains(
                     req,
                     node,
                     &mut self.0,
                     index,
                     &params.0[index].analog_gains,
                     timeout_ms,
-                )
-                .map(|_| {
-                    self.0 = params;
-                    true
-                })
+                );
+                debug!(?params, ?res);
+                self.0 = params;
+                res.map(|_| true)
             }
             SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -237,18 +241,17 @@ impl<T: RmeFormerMixerOperation> FormerMixerCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val);
-                T::write_mixer_spdif_gains(
+                let res = T::write_mixer_spdif_gains(
                     req,
                     node,
                     &mut self.0,
                     index,
                     &params.0[index].spdif_gains,
                     timeout_ms,
-                )
-                .map(|_| {
-                    self.0 = params;
-                    true
-                })
+                );
+                debug!(?params, ?res);
+                self.0 = params;
+                res.map(|_| true)
             }
             ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -258,18 +261,17 @@ impl<T: RmeFormerMixerOperation> FormerMixerCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val);
-                T::write_mixer_adat_gains(
+                let res = T::write_mixer_adat_gains(
                     req,
                     node,
                     &mut self.0,
                     index,
                     &params.0[index].adat_gains,
                     timeout_ms,
-                )
-                .map(|_| {
-                    self.0 = params;
-                    true
-                })
+                );
+                debug!(?params, ?res);
+                self.0 = params;
+                res.map(|_| true)
             }
             STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -279,18 +281,17 @@ impl<T: RmeFormerMixerOperation> FormerMixerCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val);
-                T::write_mixer_stream_gains(
+                let res = T::write_mixer_stream_gains(
                     req,
                     node,
                     &mut self.0,
                     index,
                     &params.0[index].stream_gains,
                     timeout_ms,
-                )
-                .map(|_| {
-                    self.0 = params;
-                    true
-                })
+                );
+                debug!(?params, ?res);
+                self.0 = params;
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -337,7 +338,9 @@ impl<T: RmeFfFormerMeterOperation> FormerMeterCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::read_meter(req, node, &mut self.1, timeout_ms)
+        let res = T::read_meter(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -49,7 +49,9 @@ impl<T: RmeFfLatterMeterOperation> LatterMeterCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::read_meter(req, node, &mut self.1, timeout_ms)
+        let res = T::read_meter(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -287,7 +289,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_input(req, node, &mut self.0, timeout_ms)
+        let res = T::init_input(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load_input(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -391,7 +395,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_LINE_GAIN_NAME => {
                 let mut params = self.0.input.clone();
@@ -400,7 +406,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_LINE_LEVEL_NAME => {
                 let mut params = self.0.input.clone();
@@ -419,7 +427,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                             })
                             .map(|&l| *level = l)
                     })?;
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_MIC_POWER_NAME => {
                 let mut params = self.0.input.clone();
@@ -428,7 +438,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_MIC_INST_NAME => {
                 let mut params = self.0.input.clone();
@@ -437,7 +449,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INPUT_INVERT_PHASE_NAME => {
                 let mut params = self.0.input.clone();
@@ -446,7 +460,9 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_input(req, node, &mut self.0, params, timeout_ms).map(|_| true)
+                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -479,7 +495,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_output(req, node, &mut self.0, timeout_ms)
+        let res = T::init_output(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load_output(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -586,8 +604,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_output(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             STEREO_BALANCE_NAME => {
                 let mut params = self.0.output.clone();
@@ -596,8 +615,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_output(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             STEREO_LINK_NAME => {
                 let mut params = self.0.output.clone();
@@ -606,8 +626,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_output(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             INVERT_PHASE_NAME => {
                 let mut params = self.0.output.clone();
@@ -616,8 +637,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                T::write_output(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             LINE_LEVEL_NAME => {
                 let mut params = self.0.output.clone();
@@ -637,8 +659,9 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                             })
                             .map(|&l| *level = l)
                     })?;
-                T::write_output(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -665,7 +688,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_mixers(req, node, &mut self.0, timeout_ms)
+        let res = T::init_mixers(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load_mixer(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -806,8 +831,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_mixer(req, node, &mut self.0, index, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_mixer(req, node, &mut self.0, index, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIXER_MIC_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -817,8 +843,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_mixer(req, node, &mut self.0, index, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_mixer(req, node, &mut self.0, index, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIXER_SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -828,8 +855,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_mixer(req, node, &mut self.0, index, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_mixer(req, node, &mut self.0, index, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIXER_ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -839,8 +867,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_mixer(req, node, &mut self.0, index, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_mixer(req, node, &mut self.0, index, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             MIXER_STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
@@ -850,8 +879,9 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_mixer(req, node, &mut self.0, index, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_mixer(req, node, &mut self.0, index, params, timeout_ms);
+                debug!(params = ?self.0, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -931,7 +961,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_ch_strip(req, node, self.state_mut(), timeout_ms)
+        let res = T::init_ch_strip(req, node, self.state_mut(), timeout_ms);
+        debug!(params = ?T::ch_strip(self.state()), ?res);
+        res
     }
 
     fn load_ch_strip(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1486,8 +1518,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).hpf, ?res);
+            res.map(|_| true)
         } else if n == Self::HPF_CUT_OFF_NAME {
             let mut params = T::ch_strip(self.state()).hpf.clone();
             params
@@ -1495,8 +1528,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(dst, &val)| *dst = val as u16);
-            T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).hpf, ?res);
+            res.map(|_| true)
         } else if n == Self::HPF_ROLL_OFF_NAME {
             let mut params = T::ch_strip(self.state()).hpf.clone();
             params
@@ -1514,8 +1548,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                         })
                         .map(|&l| *level = l)
                 })?;
-            T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_hpf(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).hpf, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_ACTIVATE_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1523,8 +1558,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()));
+            res.map(|_| true)
         } else if n == Self::EQ_LOW_TYPE_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1542,8 +1578,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                         })
                         .map(|&t| *eq_type = t)
                 })?;
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_HIGH_TYPE_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1561,8 +1598,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                         })
                         .map(|&t| *eq_type = t)
                 })?;
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_LOW_GAIN_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1570,8 +1608,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_GAIN_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1579,8 +1618,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_HIGH_GAIN_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1588,8 +1628,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_LOW_FREQ_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1597,8 +1638,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_FREQ_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1606,8 +1648,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_HIGH_FREQ_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1615,8 +1658,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_LOW_QUALITY_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1624,8 +1668,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_QUALITY_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1633,8 +1678,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::EQ_HIGH_QUALITY_NAME {
             let mut params = T::ch_strip(self.state()).eq.clone();
             params
@@ -1642,8 +1688,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_eq(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).eq, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_ACTIVATE_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1651,8 +1698,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_GAIN_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1660,8 +1708,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_ATTACK_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1669,8 +1718,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(attack, &val)| *attack = val as u16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_RELEASE_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1678,8 +1728,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(release, &val)| *release = val as u16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_COMP_THRESHOLD_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1687,8 +1738,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(threshold, &val)| *threshold = val as i16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_COMP_RATIO_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1696,8 +1748,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(ratio, &val)| *ratio = val as u16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_EX_THRESHOLD_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1705,8 +1758,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(threshold, &val)| *threshold = val as i16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::DYN_EX_RATIO_NAME {
             let mut params = T::ch_strip(self.state()).dynamics.clone();
             params
@@ -1714,8 +1768,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(ratio, &val)| *ratio = val as u16);
-            T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_dynamics(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).dynamics, ?res);
+            res.map(|_| true)
         } else if n == Self::AUTOLEVEL_ACTIVATE_NAME {
             let mut params = T::ch_strip(self.state()).autolevel.clone();
             params
@@ -1723,8 +1778,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).autolevel, ?res);
+            res.map(|_| true)
         } else if n == Self::AUTOLEVEL_MAX_GAIN_NAME {
             let mut params = T::ch_strip(self.state()).autolevel.clone();
             params
@@ -1732,8 +1788,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as u16);
-            T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).autolevel, ?res);
+            res.map(|_| true)
         } else if n == Self::AUTOLEVEL_HEAD_ROOM_NAME {
             let mut params = T::ch_strip(self.state()).autolevel.clone();
             params
@@ -1741,8 +1798,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(headroom, &val)| *headroom = val as u16);
-            T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).autolevel, ?res);
+            res.map(|_| true)
         } else if n == Self::AUTOLEVEL_RISE_TIME_NAME {
             let mut params = T::ch_strip(self.state()).autolevel.clone();
             params
@@ -1750,8 +1808,9 @@ pub trait FfLatterChStripCtlOperation<T: RmeFfLatterChStripOperation<U>, U> {
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(time, &val)| *time = val as u16);
-            T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms)?;
-            Ok(true)
+            let res = T::write_ch_strip_autolevel(req, node, self.state_mut(), params, timeout_ms);
+            debug!(params = ?T::ch_strip(self.state()).autolevel, ?res);
+            res.map(|_| true)
         } else {
             Ok(false)
         }
@@ -1975,7 +2034,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::init_fx(req, node, &mut self.0, timeout_ms)
+        let res = T::init_fx(req, node, &mut self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load_fx(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -2458,8 +2519,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx, ?res);
+                res.map(|_| true)
             }
             MIC_SRC_GAIN_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2468,8 +2530,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx, ?res);
+                res.map(|_| true)
             }
             SPDIF_SRC_GAIN_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2478,8 +2541,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx, ?res);
+                res.map(|_| true)
             }
             ADAT_SRC_GAIN_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2488,8 +2552,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx, ?res);
+                res.map(|_| true)
             }
             STREAM_SRC_GAIN_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2498,8 +2563,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx, ?res);
+                res.map(|_| true)
             }
             LINE_OUT_VOL_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2508,8 +2574,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx);
+                res.map(|_| true)
             }
             HP_OUT_VOL_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2518,8 +2585,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx);
+                res.map(|_| true)
             }
             SPDIF_OUT_VOL_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2528,8 +2596,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx);
+                res.map(|_| true)
             }
             ADAT_OUT_VOL_NAME => {
                 let mut params = self.0.fx.clone();
@@ -2538,8 +2607,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms)?;
-                Ok(true)
+                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                debug!(params = ?self.0.fx);
+                res.map(|_| true)
             }
             REVERB_ACTIVATE_NAME => self
                 .update_reverb(req, node, timeout_ms, |params| {
@@ -2713,7 +2783,9 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
     {
         let mut params = self.0.fx.reverb.clone();
         cb(&mut params)?;
-        T::write_fx_reverb(req, node, &mut self.0, &params, timeout_ms)
+        let res = T::write_fx_reverb(req, node, &mut self.0, &params, timeout_ms);
+        debug!(?params, ?res);
+        res
     }
 
     fn update_echo<F>(
@@ -2728,6 +2800,8 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
     {
         let mut params = self.0.fx.echo.clone();
         cb(&mut params)?;
-        T::write_fx_echo(req, node, &mut self.0, &params, timeout_ms)
+        let res = T::write_fx_echo(req, node, &mut self.0, &params, timeout_ms);
+        debug!(?params, ?res);
+        res
     }
 }

--- a/runtime/fireface/src/lib.rs
+++ b/runtime/fireface/src/lib.rs
@@ -82,6 +82,7 @@ impl RuntimeOperation<u32> for FfRuntime {
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
+        self.model.cache(&mut self.unit)?;
         self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         if self.model.measured_elem_list.len() > 0 {

--- a/runtime/fireface/src/model.rs
+++ b/runtime/fireface/src/model.rs
@@ -46,6 +46,15 @@ impl FfModel {
         })
     }
 
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
+        match &mut self.model {
+            Model::Ff800(m) => m.cache(unit),
+            Model::Ff400(m) => m.cache(unit),
+            Model::Ucx(m) => m.cache(unit),
+            Model::Ff802(m) => m.cache(unit),
+        }
+    }
+
     pub fn load(
         &mut self,
         unit: &mut (SndUnit, FwNode),

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -29,13 +29,14 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.cfg_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.status_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.meter_ctl.load(card_cntr)?;
         self.dsp_ctl.load(card_cntr)?;
-        self.cfg_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.status_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
+        self.cfg_ctl.load(card_cntr)?;
+        self.status_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -50,6 +51,8 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
         } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -70,7 +73,7 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .cfg_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -82,14 +85,14 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
 impl MeasureModel<(SndUnit, FwNode)> for UcxModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.0);
-        elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
+        elem_id_list.extend_from_slice(&self.status_ctl.0);
     }
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.status_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -101,7 +104,7 @@ impl MeasureModel<(SndUnit, FwNode)> for UcxModel {
     ) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.status_ctl.read_measured_elem(elem_id, elem_value)? {
+        } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -117,21 +120,6 @@ fn clk_src_to_string(src: &FfUcxClkSrc) -> String {
         FfUcxClkSrc::WordClk => "Word-clock",
     }
     .to_string()
-}
-
-fn update_cfg<F>(
-    unit: &mut (SndUnit, FwNode),
-    req: &mut FwReq,
-    cfg: &mut FfUcxConfig,
-    timeout_ms: u32,
-    cb: F,
-) -> Result<(), Error>
-where
-    F: Fn(&mut FfUcxConfig) -> Result<(), Error>,
-{
-    let mut cache = cfg.clone();
-    cb(&mut cache)?;
-    FfUcxProtocol::write_cfg(req, &mut unit.1, &cache, timeout_ms).map(|_| *cfg = cache)
 }
 
 #[derive(Default, Debug)]
@@ -169,15 +157,11 @@ impl CfgCtl {
 
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        FfUcxProtocol::write_cfg(req, &mut unit.1, &self.0, timeout_ms)?;
+    fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
+        FfUcxProtocol::write_cfg(req, node, &self.0, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<String> = Self::CLK_SRCS
             .iter()
             .map(|s| clk_src_to_string(s))
@@ -257,82 +241,87 @@ impl CfgCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndUnit, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            PRIMARY_CLK_SRC_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    let src = Self::CLK_SRCS.iter().nth(val as usize).ok_or_else(|| {
-                        let msg = format!("Invalid value for index of clock source: {}", val);
+            PRIMARY_CLK_SRC_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.clk_src = Self::CLK_SRCS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of clock source: {}", pos);
                         Error::new(FileError::Inval, &msg)
-                    })?;
-                    cfg.clk_src = *src;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            OPT_OUTPUT_SIGNAL_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    Self::OPT_OUT_SIGNALS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!(
-                                "Invalid value for index of optical output signal: {}",
-                                val
-                            );
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&s| cfg.opt_out_signal = s)
-                })
-            })
-            .map(|_| true),
-            EFFECT_ON_INPUT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                cfg.effect_on_inputs = elem_value.boolean()[0];
-                Ok(())
-            })
-            .map(|_| true),
-            SPDIF_OUTPUT_FMT_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                    Self::SPDIF_FMTS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid value for index of S/PDIF format: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&f| cfg.spdif_out_format = f)
-                })
-            })
-            .map(|_| true),
-            WORD_CLOCK_SINGLE_SPPED_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(elem_value, |val| {
-                    cfg.word_out_single = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
-            WORD_CLOCK_IN_TERMINATE_NAME => update_cfg(unit, req, &mut self.0, timeout_ms, |cfg| {
-                ElemValueAccessor::<bool>::get_val(elem_value, |val| {
-                    cfg.word_in_terminate = val;
-                    Ok(())
-                })
-            })
-            .map(|_| true),
+                    })
+                    .copied()?;
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            OPT_OUTPUT_SIGNAL_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.opt_out_signal = Self::OPT_OUT_SIGNALS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg =
+                            format!("Invalid value for index of optical output signal: {}", pos,);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            EFFECT_ON_INPUT_NAME => {
+                let mut params = self.0.clone();
+                params.effect_on_inputs = elem_value.boolean()[0];
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            SPDIF_OUTPUT_FMT_NAME => {
+                let mut params = self.0.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                params.spdif_out_format = Self::SPDIF_FMTS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid value for index of S/PDIF format: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .copied()?;
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            WORD_CLOCK_SINGLE_SPPED_NAME => {
+                let mut params = self.0.clone();
+                params.word_out_single = elem_value.boolean()[0];
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
+            WORD_CLOCK_IN_TERMINATE_NAME => {
+                let mut params = self.0.clone();
+                params.word_in_terminate = elem_value.boolean()[0];
+                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                self.0 = params;
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 }
 
 #[derive(Default, Debug)]
-struct StatusCtl {
-    status: FfUcxStatus,
-    measured_elem_list: Vec<ElemId>,
-}
+struct StatusCtl(Vec<ElemId>, FfUcxStatus);
 
 const EXT_SRC_LOCK_NAME: &str = "external-source-lock";
 const EXT_SRC_SYNC_NAME: &str = "external-source-sync";
@@ -357,22 +346,18 @@ impl StatusCtl {
         Some(ClkNominalRate::R192000),
     ];
 
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        FfUcxProtocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)?;
+    fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
+        FfUcxProtocol::read_status(req, node, &mut self.1, timeout_ms)
+    }
 
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         [EXT_SRC_LOCK_NAME, EXT_SRC_SYNC_NAME]
             .iter()
             .try_for_each(|name| {
                 let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, name, 0);
                 card_cntr
                     .add_bool_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), false)
-                    .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))
+                    .map(|mut elem_id_list| self.0.append(&mut elem_id_list))
             })?;
 
         let labels: Vec<String> = Self::EXT_CLK_RATES
@@ -382,7 +367,7 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, EXT_SRC_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, Self::EXT_CLK_SRCS.len(), &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_SRCS
             .iter()
@@ -391,7 +376,7 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_SRC_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = CfgCtl::CLK_RATES
             .iter()
@@ -400,54 +385,39 @@ impl StatusCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ACTIVE_CLK_RATE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| self.measured_elem_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.0.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn measure_states(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        FfUcxProtocol::read_status(req, &mut unit.1, &mut self.status, timeout_ms)
-    }
-
-    fn read_measured_elem(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             EXT_SRC_LOCK_NAME => {
                 let vals = [
-                    self.status.ext_lock.coax_iface,
-                    self.status.ext_lock.opt_iface,
-                    self.status.ext_lock.word_clk,
+                    self.1.ext_lock.coax_iface,
+                    self.1.ext_lock.opt_iface,
+                    self.1.ext_lock.word_clk,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EXT_SRC_SYNC_NAME => {
                 let vals = [
-                    self.status.ext_sync.coax_iface,
-                    self.status.ext_sync.opt_iface,
-                    self.status.ext_sync.word_clk,
+                    self.1.ext_sync.coax_iface,
+                    self.1.ext_sync.opt_iface,
+                    self.1.ext_sync.word_clk,
                 ];
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EXT_SRC_RATE_NAME => {
                 let vals: Vec<u32> = [
-                    self.status.ext_rate.coax_iface,
-                    self.status.ext_rate.opt_iface,
-                    self.status.ext_rate.word_clk,
+                    self.1.ext_rate.coax_iface,
+                    self.1.ext_rate.opt_iface,
+                    self.1.ext_rate.word_clk,
                 ]
                 .iter()
-                .map(|rate| {
-                    Self::EXT_CLK_RATES
-                        .iter()
-                        .position(|r| r.eq(rate))
-                        .map(|pos| pos as u32)
-                        .unwrap()
-                })
+                .map(|rate| Self::EXT_CLK_RATES.iter().position(|r| r.eq(rate)).unwrap() as u32)
                 .collect();
                 elem_value.set_enum(&vals);
                 Ok(true)
@@ -455,18 +425,16 @@ impl StatusCtl {
             ACTIVE_CLK_SRC_NAME => {
                 let pos = CfgCtl::CLK_SRCS
                     .iter()
-                    .position(|r| r.eq(&self.status.active_clk_src))
-                    .map(|p| p as u32)
-                    .unwrap();
+                    .position(|r| r.eq(&self.1.active_clk_src))
+                    .unwrap() as u32;
                 elem_value.set_enum(&[pos]);
                 Ok(true)
             }
             ACTIVE_CLK_RATE_NAME => {
                 let pos = CfgCtl::CLK_RATES
                     .iter()
-                    .position(|r| r.eq(&self.status.active_clk_rate))
-                    .map(|p| p as u32)
-                    .unwrap();
+                    .position(|r| r.eq(&self.1.active_clk_rate))
+                    .unwrap() as u32;
                 elem_value.set_enum(&[pos]);
                 Ok(true)
             }

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -160,7 +160,9 @@ impl CfgCtl {
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        FfUcxProtocol::write_cfg(req, node, &self.0, timeout_ms)
+        let res = FfUcxProtocol::write_cfg(req, node, &self.0, timeout_ms);
+        debug!(params = ?self.0, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -261,9 +263,10 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             OPT_OUTPUT_SIGNAL_NAME => {
                 let mut params = self.0.clone();
@@ -277,16 +280,18 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             EFFECT_ON_INPUT_NAME => {
                 let mut params = self.0.clone();
                 params.effect_on_inputs = elem_value.boolean()[0];
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             SPDIF_OUTPUT_FMT_NAME => {
                 let mut params = self.0.clone();
@@ -299,23 +304,26 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             WORD_CLOCK_IN_TERMINATE_NAME => {
                 let mut params = self.0.clone();
                 params.word_in_terminate = elem_value.boolean()[0];
-                FfUcxProtocol::write_cfg(req, node, &params, timeout_ms)?;
+                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                debug!(?params, ?res);
                 self.0 = params;
-                Ok(true)
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -349,7 +357,9 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        FfUcxProtocol::read_status(req, node, &mut self.1, timeout_ms)
+        let res = FfUcxProtocol::read_status(req, node, &mut self.1, timeout_ms);
+        debug!(params = ?self.1, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -20,12 +20,8 @@ pub struct UcxModel {
 
 const TIMEOUT_MS: u32 = 100;
 
-impl CtlModel<(SndUnit, FwNode)> for UcxModel {
-    fn load(
-        &mut self,
-        unit: &mut (SndUnit, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl UcxModel {
+    pub fn cache(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
         self.meter_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -33,6 +29,12 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
         self.status_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndUnit, FwNode)> for UcxModel {
+    fn load(&mut self, _: &mut (SndUnit, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
         self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -12,9 +12,9 @@ use {
 #[derive(Default, Debug)]
 pub struct UcxModel {
     req: FwReq,
+    meter_ctl: LatterMeterCtl<FfUcxProtocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
-    meter_ctl: MeterCtl,
     dsp_ctl: DspCtl,
 }
 
@@ -26,13 +26,14 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
         unit: &mut (SndUnit, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.meter_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.meter_ctl.load(card_cntr)?;
+
         self.cfg_ctl
             .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         self.status_ctl
             .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
-        self.meter_ctl
-            .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
         self.dsp_ctl
             .load(unit, &mut self.req, TIMEOUT_MS, card_cntr)?;
         Ok(())
@@ -44,7 +45,9 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.cfg_ctl.read(elem_id, elem_value)? {
+        if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -78,14 +81,14 @@ impl CtlModel<(SndUnit, FwNode)> for UcxModel {
 
 impl MeasureModel<(SndUnit, FwNode)> for UcxModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.0);
         elem_id_list.extend_from_slice(&self.status_ctl.measured_elem_list);
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 
     fn measure_states(&mut self, unit: &mut (SndUnit, FwNode)) -> Result<(), Error> {
-        self.status_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         self.meter_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.status_ctl
             .measure_states(unit, &mut self.req, TIMEOUT_MS)?;
         Ok(())
     }
@@ -96,26 +99,13 @@ impl MeasureModel<(SndUnit, FwNode)> for UcxModel {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.status_ctl.read_measured_elem(elem_id, elem_value)? {
+        if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.meter_ctl.read_measured_elem(elem_id, elem_value)? {
+        } else if self.status_ctl.read_measured_elem(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MeterCtl(FfLatterMeterState, Vec<ElemId>);
-
-impl FfLatterMeterCtlOperation<FfUcxProtocol> for MeterCtl {
-    fn meter(&self) -> &FfLatterMeterState {
-        &self.0
-    }
-
-    fn meter_mut(&mut self) -> &mut FfLatterMeterState {
-        &mut self.0
     }
 }
 


### PR DESCRIPTION
It's really helpful to dump logs for debugging purpose. This patchset utilizes
tracing and tracing-subscriber crates for the purpose. An option is newly added
to fireface runtime, then implement tracing events.

```
Takashi Sakamoto (18):
  protocols/fireface: arrangement of derive traits for protocol
    implementations
  runtime/fireface: use generic structure for meter controls in former
    models
  runtime/fireface: use generic structure for output control in former
    models
  runtime/fireface: use generic structure for mixer controls in former
    models
  runtime/fireface: code refactoring for controls specific to Fireface
    400
  runtime/fireface: code refactoring for controls specific to Fireface
    800
  runtime/fireface: use generic structure for meter controls in latter
    models
  runtime/fireface: use generic structure for DSP controls in latter
    models
  runtime/fireface: code refactoring for Fireface 802
  runtime/fireface: code refactoring for Fireface UCX
  runtime/fireface: add model-level cache function
  runtime/fireface: add logging by tracing crate
  runtime/fireface: add logging to common controls in former models
  runtime/fireface: add logging for controls specific to Fireface 400
  runtime/fireface: add logging for controls specific to Fireface 800
  runtime/fireface: add logging to common controls in latter models
  runtime/fireface: add logging to controls specific to Fireface 802
  runtime/fireface: add logging to controls specific to Fireface UCX

 README.rst                                    |    3 +-
 .../fireface/src/bin/ff-config-rom-parser.rs  |    5 +-
 protocols/fireface/src/former.rs              |    2 +-
 protocols/fireface/src/former/ff400.rs        |    4 +-
 protocols/fireface/src/former/ff800.rs        |    3 +-
 protocols/fireface/src/latter.rs              |    2 +-
 protocols/fireface/src/latter/ff802.rs        |    7 +-
 protocols/fireface/src/latter/ucx.rs          |    7 +-
 runtime/fireface/Cargo.toml                   |    2 +
 .../src/bin/snd-fireface-ctl-service.rs       |    6 +-
 runtime/fireface/src/ff400_model.rs           |  697 ++++----
 runtime/fireface/src/ff800_model.rs           |  609 ++++---
 runtime/fireface/src/ff802_model.rs           |  381 ++---
 runtime/fireface/src/former_ctls.rs           |  368 ++--
 runtime/fireface/src/latter_ctls.rs           | 1474 +++++++++--------
 runtime/fireface/src/lib.rs                   |   35 +-
 runtime/fireface/src/model.rs                 |    9 +
 runtime/fireface/src/ucx_model.rs             |  325 ++--
 18 files changed, 1969 insertions(+), 1970 deletions(-)
```