### PR TITLE
[PATCH 00/16] protocols/fireface: implements traits to cache/update parameters specific to latter models

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -166,6 +166,29 @@ fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
     .map(|_| T::deserialize(status, &raw))
 }
 
+/// The specification of latter model.
+pub trait RmeFfLatterSpecification {
+    /// The number of line inputs.
+    const LINE_INPUT_COUNT: usize;
+    /// The number of microphone inputs.
+    const MIC_INPUT_COUNT: usize;
+    /// The number of S/PDIF inputs.
+    const SPDIF_INPUT_COUNT: usize;
+    /// The number of ADAT inputs.
+    const ADAT_INPUT_COUNT: usize;
+    /// The number of stream inputs.
+    const STREAM_INPUT_COUNT: usize;
+
+    /// The number of line outputs.
+    const LINE_OUTPUT_COUNT: usize;
+    /// The number of headphone outputs.
+    const HP_OUTPUT_COUNT: usize;
+    /// The number of S/PDIF outputs.
+    const SPDIF_OUTPUT_COUNT: usize;
+    /// The number of ADAT outputs.
+    const ADAT_OUTPUT_COUNT: usize;
+}
+
 /// State of meters.
 ///
 /// Each value is between 0x'0000'0000'0000'0000 and 0x'3fff'ffff'ffff'ffff. 0x'0000'0000'0000'001f
@@ -186,18 +209,7 @@ pub struct FfLatterMeterState {
 const METER32_MASK: i32 = 0x07fffff0;
 
 /// Meter protocol.
-pub trait RmeFfLatterMeterOperation {
-    const LINE_INPUT_COUNT: usize;
-    const MIC_INPUT_COUNT: usize;
-    const SPDIF_INPUT_COUNT: usize;
-    const ADAT_INPUT_COUNT: usize;
-    const STREAM_INPUT_COUNT: usize;
-
-    const LINE_OUTPUT_COUNT: usize;
-    const HP_OUTPUT_COUNT: usize;
-    const SPDIF_OUTPUT_COUNT: usize;
-    const ADAT_OUTPUT_COUNT: usize;
-
+pub trait RmeFfLatterMeterOperation: RmeFfLatterSpecification {
     const LEVEL_MIN: i32 = 0x0;
     const LEVEL_MAX: i32 = 0x07fffff0;
     const LEVEL_STEP: i32 = 0x10;
@@ -318,6 +330,8 @@ pub trait RmeFfLatterMeterOperation {
     }
 }
 
+impl<O: RmeFfLatterSpecification> RmeFfLatterMeterOperation for O {}
+
 /// State of send effects (reverb and echo).
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterDspState {
@@ -374,23 +388,12 @@ fn write_dsp_cmds(
         .try_for_each(|(&cmd, _)| write_dsp_cmd(req, node, cmd, timeout_ms))
 }
 
-/// DSP protocol.
+/// The specification of DSP.
 ///
 /// DSP is configurable by quadlet write request with command aligned to little endian, which
 /// consists of two parts; 16 bit target and 16 bit coefficient. The command has odd parity
 /// bit in its most significant bit against the rest of bits.
-pub trait RmeFfLatterDspOperation {
-    const LINE_INPUT_COUNT: usize;
-    const MIC_INPUT_COUNT: usize;
-    const SPDIF_INPUT_COUNT: usize;
-    const ADAT_INPUT_COUNT: usize;
-    const STREAM_INPUT_COUNT: usize;
-
-    const LINE_OUTPUT_COUNT: usize;
-    const HP_OUTPUT_COUNT: usize;
-    const SPDIF_OUTPUT_COUNT: usize;
-    const ADAT_OUTPUT_COUNT: usize;
-
+pub trait RmeFfLatterDspOperation: RmeFfLatterSpecification {
     const PHYS_INPUT_COUNT: usize = Self::LINE_INPUT_COUNT
         + Self::MIC_INPUT_COUNT
         + Self::SPDIF_INPUT_COUNT
@@ -521,6 +524,8 @@ pub trait RmeFfLatterDspOperation {
         }
     }
 }
+
+impl<O: RmeFfLatterSpecification> RmeFfLatterDspOperation for O {}
 
 const INPUT_TO_FX_CMD: u8 = 0x01;
 const INPUT_STEREO_LINK_CMD: u8 = 0x02;

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -414,7 +414,7 @@ fn write_dsp_cmds(
 /// DSP is configurable by quadlet write request with command aligned to little endian, which
 /// consists of two parts; 16 bit target and 16 bit coefficient. The command has odd parity
 /// bit in its most significant bit against the rest of bits.
-pub trait RmeFfLatterDspOperation: RmeFfLatterSpecification {
+pub trait RmeFfLatterDspSpecification: RmeFfLatterSpecification {
     const PHYS_INPUT_COUNT: usize = Self::LINE_INPUT_COUNT
         + Self::MIC_INPUT_COUNT
         + Self::SPDIF_INPUT_COUNT
@@ -546,7 +546,7 @@ pub trait RmeFfLatterDspOperation: RmeFfLatterSpecification {
     }
 }
 
-impl<O: RmeFfLatterSpecification> RmeFfLatterDspOperation for O {}
+impl<O: RmeFfLatterSpecification> RmeFfLatterDspSpecification for O {}
 
 const INPUT_TO_FX_CMD: u8 = 0x01;
 const INPUT_STEREO_LINK_CMD: u8 = 0x02;
@@ -656,7 +656,7 @@ pub struct FfLatterInputState {
 }
 
 /// Input protocol.
-pub trait RmeFfLatterInputOperation: RmeFfLatterDspOperation {
+pub trait RmeFfLatterInputOperation: RmeFfLatterDspSpecification {
     const PHYS_INPUT_GAIN_MIN: i32 = 0;
     const PHYS_INPUT_GAIN_MAX: i32 = 120;
     const PHYS_INPUT_GAIN_STEP: i32 = 1;
@@ -749,7 +749,7 @@ pub trait RmeFfLatterInputOperation: RmeFfLatterDspOperation {
     }
 }
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterInputOperation for O {}
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterInputOperation for O {}
 
 impl From<LineOutNominalLevel> for i16 {
     fn from(level: LineOutNominalLevel) -> Self {
@@ -778,7 +778,7 @@ pub struct FfLatterOutputState {
 }
 
 /// Output protocol.
-pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
+pub trait RmeFfLatterOutputOperation: RmeFfLatterDspSpecification {
     const PHYS_OUTPUT_VOL_MIN: i32 = -650;
     const PHYS_OUTPUT_VOL_MAX: i32 = 60;
     const PHYS_OUTPUT_VOL_STEP: i32 = 1;
@@ -880,7 +880,7 @@ pub trait RmeFfLatterOutputOperation: RmeFfLatterDspOperation {
     }
 }
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterOutputOperation for O {}
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterOutputOperation for O {}
 
 /// State of mixer.
 ///
@@ -896,7 +896,7 @@ pub struct FfLatterMixerState {
 }
 
 /// Mixer protocol.
-pub trait RmeFfLatterMixerOperation: RmeFfLatterDspOperation {
+pub trait RmeFfLatterMixerOperation: RmeFfLatterDspSpecification {
     const MIXER_INPUT_GAIN_MIN: i32 = 0x0000;
     const MIXER_INPUT_GAIN_ZERO: i32 = 0x9000;
     const MIXER_INPUT_GAIN_MAX: i32 = 0xa000;
@@ -960,7 +960,7 @@ pub trait RmeFfLatterMixerOperation: RmeFfLatterDspOperation {
     }
 }
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterMixerOperation for O {}
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterMixerOperation for O {}
 
 /// Level of roll off in high pass filter.
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -1298,7 +1298,7 @@ pub struct FfLatterChStripState {
 }
 
 /// Channel strip protocol.
-pub trait RmeFfLatterChStripOperation<T>: RmeFfLatterDspOperation {
+pub trait RmeFfLatterChStripOperation<T>: RmeFfLatterDspSpecification {
     const CH_COUNT: usize;
     const CH_OFFSET: u8;
 
@@ -1445,7 +1445,7 @@ pub trait RmeFfLatterChStripOperation<T>: RmeFfLatterDspOperation {
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterInputChStripState(pub FfLatterChStripState);
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterChStripOperation<FfLatterInputChStripState> for O {
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterChStripOperation<FfLatterInputChStripState> for O {
     const CH_COUNT: usize = Self::PHYS_INPUT_COUNT;
     const CH_OFFSET: u8 = 0x00;
 
@@ -1462,7 +1462,7 @@ impl<O: RmeFfLatterDspOperation> RmeFfLatterChStripOperation<FfLatterInputChStri
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterOutputChStripState(pub FfLatterChStripState);
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterChStripOperation<FfLatterOutputChStripState> for O {
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterChStripOperation<FfLatterOutputChStripState> for O {
     const CH_COUNT: usize = Self::OUTPUT_COUNT;
     const CH_OFFSET: u8 = Self::PHYS_INPUT_COUNT as u8;
 
@@ -1781,7 +1781,7 @@ const FX_MIXER_0: u16 = 0x1e;
 const FX_MIXER_1: u16 = 0x1f;
 
 /// Mixer protocol.
-pub trait RmeFfLatterFxOperation: RmeFfLatterDspOperation {
+pub trait RmeFfLatterFxOperation: RmeFfLatterDspSpecification {
     const FX_PHYS_LEVEL_MIN: i32 = -650;
     const FX_PHYS_LEVEL_MAX: i32 = 0;
     const FX_PHYS_LEVEL_STEP: i32 = 1;
@@ -1981,7 +1981,7 @@ pub trait RmeFfLatterFxOperation: RmeFfLatterDspOperation {
     }
 }
 
-impl<O: RmeFfLatterDspOperation> RmeFfLatterFxOperation for O {}
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterFxOperation for O {}
 
 #[cfg(test)]
 mod test {

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -391,41 +391,17 @@ impl RmeFfCacheableParamsOperation<Ff802Status> for Ff802Protocol {
     }
 }
 
-const LINE_INPUT_COUNT: usize = 8;
-const MIC_INPUT_COUNT: usize = 4;
-const SPDIF_INPUT_COUNT: usize = 2;
-const ADAT_INPUT_COUNT: usize = 16;
-const STREAM_INPUT_COUNT: usize = 30;
+impl RmeFfLatterSpecification for Ff802Protocol {
+    const LINE_INPUT_COUNT: usize = 8;
+    const MIC_INPUT_COUNT: usize = 4;
+    const SPDIF_INPUT_COUNT: usize = 2;
+    const ADAT_INPUT_COUNT: usize = 16;
+    const STREAM_INPUT_COUNT: usize = 30;
 
-const LINE_OUTPUT_COUNT: usize = 8;
-const HP_OUTPUT_COUNT: usize = 4;
-const SPDIF_OUTPUT_COUNT: usize = 2;
-const ADAT_OUTPUT_COUNT: usize = 16;
-
-impl RmeFfLatterMeterOperation for Ff802Protocol {
-    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
-    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
-    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
-    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
-    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
-
-    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
-    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
-    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
-    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
-
-impl RmeFfLatterDspOperation for Ff802Protocol {
-    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
-    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
-    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
-    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
-    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
-
-    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
-    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
-    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
-    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+    const LINE_OUTPUT_COUNT: usize = 8;
+    const HP_OUTPUT_COUNT: usize = 4;
+    const SPDIF_OUTPUT_COUNT: usize = 2;
+    const ADAT_OUTPUT_COUNT: usize = 16;
 }
 
 #[cfg(test)]

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -350,41 +350,17 @@ impl RmeFfCacheableParamsOperation<FfUcxStatus> for FfUcxProtocol {
     }
 }
 
-const LINE_INPUT_COUNT: usize = 6;
-const MIC_INPUT_COUNT: usize = 2;
-const SPDIF_INPUT_COUNT: usize = 2;
-const ADAT_INPUT_COUNT: usize = 8;
-const STREAM_INPUT_COUNT: usize = 18;
+impl RmeFfLatterSpecification for FfUcxProtocol {
+    const LINE_INPUT_COUNT: usize = 6;
+    const MIC_INPUT_COUNT: usize = 2;
+    const SPDIF_INPUT_COUNT: usize = 2;
+    const ADAT_INPUT_COUNT: usize = 8;
+    const STREAM_INPUT_COUNT: usize = 18;
 
-const LINE_OUTPUT_COUNT: usize = 6;
-const HP_OUTPUT_COUNT: usize = 2;
-const SPDIF_OUTPUT_COUNT: usize = 2;
-const ADAT_OUTPUT_COUNT: usize = 8;
-
-impl RmeFfLatterMeterOperation for FfUcxProtocol {
-    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
-    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
-    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
-    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
-    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
-
-    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
-    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
-    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
-    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
-}
-
-impl RmeFfLatterDspOperation for FfUcxProtocol {
-    const LINE_INPUT_COUNT: usize = LINE_INPUT_COUNT;
-    const MIC_INPUT_COUNT: usize = MIC_INPUT_COUNT;
-    const SPDIF_INPUT_COUNT: usize = SPDIF_INPUT_COUNT;
-    const ADAT_INPUT_COUNT: usize = ADAT_INPUT_COUNT;
-    const STREAM_INPUT_COUNT: usize = STREAM_INPUT_COUNT;
-
-    const LINE_OUTPUT_COUNT: usize = LINE_OUTPUT_COUNT;
-    const HP_OUTPUT_COUNT: usize = HP_OUTPUT_COUNT;
-    const SPDIF_OUTPUT_COUNT: usize = SPDIF_OUTPUT_COUNT;
-    const ADAT_OUTPUT_COUNT: usize = ADAT_OUTPUT_COUNT;
+    const LINE_OUTPUT_COUNT: usize = 6;
+    const HP_OUTPUT_COUNT: usize = 2;
+    const SPDIF_OUTPUT_COUNT: usize = 2;
+    const ADAT_OUTPUT_COUNT: usize = 8;
 }
 
 #[cfg(test)]

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -165,13 +165,18 @@ where
             .iter_mut()
             .for_each(|vol| *vol = T::PHYS_OUTPUT_VOL_MAX as i16);
 
-        state.mixer.iter_mut().enumerate().for_each(|(i, mixer)| {
-            mixer
-                .stream_gains
-                .iter_mut()
-                .nth(i)
-                .map(|gain| *gain = T::MIXER_INPUT_GAIN_ZERO as u16);
-        });
+        state
+            .mixer
+            .0
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, mixer)| {
+                mixer
+                    .stream_gains
+                    .iter_mut()
+                    .nth(i)
+                    .map(|gain| *gain = T::MIXER_INPUT_GAIN_ZERO as u16);
+            });
 
         Self(state, Default::default())
     }
@@ -785,7 +790,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
         match elem_id.name().as_str() {
             MIXER_LINE_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let vals: Vec<i32> = self.0.mixer[index]
+                let vals: Vec<i32> = self.0.mixer.0[index]
                     .line_gains
                     .iter()
                     .map(|&gain| gain as i32)
@@ -795,7 +800,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_MIC_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let vals: Vec<i32> = self.0.mixer[index]
+                let vals: Vec<i32> = self.0.mixer.0[index]
                     .mic_gains
                     .iter()
                     .map(|&gain| gain as i32)
@@ -805,7 +810,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let vals: Vec<i32> = self.0.mixer[index]
+                let vals: Vec<i32> = self.0.mixer.0[index]
                     .spdif_gains
                     .iter()
                     .map(|&gain| gain as i32)
@@ -815,7 +820,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let vals: Vec<i32> = self.0.mixer[index]
+                let vals: Vec<i32> = self.0.mixer.0[index]
                     .adat_gains
                     .iter()
                     .map(|&gain| gain as i32)
@@ -825,7 +830,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let vals: Vec<i32> = self.0.mixer[index]
+                let vals: Vec<i32> = self.0.mixer.0[index]
                     .stream_gains
                     .iter()
                     .map(|&gain| gain as i32)
@@ -848,7 +853,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
         match elem_id.name().as_str() {
             MIXER_LINE_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let mut params = self.0.mixer[index].clone();
+                let mut params = self.0.mixer.0[index].clone();
                 params
                     .line_gains
                     .iter_mut()
@@ -860,7 +865,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_MIC_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let mut params = self.0.mixer[index].clone();
+                let mut params = self.0.mixer.0[index].clone();
                 params
                     .mic_gains
                     .iter_mut()
@@ -872,7 +877,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_SPDIF_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let mut params = self.0.mixer[index].clone();
+                let mut params = self.0.mixer.0[index].clone();
                 params
                     .spdif_gains
                     .iter_mut()
@@ -884,7 +889,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_ADAT_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let mut params = self.0.mixer[index].clone();
+                let mut params = self.0.mixer.0[index].clone();
                 params
                     .adat_gains
                     .iter_mut()
@@ -896,7 +901,7 @@ impl<T: RmeFfLatterMixerOperation> LatterDspCtl<T> {
             }
             MIXER_STREAM_SRC_GAIN_NAME => {
                 let index = elem_id.index() as usize;
-                let mut params = self.0.mixer[index].clone();
+                let mut params = self.0.mixer.0[index].clone();
                 params
                     .stream_gains
                     .iter_mut()

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -135,7 +135,9 @@ where
         + RmeFfLatterInputSpecification
         + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfLatterOutputOperation
+        + RmeFfLatterOutputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripOperation<FfLatterOutputChStripState>
@@ -147,7 +149,9 @@ where
         + RmeFfLatterInputSpecification
         + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfLatterOutputOperation
+        + RmeFfLatterOutputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripOperation<FfLatterOutputChStripState>
@@ -179,7 +183,9 @@ where
         + RmeFfLatterInputSpecification
         + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfLatterOutputOperation
+        + RmeFfLatterOutputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripOperation<FfLatterOutputChStripState>
@@ -487,7 +493,12 @@ const STEREO_LINK_NAME: &str = "output:stereo-link";
 const INVERT_PHASE_NAME: &str = "output:invert-phase";
 const LINE_LEVEL_NAME: &str = "output:line-level";
 
-impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
+impl<T> LatterDspCtl<T>
+where
+    T: RmeFfLatterOutputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>,
+{
     const VOL_TLV: DbInterval = DbInterval {
         min: -6500,
         max: 600,
@@ -507,8 +518,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::init_output(req, node, &mut self.0, timeout_ms);
-        debug!(params = ?self.0, ?res);
+        let res = T::update_wholly(req, node, &mut self.0.output, timeout_ms);
+        debug!(params = ?self.0.output, ?res);
         res
     }
 
@@ -616,8 +627,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.output, params, timeout_ms);
+                debug!(params = ?self.0.output, ?res);
                 res.map(|_| true)
             }
             STEREO_BALANCE_NAME => {
@@ -627,8 +638,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.output, params, timeout_ms);
+                debug!(params = ?self.0.output, ?res);
                 res.map(|_| true)
             }
             STEREO_LINK_NAME => {
@@ -638,8 +649,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.output, params, timeout_ms);
+                debug!(params = ?self.0.output, ?res);
                 res.map(|_| true)
             }
             INVERT_PHASE_NAME => {
@@ -649,8 +660,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.output, params, timeout_ms);
+                debug!(params = ?self.0.output, ?res);
                 res.map(|_| true)
             }
             LINE_LEVEL_NAME => {
@@ -671,8 +682,8 @@ impl<T: RmeFfLatterOutputOperation> LatterDspCtl<T> {
                             })
                             .map(|&l| *level = l)
                     })?;
-                let res = T::write_output(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.output, params, timeout_ms);
+                debug!(params = ?self.0.output, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -19,13 +19,11 @@ const SPDIF_OUTPUT_METER: &str = "meter:spdif-output";
 const ADAT_OUTPUT_METER: &str = "meter:adat-output";
 
 #[derive(Debug)]
-pub struct LatterMeterCtl<T: RmeFfLatterMeterOperation>(
-    pub Vec<ElemId>,
-    FfLatterMeterState,
-    PhantomData<T>,
-);
+pub struct LatterMeterCtl<T>(pub Vec<ElemId>, FfLatterMeterState, PhantomData<T>)
+where
+    T: RmeFfLatterMeterSpecification + RmeFfCacheableParamsOperation<FfLatterMeterState>;
 
-impl<T: RmeFfLatterMeterOperation> Default for LatterMeterCtl<T> {
+impl<T: RmeFfLatterMeterSpecification> Default for LatterMeterCtl<T> {
     fn default() -> Self {
         Self(
             Default::default(),
@@ -35,7 +33,10 @@ impl<T: RmeFfLatterMeterOperation> Default for LatterMeterCtl<T> {
     }
 }
 
-impl<T: RmeFfLatterMeterOperation> LatterMeterCtl<T> {
+impl<T> LatterMeterCtl<T>
+where
+    T: RmeFfLatterMeterSpecification + RmeFfCacheableParamsOperation<FfLatterMeterState>,
+{
     const LEVEL_TLV: DbInterval = DbInterval {
         min: -9003,
         max: 600,
@@ -49,7 +50,7 @@ impl<T: RmeFfLatterMeterOperation> LatterMeterCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::read_meter(req, node, &mut self.1, timeout_ms);
+        let res = T::cache_wholly(req, node, &mut self.1, timeout_ms);
         debug!(params = ?self.1, ?res);
         res
     }

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -147,7 +147,9 @@ where
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
         + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfLatterFxOperation;
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>;
 
 impl<T> Default for LatterDspCtl<T>
 where
@@ -167,7 +169,9 @@ where
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
         + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfLatterFxOperation,
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
 {
     fn default() -> Self {
         let mut state = T::create_dsp_state();
@@ -207,7 +211,9 @@ where
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
         + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
         + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfLatterFxOperation,
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
 {
     pub fn cache(
         &mut self,
@@ -2153,7 +2159,12 @@ const ECHO_LPF_FREQ_NAME: &str = "fx:echo-lpf-freq";
 const ECHO_VOL_NAME: &str = "fx:echo-volume";
 const ECHO_STEREO_WIDTH_NAME: &str = "fx:echo-stereo-width";
 
-impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
+impl<T> LatterDspCtl<T>
+where
+    T: RmeFfLatterFxSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
+{
     const PHYS_LEVEL_TLV: DbInterval = DbInterval {
         min: -6500,
         max: 000,
@@ -2206,8 +2217,8 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::init_fx(req, node, &mut self.0, timeout_ms);
-        debug!(params = ?self.0, ?res);
+        let res = T::update_wholly(req, node, &mut self.0.fx, timeout_ms);
+        debug!(params = ?self.0.fx, ?res);
         res
     }
 
@@ -2691,7 +2702,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx, ?res);
                 res.map(|_| true)
             }
@@ -2702,7 +2713,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx, ?res);
                 res.map(|_| true)
             }
@@ -2713,7 +2724,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx, ?res);
                 res.map(|_| true)
             }
@@ -2724,7 +2735,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx, ?res);
                 res.map(|_| true)
             }
@@ -2735,7 +2746,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::write_fx_input_gains(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx, ?res);
                 res.map(|_| true)
             }
@@ -2746,7 +2757,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx);
                 res.map(|_| true)
             }
@@ -2757,7 +2768,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx);
                 res.map(|_| true)
             }
@@ -2768,7 +2779,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx);
                 res.map(|_| true)
             }
@@ -2779,7 +2790,7 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_fx_output_volumes(req, node, &mut self.0, params, timeout_ms);
+                let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
                 debug!(params = ?self.0.fx);
                 res.map(|_| true)
             }
@@ -2953,10 +2964,10 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
     where
         F: Fn(&mut FfLatterFxReverbState) -> Result<(), Error>,
     {
-        let mut params = self.0.fx.reverb.clone();
-        cb(&mut params)?;
-        let res = T::write_fx_reverb(req, node, &mut self.0, &params, timeout_ms);
-        debug!(?params, ?res);
+        let mut params = self.0.fx.clone();
+        cb(&mut params.reverb)?;
+        let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
+        debug!(params = ?self.0.fx, ?res);
         res
     }
 
@@ -2970,10 +2981,10 @@ impl<T: RmeFfLatterFxOperation> LatterDspCtl<T> {
     where
         F: Fn(&mut FfLatterFxEchoState) -> Result<(), Error>,
     {
-        let mut params = self.0.fx.echo.clone();
-        cb(&mut params)?;
-        let res = T::write_fx_echo(req, node, &mut self.0, &params, timeout_ms);
-        debug!(?params, ?res);
+        let mut params = self.0.fx.clone();
+        cb(&mut params.echo)?;
+        let res = T::update_partially(req, node, &mut self.0.fx, params, timeout_ms);
+        debug!(params = ?self.0.fx, ?res);
         res
     }
 }

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -132,7 +132,9 @@ where
 pub struct LatterDspCtl<T>(FfLatterDspState, PhantomData<T>)
 where
     T: RmeFfLatterDspSpecification
-        + RmeFfLatterInputOperation
+        + RmeFfLatterInputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
@@ -142,7 +144,9 @@ where
 impl<T> Default for LatterDspCtl<T>
 where
     T: RmeFfLatterDspSpecification
-        + RmeFfLatterInputOperation
+        + RmeFfLatterInputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
@@ -172,7 +176,9 @@ where
 impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterDspSpecification
-        + RmeFfLatterInputOperation
+        + RmeFfLatterInputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation
         + RmeFfLatterChStripOperation<FfLatterInputChStripState>
@@ -271,7 +277,12 @@ const INPUT_MIC_POWER_NAME: &str = "input:mic-power";
 const INPUT_MIC_INST_NAME: &str = "input:mic-instrument";
 const INPUT_INVERT_PHASE_NAME: &str = "input:invert-phase";
 
-impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
+impl<T> LatterDspCtl<T>
+where
+    T: RmeFfLatterInputSpecification
+        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>,
+{
     const INPUT_GAIN_TLV: DbInterval = DbInterval {
         min: 0,
         max: 1200,
@@ -290,8 +301,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::init_input(req, node, &mut self.0, timeout_ms);
-        debug!(params = ?self.0, ?res);
+        let res = T::update_wholly(req, node, &mut self.0.input, timeout_ms);
+        debug!(params = ?self.0.input, ?res);
         res
     }
 
@@ -396,8 +407,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             INPUT_LINE_GAIN_NAME => {
@@ -407,8 +418,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             INPUT_LINE_LEVEL_NAME => {
@@ -428,8 +439,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                             })
                             .map(|&l| *level = l)
                     })?;
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             INPUT_MIC_POWER_NAME => {
@@ -439,8 +450,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             INPUT_MIC_INST_NAME => {
@@ -450,8 +461,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             INPUT_INVERT_PHASE_NAME => {
@@ -461,8 +472,8 @@ impl<T: RmeFfLatterInputOperation> LatterDspCtl<T> {
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::write_input(req, node, &mut self.0, params, timeout_ms);
-                debug!(params = ?self.0, ?res);
+                let res = T::update_partially(req, node, &mut self.0.input, params, timeout_ms);
+                debug!(params = ?self.0.input, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -131,7 +131,7 @@ where
 #[derive(Debug)]
 pub struct LatterDspCtl<T>(FfLatterDspState, PhantomData<T>)
 where
-    T: RmeFfLatterDspOperation
+    T: RmeFfLatterDspSpecification
         + RmeFfLatterInputOperation
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation
@@ -141,7 +141,7 @@ where
 
 impl<T> Default for LatterDspCtl<T>
 where
-    T: RmeFfLatterDspOperation
+    T: RmeFfLatterDspSpecification
         + RmeFfLatterInputOperation
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation
@@ -171,7 +171,7 @@ where
 
 impl<T> LatterDspCtl<T>
 where
-    T: RmeFfLatterDspOperation
+    T: RmeFfLatterDspSpecification
         + RmeFfLatterInputOperation
         + RmeFfLatterOutputOperation
         + RmeFfLatterMixerOperation


### PR DESCRIPTION
This patchset provides implementations to cache/update parameters specific to latter models.

```
Takashi Sakamoto (16):
  protocols/fireface: add trait to express specification of DSP in
    latter model
  protocols/fireface: implement traits to cache meter parameters in
    latter models
  runtime/fireface: use alternative way to cache meter parameters for
    latter models
  protocols/fireface: rename trait to express specification of DSP for
    latter models
  protocols/fireface: implement trait to update input parameters for
    latter models
  runtime/fireface: use alternative way to update input parameters for
    latter models
  protocols/fireface: implement trait to update output parameters for
    latter models
  runtime/fireface: use alternative way to update output parameters for
    latter models
  protocols/fireface: arrangement for source of mixer in latter models
  protocols/fireface: implement trait to update mixer parameters for
    latter models
  runtime/fireface: use alternative way to update mixer parameters for
    latter models
  protocols/fireface: implement trait to update channel strip parameters
    for latter models
  runtime/fireface: use alternative way to update channel strip
    parameters for latter models
  protocols/fireface: implement traits to update FX parameters for
    latter models
  runtime/fireface: use alternative way to update fx parameters for
    latter models
  runtime/fireface: code cleanup for controls of latter models

 protocols/fireface/src/latter.rs       |  762 ++++++++-------
 protocols/fireface/src/latter/ff802.rs |   46 +-
 protocols/fireface/src/latter/ucx.rs   |   46 +-
 runtime/fireface/src/latter_ctls.rs    | 1174 +++++++++++++-----------
 4 files changed, 1087 insertions(+), 941 deletions(-)
```