### PR TITLE
[PATCH 00/17] digi00x: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2023/03/25
+2023/03/28
 Takashi Sakamoto
 
 Introduction
@@ -283,6 +283,7 @@ Currently this function is available for below executables:
 * snd-oxfw-ctl-service
 * snd-fireface-ctl-service
 * snd-fireworks-ctl-service
+* snd-firewire-digi00x-ctl-service
 
 This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
 `tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.

--- a/protocols/digi00x/src/lib.rs
+++ b/protocols/digi00x/src/lib.rs
@@ -102,19 +102,6 @@ impl Default for ClockSource {
     }
 }
 
-/// Mode of optical interface.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
-pub enum OpticalInterfaceMode {
-    Adat,
-    Spdif,
-}
-
-impl Default for OpticalInterfaceMode {
-    fn default() -> Self {
-        Self::Adat
-    }
-}
-
 const SAMPLING_CLOCK_SOURCE_OFFSET: u64 = 0x0118;
 const MEDIA_CLOCK_RATE_OFFSET: u64 = 0x0110;
 const EXTERNAL_CLOCK_RATE_OFFSET: u64 = 0x0114;
@@ -133,6 +120,42 @@ fn read_clock_rate(
         1 => ClockRate::R48000,
         _ => ClockRate::R44100,
     })
+}
+
+/// The parameters for sampling clock.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dg00xSamplingClockParameters {
+    /// The source.
+    pub source: ClockSource,
+}
+
+/// The parameters for media clock.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dg00xMediaClockParameters {
+    /// The rate.
+    pub rate: ClockRate,
+}
+
+/// Mode of optical interface.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum OpticalInterfaceMode {
+    Adat,
+    Spdif,
+}
+
+impl Default for OpticalInterfaceMode {
+    fn default() -> Self {
+        Self::Adat
+    }
+}
+
+/// The parameters for media clock.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Dg00xExternalClockParameters {
+    /// The rate detected in input of external source. Once the source of sampling clock is
+    /// configured to any external source, the function can return detected frequency. Once losing
+    /// the input, it returns None.
+    pub rate: Option<ClockRate>,
 }
 
 /// The trait for common operation.
@@ -266,10 +289,14 @@ pub trait Dg00xCommonOperation {
 const MONITOR_DST_COUNT: usize = 2;
 const MONITOR_SRC_COUNT: usize = 18;
 
-/// State of monitor. The gain is between 0x00 and 0x80 for -48.0 and 0.0 dB.
-#[derive(Default, Debug)]
+/// State of monitor. At offline mode (no packet streaming runs), the monitor function is disabled
+/// and is not configurable. When packet streaming starts, the monitor function becomes
+/// configurable with reset state.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Dg00xMonitorState {
+    /// Whether to enable monitor mixer or not.
     pub enabled: bool,
+    /// The gain of monitor inputs. The value is between 0x00 and 0x80 for -48.0 and 0.0 dB.
     pub src_gains: [[u8; MONITOR_SRC_COUNT]; MONITOR_DST_COUNT],
 }
 

--- a/protocols/digi00x/src/lib.rs
+++ b/protocols/digi00x/src/lib.rs
@@ -96,6 +96,37 @@ pub trait Dg00xHardwareSpecification {
     const MONITOR_SOURCE_GAIN_STEP: u8 = 1;
 }
 
+/// Cache whole parameters.
+pub trait Dg00xWhollyCachableParamsOperation<T>: Dg00xHardwareSpecification {
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        states: &mut T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+/// Update the part of parameters.
+pub trait Dg00xPartiallyUpdatableParamsOperation<T>: Dg00xHardwareSpecification {
+    fn update_partially(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut T,
+        update: T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+/// Update whole parameters.
+pub trait Dg00xWhollyUpdatableParamsOperation<T>: Dg00xHardwareSpecification {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        states: &T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
 /// Nominal frequency of media clock.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum ClockRate {

--- a/protocols/digi00x/src/lib.rs
+++ b/protocols/digi00x/src/lib.rs
@@ -16,13 +16,6 @@ impl Dg00xHardwareSpecification for Digi002Protocol {
         &[ClockSource::Internal, ClockSource::Spdif, ClockSource::Adat];
 }
 
-impl Dg00xCommonOperation for Digi002Protocol {
-    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] =
-        &[ClockSource::Internal, ClockSource::Spdif, ClockSource::Adat];
-}
-
-impl Dg00xMonitorOperation for Digi002Protocol {}
-
 /// The protocol implementation for Digi 003.
 #[derive(Default, Debug)]
 pub struct Digi003Protocol;
@@ -35,17 +28,6 @@ impl Dg00xHardwareSpecification for Digi003Protocol {
         ClockSource::WordClock,
     ];
 }
-
-impl Dg00xCommonOperation for Digi003Protocol {
-    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] = &[
-        ClockSource::Internal,
-        ClockSource::Spdif,
-        ClockSource::Adat,
-        ClockSource::WordClock,
-    ];
-}
-
-impl Dg00xMonitorOperation for Digi003Protocol {}
 
 const BASE_OFFSET: u64 = 0xffffe0000000;
 
@@ -162,20 +144,6 @@ const MEDIA_CLOCK_RATE_OFFSET: u64 = 0x0110;
 const EXTERNAL_CLOCK_RATE_OFFSET: u64 = 0x0114;
 const OPTICAL_INTERFACE_MODE_OFFSET: u64 = 0x011c;
 const EXTERNAL_CLOCK_SOURCE_DETECTION_OFFSET: u64 = 0x012c;
-
-fn read_clock_rate(
-    req: &mut FwReq,
-    node: &mut FwNode,
-    offset: u64,
-    timeout_ms: u32,
-) -> Result<ClockRate, Error> {
-    read_quadlet(req, node, offset, timeout_ms).map(|val| match val {
-        3 => ClockRate::R96000,
-        2 => ClockRate::R88200,
-        1 => ClockRate::R48000,
-        _ => ClockRate::R44100,
-    })
-}
 
 /// The parameters for sampling clock.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
@@ -378,134 +346,6 @@ where
     }
 }
 
-/// The trait for common operation.
-pub trait Dg00xCommonOperation {
-    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource];
-
-    fn read_sampling_clock_source(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        timeout_ms: u32,
-    ) -> Result<ClockSource, Error> {
-        read_quadlet(req, node, SAMPLING_CLOCK_SOURCE_OFFSET, timeout_ms).and_then(|val| {
-            let src = match val {
-                3 => ClockSource::WordClock,
-                2 => ClockSource::Adat,
-                1 => ClockSource::Spdif,
-                _ => ClockSource::Internal,
-            };
-            Self::SAMPLING_CLOCK_SOURCES
-                .iter()
-                .find(|&s| s.eq(&src))
-                .map(|&s| s)
-                .ok_or_else(|| {
-                    let msg = format!("Unexpected clock source: {}", val);
-                    Error::new(FileError::Io, &msg)
-                })
-        })
-    }
-
-    /// The change has effect to stop processing audio data during packet streaming.
-    fn write_sampling_clock_source(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        src: ClockSource,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let val = match src {
-            ClockSource::Internal => 0,
-            ClockSource::Spdif => 1,
-            ClockSource::Adat => 2,
-            ClockSource::WordClock => 3,
-        };
-        if Self::SAMPLING_CLOCK_SOURCES
-            .iter()
-            .find(|&s| s.eq(&src))
-            .is_none()
-        {
-            let msg = format!("Invalid argument for clock source: {}", val);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-        write_quadlet(req, node, SAMPLING_CLOCK_SOURCE_OFFSET, val, timeout_ms)
-    }
-
-    fn read_media_clock_rate(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        timeout_ms: u32,
-    ) -> Result<ClockRate, Error> {
-        read_clock_rate(req, node, MEDIA_CLOCK_RATE_OFFSET, timeout_ms)
-    }
-
-    /// The change has effect to stop processing audio data during packet streaming.
-    fn write_media_clock_rate(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        rate: ClockRate,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let val = match rate {
-            ClockRate::R44100 => 0,
-            ClockRate::R48000 => 1,
-            ClockRate::R88200 => 2,
-            ClockRate::R96000 => 3,
-        };
-        write_quadlet(req, node, MEDIA_CLOCK_RATE_OFFSET, val, timeout_ms)
-    }
-
-    fn read_optical_interface_mode(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        timeout_ms: u32,
-    ) -> Result<OpticalInterfaceMode, Error> {
-        read_quadlet(req, node, OPTICAL_INTERFACE_MODE_OFFSET, timeout_ms).map(|val| {
-            if val > 0 {
-                OpticalInterfaceMode::Spdif
-            } else {
-                OpticalInterfaceMode::Adat
-            }
-        })
-    }
-
-    /// The change has effect to stop processing audio data during packet streaming.
-    fn write_optical_interface_mode(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        mode: OpticalInterfaceMode,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let val = match mode {
-            OpticalInterfaceMode::Adat => 0,
-            OpticalInterfaceMode::Spdif => 1,
-        };
-        write_quadlet(req, node, OPTICAL_INTERFACE_MODE_OFFSET, val, timeout_ms)
-    }
-
-    /// Read frequency of media clock detected in input of external source. Once the source of
-    /// sampling clock is configured to any external source, the function can return detected
-    /// frequency. Once losing the input, it returns None.
-    fn read_external_clock_source_rate(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        timeout_ms: u32,
-    ) -> Result<Option<ClockRate>, Error> {
-        read_quadlet(
-            req,
-            node,
-            EXTERNAL_CLOCK_SOURCE_DETECTION_OFFSET,
-            timeout_ms,
-        )
-        .and_then(|val| {
-            if val > 0 {
-                read_clock_rate(req, node, EXTERNAL_CLOCK_RATE_OFFSET, timeout_ms)
-                    .map(|rate| Some(rate))
-            } else {
-                Ok(None)
-            }
-        })
-    }
-}
-
 const MONITOR_DST_COUNT: usize = 2;
 const MONITOR_SRC_COUNT: usize = 18;
 
@@ -612,94 +452,5 @@ where
                         write_quadlet(req, node, offset, val, timeout_ms).map(|_| *g = gain)
                     })
             })
-    }
-}
-
-/// The trait for monitor operation. At offline mode (no packet streaming runs), the monitor
-/// function is disabled and is not configurable. When packet streaming starts, the monitor
-/// function becomes configurable with reset state.
-pub trait Dg00xMonitorOperation {
-    // 'monitor-output-0', 'monitor-output-1'.
-    const MONITOR_DST_COUNT: usize = 2;
-
-    // 'analog-input-0' .. 'analog-input-7', 'spdif-input-0', 'spdif-input-1',
-    // 'adat-input-0' .. 'adat-input-7'.
-    const MONITOR_SRC_COUNT: usize = 18;
-
-    const GAIN_MIN: u8 = 0;
-    const GAIN_MAX: u8 = 0x80;
-    const GAIN_STEP: u8 = 1;
-
-    fn read_monitor_state(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        state: &mut Dg00xMonitorState,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        read_quadlet(req, node, ENABLE_OFFSET, timeout_ms).map(|val| state.enabled = val > 0)?;
-        state
-            .src_gains
-            .iter_mut()
-            .enumerate()
-            .try_for_each(|(dst, gains)| {
-                gains.iter_mut().enumerate().try_for_each(|(src, gain)| {
-                    let offset = (dst * DST_STEP + src * SRC_STEP) as u64;
-                    read_quadlet(req, node, MONITOR_SRC_GAIN_OFFSET + offset, timeout_ms)
-                        .map(|val| *gain = (val >> 24) as u8)
-                })
-            })?;
-
-        Ok(())
-    }
-
-    fn write_monitor_state(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        state: &Dg00xMonitorState,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        Self::write_monitor_enable(req, node, state.enabled, timeout_ms)?;
-
-        state
-            .src_gains
-            .iter()
-            .enumerate()
-            .try_for_each(|(dst, gains)| {
-                gains.iter().enumerate().try_for_each(|(src, gain)| {
-                    Self::write_monitor_source_gain(req, node, dst, src, *gain, timeout_ms)
-                })
-            })?;
-
-        Ok(())
-    }
-
-    fn write_monitor_enable(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        enable: bool,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        write_quadlet(req, node, ENABLE_OFFSET, enable as u32, timeout_ms)
-    }
-
-    fn write_monitor_source_gain(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        dst: usize,
-        src: usize,
-        gain: u8,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        if dst >= Self::MONITOR_DST_COUNT {
-            let msg = format!("Invalid argument for monitor destination: {}", dst);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-        if src >= Self::MONITOR_SRC_COUNT {
-            let msg = format!("Invalid argument for monitor source: {}", src);
-            Err(Error::new(FileError::Inval, &msg))?;
-        }
-        let offset = MONITOR_SRC_GAIN_OFFSET + (dst * DST_STEP + src * SRC_STEP) as u64;
-        let val = (gain as u32) << 24;
-        write_quadlet(req, node, offset, val, timeout_ms)
     }
 }

--- a/protocols/digi00x/src/lib.rs
+++ b/protocols/digi00x/src/lib.rs
@@ -8,8 +8,13 @@ use glib::{Error, FileError};
 use hinawa::{prelude::FwReqExtManual, FwNode, FwReq, FwTcode};
 
 /// The protocol implementation for Digi 002.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Digi002Protocol;
+
+impl Dg00xHardwareSpecification for Digi002Protocol {
+    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] =
+        &[ClockSource::Internal, ClockSource::Spdif, ClockSource::Adat];
+}
 
 impl Dg00xCommonOperation for Digi002Protocol {
     const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] =
@@ -19,8 +24,17 @@ impl Dg00xCommonOperation for Digi002Protocol {
 impl Dg00xMonitorOperation for Digi002Protocol {}
 
 /// The protocol implementation for Digi 003.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct Digi003Protocol;
+
+impl Dg00xHardwareSpecification for Digi003Protocol {
+    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] = &[
+        ClockSource::Internal,
+        ClockSource::Spdif,
+        ClockSource::Adat,
+        ClockSource::WordClock,
+    ];
+}
 
 impl Dg00xCommonOperation for Digi003Protocol {
     const SAMPLING_CLOCK_SOURCES: &'static [ClockSource] = &[
@@ -70,6 +84,16 @@ fn write_quadlet(
         &mut quadlet,
         timeout_ms,
     )
+}
+
+/// The specification of hardware.
+pub trait Dg00xHardwareSpecification {
+    const SAMPLING_CLOCK_SOURCES: &'static [ClockSource];
+    const SAMPLING_CLOCK_RATES: &'static [u32] = &[44100, 48000, 88200, 96000];
+
+    const MONITOR_SOURCE_GAIN_MIN: u8 = 0;
+    const MONITOR_SOURCE_GAIN_MAX: u8 = 0x80;
+    const MONITOR_SOURCE_GAIN_STEP: u8 = 1;
 }
 
 /// Nominal frequency of media clock.

--- a/runtime/digi00x/Cargo.toml
+++ b/runtime/digi00x/Cargo.toml
@@ -22,3 +22,5 @@ ta1394-avc-general = "0.1"
 firewire-digi00x-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
+++ b/runtime/digi00x/src/bin/snd-firewire-digi00x-ctl-service.rs
@@ -14,11 +14,15 @@ struct Dg00xServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, Dg00xRuntime> for Dg00xServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/digi00x/src/lib.rs
+++ b/runtime/digi00x/src/lib.rs
@@ -19,6 +19,7 @@ use {
     nix::sys::signal,
     std::{convert::TryFrom, sync::mpsc, thread},
     ta1394_avc_general::config_rom::Ta1394ConfigRom,
+    tracing::Level,
 };
 
 enum Event {
@@ -71,7 +72,14 @@ const SPECIFIER_ID_DIGI003: u32 = 0x0000aa;
 const SPECIFIER_ID_DIGI003_RACK: u32 = 0x0000ab;
 
 impl RuntimeOperation<u32> for Dg00xRuntime {
-    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
+    fn new(card_id: u32, log_level: Option<LogLevel>) -> Result<Self, Error> {
+        if let Some(level) = log_level {
+            let fmt_level = match level {
+                LogLevel::Debug => Level::DEBUG,
+            };
+            tracing_subscriber::fmt().with_max_level(fmt_level).init();
+        }
+
         let unit = SndDigi00x::new();
         unit.open(&format!("/dev/snd/hwC{}D0", card_id), 0)?;
 

--- a/runtime/digi00x/src/model.rs
+++ b/runtime/digi00x/src/model.rs
@@ -5,66 +5,43 @@ use {super::*, alsa_ctl_tlv_codec::DbInterval, protocols::*, std::marker::Phanto
 
 const TIMEOUT_MS: u32 = 100;
 
-pub type Digi002Model =
-    Dg00xModel<Digi002CommonCtl, Digi002MeterCtl, Digi002MonitorCtl, Digi002Protocol>;
-pub type Digi003Model =
-    Dg00xModel<Digi003CommonCtl, Digi003MeterCtl, Digi003MonitorCtl, Digi003Protocol>;
-
-#[derive(Default)]
-pub struct Dg00xModel<S, T, U, V>
-where
-    S: Dg00xCommonCtlOperation<V>,
-    T: Dg00xMeterCtlOperation<V>,
-    U: Dg00xMonitorCtlOperation<V>,
-    V: Dg00xCommonOperation + Dg00xMonitorOperation,
-{
+#[derive(Default, Debug)]
+pub struct Digi002Model {
     req: FwReq,
-    common_ctl: S,
-    meter_ctl: T,
-    monitor_ctl: U,
-    _phantom: PhantomData<V>,
+    common_ctl: CommonCtl<Digi002Protocol>,
+    meter_ctl: MeterCtl<Digi002Protocol>,
+    monitor_ctl: MonitorCtl<Digi002Protocol>,
 }
 
-#[derive(Default)]
-pub struct Dg00xCommonCtl(ClockRate, Vec<ElemId>);
+impl Digi002Model {
+    pub(crate) fn cache(&mut self, (unit, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
+        self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.monitor_ctl
+            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
+        Ok(())
+    }
+}
 
-#[derive(Default)]
-pub struct Dg00xMeterCtl(Option<ClockRate>, Vec<ElemId>);
-
-#[derive(Default)]
-pub struct Dg00xMonitorCtl(Dg00xMonitorState, Vec<ElemId>);
-
-impl<S, T, U, V> CtlModel<(SndDigi00x, FwNode)> for Dg00xModel<S, T, U, V>
-where
-    S: Dg00xCommonCtlOperation<V>,
-    T: Dg00xMeterCtlOperation<V>,
-    U: Dg00xMonitorCtlOperation<V>,
-    V: Dg00xCommonOperation + Dg00xMonitorOperation,
-{
+impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
     fn load(
         &mut self,
-        unit: &mut (SndDigi00x, FwNode),
+        _: &mut (SndDigi00x, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.common_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.meter_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.monitor_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
+        self.common_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
+        self.monitor_ctl.load(card_cntr)?;
         Ok(())
     }
 
     fn read(
         &mut self,
-        unit: &mut (SndDigi00x, FwNode),
+        _: &mut (SndDigi00x, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .common_ctl
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -77,20 +54,24 @@ where
 
     fn write(
         &mut self,
-        unit: &mut (SndDigi00x, FwNode),
+        (unit, node): &mut (SndDigi00x, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .common_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .monitor_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
-        {
+        } else if self.monitor_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -98,20 +79,13 @@ where
     }
 }
 
-impl<S, T, U, V> MeasureModel<(SndDigi00x, FwNode)> for Dg00xModel<S, T, U, V>
-where
-    S: Dg00xCommonCtlOperation<V>,
-    T: Dg00xMeterCtlOperation<V>,
-    U: Dg00xMonitorCtlOperation<V>,
-    V: Dg00xCommonOperation + Dg00xMonitorOperation,
-{
+impl MeasureModel<(SndDigi00x, FwNode)> for Digi002Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.meter().1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
-        self.meter_ctl
-            .measure_states(unit, &mut self.req, TIMEOUT_MS)
+    fn measure_states(&mut self, (_, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)
     }
 
     fn measure_elem(
@@ -128,27 +102,22 @@ where
     }
 }
 
-impl<S, T, U, V> NotifyModel<(SndDigi00x, FwNode), bool> for Dg00xModel<S, T, U, V>
-where
-    S: Dg00xCommonCtlOperation<V>,
-    T: Dg00xMeterCtlOperation<V>,
-    U: Dg00xMonitorCtlOperation<V>,
-    V: Dg00xCommonOperation + Dg00xMonitorOperation,
-{
+impl NotifyModel<(SndDigi00x, FwNode), bool> for Digi002Model {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.state().1);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.state().1);
+        elem_id_list.extend_from_slice(&self.common_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
     }
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDigi00x, FwNode),
+        (unit, node): &mut (SndDigi00x, FwNode),
         &locked: &bool,
     ) -> Result<(), Error> {
-        self.common_ctl
-            .handle_lock_notification(locked, unit, &mut self.req, TIMEOUT_MS)?;
+        if locked {
+            self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        }
         self.monitor_ctl
-            .handle_streaming_event(locked, unit, &mut self.req, TIMEOUT_MS)?;
+            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -158,7 +127,7 @@ where
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.common_ctl.read_notified_elems(elem_id, elem_value)? {
+        if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.monitor_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -168,81 +137,149 @@ where
     }
 }
 
-#[derive(Default)]
-pub struct Digi002CommonCtl(Dg00xCommonCtl);
+#[derive(Default, Debug)]
+pub struct Digi003Model {
+    req: FwReq,
+    common_ctl: CommonCtl<Digi003Protocol>,
+    meter_ctl: MeterCtl<Digi003Protocol>,
+    monitor_ctl: MonitorCtl<Digi003Protocol>,
+    opt_iface_ctl: OpticalIfaceCtl,
+}
 
-impl Dg00xCommonCtlOperation<Digi002Protocol> for Digi002CommonCtl {
-    fn state(&self) -> &Dg00xCommonCtl {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut Dg00xCommonCtl {
-        &mut self.0
+impl Digi003Model {
+    pub(crate) fn cache(&mut self, (unit, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
+        self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.monitor_ctl
+            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        Ok(())
     }
 }
 
-#[derive(Default)]
-pub struct Digi002MeterCtl(Dg00xMeterCtl);
-
-impl Dg00xMeterCtlOperation<Digi002Protocol> for Digi002MeterCtl {
-    fn meter(&self) -> &Dg00xMeterCtl {
-        &self.0
+impl CtlModel<(SndDigi00x, FwNode)> for Digi003Model {
+    fn load(
+        &mut self,
+        _: &mut (SndDigi00x, FwNode),
+        card_cntr: &mut CardCntr,
+    ) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
+        self.monitor_ctl.load(card_cntr)?;
+        self.opt_iface_ctl.load(card_cntr)?;
+        Ok(())
     }
 
-    fn meter_mut(&mut self) -> &mut Dg00xMeterCtl {
-        &mut self.0
+    fn read(
+        &mut self,
+        _: &mut (SndDigi00x, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.monitor_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndDigi00x, FwNode),
+        elem_id: &ElemId,
+        _: &ElemValue,
+        elem_value: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .common_ctl
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.monitor_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.opt_iface_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-#[derive(Default)]
-pub struct Digi002MonitorCtl(Dg00xMonitorCtl);
-
-impl Dg00xMonitorCtlOperation<Digi002Protocol> for Digi002MonitorCtl {
-    fn state(&self) -> &Dg00xMonitorCtl {
-        &self.0
+impl MeasureModel<(SndDigi00x, FwNode)> for Digi003Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn state_mut(&mut self) -> &mut Dg00xMonitorCtl {
-        &mut self.0
-    }
-}
-
-#[derive(Default)]
-pub struct Digi003CommonCtl(Dg00xCommonCtl);
-
-impl Dg00xCommonCtlOperation<Digi003Protocol> for Digi003CommonCtl {
-    fn state(&self) -> &Dg00xCommonCtl {
-        &self.0
+    fn measure_states(&mut self, (_, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)
     }
 
-    fn state_mut(&mut self) -> &mut Dg00xCommonCtl {
-        &mut self.0
+    fn measure_elem(
+        &mut self,
+        _: &(SndDigi00x, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
-#[derive(Default)]
-pub struct Digi003MeterCtl(Dg00xMeterCtl);
-
-impl Dg00xMeterCtlOperation<Digi003Protocol> for Digi003MeterCtl {
-    fn meter(&self) -> &Dg00xMeterCtl {
-        &self.0
+impl NotifyModel<(SndDigi00x, FwNode), bool> for Digi003Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
     }
 
-    fn meter_mut(&mut self) -> &mut Dg00xMeterCtl {
-        &mut self.0
+    fn parse_notification(
+        &mut self,
+        (unit, node): &mut (SndDigi00x, FwNode),
+        &locked: &bool,
+    ) -> Result<(), Error> {
+        if locked {
+            self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        }
+        self.monitor_ctl
+            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
+        Ok(())
     }
-}
 
-#[derive(Default)]
-pub struct Digi003MonitorCtl(Dg00xMonitorCtl);
-
-impl Dg00xMonitorCtlOperation<Digi003Protocol> for Digi003MonitorCtl {
-    fn state(&self) -> &Dg00xMonitorCtl {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut Dg00xMonitorCtl {
-        &mut self.0
+    fn read_notified_elem(
+        &mut self,
+        _: &(SndDigi00x, FwNode),
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.monitor_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
     }
 }
 
@@ -487,187 +524,6 @@ impl OpticalIfaceCtl {
     }
 }
 
-pub trait Dg00xCommonCtlOperation<T: Dg00xCommonOperation> {
-    fn state(&self) -> &Dg00xCommonCtl;
-    fn state_mut(&mut self) -> &mut Dg00xCommonCtl;
-
-    const CLOCK_RATES: &'static [ClockRate; 4] = &[
-        ClockRate::R44100,
-        ClockRate::R48000,
-        ClockRate::R88200,
-        ClockRate::R96000,
-    ];
-
-    const OPTICAL_INTERFACE_MODES: &'static [OpticalInterfaceMode; 2] =
-        &[OpticalInterfaceMode::Adat, OpticalInterfaceMode::Spdif];
-
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut notified_elem_id_list = Vec::new();
-
-        let labels: Vec<&str> = T::SAMPLING_CLOCK_SOURCES
-            .iter()
-            .map(|s| clock_source_to_str(s))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, CLK_SRC_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-
-        let labels: Vec<&str> = Self::CLOCK_RATES
-            .iter()
-            .map(|r| clock_rate_to_str(r))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, CLK_LOCAL_RATE_NAME, 0);
-        card_cntr
-            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
-
-        let labels: Vec<&str> = Self::OPTICAL_INTERFACE_MODES
-            .iter()
-            .map(|m| optical_interface_mode_to_str(m))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OPT_IFACE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-
-        self.state_mut().1 = notified_elem_id_list;
-
-        T::read_media_clock_rate(req, &mut unit.1, timeout_ms)
-            .map(|src| self.state_mut().0 = src)?;
-
-        Ok(())
-    }
-
-    fn read(
-        &mut self,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            CLK_SRC_NAME => {
-                let src = T::read_sampling_clock_source(req, &mut unit.1, timeout_ms)?;
-                let pos = T::SAMPLING_CLOCK_SOURCES
-                    .iter()
-                    .position(|s| s.eq(&src))
-                    .unwrap();
-                elem_value.set_enum(&[pos as u32]);
-                Ok(true)
-            }
-            OPT_IFACE_NAME => {
-                let mode = T::read_optical_interface_mode(req, &mut unit.1, timeout_ms)?;
-                let pos = Self::OPTICAL_INTERFACE_MODES
-                    .iter()
-                    .position(|r| r.eq(&mode))
-                    .unwrap();
-                elem_value.set_enum(&[pos as u32]);
-                Ok(true)
-            }
-            _ => self.read_notified_elems(elem_id, elem_value),
-        }
-    }
-
-    fn write(
-        &mut self,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        elem_id: &ElemId,
-        elem_value: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            CLK_SRC_NAME => {
-                if unit.0.is_locked() {
-                    let msg = "Not configurable during packet streaming";
-                    Err(Error::new(FileError::Again, &msg))
-                } else {
-                    let val = elem_value.enumerated()[0];
-                    let &src = T::SAMPLING_CLOCK_SOURCES
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index for sampling clock sources: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })?;
-                    T::write_sampling_clock_source(req, &mut unit.1, src, timeout_ms).map(|_| true)
-                }
-            }
-            CLK_LOCAL_RATE_NAME => {
-                if unit.0.is_locked() {
-                    let msg = "Not configurable during packet streaming";
-                    Err(Error::new(FileError::Again, &msg))
-                } else {
-                    let val = elem_value.enumerated()[0];
-                    let &rate = Self::CLOCK_RATES.iter().nth(val as usize).ok_or_else(|| {
-                        let msg = format!("Invalid index for media clock rates: {}", val);
-                        Error::new(FileError::Inval, &msg)
-                    })?;
-                    T::write_media_clock_rate(req, &mut unit.1, rate, timeout_ms).map(|_| {
-                        self.state_mut().0 = rate;
-                        true
-                    })
-                }
-            }
-            OPT_IFACE_NAME => {
-                if unit.0.is_locked() {
-                    let msg = "Not configurable during packet streaming";
-                    Err(Error::new(FileError::Again, &msg))
-                } else {
-                    let val = elem_value.enumerated()[0];
-                    let &mode = Self::OPTICAL_INTERFACE_MODES
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index for optical interface mode: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })?;
-                    T::write_optical_interface_mode(req, &mut unit.1, mode, timeout_ms)
-                        .map(|_| true)
-                }
-            }
-            _ => Ok(false),
-        }
-    }
-
-    fn handle_lock_notification(
-        &mut self,
-        locked: bool,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        if locked {
-            T::read_media_clock_rate(req, &mut unit.1, timeout_ms)
-                .map(|rate| self.state_mut().0 = rate)
-        } else {
-            Ok(())
-        }
-    }
-
-    fn read_notified_elems(
-        &self,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            CLK_LOCAL_RATE_NAME => {
-                let pos = Self::CLOCK_RATES
-                    .iter()
-                    .position(|r| self.state().0.eq(r))
-                    .unwrap();
-                elem_value.set_enum(&[pos as u32]);
-                Ok(true)
-            }
-            _ => Ok(false),
-        }
-    }
-}
-
 fn optional_clock_rate_to_str(rate: &Option<ClockRate>) -> &'static str {
     if let Some(r) = rate {
         clock_rate_to_str(r)
@@ -725,68 +581,6 @@ where
                 let pos = Self::OPTIONAL_CLOCK_RATES
                     .iter()
                     .position(|r| self.external_clock_rate.rate.eq(r))
-                    .unwrap();
-                elem_value.set_enum(&[pos as u32]);
-                Ok(true)
-            }
-            _ => Ok(false),
-        }
-    }
-}
-
-pub trait Dg00xMeterCtlOperation<T: Dg00xCommonOperation> {
-    fn meter(&self) -> &Dg00xMeterCtl;
-    fn meter_mut(&mut self) -> &mut Dg00xMeterCtl;
-
-    const OPTIONAL_CLOCK_RATES: [Option<ClockRate>; 5] = [
-        None,
-        Some(ClockRate::R44100),
-        Some(ClockRate::R48000),
-        Some(ClockRate::R88200),
-        Some(ClockRate::R96000),
-    ];
-
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        let mut measured_elem_id_list = Vec::new();
-
-        let labels: Vec<&str> = Self::OPTIONAL_CLOCK_RATES
-            .iter()
-            .map(|r| optional_clock_rate_to_str(r))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, CLK_EXT_RATE_NAME, 0);
-        card_cntr
-            .add_enum_elems(&elem_id, 1, 1, &labels, None, false)
-            .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
-
-        self.meter_mut().1 = measured_elem_id_list;
-
-        self.measure_states(unit, req, timeout_ms)?;
-
-        Ok(())
-    }
-
-    fn measure_states(
-        &mut self,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        T::read_external_clock_source_rate(req, &mut unit.1, timeout_ms)
-            .map(|rate| self.meter_mut().0 = rate)
-    }
-
-    fn read(&mut self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            CLK_EXT_RATE_NAME => {
-                let pos = Self::OPTIONAL_CLOCK_RATES
-                    .iter()
-                    .position(|r| self.meter().0.eq(r))
                     .unwrap();
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
@@ -953,169 +747,6 @@ where
 
                 T::update_partially(req, node, &mut self.states, params, timeout_ms)?;
                 Ok(true)
-            }
-            _ => Ok(false),
-        }
-    }
-}
-
-pub trait Dg00xMonitorCtlOperation<T: Dg00xMonitorOperation> {
-    fn state(&self) -> &Dg00xMonitorCtl;
-    fn state_mut(&mut self) -> &mut Dg00xMonitorCtl;
-
-    const DST_LABELS: [&'static str; 2] = ["monitor-output-1", "monitor-output-2"];
-    const SRC_LABELS: [&'static str; 18] = [
-        "analog-input-1",
-        "analog-input-2",
-        "analog-input-3",
-        "analog-input-4",
-        "analog-input-5",
-        "analog-input-6",
-        "analog-input-7",
-        "analog-input-8",
-        "spdif-input-1",
-        "spdif-input-2",
-        "adat-input-1",
-        "adat-input-2",
-        "adat-input-3",
-        "adat-input-4",
-        "adat-input-5",
-        "adat-input-6",
-        "adat-input-7",
-        "adat-input-8",
-    ];
-
-    const GAIN_TLV: DbInterval = DbInterval {
-        min: -4800,
-        max: 0,
-        linear: false,
-        mute_avail: false,
-    };
-
-    fn load(
-        &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        assert_eq!(Self::DST_LABELS.len(), T::MONITOR_DST_COUNT);
-        assert_eq!(Self::SRC_LABELS.len(), T::MONITOR_SRC_COUNT);
-
-        let mut measured_elem_id_list = Vec::new();
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MONITOR_ENABLE_NAME, 0);
-        card_cntr
-            .add_bool_elems(&elem_id, 1, 1, true)
-            .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
-
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MONITOR_SRC_GAIN_NAME, 0);
-        card_cntr
-            .add_int_elems(
-                &elem_id,
-                Self::DST_LABELS.len(),
-                T::GAIN_MIN as i32,
-                T::GAIN_MAX as i32,
-                T::GAIN_STEP as i32,
-                Self::SRC_LABELS.len(),
-                Some(&Into::<Vec<u32>>::into(Self::GAIN_TLV)),
-                true,
-            )
-            .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
-
-        self.state_mut().1 = measured_elem_id_list;
-
-        T::read_monitor_state(req, &mut unit.1, &mut self.state_mut().0, timeout_ms)?;
-
-        if !unit.0.is_locked() {
-            self.state_mut().0.enabled = false;
-        }
-
-        Ok(())
-    }
-
-    fn handle_streaming_event(
-        &mut self,
-        locked: bool,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        timeout_ms: u32,
-    ) -> Result<(), Error> {
-        // Just during packet streaming, any write transaction to register has effect to configure
-        // internal multiplexer. Without packet streaming, the transaction has no effect against
-        // the multiplexer even if it's successful to change the value of register.
-        if !locked {
-            self.state_mut().0.enabled = false;
-            Ok(())
-        } else {
-            // Attempt to update the registers with cached value at the beginning of packet
-            // streaming.
-            T::write_monitor_state(req, &mut unit.1, &mut self.state_mut().0, timeout_ms)
-        }
-    }
-
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            MONITOR_ENABLE_NAME => {
-                elem_value.set_bool(&[self.state().0.enabled]);
-                Ok(true)
-            }
-            MONITOR_SRC_GAIN_NAME => {
-                let dst = elem_id.index() as usize;
-                ElemValueAccessor::<i32>::set_vals(elem_value, Self::SRC_LABELS.len(), |src| {
-                    Ok(self.state().0.src_gains[dst][src] as i32)
-                })
-                .map(|_| true)
-            }
-            _ => Ok(false),
-        }
-    }
-
-    fn write(
-        &mut self,
-        unit: &mut (SndDigi00x, FwNode),
-        req: &mut FwReq,
-        elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            MONITOR_ENABLE_NAME => {
-                if !unit.0.is_locked() {
-                    let msg = "Monitor function is configurable during packet streaming.";
-                    Err(Error::new(FileError::Again, &msg))
-                } else {
-                    let val = new.boolean()[0];
-                    T::write_monitor_enable(req, &mut unit.1, val, timeout_ms).map(|_| {
-                        self.state_mut().0.enabled = val;
-                        true
-                    })
-                }
-            }
-            MONITOR_SRC_GAIN_NAME => {
-                if !self.state().0.enabled {
-                    let msg = "Monitor is disabled.";
-                    Err(Error::new(FileError::Again, &msg))
-                } else {
-                    let dst = elem_id.index() as usize;
-                    ElemValueAccessor::<i32>::get_vals(
-                        new,
-                        old,
-                        Self::SRC_LABELS.len(),
-                        |src, val| {
-                            T::write_monitor_source_gain(
-                                req,
-                                &mut unit.1,
-                                dst,
-                                src,
-                                val as u8,
-                                timeout_ms,
-                            )
-                        },
-                    )
-                    .map(|_| true)
-                }
             }
             _ => Ok(false),
         }


### PR DESCRIPTION
The main purpose of the patchset is to support debug logging by tracing crate
in runtime crate as the other service programs support, while protocols crate is
reworked for unified way to cache and update parameters.

```
Takashi Sakamoto (17):
  protocols/digi00x: add intermediate expression for parameters
  protocols/digi00x: add a trait to express hardware specification
  protocols/digi00x: add a trait for hardware operation
  protocols/digi00x: implement trait to cache and update source of
    sampling clock
  protocols/digi00x: implement trait to cache and update rate of media
    clock
  protocols/digi00x: implement trait to cache and update mode of optical
    interface
  protocols/digi00x: implement trait to detect source of external
    sampling clock
  protocols/digi00x: implement trait to cache and update monitor
    parameters
  runtime/digi00x: implement generic structure for common controls
  runtime/digi00x: implement structure for optical interface controls
  runtime/digi00x: implement generic structure for meter controls
  runtime/digi00x: implement generic structure for monitor controls
  runtime/digi00x: use generic structure controls for models
  protocols/digi00x: delete unused implementations
  runtime/digi00x: use tracing-subscriber crate to dump debug logs
  runtime/digi00x: add tracing span and event to runtime structure
  runtime/digi00x: add tracing events for controls

 README.rst                                    |   3 +-
 protocols/digi00x/src/lib.rs                  | 405 +++++----
 runtime/digi00x/Cargo.toml                    |   2 +
 .../bin/snd-firewire-digi00x-ctl-service.rs   |   6 +-
 runtime/digi00x/src/lib.rs                    |  52 +-
 runtime/digi00x/src/model.rs                  | 776 ++++++++++--------
 6 files changed, 720 insertions(+), 524 deletions(-)
```