### PR TITLE
[PATCH 00/21] protocols/fireworks: add traits and their implementations for operations by unified way

### DIFF
--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+//! Protocol implementations for Echo Audio Audiofire series.
+//!
+//! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
+//! for Audiofire.
+
+use super::*;
+
+/// Protocol implementation for former model of AudioFire 12. The higher sampling rates are
+/// available only with firmware version 4 and former.
+#[derive(Default, Debug)]
+pub struct Audiofire12FormerProtocol;
+
+impl EfwHardwareSpecification for Audiofire12FormerProtocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] =
+        &[32000, 44100, 48000, 88200, 96000, 176400, 192000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] =
+        &[ClkSrc::Internal, ClkSrc::WordClock, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::Dsp,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [12, 12, 12];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [12, 12, 12];
+    const MONITOR_SOURCE_COUNT: usize = 12;
+    const MONITOR_DESTINATION_COUNT: usize = 12;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
+}
+
+/// Protocol implementation for later model of AudioFire 12. The higher sampling rates are
+/// available only with firmware version 4 and former.
+#[derive(Default, Debug)]
+pub struct Audiofire12LaterProtocol;
+
+impl EfwHardwareSpecification for Audiofire12LaterProtocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] =
+        &[32000, 44100, 48000, 88200, 96000, 176400, 192000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] =
+        &[ClkSrc::Internal, ClkSrc::WordClock, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::Dsp,
+        HwCap::InputGain,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [12, 12, 12];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [12, 12, 12];
+    const MONITOR_SOURCE_COUNT: usize = 12;
+    const MONITOR_DESTINATION_COUNT: usize = 12;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
+}
+
+/// Protocol implementation for former model of AudioFire 8.
+#[derive(Default, Debug)]
+pub struct Audiofire8Protocol;
+
+impl EfwHardwareSpecification for Audiofire8Protocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[32000, 44100, 48000, 88200, 96000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] =
+        &[ClkSrc::Internal, ClkSrc::WordClock, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::Dsp,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [10, 10, 10];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [10, 10, 10];
+    const MONITOR_SOURCE_COUNT: usize = 10;
+    const MONITOR_DESTINATION_COUNT: usize = 10;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 8), (PhysGroupType::Spdif, 2)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 8), (PhysGroupType::Spdif, 2)];
+}
+
+/// Protocol implementation for latter model of AudioFire 8 and AudioFirePre 8
+#[derive(Default, Debug)]
+pub struct Audiofire9Protocol;
+
+impl EfwHardwareSpecification for Audiofire9Protocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[32000, 44100, 48000, 88200, 96000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] = &[
+        ClkSrc::Internal,
+        ClkSrc::WordClock,
+        ClkSrc::Spdif,
+        ClkSrc::Adat,
+    ];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::OptionalSpdifCoax,
+        HwCap::Fpga,
+        HwCap::OptionalSpdifOpt,
+        HwCap::OptionalAdatOpt,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [16, 12, 10];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [16, 12, 10];
+    const MONITOR_SOURCE_COUNT: usize = 16;
+    const MONITOR_DESTINATION_COUNT: usize = 16;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 8), (PhysGroupType::SpdifOrAdat, 8)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 8), (PhysGroupType::SpdifOrAdat, 8)];
+}
+
+/// Protocol implementation for Audiofire 4.
+#[derive(Default, Debug)]
+pub struct Audiofire4Protocol;
+
+impl EfwHardwareSpecification for Audiofire4Protocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[32000, 44100, 48000, 88200, 96000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] = &[ClkSrc::Internal, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::PhantomPowering,
+        HwCap::OutputMapping,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [6, 6, 6];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [6, 6, 6];
+    const MONITOR_SOURCE_COUNT: usize = 6;
+    const MONITOR_DESTINATION_COUNT: usize = 6;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 4), (PhysGroupType::Spdif, 2)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 4), (PhysGroupType::Spdif, 2)];
+}
+
+/// Protocol implementation for Audiofire 2.
+#[derive(Default, Debug)]
+pub struct Audiofire2Protocol;
+
+impl EfwHardwareSpecification for Audiofire2Protocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[32000, 44100, 48000, 88200, 96000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] = &[ClkSrc::Internal, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::Fpga,
+        HwCap::PhantomPowering,
+        HwCap::OutputMapping,
+        // Fixup.
+        HwCap::NominalInput,
+        HwCap::NominalOutput,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [4, 4, 4];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [6, 6, 6];
+    const MONITOR_SOURCE_COUNT: usize = 4;
+    const MONITOR_DESTINATION_COUNT: usize = 6;
+    const MIDI_INPUT_COUNT: usize = 1;
+    const MIDI_OUTPUT_COUNT: usize = 1;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 2), (PhysGroupType::Spdif, 2)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[
+        (PhysGroupType::Analog, 2),
+        (PhysGroupType::Headphones, 2),
+        (PhysGroupType::Spdif, 2),
+    ];
+}

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -6,7 +6,7 @@
 //! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
 //! for Audiofire.
 
-use super::{port_conf::*, *};
+use super::{phys_input::*, port_conf::*, *};
 
 /// Protocol implementation for former model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
@@ -36,6 +36,8 @@ impl EfwHardwareSpecification for Audiofire12FormerProtocol {
 
     const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
 }
+
+impl EfwPhysInputSpecification for Audiofire12FormerProtocol {}
 
 /// Protocol implementation for later model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
@@ -67,6 +69,8 @@ impl EfwHardwareSpecification for Audiofire12LaterProtocol {
     const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 12)];
 }
 
+impl EfwPhysInputSpecification for Audiofire12LaterProtocol {}
+
 /// Protocol implementation for former model of AudioFire 8.
 #[derive(Default, Debug)]
 pub struct Audiofire8Protocol;
@@ -95,6 +99,8 @@ impl EfwHardwareSpecification for Audiofire8Protocol {
     const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] =
         &[(PhysGroupType::Analog, 8), (PhysGroupType::Spdif, 2)];
 }
+
+impl EfwPhysInputSpecification for Audiofire8Protocol {}
 
 /// Protocol implementation for latter model of AudioFire 8 and AudioFirePre 8
 #[derive(Default, Debug)]
@@ -134,6 +140,8 @@ impl EfwHardwareSpecification for Audiofire9Protocol {
 
 impl EfwDigitalModeSpecification for Audiofire9Protocol {}
 
+impl EfwPhysInputSpecification for Audiofire9Protocol {}
+
 /// Protocol implementation for Audiofire 4.
 #[derive(Default, Debug)]
 pub struct Audiofire4Protocol;
@@ -166,6 +174,8 @@ impl EfwHardwareSpecification for Audiofire4Protocol {
 impl EfwPhantomPoweringSpecification for Audiofire4Protocol {}
 
 impl EfwRxStreamMapsSpecification for Audiofire4Protocol {}
+
+impl EfwPhysInputSpecification for Audiofire4Protocol {}
 
 /// Protocol implementation for Audiofire 2.
 #[derive(Default, Debug)]
@@ -201,3 +211,5 @@ impl EfwHardwareSpecification for Audiofire2Protocol {
 }
 
 impl EfwRxStreamMapsSpecification for Audiofire2Protocol {}
+
+impl EfwPhysInputSpecification for Audiofire2Protocol {}

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -6,7 +6,7 @@
 //! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
 //! for Audiofire.
 
-use super::{phys_input::*, port_conf::*, *};
+use super::{phys_input::*, phys_output::*, port_conf::*, *};
 
 /// Protocol implementation for former model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
@@ -38,6 +38,8 @@ impl EfwHardwareSpecification for Audiofire12FormerProtocol {
 }
 
 impl EfwPhysInputSpecification for Audiofire12FormerProtocol {}
+
+impl EfwPhysOutputSpecification for Audiofire12FormerProtocol {}
 
 /// Protocol implementation for later model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
@@ -71,6 +73,8 @@ impl EfwHardwareSpecification for Audiofire12LaterProtocol {
 
 impl EfwPhysInputSpecification for Audiofire12LaterProtocol {}
 
+impl EfwPhysOutputSpecification for Audiofire12LaterProtocol {}
+
 /// Protocol implementation for former model of AudioFire 8.
 #[derive(Default, Debug)]
 pub struct Audiofire8Protocol;
@@ -101,6 +105,8 @@ impl EfwHardwareSpecification for Audiofire8Protocol {
 }
 
 impl EfwPhysInputSpecification for Audiofire8Protocol {}
+
+impl EfwPhysOutputSpecification for Audiofire8Protocol {}
 
 /// Protocol implementation for latter model of AudioFire 8 and AudioFirePre 8
 #[derive(Default, Debug)]
@@ -142,6 +148,8 @@ impl EfwDigitalModeSpecification for Audiofire9Protocol {}
 
 impl EfwPhysInputSpecification for Audiofire9Protocol {}
 
+impl EfwPhysOutputSpecification for Audiofire9Protocol {}
+
 /// Protocol implementation for Audiofire 4.
 #[derive(Default, Debug)]
 pub struct Audiofire4Protocol;
@@ -176,6 +184,8 @@ impl EfwPhantomPoweringSpecification for Audiofire4Protocol {}
 impl EfwRxStreamMapsSpecification for Audiofire4Protocol {}
 
 impl EfwPhysInputSpecification for Audiofire4Protocol {}
+
+impl EfwPhysOutputSpecification for Audiofire4Protocol {}
 
 /// Protocol implementation for Audiofire 2.
 #[derive(Default, Debug)]
@@ -213,3 +223,5 @@ impl EfwHardwareSpecification for Audiofire2Protocol {
 impl EfwRxStreamMapsSpecification for Audiofire2Protocol {}
 
 impl EfwPhysInputSpecification for Audiofire2Protocol {}
+
+impl EfwPhysOutputSpecification for Audiofire2Protocol {}

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -6,7 +6,7 @@
 //! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
 //! for Audiofire.
 
-use super::*;
+use super::{port_conf::*, *};
 
 /// Protocol implementation for former model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
@@ -131,6 +131,8 @@ impl EfwHardwareSpecification for Audiofire9Protocol {
     const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] =
         &[(PhysGroupType::Analog, 8), (PhysGroupType::SpdifOrAdat, 8)];
 }
+
+impl EfwDigitalModeSpecification for Audiofire9Protocol {}
 
 /// Protocol implementation for Audiofire 4.
 #[derive(Default, Debug)]

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -163,6 +163,8 @@ impl EfwHardwareSpecification for Audiofire4Protocol {
         &[(PhysGroupType::Analog, 4), (PhysGroupType::Spdif, 2)];
 }
 
+impl EfwPhantomPoweringSpecification for Audiofire4Protocol {}
+
 /// Protocol implementation for Audiofire 2.
 #[derive(Default, Debug)]
 pub struct Audiofire2Protocol;

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -41,6 +41,8 @@ impl EfwPhysInputSpecification for Audiofire12FormerProtocol {}
 
 impl EfwPhysOutputSpecification for Audiofire12FormerProtocol {}
 
+impl EfwPlaybackSoloSpecification for Audiofire12FormerProtocol {}
+
 /// Protocol implementation for later model of AudioFire 12. The higher sampling rates are
 /// available only with firmware version 4 and former.
 #[derive(Default, Debug)]
@@ -75,6 +77,8 @@ impl EfwPhysInputSpecification for Audiofire12LaterProtocol {}
 
 impl EfwPhysOutputSpecification for Audiofire12LaterProtocol {}
 
+impl EfwPlaybackSoloSpecification for Audiofire12LaterProtocol {}
+
 /// Protocol implementation for former model of AudioFire 8.
 #[derive(Default, Debug)]
 pub struct Audiofire8Protocol;
@@ -107,6 +111,8 @@ impl EfwHardwareSpecification for Audiofire8Protocol {
 impl EfwPhysInputSpecification for Audiofire8Protocol {}
 
 impl EfwPhysOutputSpecification for Audiofire8Protocol {}
+
+impl EfwPlaybackSoloSpecification for Audiofire8Protocol {}
 
 /// Protocol implementation for latter model of AudioFire 8 and AudioFirePre 8
 #[derive(Default, Debug)]
@@ -150,6 +156,8 @@ impl EfwPhysInputSpecification for Audiofire9Protocol {}
 
 impl EfwPhysOutputSpecification for Audiofire9Protocol {}
 
+impl EfwPlaybackSoloSpecification for Audiofire9Protocol {}
+
 /// Protocol implementation for Audiofire 4.
 #[derive(Default, Debug)]
 pub struct Audiofire4Protocol;
@@ -186,6 +194,8 @@ impl EfwRxStreamMapsSpecification for Audiofire4Protocol {}
 impl EfwPhysInputSpecification for Audiofire4Protocol {}
 
 impl EfwPhysOutputSpecification for Audiofire4Protocol {}
+
+impl EfwPlaybackSoloSpecification for Audiofire4Protocol {}
 
 /// Protocol implementation for Audiofire 2.
 #[derive(Default, Debug)]
@@ -225,3 +235,5 @@ impl EfwRxStreamMapsSpecification for Audiofire2Protocol {}
 impl EfwPhysInputSpecification for Audiofire2Protocol {}
 
 impl EfwPhysOutputSpecification for Audiofire2Protocol {}
+
+impl EfwPlaybackSoloSpecification for Audiofire2Protocol {}

--- a/protocols/fireworks/src/audiofire.rs
+++ b/protocols/fireworks/src/audiofire.rs
@@ -165,6 +165,8 @@ impl EfwHardwareSpecification for Audiofire4Protocol {
 
 impl EfwPhantomPoweringSpecification for Audiofire4Protocol {}
 
+impl EfwRxStreamMapsSpecification for Audiofire4Protocol {}
+
 /// Protocol implementation for Audiofire 2.
 #[derive(Default, Debug)]
 pub struct Audiofire2Protocol;
@@ -197,3 +199,5 @@ impl EfwHardwareSpecification for Audiofire2Protocol {
         (PhysGroupType::Spdif, 2),
     ];
 }
+
+impl EfwRxStreamMapsSpecification for Audiofire2Protocol {}

--- a/protocols/fireworks/src/hw_ctl.rs
+++ b/protocols/fireworks/src/hw_ctl.rs
@@ -235,6 +235,28 @@ where
     }
 }
 
+/// The parameter to disapper from IEEE 1394 bus and back.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EfwReconnectPhy;
+
+impl<O, P> EfwWhollyUpdatableParamsOperation<P, EfwReconnectPhy> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(proto: &mut P, _: &EfwReconnectPhy, timeout_ms: u32) -> Result<(), Error> {
+        let args = Vec::new();
+        let mut params = Vec::new();
+        proto.transaction(
+            CATEGORY_HWCTL,
+            CMD_RECONNECT,
+            &args,
+            &mut params,
+            timeout_ms,
+        )
+    }
+}
+
 /// Protocol about hardware control for Fireworks board module.
 pub trait HwCtlProtocol: EfwProtocolExtManual {
     fn set_clock(

--- a/protocols/fireworks/src/hw_ctl.rs
+++ b/protocols/fireworks/src/hw_ctl.rs
@@ -213,6 +213,28 @@ where
     }
 }
 
+/// The parameter to blink LED.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EfwLedBlink;
+
+impl<O, P> EfwWhollyUpdatableParamsOperation<P, EfwLedBlink> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(proto: &mut P, _: &EfwLedBlink, timeout_ms: u32) -> Result<(), Error> {
+        let args = Vec::new();
+        let mut params = Vec::new();
+        proto.transaction(
+            CATEGORY_HWCTL,
+            CMD_BLINK_LED,
+            &args,
+            &mut params,
+            timeout_ms,
+        )
+    }
+}
+
 /// Protocol about hardware control for Fireworks board module.
 pub trait HwCtlProtocol: EfwProtocolExtManual {
     fn set_clock(

--- a/protocols/fireworks/src/hw_info.rs
+++ b/protocols/fireworks/src/hw_info.rs
@@ -311,6 +311,28 @@ where
     }
 }
 
+/// The parameter of response address.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct EfwRespAddr(u64);
+
+impl<O, P> EfwWhollyUpdatableParamsOperation<P, EfwRespAddr> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(proto: &mut P, states: &EfwRespAddr, timeout_ms: u32) -> Result<(), Error> {
+        let args = [(states.0 >> 32) as u32, (states.0 & 0xffffffff) as u32];
+        let mut params = Vec::new();
+        proto.transaction(
+            CATEGORY_HWINFO,
+            CMD_CHANGE_RESP_ADDR,
+            &args,
+            &mut params,
+            timeout_ms,
+        )
+    }
+}
+
 /// Protocol about hardware information for Fireworks board module.
 pub trait HwInfoProtocol: EfwProtocolExtManual {
     /// Read hardware information.

--- a/protocols/fireworks/src/hw_info.rs
+++ b/protocols/fireworks/src/hw_info.rs
@@ -353,7 +353,6 @@ where
         timeout_ms: u32,
     ) -> Result<(), Error> {
         assert_eq!(states.offset % 4, 0);
-        assert_eq!(states.data.len() % 4, 0);
 
         // The first argument should be quadlet count.
         let args = [states.offset / 4, states.data.len() as u32];

--- a/protocols/fireworks/src/hw_info.rs
+++ b/protocols/fireworks/src/hw_info.rs
@@ -37,7 +37,7 @@ const CMD_CHANGE_RESP_ADDR: u32 = 2;
 const CMD_READ_SESSION_BLOCK: u32 = 3;
 
 /// Information of hardware.
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HwInfo {
     pub caps: Vec<HwCap>,
     pub guid: u64,
@@ -201,6 +201,21 @@ impl HwInfo {
     }
 }
 
+const HWINFO_QUADS: usize = 65;
+
+impl<O, P> EfwWhollyCachableParamsOperation<P, HwInfo> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(proto: &mut P, states: &mut HwInfo, timeout_ms: u32) -> Result<(), Error> {
+        let mut params = vec![0; HWINFO_QUADS];
+        proto
+            .transaction(CATEGORY_HWINFO, CMD_HWINFO, &[], &mut params, timeout_ms)
+            .and_then(|_| states.parse(&params))
+    }
+}
+
 /// Hardware meter.
 #[derive(Debug)]
 pub struct HwMeter {
@@ -281,7 +296,6 @@ impl HwMeter {
     }
 }
 
-const HWINFO_QUADS: usize = 65;
 const METER_QUADS: usize = 110;
 
 /// Protocol about hardware information for Fireworks board module.

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -65,6 +65,35 @@ pub trait EfwHardwareSpecification {
     }
 }
 
+/// Cache whole parameters.
+pub trait EfwWhollyCachableParamsOperation<P, T>
+where
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(proto: &mut P, states: &mut T, timeout_ms: u32) -> Result<(), Error>;
+}
+
+/// Update the part of parameters.
+pub trait EfwPartiallyUpdatableParamsOperation<P, T>
+where
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        params: &mut T,
+        update: T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+/// Update whole parameters.
+pub trait EfwWhollyUpdatableParamsOperation<P, T>
+where
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(proto: &mut P, states: &T, timeout_ms: u32) -> Result<(), Error>;
+}
+
 /// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkSrc {

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -24,6 +24,7 @@ use {
     glib::{Error, FileError},
     hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
     hw_info::HwMeter,
+    monitor::{EfwMonitorParameters, EfwMonitorSourceParameters},
 };
 
 /// The specification of hardware.
@@ -79,6 +80,18 @@ pub trait EfwHardwareSpecification {
             phys_output_meters: vec![Default::default(); Self::phys_output_count()],
             phys_input_meters: vec![Default::default(); Self::phys_input_count()],
         }
+    }
+
+    fn create_monitor_parameters() -> EfwMonitorParameters {
+        EfwMonitorParameters(vec![
+            EfwMonitorSourceParameters {
+                gains: vec![Default::default(); Self::MONITOR_SOURCE_COUNT],
+                mutes: vec![Default::default(); Self::MONITOR_SOURCE_COUNT],
+                solos: vec![Default::default(); Self::MONITOR_SOURCE_COUNT],
+                pans: vec![Default::default(); Self::MONITOR_SOURCE_COUNT],
+            };
+            Self::MONITOR_DESTINATION_COUNT
+        ])
     }
 }
 

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -25,6 +25,7 @@ use {
     hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
     hw_info::HwMeter,
     monitor::{EfwMonitorParameters, EfwMonitorSourceParameters},
+    phys_output::EfwOutputParameters,
 };
 
 /// The specification of hardware.
@@ -92,6 +93,13 @@ pub trait EfwHardwareSpecification {
             };
             Self::MONITOR_DESTINATION_COUNT
         ])
+    }
+
+    fn create_output_parameters() -> EfwOutputParameters {
+        EfwOutputParameters {
+            volumes: vec![Default::default(); Self::phys_output_count()],
+            mutes: vec![Default::default(); Self::phys_output_count()],
+        }
     }
 }
 

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -26,6 +26,7 @@ use {
     hw_info::HwMeter,
     monitor::{EfwMonitorParameters, EfwMonitorSourceParameters},
     phys_output::EfwOutputParameters,
+    playback::{EfwPlaybackParameters, EfwPlaybackSoloSpecification},
 };
 
 /// The specification of hardware.
@@ -99,6 +100,13 @@ pub trait EfwHardwareSpecification {
         EfwOutputParameters {
             volumes: vec![Default::default(); Self::phys_output_count()],
             mutes: vec![Default::default(); Self::phys_output_count()],
+        }
+    }
+
+    fn create_playback_parameters() -> EfwPlaybackParameters {
+        EfwPlaybackParameters {
+            volumes: vec![Default::default(); Self::RX_CHANNEL_COUNTS[0]],
+            mutes: vec![Default::default(); Self::RX_CHANNEL_COUNTS[0]],
         }
     }
 }

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -15,10 +15,55 @@ pub mod robot_guitar;
 pub mod transaction;
 pub mod transport;
 
+pub mod audiofire;
+pub mod onyx_f;
+
+pub mod rip;
+
 use {
     glib::{Error, FileError},
     hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
 };
+
+/// The specification of hardware.
+pub trait EfwHardwareSpecification {
+    /// The list of supported sampling transfer frequencies.
+    const SUPPORTED_SAMPLING_RATES: &'static [u32];
+    /// The list of supported sources of sampling clock.
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc];
+    /// The list of hardware capabilities.
+    const CAPABILITIES: &'static [HwCap];
+    /// The number of audio channels in received isochronous stream at each rate mode.
+    const RX_CHANNEL_COUNTS: [usize; 3];
+    /// The number of audio channels in transmitted isochronous stream at each rate mode.
+    const TX_CHANNEL_COUNTS: [usize; 3];
+    /// The total number of monitor inputs.
+    const MONITOR_SOURCE_COUNT: usize;
+    /// The total number of monitor outputs.
+    const MONITOR_DESTINATION_COUNT: usize;
+    /// The number of MIDI input port.
+    const MIDI_INPUT_COUNT: usize;
+    /// The number of MIDI output port.
+    const MIDI_OUTPUT_COUNT: usize;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)];
+
+    /// The total number of physical audio inputs.
+    fn phys_input_count() -> usize {
+        Self::PHYS_INPUT_GROUPS
+            .iter()
+            .fold(0, |count, entry| count + entry.1)
+    }
+
+    /// The total number of physical audio outputs.
+    fn phys_output_count() -> usize {
+        Self::PHYS_OUTPUT_GROUPS
+            .iter()
+            .fold(0, |count, entry| count + entry.1)
+    }
+}
 
 /// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -64,6 +109,103 @@ fn deserialize_clock_source(src: &mut ClkSrc, val: u32) {
     };
 }
 
+/// Hardware capability.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum HwCap {
+    /// The address to which response of transaction is transmitted is configurable.
+    ChangeableRespAddr,
+    /// Has control room for output mirror.
+    ControlRoom,
+    /// S/PDIF signal is available for coaxial interface as option.
+    OptionalSpdifCoax,
+    /// S/PDIF signal is available for AES/EBU XLR interface as option.
+    OptionalAesebuXlr,
+    /// Has DSP (Texas Instrument TMS320C67).
+    Dsp,
+    /// Has FPGA (Xilinx Spartan XC35250E).
+    Fpga,
+    /// Support phantom powering for any mic input.
+    PhantomPowering,
+    /// Support mapping between playback stream and physical output.
+    OutputMapping,
+    /// The gain of physical input is adjustable.
+    InputGain,
+    /// S/PDIF signal is available for optical interface as option.
+    OptionalSpdifOpt,
+    /// ADAT signal is available for optical interface as option.
+    OptionalAdatOpt,
+    /// The nominal level of input audio signal is selectable.
+    NominalInput,
+    /// The nominal level of output audio signal is selectable.
+    NominalOutput,
+    /// Has software clipping for input audio signal.
+    SoftClip,
+    /// Is robot guitar.
+    RobotGuitar,
+    /// Support chaging for guitar.
+    GuitarCharging,
+    Reserved(usize),
+    #[doc(hidden)]
+    // For my purpose.
+    InputMapping,
+    PlaybackSoloUnsupported,
+}
+
+impl Default for HwCap {
+    fn default() -> Self {
+        Self::Reserved(usize::MAX)
+    }
+}
+
+#[cfg(test)]
+fn serialize_hw_cap(cap: &HwCap) -> usize {
+    match cap {
+        HwCap::ChangeableRespAddr => 0,
+        HwCap::ControlRoom => 1,
+        HwCap::OptionalSpdifCoax => 2,
+        HwCap::OptionalAesebuXlr => 3,
+        HwCap::Dsp => 4,
+        HwCap::Fpga => 5,
+        HwCap::PhantomPowering => 6,
+        HwCap::OutputMapping => 7,
+        HwCap::InputGain => 8,
+        HwCap::OptionalSpdifOpt => 9,
+        HwCap::OptionalAdatOpt => 10,
+        HwCap::NominalInput => 11,
+        HwCap::NominalOutput => 12,
+        HwCap::SoftClip => 13,
+        HwCap::RobotGuitar => 14,
+        HwCap::GuitarCharging => 15,
+        HwCap::InputMapping => 3000,
+        HwCap::PlaybackSoloUnsupported => 3001,
+        HwCap::Reserved(pos) => *pos,
+    }
+}
+
+fn deserialize_hw_cap(cap: &mut HwCap, pos: usize) {
+    *cap = match pos {
+        0 => HwCap::ChangeableRespAddr,
+        1 => HwCap::ControlRoom,
+        2 => HwCap::OptionalSpdifCoax,
+        3 => HwCap::OptionalAesebuXlr,
+        4 => HwCap::Dsp,
+        5 => HwCap::Fpga,
+        6 => HwCap::PhantomPowering,
+        7 => HwCap::OutputMapping,
+        8 => HwCap::InputGain,
+        9 => HwCap::OptionalSpdifOpt,
+        10 => HwCap::OptionalAdatOpt,
+        11 => HwCap::NominalInput,
+        12 => HwCap::NominalOutput,
+        13 => HwCap::SoftClip,
+        14 => HwCap::RobotGuitar,
+        15 => HwCap::GuitarCharging,
+        3000 => HwCap::InputMapping,
+        3001 => HwCap::PlaybackSoloUnsupported,
+        _ => HwCap::Reserved(pos),
+    };
+}
+
 /// Nominal level of audio signal.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NominalSignalLevel {
@@ -94,6 +236,68 @@ fn deserialize_nominal_signal_level(level: &mut NominalSignalLevel, val: u32) {
         1 => NominalSignalLevel::Medium,
         _ => NominalSignalLevel::Professional,
     };
+}
+
+/// Type of physical group.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum PhysGroupType {
+    Analog,
+    Spdif,
+    Adat,
+    SpdifOrAdat,
+    AnalogMirror,
+    Headphones,
+    I2s,
+    Guitar,
+    PiezoGuitar,
+    GuitarString,
+    Unknown(u8),
+}
+
+#[cfg(test)]
+fn serialize_phys_group_type(group_type: &PhysGroupType) -> u8 {
+    match group_type {
+        PhysGroupType::Analog => 0,
+        PhysGroupType::Spdif => 1,
+        PhysGroupType::Adat => 2,
+        PhysGroupType::SpdifOrAdat => 3,
+        PhysGroupType::AnalogMirror => 4,
+        PhysGroupType::Headphones => 5,
+        PhysGroupType::I2s => 6,
+        PhysGroupType::Guitar => 7,
+        PhysGroupType::PiezoGuitar => 8,
+        PhysGroupType::GuitarString => 9,
+        PhysGroupType::Unknown(val) => *val,
+    }
+}
+
+fn deserialize_phys_group_type(group_type: &mut PhysGroupType, val: u8) {
+    *group_type = match val {
+        0 => PhysGroupType::Analog,
+        1 => PhysGroupType::Spdif,
+        2 => PhysGroupType::Adat,
+        3 => PhysGroupType::SpdifOrAdat,
+        4 => PhysGroupType::AnalogMirror,
+        5 => PhysGroupType::Headphones,
+        6 => PhysGroupType::I2s,
+        7 => PhysGroupType::Guitar,
+        8 => PhysGroupType::PiezoGuitar,
+        9 => PhysGroupType::GuitarString,
+        _ => PhysGroupType::Unknown(val),
+    };
+}
+
+impl Default for PhysGroupType {
+    fn default() -> Self {
+        Self::Unknown(u8::MAX)
+    }
+}
+
+/// Entry of physical group.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct PhysGroupEntry {
+    pub group_type: PhysGroupType,
+    pub group_count: usize,
 }
 
 #[cfg(test)]
@@ -133,6 +337,62 @@ mod test {
             let mut l = NominalSignalLevel::default();
             deserialize_nominal_signal_level(&mut l, val);
             assert_eq!(*level, l);
+        });
+    }
+
+    #[test]
+    fn phys_group_type_serdes() {
+        [
+            PhysGroupType::Analog,
+            PhysGroupType::Spdif,
+            PhysGroupType::Adat,
+            PhysGroupType::SpdifOrAdat,
+            PhysGroupType::AnalogMirror,
+            PhysGroupType::Headphones,
+            PhysGroupType::I2s,
+            PhysGroupType::Guitar,
+            PhysGroupType::PiezoGuitar,
+            PhysGroupType::GuitarString,
+            PhysGroupType::default(),
+        ]
+        .iter()
+        .for_each(|group_type| {
+            let val = serialize_phys_group_type(&group_type);
+            let mut t = PhysGroupType::default();
+            deserialize_phys_group_type(&mut t, val);
+            assert_eq!(*group_type, t);
+        });
+    }
+
+    #[test]
+    fn hw_cap_serdes() {
+        [
+            HwCap::ChangeableRespAddr,
+            HwCap::ControlRoom,
+            HwCap::OptionalSpdifCoax,
+            HwCap::OptionalAesebuXlr,
+            HwCap::Dsp,
+            HwCap::Fpga,
+            HwCap::PhantomPowering,
+            HwCap::OutputMapping,
+            HwCap::InputGain,
+            HwCap::OptionalSpdifOpt,
+            HwCap::OptionalAdatOpt,
+            HwCap::NominalInput,
+            HwCap::NominalOutput,
+            HwCap::SoftClip,
+            HwCap::RobotGuitar,
+            HwCap::GuitarCharging,
+            HwCap::InputMapping,
+            HwCap::PlaybackSoloUnsupported,
+            HwCap::default(),
+        ]
+        .iter()
+        .for_each(|cap| {
+            let val = serialize_hw_cap(&cap);
+            let mut c = HwCap::default();
+            deserialize_hw_cap(&mut c, val);
+            assert_eq!(*cap, c);
         });
     }
 }

--- a/protocols/fireworks/src/lib.rs
+++ b/protocols/fireworks/src/lib.rs
@@ -23,6 +23,7 @@ pub mod rip;
 use {
     glib::{Error, FileError},
     hitaki::{prelude::EfwProtocolExtManual, EfwProtocolError},
+    hw_info::HwMeter,
 };
 
 /// The specification of hardware.
@@ -62,6 +63,22 @@ pub trait EfwHardwareSpecification {
         Self::PHYS_OUTPUT_GROUPS
             .iter()
             .fold(0, |count, entry| count + entry.1)
+    }
+
+    fn create_hardware_meter() -> HwMeter {
+        HwMeter {
+            detected_clk_srcs: Self::SUPPORTED_SAMPLING_CLOCKS
+                .iter()
+                .map(|&src| (src, Default::default()))
+                .collect(),
+            detected_midi_inputs: Default::default(),
+            detected_midi_outputs: Default::default(),
+            guitar_charging: Default::default(),
+            guitar_stereo_connect: Default::default(),
+            guitar_hex_signal: Default::default(),
+            phys_output_meters: vec![Default::default(); Self::phys_output_count()],
+            phys_input_meters: vec![Default::default(); Self::phys_input_count()],
+        }
     }
 }
 

--- a/protocols/fireworks/src/monitor.rs
+++ b/protocols/fireworks/src/monitor.rs
@@ -37,6 +37,211 @@ pub struct EfwMonitorSourceParameters {
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct EfwMonitorParameters(pub Vec<EfwMonitorSourceParameters>);
 
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwMonitorParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwMonitorParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.0.len(), Self::MONITOR_DESTINATION_COUNT);
+
+        states
+            .0
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(dst_ch, sources)| {
+                assert_eq!(sources.gains.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(sources.mutes.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(sources.solos.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(sources.pans.len(), Self::MONITOR_SOURCE_COUNT);
+
+                sources
+                    .gains
+                    .iter_mut()
+                    .enumerate()
+                    .try_for_each(|(src_ch, gain)| {
+                        let args = [src_ch as u32, dst_ch as u32, 0];
+                        let mut params = vec![0; 3];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_GET_VOL,
+                                &args,
+                                &mut params,
+                                timeout_ms,
+                            )
+                            .map(|_| *gain = params[2] as i32)
+                    })?;
+
+                sources
+                    .mutes
+                    .iter_mut()
+                    .enumerate()
+                    .try_for_each(|(src_ch, mute)| {
+                        let args = [src_ch as u32, dst_ch as u32, 0];
+                        let mut params = vec![0; 3];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_GET_MUTE,
+                                &args,
+                                &mut params,
+                                timeout_ms,
+                            )
+                            .map(|_| *mute = params[2] > 0)
+                    })?;
+
+                sources
+                    .solos
+                    .iter_mut()
+                    .enumerate()
+                    .try_for_each(|(src_ch, solo)| {
+                        let args = [src_ch as u32, dst_ch as u32, 0];
+                        let mut params = vec![0; 3];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_GET_SOLO,
+                                &args,
+                                &mut params,
+                                timeout_ms,
+                            )
+                            .map(|_| *solo = params[2] > 0)
+                    })?;
+
+                sources
+                    .pans
+                    .iter_mut()
+                    .enumerate()
+                    .try_for_each(|(src_ch, pan)| {
+                        let args = [src_ch as u32, dst_ch as u32, 0];
+                        let mut params = vec![0; 3];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_GET_PAN,
+                                &args,
+                                &mut params,
+                                timeout_ms,
+                            )
+                            .map(|_| *pan = params[2] as u8)
+                    })
+            })
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwMonitorParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwMonitorParameters,
+        updates: EfwMonitorParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.0.len(), Self::MONITOR_DESTINATION_COUNT);
+
+        states
+            .0
+            .iter_mut()
+            .zip(updates.0.iter())
+            .enumerate()
+            .try_for_each(|(dst_ch, (input, update))| {
+                assert_eq!(input.gains.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(input.mutes.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(input.solos.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(input.pans.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(update.gains.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(update.mutes.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(update.solos.len(), Self::MONITOR_SOURCE_COUNT);
+                assert_eq!(update.pans.len(), Self::MONITOR_SOURCE_COUNT);
+
+                input
+                    .gains
+                    .iter_mut()
+                    .zip(update.gains.iter())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(n))
+                    .try_for_each(|(src_ch, (curr, &gain))| {
+                        let args = [src_ch as u32, dst_ch as u32, gain as u32];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_SET_VOL,
+                                &args,
+                                &mut vec![0; 3],
+                                timeout_ms,
+                            )
+                            .map(|_| *curr = gain)
+                    })?;
+
+                input
+                    .mutes
+                    .iter_mut()
+                    .zip(update.mutes.iter())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(n))
+                    .try_for_each(|(src_ch, (curr, &mute))| {
+                        let args = [src_ch as u32, dst_ch as u32, mute as u32];
+                        let mut params = vec![0; 3];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_SET_MUTE,
+                                &args,
+                                &mut params,
+                                timeout_ms,
+                            )
+                            .map(|_| *curr = mute)
+                    })?;
+
+                input
+                    .solos
+                    .iter_mut()
+                    .zip(update.solos.iter())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(n))
+                    .try_for_each(|(src_ch, (curr, &solo))| {
+                        let args = [src_ch as u32, dst_ch as u32, solo as u32];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_SET_SOLO,
+                                &args,
+                                &mut vec![0; 3],
+                                timeout_ms,
+                            )
+                            .map(|_| *curr = solo)
+                    })?;
+
+                input
+                    .pans
+                    .iter_mut()
+                    .zip(update.pans.iter())
+                    .enumerate()
+                    .filter(|(_, (o, n))| !o.eq(n))
+                    .try_for_each(|(src_ch, (curr, &pan))| {
+                        let args = [src_ch as u32, dst_ch as u32, pan as u32];
+                        proto
+                            .transaction(
+                                CATEGORY_MONITOR,
+                                CMD_SET_PAN,
+                                &args,
+                                &mut vec![0; 3],
+                                timeout_ms,
+                            )
+                            .map(|_| *curr = pan)
+                    })
+            })
+    }
+}
+
 /// Protocol about input monitor for Fireworks board module.
 pub trait MonitorProtocol: EfwProtocolExtManual {
     /// Set volume of monitor. The value of vol is unsigned fixed-point number of 8.24 format; i.e. Q24.

--- a/protocols/fireworks/src/onyx_f.rs
+++ b/protocols/fireworks/src/onyx_f.rs
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+//! Protocol implementations for Mackie Onyx-F series.
+//!
+//! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
+//! for Mackie Onyx-F series.
+
+use super::*;
+
+/// Protocol implementation for former model of Onyx 1200F.
+#[derive(Default, Debug)]
+pub struct Onyx1200fProtocol;
+
+impl EfwHardwareSpecification for Onyx1200fProtocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[44100, 48000, 88200, 96000, 176400, 192000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] = &[
+        ClkSrc::Internal,
+        ClkSrc::WordClock,
+        ClkSrc::Spdif,
+        ClkSrc::Adat,
+        ClkSrc::Adat2,
+    ];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::OptionalSpdifCoax,
+        HwCap::OptionalAesebuXlr,
+        HwCap::Dsp,
+        HwCap::Fpga,
+        // Fixup.
+        HwCap::ControlRoom,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [30, 16, 8];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [34, 16, 8];
+    const MONITOR_SOURCE_COUNT: usize = 30;
+    const MONITOR_DESTINATION_COUNT: usize = 34;
+    const MIDI_INPUT_COUNT: usize = 2;
+    const MIDI_OUTPUT_COUNT: usize = 2;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[
+        (PhysGroupType::Analog, 12),
+        (PhysGroupType::Adat, 8),
+        (PhysGroupType::Adat, 8),
+        (PhysGroupType::Spdif, 2),
+    ];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[
+        (PhysGroupType::Analog, 8),
+        (PhysGroupType::Adat, 8),
+        (PhysGroupType::Adat, 8),
+        (PhysGroupType::Headphones, 4),
+        (PhysGroupType::Spdif, 2),
+        //(PhysGroupType::AnalogMirror, 2), This is not operable from software.
+    ];
+}
+
+/// Protocol implementation for Mackie Onyx 400F. The higher sampling rates are available only with
+/// firmware version 4 and former.
+#[derive(Default, Debug)]
+pub struct Onyx400fProtocol;
+
+impl EfwHardwareSpecification for Onyx400fProtocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[44100, 48000, 88200, 96000, 176400, 192000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] =
+        &[ClkSrc::Internal, ClkSrc::WordClock, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] =
+        &[HwCap::ChangeableRespAddr, HwCap::ControlRoom, HwCap::Dsp];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [10, 10, 10];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [10, 10, 10];
+    const MONITOR_SOURCE_COUNT: usize = 10;
+    const MONITOR_DESTINATION_COUNT: usize = 10;
+    const MIDI_INPUT_COUNT: usize = 2;
+    const MIDI_OUTPUT_COUNT: usize = 2;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] =
+        &[(PhysGroupType::Analog, 8), (PhysGroupType::Spdif, 2)];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[
+        (PhysGroupType::Analog, 8),
+        (PhysGroupType::Spdif, 2),
+        //(PhysGroupType::AnalogMirror, 2), This is not operable from software.
+    ];
+}

--- a/protocols/fireworks/src/onyx_f.rs
+++ b/protocols/fireworks/src/onyx_f.rs
@@ -6,7 +6,7 @@
 //! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
 //! for Mackie Onyx-F series.
 
-use super::*;
+use super::{port_conf::*, *};
 
 /// Protocol implementation for former model of Onyx 1200F.
 #[derive(Default, Debug)]
@@ -54,6 +54,8 @@ impl EfwHardwareSpecification for Onyx1200fProtocol {
     ];
 }
 
+impl EfwControlRoomSpecification for Onyx1200fProtocol {}
+
 /// Protocol implementation for Mackie Onyx 400F. The higher sampling rates are available only with
 /// firmware version 4 and former.
 #[derive(Default, Debug)]
@@ -81,3 +83,5 @@ impl EfwHardwareSpecification for Onyx400fProtocol {
         //(PhysGroupType::AnalogMirror, 2), This is not operable from software.
     ];
 }
+
+impl EfwControlRoomSpecification for Onyx400fProtocol {}

--- a/protocols/fireworks/src/onyx_f.rs
+++ b/protocols/fireworks/src/onyx_f.rs
@@ -56,6 +56,8 @@ impl EfwHardwareSpecification for Onyx1200fProtocol {
 
 impl EfwControlRoomSpecification for Onyx1200fProtocol {}
 
+impl EfwDigitalModeSpecification for Onyx1200fProtocol {}
+
 /// Protocol implementation for Mackie Onyx 400F. The higher sampling rates are available only with
 /// firmware version 4 and former.
 #[derive(Default, Debug)]

--- a/protocols/fireworks/src/phys_input.rs
+++ b/protocols/fireworks/src/phys_input.rs
@@ -20,6 +20,89 @@ pub struct EfwPhysInputParameters {
     pub nominals: Vec<NominalSignalLevel>,
 }
 
+/// The specification of physical input.
+pub trait EfwPhysInputSpecification: EfwHardwareSpecification {
+    fn phys_analog_input_count() -> usize {
+        Self::PHYS_INPUT_GROUPS
+            .iter()
+            .filter(|(group_type, _)| PhysGroupType::Analog.eq(group_type))
+            .fold(0, |total, (_, count)| total + count)
+    }
+
+    fn create_phys_input_parameters() -> EfwPhysInputParameters {
+        EfwPhysInputParameters {
+            nominals: vec![Default::default(); Self::phys_analog_input_count()],
+        }
+    }
+}
+
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwPhysInputParameters> for O
+where
+    O: EfwPhysInputSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwPhysInputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.nominals.len(), Self::phys_analog_input_count());
+
+        states
+            .nominals
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, level)| {
+                let args = [ch as u32, 0];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_INPUT,
+                        CMD_GET_NOMINAL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| deserialize_nominal_signal_level(level, params[1]))
+            })
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwPhysInputParameters> for O
+where
+    O: EfwPhysInputSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwPhysInputParameters,
+        updates: EfwPhysInputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.nominals.len(), Self::phys_analog_input_count());
+        assert_eq!(updates.nominals.len(), Self::phys_analog_input_count());
+
+        states
+            .nominals
+            .iter_mut()
+            .zip(&updates.nominals)
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, level))| {
+                let args = [ch as u32, serialize_nominal_signal_level(level)];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_INPUT,
+                        CMD_SET_NOMINAL,
+                        &args,
+                        &mut vec![0; 2],
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = *level)
+            })
+    }
+}
+
 /// Protocol about physical input for Fireworks board module.
 pub trait PhysInputProtocol: EfwProtocolExtManual {
     fn set_nominal(

--- a/protocols/fireworks/src/phys_output.rs
+++ b/protocols/fireworks/src/phys_output.rs
@@ -27,11 +27,202 @@ pub struct EfwOutputParameters {
     pub mutes: Vec<bool>,
 }
 
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwOutputParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwOutputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.volumes.len(), Self::phys_output_count());
+        assert_eq!(states.mutes.len(), Self::phys_output_count());
+
+        states
+            .volumes
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, volume)| {
+                let args = [ch as u32, 0];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_GET_VOL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *volume = params[1] as i32)
+            })?;
+
+        states
+            .mutes
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, mute)| {
+                let args = [ch as u32, 0];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_GET_MUTE,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *mute = params[1] > 0)
+            })
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwOutputParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwOutputParameters,
+        updates: EfwOutputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.volumes.len(), Self::phys_output_count());
+        assert_eq!(states.mutes.len(), Self::phys_output_count());
+
+        states
+            .volumes
+            .iter_mut()
+            .zip(updates.volumes.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &vol))| {
+                let args = [ch as u32, vol as u32];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_SET_VOL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = vol)
+            })?;
+
+        states
+            .mutes
+            .iter_mut()
+            .zip(updates.mutes.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &mute))| {
+                let args = [ch as u32, mute as u32];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_SET_MUTE,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = mute)
+            })
+    }
+}
+
 /// The parameters of physical outputs.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct EfwPhysOutputParameters {
     /// The nominal signal level of physical output.
     pub nominals: Vec<NominalSignalLevel>,
+}
+
+/// The specification of physical output.
+pub trait EfwPhysOutputSpecification: EfwHardwareSpecification {
+    fn phys_analog_output_count() -> usize {
+        Self::PHYS_INPUT_GROUPS
+            .iter()
+            .filter(|(group_type, _)| PhysGroupType::Analog.eq(group_type))
+            .fold(0, |total, (_, count)| total + count)
+    }
+
+    fn create_phys_output_parameters() -> EfwPhysOutputParameters {
+        EfwPhysOutputParameters {
+            nominals: vec![Default::default(); Self::phys_analog_output_count()],
+        }
+    }
+}
+
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwPhysOutputParameters> for O
+where
+    O: EfwPhysOutputSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwPhysOutputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.nominals.len(), Self::phys_analog_output_count());
+
+        states
+            .nominals
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, level)| {
+                let args = [ch as u32, 0];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_GET_NOMINAL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| deserialize_nominal_signal_level(level, params[1]))
+            })
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwPhysOutputParameters> for O
+where
+    O: EfwPhysOutputSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwPhysOutputParameters,
+        updates: EfwPhysOutputParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.nominals.len(), Self::phys_analog_output_count());
+        assert_eq!(updates.nominals.len(), Self::phys_analog_output_count());
+
+        states
+            .nominals
+            .iter_mut()
+            .zip(updates.nominals.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &level))| {
+                let args = [ch as u32, serialize_nominal_signal_level(&level)];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PHYS_OUTPUT,
+                        CMD_SET_NOMINAL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = level)
+            })
+    }
 }
 
 /// Protocol about physical output for Fireworks board module.

--- a/protocols/fireworks/src/playback.rs
+++ b/protocols/fireworks/src/playback.rs
@@ -27,11 +27,205 @@ pub struct EfwPlaybackParameters {
     pub mutes: Vec<bool>,
 }
 
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwPlaybackParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwPlaybackParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.volumes.len(), Self::RX_CHANNEL_COUNTS[0]);
+        assert_eq!(states.mutes.len(), Self::RX_CHANNEL_COUNTS[0]);
+
+        states
+            .volumes
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, vol)| {
+                let args = [ch as u32, 0];
+                let mut resps = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_GET_VOL,
+                        &args,
+                        &mut resps,
+                        timeout_ms,
+                    )
+                    .map(|_| *vol = resps[1] as i32)
+            })?;
+
+        states
+            .mutes
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, mute)| {
+                let args = [ch as u32, 0];
+                let mut resps = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_GET_MUTE,
+                        &args,
+                        &mut resps,
+                        timeout_ms,
+                    )
+                    .map(|_| *mute = resps[1] > 0)
+            })?;
+
+        Ok(())
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwPlaybackParameters> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwPlaybackParameters,
+        updates: EfwPlaybackParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.volumes.len(), Self::RX_CHANNEL_COUNTS[0]);
+        assert_eq!(states.mutes.len(), Self::RX_CHANNEL_COUNTS[0]);
+        assert_eq!(updates.volumes.len(), Self::RX_CHANNEL_COUNTS[0]);
+        assert_eq!(updates.mutes.len(), Self::RX_CHANNEL_COUNTS[0]);
+
+        states
+            .volumes
+            .iter_mut()
+            .zip(updates.volumes.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &vol))| {
+                let args = [ch as u32, vol as u32];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_SET_VOL,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = vol)
+            })?;
+
+        states
+            .mutes
+            .iter_mut()
+            .zip(updates.mutes.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &mute))| {
+                let args = [ch as u32, mute as u32];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_SET_MUTE,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = mute)
+            })?;
+
+        Ok(())
+    }
+}
+
 /// The parameters of playback.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct EfwPlaybackSoloParameters {
     /// Whether to mute the other channels.
     pub solos: Vec<bool>,
+}
+
+/// The specification for solo of playback.
+pub trait EfwPlaybackSoloSpecification: EfwHardwareSpecification {
+    fn create_playback_solo_parameters() -> EfwPlaybackSoloParameters {
+        EfwPlaybackSoloParameters {
+            solos: vec![Default::default(); Self::RX_CHANNEL_COUNTS[0]],
+        }
+    }
+}
+
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwPlaybackSoloParameters> for O
+where
+    O: EfwPlaybackSoloSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwPlaybackSoloParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.solos.len(), Self::RX_CHANNEL_COUNTS[0]);
+
+        states
+            .solos
+            .iter_mut()
+            .enumerate()
+            .try_for_each(|(ch, solo)| {
+                let args = [ch as u32, 0];
+                let mut resps = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_GET_SOLO,
+                        &args,
+                        &mut resps,
+                        timeout_ms,
+                    )
+                    .map(|_| *solo = resps[1] > 0)
+            })?;
+
+        Ok(())
+    }
+}
+
+impl<O, P> EfwPartiallyUpdatableParamsOperation<P, EfwPlaybackSoloParameters> for O
+where
+    O: EfwPlaybackSoloSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_partially(
+        proto: &mut P,
+        states: &mut EfwPlaybackSoloParameters,
+        updates: EfwPlaybackSoloParameters,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        assert_eq!(states.solos.len(), Self::RX_CHANNEL_COUNTS[0]);
+        assert_eq!(updates.solos.len(), Self::RX_CHANNEL_COUNTS[0]);
+
+        states
+            .solos
+            .iter_mut()
+            .zip(updates.solos.iter())
+            .enumerate()
+            .filter(|(_, (o, n))| !o.eq(n))
+            .try_for_each(|(ch, (curr, &solo))| {
+                let args = [ch as u32, solo as u32];
+                let mut params = vec![0; 2];
+                proto
+                    .transaction(
+                        CATEGORY_PLAYBACK,
+                        CMD_SET_SOLO,
+                        &args,
+                        &mut params,
+                        timeout_ms,
+                    )
+                    .map(|_| *curr = solo)
+            })?;
+
+        Ok(())
+    }
 }
 
 /// Protocol about stream playback for Fireworks board module.

--- a/protocols/fireworks/src/port_conf.rs
+++ b/protocols/fireworks/src/port_conf.rs
@@ -264,6 +264,55 @@ where
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct EfwPhantomPowering(pub bool);
 
+/// The specification for mode of digital input and output.
+pub trait EfwPhantomPoweringSpecification: EfwHardwareSpecification {}
+
+impl<O, P> EfwWhollyCachableParamsOperation<P, EfwPhantomPowering> for O
+where
+    O: EfwPhantomPoweringSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn cache_wholly(
+        proto: &mut P,
+        states: &mut EfwPhantomPowering,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let args = Vec::new();
+        let mut params = vec![0];
+        proto
+            .transaction(
+                CATEGORY_PORT_CONF,
+                CMD_GET_PHANTOM,
+                &args,
+                &mut params,
+                timeout_ms,
+            )
+            .map(|_| states.0 = params[0] > 0)
+    }
+}
+
+impl<O, P> EfwWhollyUpdatableParamsOperation<P, EfwPhantomPowering> for O
+where
+    O: EfwPhantomPoweringSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(
+        proto: &mut P,
+        states: &EfwPhantomPowering,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let args = [states.0 as u32];
+        let mut params = Vec::new();
+        proto.transaction(
+            CATEGORY_PORT_CONF,
+            CMD_SET_PHANTOM,
+            &args,
+            &mut params,
+            timeout_ms,
+        )
+    }
+}
+
 /// Mapping between rx stream channel pairs and physical output channel pairs per mode of sampling
 /// transfer frequency.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]

--- a/protocols/fireworks/src/rip.rs
+++ b/protocols/fireworks/src/rip.rs
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+//! Protocol implementations for Robot Interface Pack.
+//!
+//! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
+//! for Gibson Robot Interface Pack.
+
+use super::*;
+
+/// Protocol implementation for former model of Robot Interface Pack (RIP).
+#[derive(Default, Debug)]
+pub struct RipProtocol;
+
+impl EfwHardwareSpecification for RipProtocol {
+    const SUPPORTED_SAMPLING_RATES: &'static [u32] = &[44100, 48000, 88200, 96000, 176400, 192000];
+    const SUPPORTED_SAMPLING_CLOCKS: &'static [ClkSrc] =
+        &[ClkSrc::Internal, ClkSrc::WordClock, ClkSrc::Spdif];
+    const CAPABILITIES: &'static [HwCap] = &[
+        HwCap::ChangeableRespAddr,
+        HwCap::Fpga,
+        HwCap::RobotGuitar,
+        HwCap::GuitarCharging,
+    ];
+    const TX_CHANNEL_COUNTS: [usize; 3] = [8, 8, 8];
+    const RX_CHANNEL_COUNTS: [usize; 3] = [2, 2, 2];
+    const MONITOR_SOURCE_COUNT: usize = 8;
+    const MONITOR_DESTINATION_COUNT: usize = 2;
+    const MIDI_INPUT_COUNT: usize = 0;
+    const MIDI_OUTPUT_COUNT: usize = 0;
+
+    const PHYS_INPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[
+        (PhysGroupType::Guitar, 1),
+        (PhysGroupType::PiezoGuitar, 1),
+        (PhysGroupType::GuitarString, 6),
+    ];
+
+    const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 2)];
+}

--- a/protocols/fireworks/src/rip.rs
+++ b/protocols/fireworks/src/rip.rs
@@ -37,3 +37,5 @@ impl EfwHardwareSpecification for RipProtocol {
 
     const PHYS_OUTPUT_GROUPS: &'static [(PhysGroupType, usize)] = &[(PhysGroupType::Analog, 2)];
 }
+
+impl EfwPlaybackSoloSpecification for RipProtocol {}

--- a/protocols/fireworks/src/rip.rs
+++ b/protocols/fireworks/src/rip.rs
@@ -6,7 +6,7 @@
 //! The module includes protocol about port configuration defined by Echo Audio Digital Corporation
 //! for Gibson Robot Interface Pack.
 
-use super::*;
+use super::{robot_guitar::*, *};
 
 /// Protocol implementation for former model of Robot Interface Pack (RIP).
 #[derive(Default, Debug)]
@@ -39,3 +39,5 @@ impl EfwHardwareSpecification for RipProtocol {
 }
 
 impl EfwPlaybackSoloSpecification for RipProtocol {}
+
+impl EfwRobotGuitarSpecification for RipProtocol {}

--- a/protocols/fireworks/src/transport.rs
+++ b/protocols/fireworks/src/transport.rs
@@ -13,6 +13,7 @@ const CATEGORY_TRANSPORT: u32 = 2;
 const CMD_SET_TRANSMIT_MODE: u32 = 0;
 
 /// The format of packet in transmission.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum TxPacketFormat {
     /// Unique.
     Unique,
@@ -20,19 +21,54 @@ pub enum TxPacketFormat {
     Iec61883,
 }
 
-impl From<TxPacketFormat> for u32 {
-    fn from(fmt: TxPacketFormat) -> Self {
-        match fmt {
-            TxPacketFormat::Unique => 0,
-            TxPacketFormat::Iec61883 => 1,
-        }
+impl Default for TxPacketFormat {
+    fn default() -> Self {
+        Self::Iec61883
+    }
+}
+
+fn serialize_tx_packet_format(fmt: &TxPacketFormat) -> u32 {
+    match fmt {
+        TxPacketFormat::Unique => 0,
+        TxPacketFormat::Iec61883 => 1,
+    }
+}
+
+#[cfg(test)]
+fn deserialize_tx_packet_format(fmt: &mut TxPacketFormat, val: u32) {
+    *fmt = match val {
+        1 => TxPacketFormat::Iec61883,
+        _ => TxPacketFormat::Unique,
+    };
+}
+
+impl<O, P> EfwWhollyUpdatableParamsOperation<P, TxPacketFormat> for O
+where
+    O: EfwHardwareSpecification,
+    P: EfwProtocolExtManual,
+{
+    fn update_wholly(proto: &mut P, states: &TxPacketFormat, timeout_ms: u32) -> Result<(), Error> {
+        assert!(Self::CAPABILITIES
+            .iter()
+            .find(|cap| HwCap::ChangeableRespAddr.eq(cap))
+            .is_some());
+
+        let args = [serialize_tx_packet_format(states)];
+        let mut params = Vec::new();
+        proto.transaction(
+            CATEGORY_TRANSPORT,
+            CMD_SET_TRANSMIT_MODE,
+            &args,
+            &mut params,
+            timeout_ms,
+        )
     }
 }
 
 /// Protocol about transmission for Fireworks board module.
 pub trait TransportProtocol: EfwProtocolExtManual {
     fn get_packet_format(&mut self, fmt: TxPacketFormat, timeout_ms: u32) -> Result<(), Error> {
-        let args = [u32::from(fmt)];
+        let args = [serialize_tx_packet_format(&fmt)];
         self.transaction(
             CATEGORY_TRANSPORT,
             CMD_SET_TRANSMIT_MODE,
@@ -44,3 +80,20 @@ pub trait TransportProtocol: EfwProtocolExtManual {
 }
 
 impl<O: EfwProtocolExtManual> TransportProtocol for O {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn tx_packet_format_serdes() {
+        [TxPacketFormat::Unique, TxPacketFormat::Iec61883]
+            .iter()
+            .for_each(|fmt| {
+                let val = serialize_tx_packet_format(fmt);
+                let mut f = TxPacketFormat::default();
+                deserialize_tx_packet_format(&mut f, val);
+                assert_eq!(*fmt, f);
+            });
+    }
+}

--- a/runtime/fireworks/src/lib.rs
+++ b/runtime/fireworks/src/lib.rs
@@ -22,6 +22,7 @@ use {
     },
     hitaki::{prelude::*, SndEfw},
     nix::sys::signal,
+    protocols::HwCap,
     std::{sync::mpsc, thread, time},
 };
 

--- a/runtime/fireworks/src/port_ctl.rs
+++ b/runtime/fireworks/src/port_ctl.rs
@@ -3,7 +3,7 @@
 
 use {
     super::*,
-    protocols::{hw_info::*, port_conf::*},
+    protocols::{hw_info::*, port_conf::*, *},
 };
 
 fn phys_group_type_to_str(phys_group_type: &PhysGroupType) -> &'static str {


### PR DESCRIPTION
Current implementation has ad-hoc implementations for control operations, while it is not necessarily convenient in a point of code maintenance, especially for the case that the device includes out-of-specification behaviour.

This patchset introduces a trait to express hardware specification, then implements the
trait for each model. Some trait is added for cache and update operation for hardware
parameters, and they are implemented for operations. They are planned to be used for future work.

```
Takashi Sakamoto (21):
  protocols/fireworks: add trait and its implementation to express
    hardware specification
  protocols/fireworks: add some trait to cache and update parameters
  protocols/fireworks: implement cache trait for hardware information
  protocols/fireworks: implement cache trait for hardware meters
  protocols/fireworks: implement cache and update traits for sampling
    clock configuration
  protocols/fireworks: implement cache and update traits for control
    room
  protocols/fireworks: implement cache and update traits for mode of
    digital input and output
  protocols/fireworks: implement cache and update traits for phantom
    powering
  protocols/fireworks: implement cache and update traits for rx stream
    channel mapping
  protocols/fireworks: implement cache and update traits for monitor
    parameters
  protocols/fireworks: implement cache and update traits for physical
    input parameters
  protocols/fireworks: implement cache and update traits for physical
    output parameters
  protocols/fireworks: implement cache and update traits for playback
    parameters
  protocols/fireworks: implement cache and update traits for robot
    guitar parameters
  protocols/fireworks: implement cache and update traits for flags of
    hardware controls
  protocols/fireworks: implement update traits for tx packet format
  protocols/fireworks: implement update traits for response address
  protocols/fireworks: implement cache traits for content of session
    block
  protocols/fireworks: implement update traits for LED blink
  protocols/fireworks: implement update traits for reconnecting PHY of
    IEEE 1394
  protocols/fireworks: implement update traits for flash memory
    operation

 protocols/fireworks/src/audiofire.rs    | 239 ++++++++++++++++
 protocols/fireworks/src/flash.rs        | 326 ++++++++++++++++-----
 protocols/fireworks/src/hw_ctl.rs       | 159 +++++++++++
 protocols/fireworks/src/hw_info.rs      | 212 +++++++-------
 protocols/fireworks/src/lib.rs          | 335 ++++++++++++++++++++++
 protocols/fireworks/src/monitor.rs      | 205 ++++++++++++++
 protocols/fireworks/src/onyx_f.rs       |  89 ++++++
 protocols/fireworks/src/phys_input.rs   |  83 ++++++
 protocols/fireworks/src/phys_output.rs  | 191 +++++++++++++
 protocols/fireworks/src/playback.rs     | 194 +++++++++++++
 protocols/fireworks/src/port_conf.rs    | 358 ++++++++++++++++++++++++
 protocols/fireworks/src/rip.rs          |  43 +++
 protocols/fireworks/src/robot_guitar.rs |  56 ++++
 protocols/fireworks/src/transport.rs    |  67 ++++-
 runtime/fireworks/src/lib.rs            |   1 +
 runtime/fireworks/src/port_ctl.rs       |   2 +-
 16 files changed, 2365 insertions(+), 195 deletions(-)
 create mode 100644 protocols/fireworks/src/audiofire.rs
 create mode 100644 protocols/fireworks/src/onyx_f.rs
 create mode 100644 protocols/fireworks/src/rip.rs
```