### PR TITLE
[PATCH 00/19] protocols/fireface: add common trait to operate configuration and status registers

### DIFF
--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -351,6 +351,8 @@ fn write_config<T: RmeFfParamsSerialize<U, u8>, U>(
     )
 }
 
+const FORMER_STATUS_SIZE: usize = 8;
+
 /// Configuration of S/PDIF output.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FormerSpdifOutput {

--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -353,6 +353,25 @@ fn write_config<T: RmeFfParamsSerialize<U, u8>, U>(
 
 const FORMER_STATUS_SIZE: usize = 8;
 
+fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
+    req: &mut FwReq,
+    node: &mut FwNode,
+    offset: u64,
+    status: &mut U,
+    timeout_ms: u32,
+) -> Result<(), Error> {
+    let mut raw = [0; FORMER_STATUS_SIZE];
+    req.transaction_sync(
+        node,
+        FwTcode::ReadBlockRequest,
+        offset,
+        raw.len(),
+        &mut raw,
+        timeout_ms,
+    )
+    .map(|_| T::deserialize(status, &raw))
+}
+
 /// Configuration of S/PDIF output.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FormerSpdifOutput {

--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -334,6 +334,8 @@ pub trait RmeFormerMixerOperation {
     }
 }
 
+const FORMER_CONFIG_SIZE: usize = 12;
+
 /// Configuration of S/PDIF output.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FormerSpdifOutput {

--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -332,6 +332,25 @@ pub trait RmeFormerMixerOperation {
 
 const FORMER_CONFIG_SIZE: usize = 12;
 
+fn write_config<T: RmeFfParamsSerialize<U, u8>, U>(
+    req: &mut FwReq,
+    node: &mut FwNode,
+    offset: u64,
+    config: &U,
+    timeout_ms: u32,
+) -> Result<(), Error> {
+    let mut raw = T::serialize(config);
+
+    req.transaction_sync(
+        node,
+        FwTcode::WriteBlockRequest,
+        offset,
+        raw.len(),
+        &mut raw,
+        timeout_ms,
+    )
+}
+
 /// Configuration of S/PDIF output.
 #[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
 pub struct FormerSpdifOutput {

--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -6,11 +6,7 @@
 pub mod ff400;
 pub mod ff800;
 
-use {
-    super::*,
-    glib::Error,
-    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-};
+use super::*;
 
 /// State of hardware meter.
 ///

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -3,11 +3,7 @@
 
 //! Protocol defined by RME GmbH for Fireface 400.
 
-use {
-    super::*,
-    glib::Error,
-    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-};
+use super::*;
 
 /// The protocol implementation for Fireface 400.
 #[derive(Default, Debug)]
@@ -16,7 +12,7 @@ pub struct Ff400Protocol;
 const MIXER_OFFSET: usize = 0x000080080000;
 const OUTPUT_OFFSET: usize = 0x000080080f80;
 const METER_OFFSET: usize = 0x000080100000;
-const CFG_OFFSET: usize = 0x000080100514;
+const CFG_OFFSET: u64 = 0x000080100514;
 const STATUS_OFFSET: usize = 0x0000801c0000;
 const AMP_OFFSET: usize = 0x0000801c0180;
 
@@ -1066,6 +1062,17 @@ impl RmeFfParamsDeserialize<Ff400Config, u8> for Ff400Protocol {
 
         params.word_out_single = quads[2] & Q2_WORD_OUT_SINGLE_SPEED_MASK > 0;
         params.continue_at_errors = quads[2] & Q2_CONTINUE_AT_ERRORS > 0;
+    }
+}
+
+impl RmeFfWhollyUpdatableParamsOperation<Ff400Config> for Ff400Protocol {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &Ff400Config,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        write_config::<Ff400Protocol, Ff400Config>(req, node, CFG_OFFSET, params, timeout_ms)
     }
 }
 

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -13,7 +13,7 @@ const MIXER_OFFSET: usize = 0x000080080000;
 const OUTPUT_OFFSET: usize = 0x000080080f80;
 const METER_OFFSET: usize = 0x000080100000;
 const CFG_OFFSET: u64 = 0x000080100514;
-const STATUS_OFFSET: usize = 0x0000801c0000;
+const STATUS_OFFSET: u64 = 0x0000801c0000;
 const AMP_OFFSET: usize = 0x0000801c0180;
 
 const ANALOG_INPUT_COUNT: usize = 8;
@@ -578,6 +578,17 @@ impl RmeFfParamsDeserialize<Ff400Status, u8> for Ff400Protocol {
     }
 }
 
+impl RmeFfCacheableParamsOperation<Ff400Status> for Ff400Protocol {
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut Ff400Status,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        read_status::<Ff400Protocol, Ff400Status>(req, node, STATUS_OFFSET, params, timeout_ms)
+    }
+}
+
 fn deserialize_status(status: &mut Ff400Status, quads: &[u32]) {
     assert!(quads.len() >= Ff400Status::QUADLET_COUNT);
 
@@ -596,7 +607,7 @@ impl Ff400Protocol {
         req.transaction_sync(
             node,
             FwTcode::ReadBlockRequest,
-            STATUS_OFFSET as u64,
+            STATUS_OFFSET,
             raw.len(),
             &mut raw,
             timeout_ms,

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -1076,44 +1076,6 @@ impl RmeFfWhollyUpdatableParamsOperation<Ff400Config> for Ff400Protocol {
     }
 }
 
-fn serialize_config(config: &Ff400Config, quads: &mut [u32]) {
-    assert_eq!(quads.len(), Ff400Config::QUADLET_COUNT);
-
-    let raw = Ff400Protocol::serialize(config);
-    let mut quadlet = [0; 4];
-    quads.iter_mut().enumerate().for_each(|(i, quad)| {
-        let pos = i * 4;
-        quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
-        *quad = u32::from_le_bytes(quadlet);
-    });
-}
-
-impl Ff400Protocol {
-    pub fn write_cfg(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        cfg: &Ff400Config,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut quads = [0u32; 3];
-        serialize_config(cfg, &mut quads);
-
-        let mut raw = [0; 12];
-        quads.iter().enumerate().for_each(|(i, quad)| {
-            let pos = i * 4;
-            raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
-        });
-        req.transaction_sync(
-            node,
-            FwTcode::WriteBlockRequest,
-            CFG_OFFSET as u64,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -589,42 +589,6 @@ impl RmeFfCacheableParamsOperation<Ff400Status> for Ff400Protocol {
     }
 }
 
-fn deserialize_status(status: &mut Ff400Status, quads: &[u32]) {
-    assert!(quads.len() >= Ff400Status::QUADLET_COUNT);
-
-    let raw: Vec<u8> = quads.iter().flat_map(|quad| quad.to_le_bytes()).collect();
-    Ff400Protocol::deserialize(status, &raw);
-}
-
-impl Ff400Protocol {
-    pub fn read_status(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        status: &mut Ff400Status,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut raw = [0; 8];
-        req.transaction_sync(
-            node,
-            FwTcode::ReadBlockRequest,
-            STATUS_OFFSET,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| {
-            let mut quadlet = [0; 4];
-            let mut quads = [0u32; 2];
-            quads.iter_mut().enumerate().for_each(|(i, quad)| {
-                let pos = i * 4;
-                quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
-                *quad = u32::from_le_bytes(quadlet);
-            });
-            deserialize_status(status, &quads)
-        })
-    }
-}
-
 // NOTE: for first quadlet of configuration quadlets.
 const Q0_HP_OUT_LEVEL_MASK: u32 = 0x00060000;
 const Q0_HP_OUT_LEVEL_HIGH_FLAG: u32 = 0x00040000;

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -12,7 +12,7 @@ pub struct Ff800Protocol;
 const MIXER_OFFSET: usize = 0x000080080000;
 const OUTPUT_OFFSET: usize = 0x000080081f80;
 const METER_OFFSET: usize = 0x000080100000;
-const STATUS_OFFSET: usize = 0x0000801c0000;
+const STATUS_OFFSET: u64 = 0x0000801c0000;
 const CFG_OFFSET: u64 = 0x0000fc88f014;
 
 // TODO: 4 quadlets are read at once.
@@ -494,6 +494,17 @@ impl RmeFfParamsDeserialize<Ff800Status, u8> for Ff800Protocol {
             Q1_CONF_CLK_RATE_192000_FLAGS => ClkNominalRate::R192000,
             Q1_CONF_CLK_RATE_44100_FLAGS | _ => ClkNominalRate::R44100,
         };
+    }
+}
+
+impl RmeFfCacheableParamsOperation<Ff800Status> for Ff800Protocol {
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut Ff800Status,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        read_status::<Ff800Protocol, Ff800Status>(req, node, STATUS_OFFSET, params, timeout_ms)
     }
 }
 

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -1003,44 +1003,6 @@ impl RmeFfWhollyUpdatableParamsOperation<Ff800Config> for Ff800Protocol {
     }
 }
 
-fn serialize_config(config: &Ff800Config, quads: &mut [u32]) {
-    assert_eq!(quads.len(), Ff800Config::QUADLET_COUNT);
-
-    let raw = Ff800Protocol::serialize(config);
-    let mut quadlet = [0; 4];
-    quads.iter_mut().enumerate().for_each(|(i, quad)| {
-        let pos = i * 4;
-        quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
-        *quad = u32::from_le_bytes(quadlet);
-    });
-}
-
-impl Ff800Protocol {
-    pub fn write_cfg(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        cfg: &Ff800Config,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut quads = [0u32; 3];
-        serialize_config(&cfg, &mut quads);
-
-        let mut raw = [0; 12];
-        quads.iter().enumerate().for_each(|(i, quad)| {
-            let pos = i * 4;
-            raw[pos..(pos + 4)].copy_from_slice(&quad.to_le_bytes())
-        });
-        req.transaction_sync(
-            node,
-            FwTcode::WriteBlockRequest,
-            CFG_OFFSET as u64,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -2,7 +2,6 @@
 // Copyright (c) 2021 Takashi Sakamoto
 
 //! Protocol defined by RME GmbH for Fireface 800.
-use hinawa::{FwNode, FwReq};
 
 use super::*;
 
@@ -14,7 +13,7 @@ const MIXER_OFFSET: usize = 0x000080080000;
 const OUTPUT_OFFSET: usize = 0x000080081f80;
 const METER_OFFSET: usize = 0x000080100000;
 const STATUS_OFFSET: usize = 0x0000801c0000;
-const CFG_OFFSET: usize = 0x0000fc88f014;
+const CFG_OFFSET: u64 = 0x0000fc88f014;
 
 // TODO: 4 quadlets are read at once.
 #[allow(dead_code)]
@@ -990,6 +989,17 @@ impl RmeFfParamsDeserialize<Ff800Config, u8> for Ff800Protocol {
 
         params.word_out_single = quads[2] & Q2_WORD_OUT_SINGLE_SPEED_MASK > 0;
         params.continue_at_errors = quads[2] & Q2_CONTINUE_AT_ERRORS > 0;
+    }
+}
+
+impl RmeFfWhollyUpdatableParamsOperation<Ff800Config> for Ff800Protocol {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &Ff800Config,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        write_config::<Ff800Protocol, Ff800Config>(req, node, CFG_OFFSET, params, timeout_ms)
     }
 }
 

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -508,41 +508,6 @@ impl RmeFfCacheableParamsOperation<Ff800Status> for Ff800Protocol {
     }
 }
 
-fn deserialize_status(status: &mut Ff800Status, quads: &[u32]) {
-    assert!(quads.len() >= Ff800Status::QUADLET_COUNT);
-    let raw: Vec<u8> = quads.iter().flat_map(|quad| quad.to_le_bytes()).collect();
-    Ff800Protocol::deserialize(status, &raw);
-}
-
-impl Ff800Protocol {
-    pub fn read_status(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        status: &mut Ff800Status,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut raw = [0; 8];
-        req.transaction_sync(
-            node,
-            FwTcode::ReadBlockRequest,
-            STATUS_OFFSET as u64,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| {
-            let mut quadlet = [0; 4];
-            let mut quads = [0u32; 2];
-            quads.iter_mut().enumerate().for_each(|(i, quad)| {
-                let pos = i * 4;
-                quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
-                *quad = u32::from_le_bytes(quadlet);
-            });
-            deserialize_status(status, &quads)
-        })
-    }
-}
-
 // NOTE: for first quadlet of configuration quadlets.
 const Q0_LINE_OUT_LEVEL_MASK: u32 = 0x00001c00;
 const Q0_LINE_OUT_LEVEL_CON_FLAG: u32 = 0x00001000;

--- a/protocols/fireface/src/former/ff800.rs
+++ b/protocols/fireface/src/former/ff800.rs
@@ -178,7 +178,6 @@ impl Ff800ClkLockStatus {
     const QUADLET_COUNT: usize = 2;
 }
 
-#[cfg(test)]
 fn serialize_lock_status(status: &Ff800ClkLockStatus, quads: &mut [u32]) {
     assert!(quads.len() >= Ff800ClkLockStatus::QUADLET_COUNT);
 
@@ -232,7 +231,6 @@ impl Ff800ClkSyncStatus {
     const QUADLET_COUNT: usize = 2;
 }
 
-#[cfg(test)]
 fn serialize_sync_status(status: &Ff800ClkSyncStatus, quads: &mut [u32]) {
     assert!(quads.len() >= Ff800ClkSyncStatus::QUADLET_COUNT);
 
@@ -296,194 +294,213 @@ pub struct Ff800Status {
 }
 
 impl Ff800Status {
-    const QUADLET_COUNT: usize = 2;
+    const QUADLET_COUNT: usize = FORMER_STATUS_SIZE / 4;
 }
 
-#[cfg(test)]
-fn serialize_status(status: &Ff800Status, quads: &mut [u32]) {
-    assert!(quads.len() >= Ff800Status::QUADLET_COUNT);
+impl RmeFfParamsSerialize<Ff800Status, u8> for Ff800Protocol {
+    fn serialize(params: &Ff800Status) -> Vec<u8> {
+        let mut quads = [0; Ff800Status::QUADLET_COUNT];
 
-    serialize_lock_status(&status.lock, quads);
-    serialize_sync_status(&status.sync, quads);
+        serialize_lock_status(&params.lock, &mut quads);
+        serialize_sync_status(&params.sync, &mut quads);
 
-    quads[0] &= !Q0_SPDIF_RATE_MASK;
-    if let Some(rate) = &status.spdif_rate {
-        let flag = match rate {
-            ClkNominalRate::R32000 => Q0_SPDIF_RATE_32000_FLAGS,
-            ClkNominalRate::R44100 => Q0_SPDIF_RATE_44100_FLAGS,
-            ClkNominalRate::R48000 => Q0_SPDIF_RATE_48000_FLAGS,
-            ClkNominalRate::R64000 => Q0_SPDIF_RATE_64000_FLAGS,
-            ClkNominalRate::R88200 => Q0_SPDIF_RATE_88200_FLAGS,
-            ClkNominalRate::R96000 => Q0_SPDIF_RATE_96000_FLAGS,
-            ClkNominalRate::R128000 => Q0_SPDIF_RATE_128000_FLAGS,
-            ClkNominalRate::R176400 => Q0_SPDIF_RATE_176400_FLAGS,
-            ClkNominalRate::R192000 => Q0_SPDIF_RATE_192000_FLAGS,
+        quads[0] &= !Q0_SPDIF_RATE_MASK;
+        if let Some(rate) = &params.spdif_rate {
+            let flag = match rate {
+                ClkNominalRate::R32000 => Q0_SPDIF_RATE_32000_FLAGS,
+                ClkNominalRate::R44100 => Q0_SPDIF_RATE_44100_FLAGS,
+                ClkNominalRate::R48000 => Q0_SPDIF_RATE_48000_FLAGS,
+                ClkNominalRate::R64000 => Q0_SPDIF_RATE_64000_FLAGS,
+                ClkNominalRate::R88200 => Q0_SPDIF_RATE_88200_FLAGS,
+                ClkNominalRate::R96000 => Q0_SPDIF_RATE_96000_FLAGS,
+                ClkNominalRate::R128000 => Q0_SPDIF_RATE_128000_FLAGS,
+                ClkNominalRate::R176400 => Q0_SPDIF_RATE_176400_FLAGS,
+                ClkNominalRate::R192000 => Q0_SPDIF_RATE_192000_FLAGS,
+            };
+            quads[0] |= flag;
+        }
+
+        quads[0] &= !Q0_ACTIVE_CLK_SRC_MASK;
+        let flag = match &params.active_clk_src {
+            Ff800ClkSrc::AdatA => Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS,
+            Ff800ClkSrc::AdatB => Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS,
+            Ff800ClkSrc::Spdif => Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS,
+            Ff800ClkSrc::WordClock => Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS,
+            Ff800ClkSrc::Tco => Q0_ACTIVE_CLK_SRC_TCO_FLAGS,
+            Ff800ClkSrc::Internal => Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS,
         };
         quads[0] |= flag;
-    }
 
-    quads[0] &= !Q0_ACTIVE_CLK_SRC_MASK;
-    let flag = match &status.active_clk_src {
-        Ff800ClkSrc::AdatA => Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS,
-        Ff800ClkSrc::AdatB => Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS,
-        Ff800ClkSrc::Spdif => Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS,
-        Ff800ClkSrc::WordClock => Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS,
-        Ff800ClkSrc::Tco => Q0_ACTIVE_CLK_SRC_TCO_FLAGS,
-        Ff800ClkSrc::Internal => Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS,
-    };
-    quads[0] |= flag;
+        quads[0] &= !Q0_EXT_CLK_RATE_MASK;
+        if let Some(rate) = &params.external_clk_rate {
+            let flag = match rate {
+                ClkNominalRate::R32000 => Q0_EXT_CLK_RATE_32000_FLAGS,
+                ClkNominalRate::R44100 => Q0_EXT_CLK_RATE_44100_FLAGS,
+                ClkNominalRate::R48000 => Q0_EXT_CLK_RATE_48000_FLAGS,
+                ClkNominalRate::R64000 => Q0_EXT_CLK_RATE_64000_FLAGS,
+                ClkNominalRate::R88200 => Q0_EXT_CLK_RATE_88200_FLAGS,
+                ClkNominalRate::R96000 => Q0_EXT_CLK_RATE_96000_FLAGS,
+                ClkNominalRate::R128000 => Q0_EXT_CLK_RATE_128000_FLAGS,
+                ClkNominalRate::R176400 => Q0_EXT_CLK_RATE_176400_FLAGS,
+                ClkNominalRate::R192000 => Q0_EXT_CLK_RATE_192000_FLAGS,
+            };
+            quads[0] |= flag;
+        }
 
-    quads[0] &= !Q0_EXT_CLK_RATE_MASK;
-    if let Some(rate) = &status.external_clk_rate {
-        let flag = match rate {
-            ClkNominalRate::R32000 => Q0_EXT_CLK_RATE_32000_FLAGS,
-            ClkNominalRate::R44100 => Q0_EXT_CLK_RATE_44100_FLAGS,
-            ClkNominalRate::R48000 => Q0_EXT_CLK_RATE_48000_FLAGS,
-            ClkNominalRate::R64000 => Q0_EXT_CLK_RATE_64000_FLAGS,
-            ClkNominalRate::R88200 => Q0_EXT_CLK_RATE_88200_FLAGS,
-            ClkNominalRate::R96000 => Q0_EXT_CLK_RATE_96000_FLAGS,
-            ClkNominalRate::R128000 => Q0_EXT_CLK_RATE_128000_FLAGS,
-            ClkNominalRate::R176400 => Q0_EXT_CLK_RATE_176400_FLAGS,
-            ClkNominalRate::R192000 => Q0_EXT_CLK_RATE_192000_FLAGS,
+        quads[1] &= !Q1_SPDIF_IN_IFACE_MASK;
+        if params.spdif_in.iface == SpdifIface::Optical {
+            quads[1] |= Q1_SPDIF_IN_IFACE_MASK;
+        }
+
+        quads[1] &= !Q1_SPDIF_OUT_FMT_MASK;
+        if params.spdif_out.format == SpdifFormat::Professional {
+            quads[1] |= Q1_SPDIF_OUT_FMT_MASK;
+        }
+
+        quads[1] &= !Q1_SPDIF_OUT_EMPHASIS_MASK;
+        if params.spdif_out.emphasis {
+            quads[1] |= Q1_SPDIF_OUT_EMPHASIS_MASK;
+        }
+
+        quads[1] &= !Q1_OPT_OUT_SIGNAL_MASK;
+        if params.opt_out_signal == OpticalOutputSignal::Spdif {
+            quads[1] |= Q1_OPT_OUT_SIGNAL_MASK;
+        }
+
+        quads[1] &= !Q1_WORD_OUT_SINGLE_MASK;
+        if params.word_out_single {
+            quads[1] |= Q1_WORD_OUT_SINGLE_MASK;
+        }
+
+        quads[1] &= !Q1_CONF_CLK_SRC_MASK;
+        let flag = match &params.configured_clk_src {
+            Ff800ClkSrc::Internal => Q1_CONF_CLK_SRC_INTERNAL_FLAGS,
+            Ff800ClkSrc::AdatB => Q1_CONF_CLK_SRC_ADAT_B_FLAGS,
+            Ff800ClkSrc::Spdif => Q1_CONF_CLK_SRC_SPDIF_FLAGS,
+            Ff800ClkSrc::WordClock => Q1_CONF_CLK_SRC_WORD_CLK_FLAGS,
+            Ff800ClkSrc::Tco => Q1_CONF_CLK_SRC_TCO_FLAGS,
+            Ff800ClkSrc::AdatA => Q1_CONF_CLK_SRC_ADAT_A_FLAGS,
         };
-        quads[0] |= flag;
+        quads[1] |= flag;
+
+        quads[1] &= !Q1_CONF_CLK_RATE_MASK;
+        let flag = match &params.configured_clk_rate {
+            ClkNominalRate::R32000 => Q1_CONF_CLK_RATE_32000_FLAGS,
+            ClkNominalRate::R44100 => Q1_CONF_CLK_RATE_44100_FLAGS,
+            ClkNominalRate::R48000 => Q1_CONF_CLK_RATE_48000_FLAGS,
+            ClkNominalRate::R64000 => Q1_CONF_CLK_RATE_64000_FLAGS,
+            ClkNominalRate::R88200 => Q1_CONF_CLK_RATE_88200_FLAGS,
+            ClkNominalRate::R96000 => Q1_CONF_CLK_RATE_96000_FLAGS,
+            ClkNominalRate::R128000 => Q1_CONF_CLK_RATE_128000_FLAGS,
+            ClkNominalRate::R176400 => Q1_CONF_CLK_RATE_176400_FLAGS,
+            ClkNominalRate::R192000 => Q1_CONF_CLK_RATE_192000_FLAGS,
+        };
+        quads[1] |= flag;
+
+        quads.iter().flat_map(|quad| quad.to_le_bytes()).collect()
     }
+}
 
-    quads[1] &= !Q1_SPDIF_IN_IFACE_MASK;
-    if status.spdif_in.iface == SpdifIface::Optical {
-        quads[1] |= Q1_SPDIF_IN_IFACE_MASK;
+impl RmeFfParamsDeserialize<Ff800Status, u8> for Ff800Protocol {
+    fn deserialize(params: &mut Ff800Status, raw: &[u8]) {
+        assert!(raw.len() >= FORMER_STATUS_SIZE);
+
+        let mut quads = [0; Ff800Status::QUADLET_COUNT];
+        let mut quadlet = [0; 4];
+        quads.iter_mut().enumerate().for_each(|(i, quad)| {
+            let pos = i * 4;
+            quadlet.copy_from_slice(&raw[pos..(pos + 4)]);
+            *quad = u32::from_le_bytes(quadlet);
+        });
+
+        deserialize_lock_status(&mut params.lock, &quads);
+        deserialize_sync_status(&mut params.sync, &quads);
+
+        params.spdif_rate = match quads[0] & Q0_SPDIF_RATE_MASK {
+            Q0_SPDIF_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
+            Q0_SPDIF_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
+            Q0_SPDIF_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
+            Q0_SPDIF_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
+            Q0_SPDIF_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
+            Q0_SPDIF_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
+            Q0_SPDIF_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
+            Q0_SPDIF_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
+            Q0_SPDIF_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
+            _ => None,
+        };
+
+        params.active_clk_src = match quads[0] & Q0_ACTIVE_CLK_SRC_MASK {
+            Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS => Ff800ClkSrc::AdatA,
+            Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
+            Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
+            Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
+            Q0_ACTIVE_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
+            Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
+            _ => unreachable!(),
+        };
+
+        params.external_clk_rate = match quads[0] & Q0_EXT_CLK_RATE_MASK {
+            Q0_EXT_CLK_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
+            Q0_EXT_CLK_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
+            Q0_EXT_CLK_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
+            Q0_EXT_CLK_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
+            Q0_EXT_CLK_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
+            Q0_EXT_CLK_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
+            Q0_EXT_CLK_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
+            Q0_EXT_CLK_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
+            Q0_EXT_CLK_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
+            _ => None,
+        };
+
+        params.spdif_in.iface = if quads[1] & Q1_SPDIF_IN_IFACE_MASK > 0 {
+            SpdifIface::Optical
+        } else {
+            SpdifIface::Coaxial
+        };
+
+        params.spdif_out.format = if quads[1] & Q1_SPDIF_OUT_FMT_MASK > 0 {
+            SpdifFormat::Professional
+        } else {
+            SpdifFormat::Consumer
+        };
+
+        params.spdif_out.emphasis = quads[1] & Q1_SPDIF_OUT_EMPHASIS_MASK > 0;
+
+        params.opt_out_signal = if quads[1] & Q1_OPT_OUT_SIGNAL_MASK > 0 {
+            OpticalOutputSignal::Spdif
+        } else {
+            OpticalOutputSignal::Adat
+        };
+
+        params.word_out_single = quads[1] & Q1_WORD_OUT_SINGLE_MASK > 0;
+
+        params.configured_clk_src = match quads[1] & Q1_CONF_CLK_SRC_MASK {
+            Q1_CONF_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
+            Q1_CONF_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
+            Q1_CONF_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
+            Q1_CONF_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
+            Q1_CONF_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
+            Q1_CONF_CLK_SRC_ADAT_A_FLAGS | _ => Ff800ClkSrc::AdatA,
+        };
+
+        params.configured_clk_rate = match quads[1] & Q1_CONF_CLK_RATE_MASK {
+            Q1_CONF_CLK_RATE_32000_FLAGS => ClkNominalRate::R32000,
+            Q1_CONF_CLK_RATE_48000_FLAGS => ClkNominalRate::R48000,
+            Q1_CONF_CLK_RATE_64000_FLAGS => ClkNominalRate::R64000,
+            Q1_CONF_CLK_RATE_88200_FLAGS => ClkNominalRate::R88200,
+            Q1_CONF_CLK_RATE_96000_FLAGS => ClkNominalRate::R96000,
+            Q1_CONF_CLK_RATE_128000_FLAGS => ClkNominalRate::R128000,
+            Q1_CONF_CLK_RATE_176400_FLAGS => ClkNominalRate::R176400,
+            Q1_CONF_CLK_RATE_192000_FLAGS => ClkNominalRate::R192000,
+            Q1_CONF_CLK_RATE_44100_FLAGS | _ => ClkNominalRate::R44100,
+        };
     }
-
-    quads[1] &= !Q1_SPDIF_OUT_FMT_MASK;
-    if status.spdif_out.format == SpdifFormat::Professional {
-        quads[1] |= Q1_SPDIF_OUT_FMT_MASK;
-    }
-
-    quads[1] &= !Q1_SPDIF_OUT_EMPHASIS_MASK;
-    if status.spdif_out.emphasis {
-        quads[1] |= Q1_SPDIF_OUT_EMPHASIS_MASK;
-    }
-
-    quads[1] &= !Q1_OPT_OUT_SIGNAL_MASK;
-    if status.opt_out_signal == OpticalOutputSignal::Spdif {
-        quads[1] |= Q1_OPT_OUT_SIGNAL_MASK;
-    }
-
-    quads[1] &= !Q1_WORD_OUT_SINGLE_MASK;
-    if status.word_out_single {
-        quads[1] |= Q1_WORD_OUT_SINGLE_MASK;
-    }
-
-    quads[1] &= !Q1_CONF_CLK_SRC_MASK;
-    let flag = match &status.configured_clk_src {
-        Ff800ClkSrc::Internal => Q1_CONF_CLK_SRC_INTERNAL_FLAGS,
-        Ff800ClkSrc::AdatB => Q1_CONF_CLK_SRC_ADAT_B_FLAGS,
-        Ff800ClkSrc::Spdif => Q1_CONF_CLK_SRC_SPDIF_FLAGS,
-        Ff800ClkSrc::WordClock => Q1_CONF_CLK_SRC_WORD_CLK_FLAGS,
-        Ff800ClkSrc::Tco => Q1_CONF_CLK_SRC_TCO_FLAGS,
-        Ff800ClkSrc::AdatA => Q1_CONF_CLK_SRC_ADAT_A_FLAGS,
-    };
-    quads[1] |= flag;
-
-    quads[1] &= !Q1_CONF_CLK_RATE_MASK;
-    let flag = match &status.configured_clk_rate {
-        ClkNominalRate::R32000 => Q1_CONF_CLK_RATE_32000_FLAGS,
-        ClkNominalRate::R44100 => Q1_CONF_CLK_RATE_44100_FLAGS,
-        ClkNominalRate::R48000 => Q1_CONF_CLK_RATE_48000_FLAGS,
-        ClkNominalRate::R64000 => Q1_CONF_CLK_RATE_64000_FLAGS,
-        ClkNominalRate::R88200 => Q1_CONF_CLK_RATE_88200_FLAGS,
-        ClkNominalRate::R96000 => Q1_CONF_CLK_RATE_96000_FLAGS,
-        ClkNominalRate::R128000 => Q1_CONF_CLK_RATE_128000_FLAGS,
-        ClkNominalRate::R176400 => Q1_CONF_CLK_RATE_176400_FLAGS,
-        ClkNominalRate::R192000 => Q1_CONF_CLK_RATE_192000_FLAGS,
-    };
-    quads[1] |= flag;
 }
 
 fn deserialize_status(status: &mut Ff800Status, quads: &[u32]) {
     assert!(quads.len() >= Ff800Status::QUADLET_COUNT);
-
-    deserialize_lock_status(&mut status.lock, quads);
-    deserialize_sync_status(&mut status.sync, quads);
-
-    status.spdif_rate = match quads[0] & Q0_SPDIF_RATE_MASK {
-        Q0_SPDIF_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
-        Q0_SPDIF_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
-        Q0_SPDIF_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
-        Q0_SPDIF_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
-        Q0_SPDIF_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
-        Q0_SPDIF_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
-        Q0_SPDIF_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
-        Q0_SPDIF_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
-        Q0_SPDIF_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
-        _ => None,
-    };
-
-    status.active_clk_src = match quads[0] & Q0_ACTIVE_CLK_SRC_MASK {
-        Q0_ACTIVE_CLK_SRC_ADAT_A_FLAGS => Ff800ClkSrc::AdatA,
-        Q0_ACTIVE_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
-        Q0_ACTIVE_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
-        Q0_ACTIVE_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
-        Q0_ACTIVE_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
-        Q0_ACTIVE_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
-        _ => unreachable!(),
-    };
-
-    status.external_clk_rate = match quads[0] & Q0_EXT_CLK_RATE_MASK {
-        Q0_EXT_CLK_RATE_32000_FLAGS => Some(ClkNominalRate::R32000),
-        Q0_EXT_CLK_RATE_44100_FLAGS => Some(ClkNominalRate::R44100),
-        Q0_EXT_CLK_RATE_48000_FLAGS => Some(ClkNominalRate::R48000),
-        Q0_EXT_CLK_RATE_64000_FLAGS => Some(ClkNominalRate::R64000),
-        Q0_EXT_CLK_RATE_88200_FLAGS => Some(ClkNominalRate::R88200),
-        Q0_EXT_CLK_RATE_96000_FLAGS => Some(ClkNominalRate::R96000),
-        Q0_EXT_CLK_RATE_128000_FLAGS => Some(ClkNominalRate::R128000),
-        Q0_EXT_CLK_RATE_176400_FLAGS => Some(ClkNominalRate::R176400),
-        Q0_EXT_CLK_RATE_192000_FLAGS => Some(ClkNominalRate::R192000),
-        _ => None,
-    };
-
-    status.spdif_in.iface = if quads[1] & Q1_SPDIF_IN_IFACE_MASK > 0 {
-        SpdifIface::Optical
-    } else {
-        SpdifIface::Coaxial
-    };
-
-    status.spdif_out.format = if quads[1] & Q1_SPDIF_OUT_FMT_MASK > 0 {
-        SpdifFormat::Professional
-    } else {
-        SpdifFormat::Consumer
-    };
-
-    status.spdif_out.emphasis = quads[1] & Q1_SPDIF_OUT_EMPHASIS_MASK > 0;
-
-    status.opt_out_signal = if quads[1] & Q1_OPT_OUT_SIGNAL_MASK > 0 {
-        OpticalOutputSignal::Spdif
-    } else {
-        OpticalOutputSignal::Adat
-    };
-
-    status.word_out_single = quads[1] & Q1_WORD_OUT_SINGLE_MASK > 0;
-
-    status.configured_clk_src = match quads[1] & Q1_CONF_CLK_SRC_MASK {
-        Q1_CONF_CLK_SRC_INTERNAL_FLAGS => Ff800ClkSrc::Internal,
-        Q1_CONF_CLK_SRC_ADAT_B_FLAGS => Ff800ClkSrc::AdatB,
-        Q1_CONF_CLK_SRC_SPDIF_FLAGS => Ff800ClkSrc::Spdif,
-        Q1_CONF_CLK_SRC_WORD_CLK_FLAGS => Ff800ClkSrc::WordClock,
-        Q1_CONF_CLK_SRC_TCO_FLAGS => Ff800ClkSrc::Tco,
-        Q1_CONF_CLK_SRC_ADAT_A_FLAGS | _ => Ff800ClkSrc::AdatA,
-    };
-
-    status.configured_clk_rate = match quads[1] & Q1_CONF_CLK_RATE_MASK {
-        Q1_CONF_CLK_RATE_32000_FLAGS => ClkNominalRate::R32000,
-        Q1_CONF_CLK_RATE_48000_FLAGS => ClkNominalRate::R48000,
-        Q1_CONF_CLK_RATE_64000_FLAGS => ClkNominalRate::R64000,
-        Q1_CONF_CLK_RATE_88200_FLAGS => ClkNominalRate::R88200,
-        Q1_CONF_CLK_RATE_96000_FLAGS => ClkNominalRate::R96000,
-        Q1_CONF_CLK_RATE_128000_FLAGS => ClkNominalRate::R128000,
-        Q1_CONF_CLK_RATE_176400_FLAGS => ClkNominalRate::R176400,
-        Q1_CONF_CLK_RATE_192000_FLAGS => ClkNominalRate::R192000,
-        Q1_CONF_CLK_RATE_44100_FLAGS | _ => ClkNominalRate::R44100,
-    };
+    let raw: Vec<u8> = quads.iter().flat_map(|quad| quad.to_le_bytes()).collect();
+    Ff800Protocol::deserialize(status, &raw);
 }
 
 impl Ff800Protocol {
@@ -1041,234 +1058,237 @@ mod test {
         assert_eq!(target, orig);
     }
 
+    fn quads_to_bytes(quads: &[u32]) -> Vec<u8> {
+        quads.iter().flat_map(|quad| quad.to_le_bytes()).collect()
+    }
+
     #[test]
     fn status_serdes() {
         let mut status = Ff800Status::default();
 
         let quads = [0x02001000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.lock.adat_a, true);
 
         let quads = [0x02002000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.lock.adat_b, true);
 
         let quads = [0x02040000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.lock.spdif, true);
 
         let quads = [0x22000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.lock.word_clock, true);
 
         let quads = [0x02000400, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.adat_a, true);
 
         let quads = [0x02000800, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.adat_b, true);
 
         let quads = [0x02100800, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.spdif, true);
 
         let quads = [0x42000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.word_clock, true);
 
         let quads = [0x02000000, 0x00800000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.tco, true);
 
         let quads = [0x02004000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R32000));
 
         let quads = [0x02008000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R44100));
 
         let quads = [0x0200c000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R48000));
 
         let quads = [0x02010000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R64000));
 
         let quads = [0x02014000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R88200));
 
         let quads = [0x02018000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R96000));
 
         let quads = [0x0201c000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R128000));
 
         let quads = [0x02020000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R176400));
 
         let quads = [0x02024000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_rate, Some(ClkNominalRate::R192000));
 
         let quads = [0x02000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::AdatA);
 
         let quads = [0x02400000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::AdatB);
 
         let quads = [0x02c00000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::Spdif);
 
         let quads = [0x03000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::WordClock);
 
         let quads = [0x03800000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::Tco);
 
         let quads = [0x03c00000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.active_clk_src, Ff800ClkSrc::Internal);
 
         let quads = [0x02000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R32000));
 
         let quads = [0x04000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R44100));
 
         let quads = [0x06000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R48000));
 
         let quads = [0x08000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R64000));
 
         let quads = [0x0a000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R88200));
 
         let quads = [0x0e000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R96000));
 
         let quads = [0x0c000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R128000));
 
         let quads = [0x10000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R176400));
 
         let quads = [0x12000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.external_clk_rate, Some(ClkNominalRate::R192000));
 
         let quads = [0x02000000, 0x00400000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.lock.tco, true);
 
         let quads = [0x02000000, 0x00800000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.sync.tco, true);
 
         let quads = [0x02000000, 0x00002000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.word_out_single, true);
 
         let quads = [0x02000000, 0x00000200];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_in.iface, SpdifIface::Optical);
 
         let quads = [0x02000000, 0x00000100];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.opt_out_signal, OpticalOutputSignal::Spdif);
 
         let quads = [0x02000000, 0x00000040];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_out.emphasis, true);
 
         let quads = [0x02000000, 0x00000020];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.spdif_out.format, SpdifFormat::Professional);
 
         let quads = [0x02000000, 0x00000002];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R32000);
 
         let quads = [0x02000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R44100);
 
         let quads = [0x02000000, 0x00000006];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R48000);
 
         let quads = [0x02000000, 0x0000000a];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R64000);
 
         let quads = [0x02000000, 0x00000008];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R88200);
 
         let quads = [0x02000000, 0x0000000e];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R96000);
 
         let quads = [0x02000000, 0x00000012];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R128000);
 
         let quads = [0x02000000, 0x00000010];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R176400);
 
         let quads = [0x02000000, 0x00000016];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_rate, ClkNominalRate::R192000);
 
         let quads = [0x02000000, 0x00001000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::WordClock);
 
         let quads = [0x02000000, 0x00001800];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::Tco);
 
         let quads = [0x02000000, 0x00000c00];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::Spdif);
 
         let quads = [0x02000000, 0x00000400];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::AdatB);
 
         let quads = [0x02000000, 0x00000001];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::Internal);
 
         let quads = [0x02000000, 0x00000000];
-        deserialize_status(&mut status, &quads);
+        Ff800Protocol::deserialize(&mut status, &quads_to_bytes(&quads));
         assert_eq!(status.configured_clk_src, Ff800ClkSrc::AdatA);
 
-        let mut quads = [0; Ff800Status::QUADLET_COUNT];
-        serialize_status(&status, &mut quads);
+        let raw = Ff800Protocol::serialize(&status);
         let mut target = Ff800Status::default();
-        deserialize_status(&mut target, &quads);
+        Ff800Protocol::deserialize(&mut target, &raw);
         assert_eq!(target, status);
     }
 

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -172,33 +172,6 @@ fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
     .map(|_| T::deserialize(status, &raw))
 }
 
-/// Status protocol.
-pub trait RmeFfLatterStatusOperation<U>
-where
-    U: RmeFfLatterRegisterValueOperation,
-{
-    fn read_status(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        status: &mut U,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut raw = [0; 4];
-        req.transaction_sync(
-            node,
-            FwTcode::ReadQuadletRequest,
-            DSP_OFFSET as u64,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-        .map(|_| {
-            let quad = u32::from_le_bytes(raw);
-            status.deserialize(&quad)
-        })
-    }
-}
-
 /// State of meters.
 ///
 /// Each value is between 0x'0000'0000'0000'0000 and 0x'3fff'ffff'ffff'ffff. 0x'0000'0000'0000'001f

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -58,6 +58,8 @@ fn deserialize_midi_tx_low_offset(offset: &mut FfLatterMidiTxLowOffset, quad: &u
     }
 }
 
+const LATTER_CONFIG_SIZE: usize = 4;
+
 /// Operation for configuration structure.
 pub trait RmeFfLatterRegisterValueOperation {
     fn serialize(&self, quad: &mut u32);

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -6,11 +6,7 @@
 pub mod ff802;
 pub mod ucx;
 
-use {
-    super::*,
-    glib::Error,
-    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
-};
+use super::*;
 
 const CFG_OFFSET: usize = 0xffff00000014;
 const DSP_OFFSET: usize = 0xffff0000001c;

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -154,6 +154,24 @@ fn deserialize_clock_rate_optional(
 
 const LATTER_STATUS_SIZE: usize = 4;
 
+fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
+    req: &mut FwReq,
+    node: &mut FwNode,
+    status: &mut U,
+    timeout_ms: u32,
+) -> Result<(), Error> {
+    let mut raw = [0; 4];
+    req.transaction_sync(
+        node,
+        FwTcode::ReadQuadletRequest,
+        DSP_OFFSET as u64,
+        raw.len(),
+        &mut raw,
+        timeout_ms,
+    )
+    .map(|_| T::deserialize(status, &raw))
+}
+
 /// Status protocol.
 pub trait RmeFfLatterStatusOperation<U>
 where

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -152,6 +152,8 @@ fn deserialize_clock_rate_optional(
     };
 }
 
+const LATTER_STATUS_SIZE: usize = 4;
+
 /// Status protocol.
 pub trait RmeFfLatterStatusOperation<U>
 where

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -84,30 +84,6 @@ pub trait RmeFfLatterRegisterValueOperation {
     fn deserialize(&mut self, quad: &u32);
 }
 
-/// Configuration protocol.
-pub trait RmeFfLatterConfigOperation<U: RmeFfLatterRegisterValueOperation> {
-    fn write_cfg(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        cfg: &U,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut quad = 0u32;
-        cfg.serialize(&mut quad);
-
-        let mut raw = [0; 4];
-        raw.copy_from_slice(&quad.to_le_bytes());
-        req.transaction_sync(
-            node,
-            FwTcode::WriteQuadletRequest,
-            CFG_OFFSET,
-            raw.len(),
-            &mut raw,
-            timeout_ms,
-        )
-    }
-}
-
 // For status register (0x'ffff'0000'001c).
 const STATUS_CLK_RATE_32000: u32 = 0x00;
 const STATUS_CLK_RATE_44100: u32 = 0x01;

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -380,6 +380,17 @@ impl RmeFfParamsDeserialize<Ff802Status, u8> for Ff802Protocol {
     }
 }
 
+impl RmeFfCacheableParamsOperation<Ff802Status> for Ff802Protocol {
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        status: &mut Ff802Status,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        read_status::<Ff802Protocol, Ff802Status>(req, node, status, timeout_ms)
+    }
+}
+
 impl RmeFfLatterRegisterValueOperation for Ff802Status {
     fn serialize(&self, quad: &mut u32) {
         let raw = Ff802Protocol::serialize(self);

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -161,6 +161,17 @@ impl RmeFfParamsDeserialize<Ff802Config, u8> for Ff802Protocol {
     }
 }
 
+impl RmeFfWhollyUpdatableParamsOperation<Ff802Config> for Ff802Protocol {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &Ff802Config,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        write_config::<Ff802Protocol, Ff802Config>(req, node, params, timeout_ms)
+    }
+}
+
 impl RmeFfLatterRegisterValueOperation for Ff802Config {
     fn serialize(&self, quad: &mut u32) {
         let raw = Ff802Protocol::serialize(self);

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -391,21 +391,6 @@ impl RmeFfCacheableParamsOperation<Ff802Status> for Ff802Protocol {
     }
 }
 
-impl RmeFfLatterRegisterValueOperation for Ff802Status {
-    fn serialize(&self, quad: &mut u32) {
-        let raw = Ff802Protocol::serialize(self);
-        let mut quadlet = [0; 4];
-        quadlet.copy_from_slice(&raw[..4]);
-        *quad = u32::from_le_bytes(quadlet);
-    }
-
-    fn deserialize(&mut self, quad: &u32) {
-        Ff802Protocol::deserialize(self, &quad.to_le_bytes());
-    }
-}
-
-impl RmeFfLatterStatusOperation<Ff802Status> for Ff802Protocol {}
-
 const LINE_INPUT_COUNT: usize = 8;
 const MIC_INPUT_COUNT: usize = 4;
 const SPDIF_INPUT_COUNT: usize = 2;

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -171,22 +171,6 @@ impl RmeFfWhollyUpdatableParamsOperation<Ff802Config> for Ff802Protocol {
         write_config::<Ff802Protocol, Ff802Config>(req, node, params, timeout_ms)
     }
 }
-
-impl RmeFfLatterRegisterValueOperation for Ff802Config {
-    fn serialize(&self, quad: &mut u32) {
-        let raw = Ff802Protocol::serialize(self);
-        let mut quadlet = [0; 4];
-        quadlet.copy_from_slice(&raw[..4]);
-        *quad = u32::from_le_bytes(quadlet);
-    }
-
-    fn deserialize(&mut self, quad: &u32) {
-        Ff802Protocol::deserialize(self, &quad.to_le_bytes());
-    }
-}
-
-impl RmeFfLatterConfigOperation<Ff802Config> for Ff802Protocol {}
-
 // For status register (0x'ffff'0000'001c).
 const STATUS_ACTIVE_CLK_RATE_MASK: u32 = 0xf0000000;
 const STATUS_ADAT_B_RATE_MASK: u32 = 0x0f000000;

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -144,21 +144,6 @@ impl RmeFfWhollyUpdatableParamsOperation<FfUcxConfig> for FfUcxProtocol {
     }
 }
 
-impl RmeFfLatterRegisterValueOperation for FfUcxConfig {
-    fn serialize(&self, quad: &mut u32) {
-        let raw = FfUcxProtocol::serialize(self);
-        let mut quadlet = [0; 4];
-        quadlet.copy_from_slice(&raw[..4]);
-        *quad = u32::from_le_bytes(quadlet);
-    }
-
-    fn deserialize(&mut self, quad: &u32) {
-        FfUcxProtocol::deserialize(self, &quad.to_le_bytes());
-    }
-}
-
-impl RmeFfLatterConfigOperation<FfUcxConfig> for FfUcxProtocol {}
-
 // For status register (0x'ffff'0000'001c).
 #[allow(dead_code)]
 const STATUS_ACTIVE_CLK_RATE_MASK: u32 = 0x0f000000;

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -339,6 +339,17 @@ impl RmeFfParamsDeserialize<FfUcxStatus, u8> for FfUcxProtocol {
     }
 }
 
+impl RmeFfCacheableParamsOperation<FfUcxStatus> for FfUcxProtocol {
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        status: &mut FfUcxStatus,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        read_status::<FfUcxProtocol, FfUcxStatus>(req, node, status, timeout_ms)
+    }
+}
+
 impl RmeFfLatterRegisterValueOperation for FfUcxStatus {
     fn serialize(&self, quad: &mut u32) {
         let raw = FfUcxProtocol::serialize(self);

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -133,6 +133,17 @@ impl RmeFfParamsDeserialize<FfUcxConfig, u8> for FfUcxProtocol {
     }
 }
 
+impl RmeFfWhollyUpdatableParamsOperation<FfUcxConfig> for FfUcxProtocol {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &FfUcxConfig,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        write_config::<FfUcxProtocol, FfUcxConfig>(req, node, params, timeout_ms)
+    }
+}
+
 impl RmeFfLatterRegisterValueOperation for FfUcxConfig {
     fn serialize(&self, quad: &mut u32) {
         let raw = FfUcxProtocol::serialize(self);

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -350,21 +350,6 @@ impl RmeFfCacheableParamsOperation<FfUcxStatus> for FfUcxProtocol {
     }
 }
 
-impl RmeFfLatterRegisterValueOperation for FfUcxStatus {
-    fn serialize(&self, quad: &mut u32) {
-        let raw = FfUcxProtocol::serialize(self);
-        let mut quadlet = [0; 4];
-        quadlet.copy_from_slice(&raw[..4]);
-        *quad = u32::from_le_bytes(quadlet);
-    }
-
-    fn deserialize(&mut self, quad: &u32) {
-        FfUcxProtocol::deserialize(self, &quad.to_le_bytes());
-    }
-}
-
-impl RmeFfLatterStatusOperation<FfUcxStatus> for FfUcxProtocol {}
-
 const LINE_INPUT_COUNT: usize = 6;
 const MIC_INPUT_COUNT: usize = 2;
 const SPDIF_INPUT_COUNT: usize = 2;

--- a/protocols/fireface/src/lib.rs
+++ b/protocols/fireface/src/lib.rs
@@ -117,3 +117,15 @@ impl Default for LineOutNominalLevel {
         Self::High
     }
 }
+
+/// Parameters deserializer.
+pub trait RmeFfParamsDeserialize<T, U> {
+    /// Deserialize parameters into raw data.
+    fn deserialize(params: &mut T, raw: &[U]);
+}
+
+/// Parameters serializer.
+pub trait RmeFfParamsSerialize<T, U> {
+    /// Serialize parameters from raw data.
+    fn serialize(params: &T) -> Vec<U>;
+}

--- a/protocols/fireface/src/lib.rs
+++ b/protocols/fireface/src/lib.rs
@@ -144,3 +144,14 @@ pub trait RmeFfWhollyUpdatableParamsOperation<T> {
         timeout_ms: u32,
     ) -> Result<(), Error>;
 }
+
+/// Operation for parameters which can be cached wholly at once.
+pub trait RmeFfCacheableParamsOperation<T> {
+    /// Cache whole parameters from registers.
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}

--- a/protocols/fireface/src/lib.rs
+++ b/protocols/fireface/src/lib.rs
@@ -6,7 +6,11 @@
 pub mod former;
 pub mod latter;
 
-use ieee1212_config_rom::*;
+use {
+    glib::Error,
+    hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode},
+    ieee1212_config_rom::*,
+};
 
 const RME_OUI: u32 = 0x00000a35;
 
@@ -128,4 +132,15 @@ pub trait RmeFfParamsDeserialize<T, U> {
 pub trait RmeFfParamsSerialize<T, U> {
     /// Serialize parameters from raw data.
     fn serialize(params: &T) -> Vec<U>;
+}
+
+/// Operation for parameters which can be updated wholly at once.
+pub trait RmeFfWhollyUpdatableParamsOperation<T> {
+    /// Update registers for whole parameters.
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
 }

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -311,7 +311,7 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = Ff400Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        let res = Ff400Protocol::cache_wholly(req, node, &mut self.1, timeout_ms);
         debug!(params = ?self.1, ?res);
         res
     }

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -445,7 +445,7 @@ impl CfgCtl {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         self.0.init(&status);
-        let res = Ff400Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        let res = Ff400Protocol::update_wholly(req, node, &self.0, timeout_ms);
         debug!(params = ?self.0, ?res);
         res
     }
@@ -669,7 +669,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -685,7 +685,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -698,7 +698,7 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -711,7 +711,7 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(enabled, val)| *enabled = val);
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -724,7 +724,7 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -740,7 +740,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -757,7 +757,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -773,7 +773,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -781,7 +781,7 @@ impl CfgCtl {
             SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_in.use_preemble = elem_value.boolean()[0];
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -797,7 +797,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -805,7 +805,7 @@ impl CfgCtl {
             SPDIF_OUTPUT_EMPHASIS_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.emphasis = elem_value.boolean()[0];
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -813,7 +813,7 @@ impl CfgCtl {
             SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.non_audio = elem_value.boolean()[0];
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -830,7 +830,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -838,7 +838,7 @@ impl CfgCtl {
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                let res = Ff400Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff400Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -339,7 +339,7 @@ impl CfgCtl {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         self.0.init(&status);
-        let res = Ff800Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        let res = Ff800Protocol::update_wholly(req, node, &self.0, timeout_ms);
         debug!(params = ?self.0, ?res);
         res
     }
@@ -548,7 +548,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -571,7 +571,7 @@ impl CfgCtl {
                             })
                             .map(|j| *jack = *j)
                     })?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -587,7 +587,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -600,7 +600,7 @@ impl CfgCtl {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -608,7 +608,7 @@ impl CfgCtl {
             INPUT_INST_DRIVE_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.drive = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -616,7 +616,7 @@ impl CfgCtl {
             INPUT_INST_LIMITTER_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.limitter = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -624,7 +624,7 @@ impl CfgCtl {
             INPUT_INST_SPKR_EMU_NAME => {
                 let mut params = self.0.clone();
                 params.analog_in.inst.speaker_emulation = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -640,7 +640,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -656,7 +656,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -664,7 +664,7 @@ impl CfgCtl {
             SPDIF_INPUT_USE_PREEMBLE_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_in.use_preemble = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -680,7 +680,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -688,7 +688,7 @@ impl CfgCtl {
             SPDIF_OUTPUT_EMPHASIS_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.emphasis = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -696,7 +696,7 @@ impl CfgCtl {
             SPDIF_OUTPUT_NON_AUDIO_NAME => {
                 let mut params = self.0.clone();
                 params.spdif_out.non_audio = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -713,7 +713,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -721,7 +721,7 @@ impl CfgCtl {
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                let res = Ff800Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff800Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -180,7 +180,7 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = Ff800Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        let res = Ff800Protocol::cache_wholly(req, node, &mut self.1, timeout_ms);
         debug!(params = ?self.1, ?res);
         res
     }

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -172,7 +172,7 @@ impl CfgCtl {
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = Ff802Protocol::write_cfg(req, node, &self.0, timeout_ms);
+        let res = Ff802Protocol::update_wholly(req, node, &self.0, timeout_ms);
         debug!(params = ?self.0, ?res);
         res
     }
@@ -282,7 +282,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -298,7 +298,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -315,7 +315,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -323,7 +323,7 @@ impl CfgCtl {
             EFFECT_ON_INPUT_NAME => {
                 let mut params = self.0.clone();
                 params.effect_on_inputs = elem_value.boolean()[0];
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -339,7 +339,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -347,7 +347,7 @@ impl CfgCtl {
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                let res = Ff802Protocol::write_cfg(req, node, &params, timeout_ms);
+                let res = Ff802Protocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -3,10 +3,7 @@
 
 use {
     super::{latter_ctls::*, *},
-    protocols::{
-        latter::{ff802::*, *},
-        *,
-    },
+    protocols::{latter::ff802::*, *},
 };
 
 #[derive(Default, Debug)]
@@ -388,7 +385,7 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = Ff802Protocol::read_status(req, node, &mut self.1, timeout_ms);
+        let res = Ff802Protocol::cache_wholly(req, node, &mut self.1, timeout_ms);
         debug!(params = ?self.1, ?res);
         res
     }

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -3,10 +3,7 @@
 
 use {
     super::{latter_ctls::*, *},
-    protocols::{
-        latter::{ucx::*, *},
-        *,
-    },
+    protocols::{latter::ucx::*, *},
 };
 
 #[derive(Default, Debug)]
@@ -357,7 +354,7 @@ impl StatusCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = FfUcxProtocol::read_status(req, node, &mut self.1, timeout_ms);
+        let res = FfUcxProtocol::cache_wholly(req, node, &mut self.1, timeout_ms);
         debug!(params = ?self.1, ?res);
         res
     }

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -160,7 +160,7 @@ impl CfgCtl {
     const SPDIF_FMTS: [SpdifFormat; 2] = [SpdifFormat::Consumer, SpdifFormat::Professional];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = FfUcxProtocol::write_cfg(req, node, &self.0, timeout_ms);
+        let res = FfUcxProtocol::update_wholly(req, node, &self.0, timeout_ms);
         debug!(params = ?self.0, ?res);
         res
     }
@@ -263,7 +263,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -280,7 +280,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -288,7 +288,7 @@ impl CfgCtl {
             EFFECT_ON_INPUT_NAME => {
                 let mut params = self.0.clone();
                 params.effect_on_inputs = elem_value.boolean()[0];
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -304,7 +304,7 @@ impl CfgCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -312,7 +312,7 @@ impl CfgCtl {
             WORD_CLOCK_SINGLE_SPPED_NAME => {
                 let mut params = self.0.clone();
                 params.word_out_single = elem_value.boolean()[0];
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)
@@ -320,7 +320,7 @@ impl CfgCtl {
             WORD_CLOCK_IN_TERMINATE_NAME => {
                 let mut params = self.0.clone();
                 params.word_in_terminate = elem_value.boolean()[0];
-                let res = FfUcxProtocol::write_cfg(req, node, &params, timeout_ms);
+                let res = FfUcxProtocol::update_wholly(req, node, &params, timeout_ms);
                 debug!(?params, ?res);
                 self.0 = params;
                 res.map(|_| true)


### PR DESCRIPTION
The typical way to operate devices of RME FireFace series is accessing
to registers by read and write transaction. The operation could consists of
deserializer/serializer and read/write transaction.

This patchset arranges current implementations to add some traits for the
purpose and to use their implementations. As a result, the previous implementations
are obsoleted.

```
Takashi Sakamoto (19):
  protocols/fireface: add trait to serialize/deserialize parameters
  protocols/fireface: implement trait to serialize/deserialize
    configuration in Fireface 800
  protocols/fireface: implement trait to serialize/deserialize
    configuration in Fireface 400
  protocols/fireface: add trait to update whole parameters at once
  protocols/fireface: implement trait to update configuration in former
    models
  runtime/fireface: use alternative way to update configuration in
    former models
  protocols/fireface: implement trait to serialize/deserialize
    configuration in Fireface 802
  protocols/fireface: implement trait to serialize/deserialize
    configuration in Fireface UCX
  protocols/fireface: implement trait to update configuration in latter
    models
  runtime/fireface: use alternative way to update configuration in
    latter models
  protocols/fireface: implement trait to serialize/deserialize status in
    Fireface 800
  protocols/fireface: implement trait to serialize/deserialize status in
    Fireface 400
  protocols/fireface: add trait to cache whole parameters at once
  protocols/fireface: implement trait to cache status in former models
  runtime/fireface: use alternative way to cache status in former models
  protocols/fireface: implement trait to serialize/deserialize status in
    Fireface 802
  protocols/fireface: implement trait to serialize/deserialize status in
    Fireface UCX
  protocols/fireface: protocols/fireface: implement trait to cache
    status in latter models
  runtime/fireface: use alternative way to cache status in lattr models

 protocols/fireface/src/former.rs       |  48 +-
 protocols/fireface/src/former/ff400.rs | 630 ++++++++++---------
 protocols/fireface/src/former/ff800.rs | 806 +++++++++++++------------
 protocols/fireface/src/latter.rs       |  95 ++-
 protocols/fireface/src/latter/ff802.rs | 145 +++--
 protocols/fireface/src/latter/ucx.rs   | 138 +++--
 protocols/fireface/src/lib.rs          |  40 +-
 runtime/fireface/src/ff400_model.rs    |  32 +-
 runtime/fireface/src/ff800_model.rs    |  34 +-
 runtime/fireface/src/ff802_model.rs    |  21 +-
 runtime/fireface/src/ucx_model.rs      |  21 +-
 11 files changed, 1065 insertions(+), 945 deletions(-)
```