### PR TITLE
[PATCH 00/12] protocols/firewirks: use intermediate expression for parameters between protocols/runtime crates

### DIFF
--- a/protocols/fireworks/src/flash.rs
+++ b/protocols/fireworks/src/flash.rs
@@ -476,9 +476,7 @@ mod test {
             F: Fn(&Self, u32, u32, u32, u32, EfwProtocolError, &[u32]) + 'static,
         {
             // Dummy.
-            unsafe {
-                SignalHandlerId::from_glib(0)
-            }
+            unsafe { SignalHandlerId::from_glib(0) }
         }
     }
 }

--- a/protocols/fireworks/src/hw_info.rs
+++ b/protocols/fireworks/src/hw_info.rs
@@ -75,6 +75,7 @@ pub enum HwCap {
     #[doc(hidden)]
     // For my purpose.
     InputMapping,
+    PlaybackSoloUnsupported,
 }
 
 impl From<usize> for HwCap {
@@ -238,7 +239,13 @@ impl HwInfo {
                 caps.push(HwCap::NominalInput);
                 caps.push(HwCap::NominalOutput);
             }
-            O1200F => caps.push(HwCap::ControlRoom),
+            O400F => {
+                caps.push(HwCap::PlaybackSoloUnsupported);
+            }
+            O1200F => {
+                caps.push(HwCap::ControlRoom);
+                caps.push(HwCap::PlaybackSoloUnsupported);
+            }
             _ => (),
         }
 

--- a/protocols/fireworks/src/hw_info.rs
+++ b/protocols/fireworks/src/hw_info.rs
@@ -261,7 +261,11 @@ impl HwInfo {
     fn parse_supported_clk_srcs(flags: u32) -> Vec<ClkSrc> {
         (0..6)
             .filter(|&i| (1 << i) & flags > 0)
-            .map(|i| ClkSrc::from(i))
+            .map(|i| {
+                let mut src = ClkSrc::default();
+                deserialize_clock_source(&mut src, i as u32);
+                src
+            })
             .collect()
     }
 
@@ -338,7 +342,10 @@ impl HwMeter {
 
         self.detected_clk_srcs
             .iter_mut()
-            .for_each(|(src, detected)| *detected = (1 << usize::from(*src)) & flags > 0);
+            .for_each(|(src, detected)| {
+                let pos = serialize_clock_source(src);
+                *detected = (1 << pos) & flags > 0
+            });
 
         // I note that quads[1..4] is reserved space and it stores previous set command for FPGA device.
 

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -29,43 +29,39 @@ pub enum ClkSrc {
     Adat,
     Adat2,
     Continuous,
-    Reserved(usize),
+    Reserved(u32),
 }
 
 impl Default for ClkSrc {
     fn default() -> Self {
-        Self::Reserved(usize::MAX)
+        Self::Reserved(u32::MAX)
     }
 }
 
-impl From<ClkSrc> for usize {
-    fn from(src: ClkSrc) -> Self {
-        match src {
-            ClkSrc::Internal => 0,
-            // blank.
-            ClkSrc::WordClock => 2,
-            ClkSrc::Spdif => 3,
-            ClkSrc::Adat => 4,
-            ClkSrc::Adat2 => 5,
-            ClkSrc::Continuous => 6,
-            ClkSrc::Reserved(val) => val,
-        }
+fn serialize_clock_source(src: &ClkSrc) -> u32 {
+    match src {
+        ClkSrc::Internal => 0,
+        // blank.
+        ClkSrc::WordClock => 2,
+        ClkSrc::Spdif => 3,
+        ClkSrc::Adat => 4,
+        ClkSrc::Adat2 => 5,
+        ClkSrc::Continuous => 6,
+        ClkSrc::Reserved(val) => *val,
     }
 }
 
-impl From<usize> for ClkSrc {
-    fn from(val: usize) -> Self {
-        match val {
-            0 => ClkSrc::Internal,
-            // blank.
-            2 => ClkSrc::WordClock,
-            3 => ClkSrc::Spdif,
-            4 => ClkSrc::Adat,
-            5 => ClkSrc::Adat2,
-            6 => ClkSrc::Continuous,
-            _ => ClkSrc::Reserved(val),
-        }
-    }
+fn deserialize_clock_source(src: &mut ClkSrc, val: u32) {
+    *src = match val {
+        0 => ClkSrc::Internal,
+        // blank.
+        2 => ClkSrc::WordClock,
+        3 => ClkSrc::Spdif,
+        4 => ClkSrc::Adat,
+        5 => ClkSrc::Adat2,
+        6 => ClkSrc::Continuous,
+        _ => ClkSrc::Reserved(val),
+    };
 }
 
 /// Nominal level of audio signal.
@@ -95,5 +91,30 @@ impl From<u32> for NominalSignalLevel {
             1 => NominalSignalLevel::Medium,
             _ => NominalSignalLevel::Professional,
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn clock_source_serdes() {
+        [
+            ClkSrc::Internal,
+            ClkSrc::WordClock,
+            ClkSrc::Spdif,
+            ClkSrc::Adat,
+            ClkSrc::Adat2,
+            ClkSrc::Continuous,
+            ClkSrc::default(),
+        ]
+        .iter()
+        .for_each(|src| {
+            let val = serialize_clock_source(&src);
+            let mut s = ClkSrc::default();
+            deserialize_clock_source(&mut s, val);
+            assert_eq!(*src, s);
+        });
     }
 }

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -74,24 +74,26 @@ pub enum NominalSignalLevel {
     Consumer,
 }
 
-impl From<NominalSignalLevel> for u32 {
-    fn from(level: NominalSignalLevel) -> Self {
-        match level {
-            NominalSignalLevel::Consumer => 2,
-            NominalSignalLevel::Medium => 1,
-            NominalSignalLevel::Professional => 0,
-        }
+impl Default for NominalSignalLevel {
+    fn default() -> Self {
+        Self::Professional
     }
 }
 
-impl From<u32> for NominalSignalLevel {
-    fn from(val: u32) -> Self {
-        match val {
-            2 => NominalSignalLevel::Consumer,
-            1 => NominalSignalLevel::Medium,
-            _ => NominalSignalLevel::Professional,
-        }
+fn serialize_nominal_signal_level(level: &NominalSignalLevel) -> u32 {
+    match level {
+        NominalSignalLevel::Consumer => 2,
+        NominalSignalLevel::Medium => 1,
+        NominalSignalLevel::Professional => 0,
     }
+}
+
+fn deserialize_nominal_signal_level(level: &mut NominalSignalLevel, val: u32) {
+    *level = match val {
+        2 => NominalSignalLevel::Consumer,
+        1 => NominalSignalLevel::Medium,
+        _ => NominalSignalLevel::Professional,
+    };
 }
 
 #[cfg(test)]
@@ -115,6 +117,22 @@ mod test {
             let mut s = ClkSrc::default();
             deserialize_clock_source(&mut s, val);
             assert_eq!(*src, s);
+        });
+    }
+
+    #[test]
+    fn nominal_signal_level_serdes() {
+        [
+            NominalSignalLevel::Professional,
+            NominalSignalLevel::Medium,
+            NominalSignalLevel::Consumer,
+        ]
+        .iter()
+        .for_each(|level| {
+            let val = serialize_nominal_signal_level(&level);
+            let mut l = NominalSignalLevel::default();
+            deserialize_nominal_signal_level(&mut l, val);
+            assert_eq!(*level, l);
         });
     }
 }

--- a/protocols/fireworks/src/monitor.rs
+++ b/protocols/fireworks/src/monitor.rs
@@ -19,6 +19,24 @@ const CMD_GET_SOLO: u32 = 5;
 const CMD_SET_PAN: u32 = 6;
 const CMD_GET_PAN: u32 = 7;
 
+/// The parameters of input monitor.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwMonitorSourceParameters {
+    /// The gain of monitor input. The value is unsigned fixed-point number of 8.24 format; i.e.
+    /// Q24. It is 0x00000000..0x02000000 for -144.0..+6.0 dB.
+    pub gains: Vec<i32>,
+    /// Whether to mute the monitor input.
+    pub mutes: Vec<bool>,
+    /// Whether to mute the other monitor sources.
+    pub solos: Vec<bool>,
+    /// L/R balance of monitor input. It is 0..255 from left to right.
+    pub pans: Vec<u8>,
+}
+
+/// The parameters of input monitor.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwMonitorParameters(pub Vec<EfwMonitorSourceParameters>);
+
 /// Protocol about input monitor for Fireworks board module.
 pub trait MonitorProtocol: EfwProtocolExtManual {
     /// Set volume of monitor. The value of vol is unsigned fixed-point number of 8.24 format; i.e. Q24.

--- a/protocols/fireworks/src/phys_input.rs
+++ b/protocols/fireworks/src/phys_input.rs
@@ -21,7 +21,7 @@ pub trait PhysInputProtocol: EfwProtocolExtManual {
         level: NominalSignalLevel,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let args = [ch as u32, u32::from(level)];
+        let args = [ch as u32, serialize_nominal_signal_level(&level)];
         self.transaction(
             CATEGORY_PHYS_INPUT,
             CMD_SET_NOMINAL,
@@ -41,7 +41,11 @@ pub trait PhysInputProtocol: EfwProtocolExtManual {
             &mut params,
             timeout_ms,
         )
-        .map(|_| NominalSignalLevel::from(params[1]))
+        .map(|_| {
+            let mut level = NominalSignalLevel::default();
+            deserialize_nominal_signal_level(&mut level, params[1]);
+            level
+        })
     }
 }
 

--- a/protocols/fireworks/src/phys_input.rs
+++ b/protocols/fireworks/src/phys_input.rs
@@ -13,6 +13,13 @@ const CATEGORY_PHYS_INPUT: u32 = 5;
 const CMD_SET_NOMINAL: u32 = 8;
 const CMD_GET_NOMINAL: u32 = 9;
 
+/// The parameters of physical inputs.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwPhysInputParameters {
+    /// The nominal signal level of physical input.
+    pub nominals: Vec<NominalSignalLevel>,
+}
+
 /// Protocol about physical input for Fireworks board module.
 pub trait PhysInputProtocol: EfwProtocolExtManual {
     fn set_nominal(

--- a/protocols/fireworks/src/playback.rs
+++ b/protocols/fireworks/src/playback.rs
@@ -17,6 +17,23 @@ const CMD_GET_MUTE: u32 = 3;
 const CMD_SET_SOLO: u32 = 4;
 const CMD_GET_SOLO: u32 = 5;
 
+/// The parameters of playback.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwPlaybackParameters {
+    /// The volume of playback. The value is unsigned fixed-point number of 8.24 format; i.e. Q24.
+    /// It is between 0x00000000..0x02000000 for -144.0..+6.0 dB.
+    pub volumes: Vec<i32>,
+    /// Whether to mute the playback.
+    pub mutes: Vec<bool>,
+}
+
+/// The parameters of playback.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwPlaybackSoloParameters {
+    /// Whether to mute the other channels.
+    pub solos: Vec<bool>,
+}
+
 /// Protocol about stream playback for Fireworks board module.
 pub trait PlaybackProtocol: EfwProtocolExtManual {
     /// Set volume of stream playback. The value of vol is unsigned fixed-point number of 8.24

--- a/protocols/fireworks/src/port_conf.rs
+++ b/protocols/fireworks/src/port_conf.rs
@@ -63,6 +63,10 @@ fn deserialize_digital_mode(val: u32) -> EfwDigitalMode {
     }
 }
 
+/// The parameters for phantom powering.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EfwPhantomPowering(pub bool);
+
 const MAP_SIZE: usize = 70;
 const MAP_ENTRY_COUNT: usize = 32;
 const MAP_ENTRY_DISABLE: u32 = 0xffffffff;

--- a/protocols/fireworks/src/port_conf.rs
+++ b/protocols/fireworks/src/port_conf.rs
@@ -67,6 +67,16 @@ fn deserialize_digital_mode(val: u32) -> EfwDigitalMode {
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EfwPhantomPowering(pub bool);
 
+/// Mapping between rx stream channel pairs and physical output channel pairs per mode of sampling
+/// transfer frequency.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwRxStreamMaps(pub Vec<Vec<Option<usize>>>);
+
+/// Mapping between tx stream channel pairs and physical input channel pairs per mode of sampling
+/// transfer frequency.
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct EfwTxStreamMaps(pub Vec<Vec<Option<usize>>>);
+
 const MAP_SIZE: usize = 70;
 const MAP_ENTRY_COUNT: usize = 32;
 const MAP_ENTRY_DISABLE: u32 = 0xffffffff;

--- a/protocols/fireworks/src/port_conf.rs
+++ b/protocols/fireworks/src/port_conf.rs
@@ -19,6 +19,10 @@ const CMD_GET_PHANTOM: u32 = 5;
 const CMD_SET_STREAM_MAP: u32 = 6;
 const CMD_GET_STREAM_MAP: u32 = 7;
 
+/// The parameters for source of control room.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EfwControlRoomSource(pub usize);
+
 /// Type of audio signal for dignal input and output.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum DigitalMode {

--- a/protocols/fireworks/src/robot_guitar.rs
+++ b/protocols/fireworks/src/robot_guitar.rs
@@ -14,7 +14,7 @@ const CMD_SET_CHARGE_STATE: u32 = 7;
 const CMD_GET_CHARGE_STATE: u32 = 8;
 
 /// State of charging for Robot Guitar.
-#[derive(Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct GuitarChargeState {
     pub manual_charge: bool,
     pub auto_charge: bool,

--- a/protocols/fireworks/src/transaction.rs
+++ b/protocols/fireworks/src/transaction.rs
@@ -26,8 +26,7 @@ glib::wrapper! {
 
 impl EfwTransaction {
     pub fn new() -> Self {
-        Object::new(&[])
-            .expect("Failed to create EfwTransaction")
+        Object::new(&[]).expect("Failed to create EfwTransaction")
     }
 
     pub fn bind(&self, node: &FwNode) -> Result<(), Error> {
@@ -46,7 +45,7 @@ impl EfwTransaction {
 }
 
 mod imp {
-    use {once_cell::sync::Lazy, super::*};
+    use {super::*, once_cell::sync::Lazy};
 
     pub const COMMAND_OFFSET: u64 = 0xecc000000000;
     pub const RESPONSE_OFFSET: u64 = 0xecc080000000;
@@ -70,15 +69,13 @@ mod imp {
     impl ObjectImpl for EfwTransactionPrivate {
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-                vec![
-                    ParamSpecObject::new(
-                        "node",
-                        "node",
-                        "An instance of FwNode",
-                        FwNode::static_type(),
-                        ParamFlags::READWRITE,
-                    ),
-                ]
+                vec![ParamSpecObject::new(
+                    "node",
+                    "node",
+                    "An instance of FwNode",
+                    FwNode::static_type(),
+                    ParamFlags::READWRITE,
+                )]
             });
 
             PROPERTIES.as_ref()

--- a/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
+++ b/runtime/fireworks/src/bin/snd-fireworks-ctl-service.rs
@@ -18,7 +18,7 @@ struct Arguments {
 
 impl ServiceCmd<Arguments, u32, EfwRuntime> for EfwServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None) 
+        (args.card_id, None)
     }
 }
 

--- a/runtime/fireworks/src/lib.rs
+++ b/runtime/fireworks/src/lib.rs
@@ -13,7 +13,7 @@ mod port_ctl;
 
 use {
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*, *},
+    core::{card_cntr::*, dispatcher::*, *},
     firewire_fireworks_protocols as protocols,
     glib::{source, Error, FileError},
     hinawa::{

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -136,7 +136,7 @@ impl CtlModel<SndEfw> for EfwModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.mixer_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
+        } else if self.mixer_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.output_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -109,7 +109,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.input_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.port_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
+        } else if self.port_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .guitar_ctl
@@ -198,7 +198,7 @@ impl NotifyModel<SndEfw, bool> for EfwModel {
     ) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.port_ctl.read_notified_elem(elem_id, elem_value)? {
+        } else if self.port_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -106,7 +106,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
+        } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -138,7 +138,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.output_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.input_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
+        } else if self.input_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.port_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -83,7 +83,7 @@ impl CtlModel<SndEfw> for EfwModel {
             &self.hw_info,
             card_cntr,
             unit,
-            self.clk_ctl.curr_rate,
+            self.clk_ctl.params.rate,
             TIMEOUT_MS,
         )?;
         self.meter_ctl.load(&self.hw_info, card_cntr)?;
@@ -185,7 +185,7 @@ impl NotifyModel<SndEfw, bool> for EfwModel {
         if locked {
             self.clk_ctl.cache(unit, TIMEOUT_MS)?;
             self.port_ctl
-                .cache(unit, self.clk_ctl.curr_rate, TIMEOUT_MS)?;
+                .cache(unit, self.clk_ctl.params.rate, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -77,7 +77,8 @@ impl CtlModel<SndEfw> for EfwModel {
             .load(&self.hw_info, card_cntr, unit, TIMEOUT_MS)?;
         self.mixer_ctl
             .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
-        self.output_ctl.load(&self.hw_info, card_cntr)?;
+        self.output_ctl
+            .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
         self.input_ctl
             .load(unit, &self.hw_info, card_cntr, TIMEOUT_MS)?;
         self.port_ctl.load(
@@ -103,10 +104,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.mixer_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
             Ok(true)
-        } else if self
-            .output_ctl
-            .read(unit, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
             Ok(true)
@@ -138,7 +136,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.mixer_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.output_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
+        } else if self.output_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self.input_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -10,6 +10,7 @@ const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default)]
 pub struct EfwModel {
+    hw_info: HwInfo,
     clk_ctl: clk_ctl::ClkCtl,
     mixer_ctl: mixer_ctl::MixerCtl,
     output_ctl: output_ctl::OutputCtl,
@@ -70,17 +71,24 @@ impl EfwModel {
 
 impl CtlModel<SndEfw> for EfwModel {
     fn load(&mut self, unit: &mut SndEfw, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let mut hwinfo = HwInfo::default();
-        unit.get_hw_info(&mut hwinfo, TIMEOUT_MS)?;
-        self.clk_ctl.load(&hwinfo, card_cntr, unit, TIMEOUT_MS)?;
-        self.mixer_ctl.load(&hwinfo, card_cntr)?;
-        self.output_ctl.load(&hwinfo, card_cntr)?;
-        self.input_ctl.load(unit, &hwinfo, card_cntr, TIMEOUT_MS)?;
-        self.port_ctl
-            .load(&hwinfo, card_cntr, unit, self.clk_ctl.curr_rate, TIMEOUT_MS)?;
-        self.meter_ctl.load(&hwinfo, card_cntr)?;
-        self.guitar_ctl.load(&hwinfo, card_cntr)?;
-        self.iec60958_ctl.load(&hwinfo, card_cntr)?;
+        self.hw_info = HwInfo::default();
+        unit.get_hw_info(&mut self.hw_info, TIMEOUT_MS)?;
+        self.clk_ctl
+            .load(&self.hw_info, card_cntr, unit, TIMEOUT_MS)?;
+        self.mixer_ctl.load(&self.hw_info, card_cntr)?;
+        self.output_ctl.load(&self.hw_info, card_cntr)?;
+        self.input_ctl
+            .load(unit, &self.hw_info, card_cntr, TIMEOUT_MS)?;
+        self.port_ctl.load(
+            &self.hw_info,
+            card_cntr,
+            unit,
+            self.clk_ctl.curr_rate,
+            TIMEOUT_MS,
+        )?;
+        self.meter_ctl.load(&self.hw_info, card_cntr)?;
+        self.guitar_ctl.load(&self.hw_info, card_cntr)?;
+        self.iec60958_ctl.load(&self.hw_info, card_cntr)?;
         Ok(())
     }
 

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -91,19 +91,20 @@ impl CtlModel<SndEfw> for EfwModel {
         self.meter_ctl.load(&self.hw_info, card_cntr)?;
         self.guitar_ctl
             .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
-        self.iec60958_ctl.load(&self.hw_info, card_cntr)?;
+        self.iec60958_ctl
+            .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
         Ok(())
     }
 
     fn read(
         &mut self,
-        unit: &mut SndEfw,
+        _: &mut SndEfw,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_ctl.read(unit, elem_id, elem_value, TIMEOUT_MS)? {
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -113,10 +114,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.guitar_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .iec60958_ctl
-            .read(unit, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        } else if self.iec60958_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -142,10 +140,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.guitar_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self
-            .iec60958_ctl
-            .write(unit, elem_id, old, new, TIMEOUT_MS)?
-        {
+        } else if self.iec60958_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -75,7 +75,8 @@ impl CtlModel<SndEfw> for EfwModel {
         unit.get_hw_info(&mut self.hw_info, TIMEOUT_MS)?;
         self.clk_ctl
             .load(&self.hw_info, card_cntr, unit, TIMEOUT_MS)?;
-        self.mixer_ctl.load(&self.hw_info, card_cntr)?;
+        self.mixer_ctl
+            .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
         self.output_ctl.load(&self.hw_info, card_cntr)?;
         self.input_ctl
             .load(unit, &self.hw_info, card_cntr, TIMEOUT_MS)?;

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -185,7 +185,7 @@ impl NotifyModel<SndEfw, bool> for EfwModel {
         if locked {
             self.clk_ctl.cache(unit, TIMEOUT_MS)?;
             self.port_ctl
-                .cache(unit, self.clk_ctl.params.rate, TIMEOUT_MS)?;
+                .cache(&self.hw_info, unit, self.clk_ctl.params.rate, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/fireworks/src/model.rs
+++ b/runtime/fireworks/src/model.rs
@@ -89,7 +89,8 @@ impl CtlModel<SndEfw> for EfwModel {
             TIMEOUT_MS,
         )?;
         self.meter_ctl.load(&self.hw_info, card_cntr)?;
-        self.guitar_ctl.load(&self.hw_info, card_cntr)?;
+        self.guitar_ctl
+            .load(&self.hw_info, unit, card_cntr, TIMEOUT_MS)?;
         self.iec60958_ctl.load(&self.hw_info, card_cntr)?;
         Ok(())
     }
@@ -110,10 +111,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.port_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .guitar_ctl
-            .read(unit, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        } else if self.guitar_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self
             .iec60958_ctl
@@ -142,7 +140,7 @@ impl CtlModel<SndEfw> for EfwModel {
             Ok(true)
         } else if self.port_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
             Ok(true)
-        } else if self.guitar_ctl.write(unit, elem_id, old, new, TIMEOUT_MS)? {
+        } else if self.guitar_ctl.write(unit, elem_id, new, TIMEOUT_MS)? {
             Ok(true)
         } else if self
             .iec60958_ctl

--- a/runtime/fireworks/src/output_ctl.rs
+++ b/runtime/fireworks/src/output_ctl.rs
@@ -9,7 +9,8 @@ use {
 
 #[derive(Default)]
 pub struct OutputCtl {
-    phys_outputs: usize,
+    all_params: EfwOutputParameters,
+    phys_params: EfwPhysOutputParameters,
 }
 
 const OUT_VOL_NAME: &str = "output-volume";
@@ -34,14 +35,47 @@ impl OutputCtl {
         NominalSignalLevel::Consumer,
     ];
 
-    pub fn load(&mut self, hwinfo: &HwInfo, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.phys_outputs = hwinfo.phys_outputs.iter().fold(0, |accm, entry| {
+    fn cache(&mut self, hw_info: &HwInfo, unit: &mut SndEfw, timeout_ms: u32) -> Result<(), Error> {
+        let count = hw_info.phys_outputs.iter().fold(0, |accm, entry| {
             if entry.group_type != PhysGroupType::AnalogMirror {
                 accm + entry.group_count
             } else {
                 accm
             }
         });
+
+        self.all_params = Default::default();
+        (0..count).try_for_each(|ch| {
+            unit.get_vol(ch, timeout_ms)
+                .map(|vol| self.all_params.volumes.push(vol))?;
+            unit.get_mute(ch, timeout_ms)
+                .map(|enabled| self.all_params.mutes.push(enabled))?;
+            Ok::<(), Error>(())
+        })?;
+
+        if hw_info
+            .caps
+            .iter()
+            .find(|&cap| *cap == HwCap::NominalOutput)
+            .is_some()
+        {
+            (0..count).try_for_each(|ch| {
+                unit.get_nominal(ch, timeout_ms)
+                    .map(|nominal| self.phys_params.nominals.push(nominal))
+            })?;
+        }
+
+        Ok(())
+    }
+
+    pub fn load(
+        &mut self,
+        hwinfo: &HwInfo,
+        unit: &mut SndEfw,
+        card_cntr: &mut CardCntr,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.cache(hwinfo, unit, timeout_ms)?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUT_VOL_NAME, 0);
         let _ = card_cntr.add_int_elems(
@@ -50,13 +84,13 @@ impl OutputCtl {
             Self::COEF_MIN,
             Self::COEF_MAX,
             Self::COEF_STEP,
-            self.phys_outputs,
+            self.all_params.volumes.len(),
             Some(&Into::<Vec<u32>>::into(Self::COEF_TLV)),
             true,
         )?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUT_MUTE_NAME, 0);
-        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.phys_outputs, true)?;
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, self.all_params.mutes.len(), true)?;
 
         if hwinfo
             .caps
@@ -68,7 +102,7 @@ impl OutputCtl {
             let _ = card_cntr.add_enum_elems(
                 &elem_id,
                 1,
-                self.phys_outputs,
+                self.phys_params.nominals.len(),
                 &Self::OUT_NOMINAL_LABELS,
                 None,
                 true,
@@ -78,35 +112,30 @@ impl OutputCtl {
         Ok(())
     }
 
-    pub fn read(
-        &mut self,
-        unit: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
+    pub fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUT_VOL_NAME => {
-                ElemValueAccessor::<i32>::set_vals(elem_value, self.phys_outputs, |idx| {
-                    unit.get_vol(idx, timeout_ms)
-                })?;
+                elem_value.set_int(&self.all_params.volumes);
                 Ok(true)
             }
             OUT_MUTE_NAME => {
-                ElemValueAccessor::<bool>::set_vals(elem_value, self.phys_outputs, |idx| {
-                    unit.get_mute(idx, timeout_ms)
-                })?;
+                elem_value.set_bool(&self.all_params.mutes);
                 Ok(true)
             }
             OUT_NOMINAL_NAME => {
-                ElemValueAccessor::<u32>::set_vals(elem_value, self.phys_outputs, |idx| {
-                    let level = unit.get_nominal(idx, timeout_ms)?;
-                    if let Some(pos) = Self::OUT_NOMINAL_LEVELS.iter().position(|&l| l == level) {
-                        Ok(pos as u32)
-                    } else {
-                        unreachable!();
-                    }
-                })?;
+                let vals: Vec<u32> = self
+                    .phys_params
+                    .nominals
+                    .iter()
+                    .map(|level| {
+                        Self::OUT_NOMINAL_LEVELS
+                            .iter()
+                            .position(|l| l.eq(level))
+                            .map(|pos| pos as u32)
+                            .unwrap()
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
                 Ok(true)
             }
             _ => Ok(false),
@@ -117,32 +146,57 @@ impl OutputCtl {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             OUT_VOL_NAME => {
-                ElemValueAccessor::<i32>::get_vals(new, old, self.phys_outputs, |idx, val| {
-                    unit.set_vol(idx, val, timeout_ms)
-                })?;
+                self.all_params
+                    .volumes
+                    .iter_mut()
+                    .zip(elem_value.int())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(n))
+                    .try_for_each(|(ch, (o, &val))| {
+                        unit.set_vol(ch, val, timeout_ms).map(|_| *o = val)
+                    })?;
                 Ok(true)
             }
             OUT_MUTE_NAME => {
-                ElemValueAccessor::<bool>::get_vals(new, old, self.phys_outputs, |idx, val| {
-                    unit.set_mute(idx, val, timeout_ms)
-                })?;
+                self.all_params
+                    .mutes
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(&n))
+                    .try_for_each(|(ch, (o, val))| {
+                        unit.set_mute(ch, val, timeout_ms).map(|_| *o = val)
+                    })?;
                 Ok(true)
             }
             OUT_NOMINAL_NAME => {
-                ElemValueAccessor::<u32>::get_vals(new, old, self.phys_outputs, |idx, val| {
-                    if let Some(&level) = Self::OUT_NOMINAL_LEVELS.iter().nth(val as usize) {
-                        unit.set_nominal(idx, level, timeout_ms)
-                    } else {
-                        let label = "Invalid value for nominal level of output";
-                        Err(Error::new(FileError::Io, &label))
-                    }
-                })?;
+                self.phys_params
+                    .nominals
+                    .iter_mut()
+                    .zip(elem_value.enumerated())
+                    .enumerate()
+                    .try_for_each(|(ch, (o, &val))| {
+                        let pos = val as usize;
+                        let level = Self::OUT_NOMINAL_LEVELS
+                            .iter()
+                            .nth(pos)
+                            .ok_or_else(|| {
+                                let msg =
+                                    format!("Invalid value for nominal level of output: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .copied()?;
+                        if level.eq(o) {
+                            unit.set_nominal(ch, level, timeout_ms).map(|_| *o = level)
+                        } else {
+                            Ok(())
+                        }
+                    })?;
                 Ok(true)
             }
             _ => Ok(false),


### PR DESCRIPTION
Current implementation uses ad-hoc parameter expression between protocols and runtime crates. It is too convenient to refactor traits in protocols crate.

This commit adds some intermediate expression for them.

```
Takashi Sakamoto (12):
  runtime/fireworks: cache hardware information retrieved from the
    target device
  protocols/fireworks: add intermediate expression to cache sampling
    clock configuration
  protocols/fireworks: add intermediate expression to cache control room
    source
  protocols/fireworks: use intermediate expression to cache mode of
    digital input and output
  protocols/fireworks: add intermediate expression to cache phantom
    powering configuration
  protocols/fireworks: add intermediate expression to cache stream
    mapping configuration
  protocols/fireworks: add intermediate expression to cache input
    monitor configuration
  protocols/fireworks: add intermediate expression to cache playback
    configuration
  protocols/fireworks: add intermediate expression to cache physical
    output configuration
  protocols/fireworks: add intermediate expression to cache physical
    input configuration
  protocols/fireworks: use intermediate expression to cache robot guitar
    configuration
  protocols/fireworks: add intermediate expression to cache hardware
    control flag

 protocols/fireworks/src/flash.rs              |   4 +-
 protocols/fireworks/src/hw_ctl.rs             |  21 +-
 protocols/fireworks/src/hw_info.rs            |   9 +-
 protocols/fireworks/src/lib.rs                |   6 +
 protocols/fireworks/src/monitor.rs            |  18 ++
 protocols/fireworks/src/phys_input.rs         |   7 +
 protocols/fireworks/src/phys_output.rs        |  17 +
 protocols/fireworks/src/playback.rs           |  17 +
 protocols/fireworks/src/port_conf.rs          |  69 ++--
 protocols/fireworks/src/robot_guitar.rs       |   2 +-
 protocols/fireworks/src/transaction.rs        |  21 +-
 .../src/bin/snd-fireworks-ctl-service.rs      |   2 +-
 runtime/fireworks/src/clk_ctl.rs              |  71 ++--
 runtime/fireworks/src/guitar_ctl.rs           |  86 ++---
 runtime/fireworks/src/iec60958_ctl.rs         |  50 ++-
 runtime/fireworks/src/input_ctl.rs            | 135 ++++----
 runtime/fireworks/src/lib.rs                  |   2 +-
 runtime/fireworks/src/mixer_ctl.rs            | 306 ++++++++++++------
 runtime/fireworks/src/model.rs                |  74 ++---
 runtime/fireworks/src/output_ctl.rs           | 140 +++++---
 runtime/fireworks/src/port_ctl.rs             | 252 +++++++++------
 21 files changed, 842 insertions(+), 467 deletions(-)
```