### PR TITLE
[PATCH 0/9] runtime/tascam: use generic structure for controls

### DIFF
--- a/protocols/tascam/src/asynch.rs
+++ b/protocols/tascam/src/asynch.rs
@@ -31,8 +31,7 @@ impl TascamExpander {
     pub const QUADLET_COUNT: usize = imp::RESPONSE_FRAME_SIZE / 4;
 
     pub fn new() -> Self {
-        Object::new(&[])
-            .expect("Failed to create TascamExpander")
+        Object::new(&[]).expect("Failed to create TascamExpander")
     }
 
     fn node(&self) -> FwNode {
@@ -66,21 +65,45 @@ impl TascamExpander {
     pub fn listen(&self) -> Result<(), Error> {
         let mut frames = 1u32.to_be_bytes();
         let mut req = FwReq::new();
-        write_quadlet(&mut req, &self.node(), imp::ENABLE_NOTIFICATION, &mut frames, 100)
+        write_quadlet(
+            &mut req,
+            &self.node(),
+            imp::ENABLE_NOTIFICATION,
+            &mut frames,
+            100,
+        )
     }
 
     pub fn unlisten(&self) {
         let mut frames = 0u32.to_be_bytes();
         let mut req = FwReq::new();
-        let _ = write_quadlet(&mut req, &self.node(), imp::ENABLE_NOTIFICATION, &mut frames, 100);
+        let _ = write_quadlet(
+            &mut req,
+            &self.node(),
+            imp::ENABLE_NOTIFICATION,
+            &mut frames,
+            100,
+        );
     }
 
     pub fn unbind(&self) {
         self.release();
 
         let mut req = FwReq::new();
-        let _ = write_quadlet(&mut req, &self.node(), imp::ADDR_HIGH_OFFSET, &mut [0; 4], 100);
-        let _ = write_quadlet(&mut req, &self.node(), imp::ADDR_LOW_OFFSET, &mut [0; 4], 100);
+        let _ = write_quadlet(
+            &mut req,
+            &self.node(),
+            imp::ADDR_HIGH_OFFSET,
+            &mut [0; 4],
+            100,
+        );
+        let _ = write_quadlet(
+            &mut req,
+            &self.node(),
+            imp::ADDR_LOW_OFFSET,
+            &mut [0; 4],
+            100,
+        );
 
         let private = imp::TascamExpanderPrivate::from_instance(self);
         *private.0.borrow_mut() = None;
@@ -88,7 +111,7 @@ impl TascamExpander {
 }
 
 mod imp {
-    use {once_cell::sync::Lazy, super::*};
+    use {super::*, once_cell::sync::Lazy};
 
     pub const RESPONSE_REGION_START: u64 = 0xffffe0000000;
     pub const RESPONSE_REGION_END: u64 = 0xfffff0000000;
@@ -106,28 +129,26 @@ mod imp {
 
     #[glib::object_subclass]
     impl ObjectSubclass for TascamExpanderPrivate {
-            const NAME: &'static str = "TascamExpander";
-            type Type = super::TascamExpander;
-            type ParentType = FwResp;
-            type Interfaces = (TascamProtocol,);
+        const NAME: &'static str = "TascamExpander";
+        type Type = super::TascamExpander;
+        type ParentType = FwResp;
+        type Interfaces = (TascamProtocol,);
 
-            fn new() -> Self {
-                Self::default()
-            }
+        fn new() -> Self {
+            Self::default()
+        }
     }
 
     impl ObjectImpl for TascamExpanderPrivate {
         fn properties() -> &'static [ParamSpec] {
             static PROPERTIES: Lazy<Vec<ParamSpec>> = Lazy::new(|| {
-                vec![
-                    ParamSpecObject::new(
-                        "node",
-                        "node",
-                        "An instance of FwNode",
-                        FwNode::static_type(),
-                        ParamFlags::READWRITE,
-                    ),
-                ]
+                vec![ParamSpecObject::new(
+                    "node",
+                    "node",
+                    "An instance of FwNode",
+                    FwNode::static_type(),
+                    ParamFlags::READWRITE,
+                )]
             });
 
             PROPERTIES.as_ref()

--- a/protocols/tascam/src/bin/tascam-hardware-info.rs
+++ b/protocols/tascam/src/bin/tascam-hardware-info.rs
@@ -5,8 +5,8 @@ use {
     firewire_tascam_protocols as protocols,
     glib::{FileError, MainContext, MainLoop},
     hinawa::{prelude::FwNodeExt, FwNode, FwNodeError, FwReq},
-    std::{sync::Arc, thread},
     protocols::*,
+    std::{sync::Arc, thread},
 };
 
 const TIMEOUT_MS: u32 = 50;

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -13,11 +13,15 @@ pub mod fw1884;
 use super::*;
 
 /// Signal source of sampling clock.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkSrc {
+    /// Internal oscillator.
     Internal,
+    /// Word clock signal from BNC input interface.
     Wordclock,
+    /// S/PDIF signal from coaxial input interface.
     Spdif,
+    /// ADAT signal from optical input interface.
     Adat,
 }
 
@@ -28,11 +32,15 @@ impl Default for ClkSrc {
 }
 
 /// Nominal frequency of media clock.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkRate {
+    /// At 44.1 kHz.
     R44100,
+    /// At 48.0 kHz.
     R48000,
+    /// At 88.2 kHz.
     R88200,
+    /// At 96.0 kHz.
     R96000,
 }
 
@@ -40,6 +48,15 @@ impl Default for ClkRate {
     fn default() -> Self {
         Self::R44100
     }
+}
+
+/// The parameters of sampling and media clock.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TascamClockParameters {
+    /// The source of sampling clock.
+    pub sampling_clock_source: ClkSrc,
+    /// The rate of media clock.
+    pub media_clock_rate: ClkRate,
 }
 
 /// Mode of monitor.

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -59,6 +59,20 @@ pub struct TascamClockParameters {
     pub media_clock_rate: ClkRate,
 }
 
+/// The parameters of threshold to detect input signal. The value is between 1 and 0x7fff. The dB
+/// level can be calculated by below formula.
+///
+/// ```text
+/// level = 20 * log10(value / 0x7fff)
+/// ```
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TascamInputDetectionThreshold {
+    /// For signal detection itself.
+    pub signal: u16,
+    /// For over-level detection.
+    pub over_level: u16,
+}
+
 /// Mode of monitor.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MonitorMode {

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -590,9 +590,13 @@ pub trait IsochOpticalOperation {
 }
 
 /// State of console.
-#[derive(Default, Debug)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IsochConsoleState {
+    /// Whether to enable host mode.
     pub host_mode: bool,
+
+    /// Whether to assign master fader to analog output 1/2.
+    pub master_fader_assign: bool,
 }
 
 const MASTER_FADER_ASSIGNS: [(bool, u32, u32); 2] = [

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -258,7 +258,7 @@ fn write_config_flag<T: Copy + Eq>(
 }
 
 /// Source of output coaxial interface.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoaxialOutputSource {
     /// A pair in stream inputs.
     StreamInputPair,

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -628,13 +628,26 @@ pub trait IsochConsoleOperation {
 const RACK_STATE_SIZE: usize = 72;
 
 /// State of rack.
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct IsochRackState([u8; RACK_STATE_SIZE]);
 
 impl Default for IsochRackState {
     fn default() -> Self {
         Self([0; RACK_STATE_SIZE])
     }
+}
+
+/// The parameters of input.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct IsochRackInputParameters {
+    /// Gain of signal to stereo monitor. The value is between 0 and 0x7fff.
+    pub gains: [i16; 18],
+    /// L/R balance to stereo monitor. The value is between 0 and 255.
+    pub balances: [u8; 18],
+    /// Whether to mute.
+    pub mutes: [bool; 18],
+    /// The raw state of parameters.
+    pub state: IsochRackState,
 }
 
 const INPUT_OFFSET: u64 = 0x0408;

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -503,9 +503,11 @@ pub trait IsochCommonOperation {
 }
 
 /// Source of S/PDIF input.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SpdifCaptureSource {
+    /// To coaxial interface.
     Coaxial,
+    /// To optical interface.
     Optical,
 }
 
@@ -516,7 +518,7 @@ impl Default for SpdifCaptureSource {
 }
 
 /// Source of optical output.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OpticalOutputSource {
     /// 4 pairs in stream inputs.
     StreamInputPairs,
@@ -534,7 +536,16 @@ impl Default for OpticalOutputSource {
     }
 }
 
-const SPDIF_CAPTURE_SOURCES: [(SpdifCaptureSource, u32, u32); 2] = [
+/// The parameters of digital input and output interfaces.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct TascamOpticalIfaceParameters {
+    /// The input interface from which the S/PDIF signal is captured.
+    pub capture_source: SpdifCaptureSource,
+    /// The source signal of optical output interface.
+    pub output_source: OpticalOutputSource,
+}
+
+const SPDIF_CAPTURE_SOURCES: &[(SpdifCaptureSource, u32, u32)] = &[
     (SpdifCaptureSource::Coaxial, 0x00000000, 0x00010000),
     (SpdifCaptureSource::Optical, 0x00000001, 0x00000100),
 ];

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -13,7 +13,7 @@ pub struct Fw1082Model {
     clock_ctl: ClockCtl<Fw1082Protocol>,
     input_threshold_ctl: InputDetectionThreshold<Fw1082Protocol>,
     coax_output_ctl: CoaxOutputCtl<Fw1082Protocol>,
-    meter_ctl: MeterCtl,
+    meter_ctl: MeterCtl<Fw1082Protocol>,
     console_ctl: ConsoleCtl,
     seq_state: SequencerState<Fw1082SurfaceState>,
 }
@@ -34,38 +34,6 @@ impl Default for Fw1082Model {
 }
 
 const TIMEOUT_MS: u32 = 50;
-
-#[derive(Default)]
-struct MeterCtl(IsochMeterState, Vec<ElemId>);
-
-impl IsochMeterCtlOperation<Fw1082Protocol> for MeterCtl {
-    fn meter(&self) -> &IsochMeterState {
-        &self.0
-    }
-
-    fn meter_mut(&mut self) -> &mut IsochMeterState {
-        &mut self.0
-    }
-
-    const INPUT_LABELS: &'static [&'static str] = &[
-        "analog-input-1",
-        "analog-input-2",
-        "analog-input-3",
-        "analog-input-4",
-        "analog-input-5",
-        "analog-input-6",
-        "analog-input-7",
-        "analog-input-8",
-        "spdif-input-1",
-        "spdif-input-2",
-    ];
-    const OUTPUT_LABELS: &'static [&'static str] = &[
-        "analog-output-1",
-        "analog-output-2",
-        "spdif-output-1",
-        "spdif-output-2",
-    ];
-}
 
 #[derive(Default)]
 struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);
@@ -141,13 +109,13 @@ impl SequencerCtlOperation<SndTascam, Fw1082Protocol, Fw1082SurfaceState> for Fw
 
 impl MeasureModel<(SndTascam, FwNode)> for Fw1082Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.console_ctl.1);
     }
 
     fn measure_states(&mut self, unit: &mut (SndTascam, FwNode)) -> Result<(), Error> {
         unit.0.read_state(&mut self.image)?;
-        self.meter_ctl.parse_state(&self.image)?;
+        self.meter_ctl.parse(&self.image)?;
         self.console_ctl.parse_states(&self.image)?;
         Ok(())
     }
@@ -158,7 +126,7 @@ impl MeasureModel<(SndTascam, FwNode)> for Fw1082Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.meter_ctl.read_state(elem_id, elem_value)? {
+        if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.console_ctl.read_states(elem_id, elem_value)? {
             Ok(true)
@@ -175,6 +143,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
         unit.0.read_state(&mut self.image)?;
+        self.meter_ctl.parse(&self.image)?;
 
         self.clock_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -186,10 +155,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         self.clock_ctl.load(card_cntr)?;
         self.input_threshold_ctl.load(card_cntr)?;
         self.coax_output_ctl.load(card_cntr)?;
-
-        self.meter_ctl
-            .load_state(card_cntr, &self.image)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
 
         self.console_ctl
             .load_params(card_cntr, &self.image)
@@ -210,7 +176,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             Ok(true)
         } else if self.coax_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.meter_ctl.read_state(elem_id, elem_value)? {
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.console_ctl.read_params(
             &mut unit.1,

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -10,6 +10,7 @@ use {
 pub struct Fw1082Model {
     req: FwReq,
     image: Vec<u32>,
+    clock_ctl: ClockCtl<Fw1082Protocol>,
     meter_ctl: MeterCtl,
     common_ctl: CommonCtl,
     console_ctl: ConsoleCtl,
@@ -21,6 +22,7 @@ impl Default for Fw1082Model {
         Self {
             req: Default::default(),
             image: vec![0u32; 64],
+            clock_ctl: Default::default(),
             meter_ctl: Default::default(),
             common_ctl: Default::default(),
             console_ctl: Default::default(),
@@ -176,6 +178,12 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
         unit.0.read_state(&mut self.image)?;
+
+        self.clock_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
+        self.clock_ctl.load(card_cntr)?;
+
         self.meter_ctl
             .load_state(card_cntr, &self.image)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -195,7 +203,9 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.meter_ctl.read_state(elem_id, elem_value)? {
+        if self.clock_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)
         } else if self.common_ctl.read_params(
             &mut unit.1,
@@ -225,7 +235,16 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
+        if self.clock_ctl.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self
             .common_ctl
             .write_params(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -4,7 +4,7 @@
 use {
     super::{isoch_ctls::*, *},
     alsactl::*,
-    protocols::isoch::{fw1082::*, *},
+    protocols::isoch::fw1082::*,
 };
 
 pub struct Fw1082Model {
@@ -14,7 +14,7 @@ pub struct Fw1082Model {
     input_threshold_ctl: InputDetectionThreshold<Fw1082Protocol>,
     coax_output_ctl: CoaxOutputCtl<Fw1082Protocol>,
     meter_ctl: MeterCtl<Fw1082Protocol>,
-    console_ctl: ConsoleCtl,
+    console_ctl: ConsoleCtl<Fw1082Protocol>,
     seq_state: SequencerState<Fw1082SurfaceState>,
 }
 
@@ -34,19 +34,6 @@ impl Default for Fw1082Model {
 }
 
 const TIMEOUT_MS: u32 = 50;
-
-#[derive(Default)]
-struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);
-
-impl IsochConsoleCtlOperation<Fw1082Protocol> for ConsoleCtl {
-    fn state(&self) -> &IsochConsoleState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut IsochConsoleState {
-        &mut self.0
-    }
-}
 
 impl SequencerCtlOperation<SndTascam, Fw1082Protocol, Fw1082SurfaceState> for Fw1082Model {
     fn state(&self) -> &SequencerState<Fw1082SurfaceState> {
@@ -110,13 +97,13 @@ impl SequencerCtlOperation<SndTascam, Fw1082Protocol, Fw1082SurfaceState> for Fw
 impl MeasureModel<(SndTascam, FwNode)> for Fw1082Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.console_ctl.1);
+        elem_id_list.extend_from_slice(&self.console_ctl.elem_id_list);
     }
 
     fn measure_states(&mut self, unit: &mut (SndTascam, FwNode)) -> Result<(), Error> {
         unit.0.read_state(&mut self.image)?;
         self.meter_ctl.parse(&self.image)?;
-        self.console_ctl.parse_states(&self.image)?;
+        self.console_ctl.parse(&self.image)?;
         Ok(())
     }
 
@@ -128,7 +115,7 @@ impl MeasureModel<(SndTascam, FwNode)> for Fw1082Model {
     ) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.console_ctl.read_states(elem_id, elem_value)? {
+        } else if self.console_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -144,6 +131,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
     ) -> Result<(), Error> {
         unit.0.read_state(&mut self.image)?;
         self.meter_ctl.parse(&self.image)?;
+        self.console_ctl.parse(&self.image)?;
 
         self.clock_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -151,22 +139,21 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.coax_output_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.console_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clock_ctl.load(card_cntr)?;
         self.input_threshold_ctl.load(card_cntr)?;
         self.coax_output_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
-
-        self.console_ctl
-            .load_params(card_cntr, &self.image)
-            .map(|mut elem_id_list| self.console_ctl.1.append(&mut elem_id_list))?;
+        self.console_ctl.load(card_cntr)?;
 
         Ok(())
     }
 
     fn read(
         &mut self,
-        unit: &mut (SndTascam, FwNode),
+        _: &mut (SndTascam, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
@@ -178,13 +165,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.console_ctl.read_params(
-            &mut unit.1,
-            &mut self.req,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.console_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -223,13 +204,10 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.console_ctl.write_params(
-            &mut unit.1,
-            &mut self.req,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        } else if self
+            .console_ctl
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+        {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -12,8 +12,8 @@ pub struct Fw1082Model {
     image: Vec<u32>,
     clock_ctl: ClockCtl<Fw1082Protocol>,
     input_threshold_ctl: InputDetectionThreshold<Fw1082Protocol>,
+    coax_output_ctl: CoaxOutputCtl<Fw1082Protocol>,
     meter_ctl: MeterCtl,
-    common_ctl: CommonCtl,
     console_ctl: ConsoleCtl,
     seq_state: SequencerState<Fw1082SurfaceState>,
 }
@@ -25,8 +25,8 @@ impl Default for Fw1082Model {
             image: vec![0u32; 64],
             clock_ctl: Default::default(),
             input_threshold_ctl: Default::default(),
+            coax_output_ctl: Default::default(),
             meter_ctl: Default::default(),
-            common_ctl: Default::default(),
             console_ctl: Default::default(),
             seq_state: Default::default(),
         }
@@ -66,11 +66,6 @@ impl IsochMeterCtlOperation<Fw1082Protocol> for MeterCtl {
         "spdif-output-2",
     ];
 }
-
-#[derive(Default)]
-struct CommonCtl;
-
-impl IsochCommonCtlOperation<Fw1082Protocol> for CommonCtl {}
 
 #[derive(Default)]
 struct ConsoleCtl(IsochConsoleState, Vec<ElemId>);
@@ -185,15 +180,16 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.input_threshold_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.coax_output_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clock_ctl.load(card_cntr)?;
         self.input_threshold_ctl.load(card_cntr)?;
+        self.coax_output_ctl.load(card_cntr)?;
 
         self.meter_ctl
             .load_state(card_cntr, &self.image)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
-
-        self.common_ctl.load_params(card_cntr)?;
 
         self.console_ctl
             .load_params(card_cntr, &self.image)
@@ -212,15 +208,9 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             Ok(true)
         } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.meter_ctl.read_state(elem_id, elem_value)? {
+        } else if self.coax_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.common_ctl.read_params(
-            &mut unit.1,
-            &mut self.req,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)
         } else if self.console_ctl.read_params(
             &mut unit.1,
@@ -259,10 +249,13 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .common_ctl
-            .write_params(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.coax_output_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.console_ctl.write_params(
             &mut unit.1,

--- a/runtime/tascam/src/fw1804_model.rs
+++ b/runtime/tascam/src/fw1804_model.rs
@@ -11,6 +11,7 @@ pub struct Fw1804Model {
     req: FwReq,
     image: Vec<u32>,
     clock_ctl: ClockCtl<Fw1804Protocol>,
+    input_threshold_ctl: InputDetectionThreshold<Fw1804Protocol>,
     meter_ctl: MeterCtl,
     common_ctl: CommonCtl,
     optical_ctl: OpticalCtl,
@@ -23,6 +24,7 @@ impl Default for Fw1804Model {
             req: Default::default(),
             image: vec![0u32; 64],
             clock_ctl: Default::default(),
+            input_threshold_ctl: Default::default(),
             meter_ctl: Default::default(),
             common_ctl: Default::default(),
             optical_ctl: Default::default(),
@@ -150,8 +152,11 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
 
         self.clock_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.input_threshold_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clock_ctl.load(card_cntr)?;
+        self.input_threshold_ctl.load(card_cntr)?;
 
         self.meter_ctl.load_state(card_cntr, &self.image)?;
         self.common_ctl.load_params(card_cntr)?;
@@ -168,6 +173,8 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.clock_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)
@@ -203,6 +210,14 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
     ) -> Result<bool, Error> {
         if self.clock_ctl.write(
             &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_threshold_ctl.write(
             &mut self.req,
             &mut unit.1,
             elem_id,

--- a/runtime/tascam/src/fw1884_model.rs
+++ b/runtime/tascam/src/fw1884_model.rs
@@ -12,6 +12,7 @@ pub struct Fw1884Model {
     image: Vec<u32>,
     meter_ctl: MeterCtl,
     clock_ctl: ClockCtl<Fw1884Protocol>,
+    input_threshold_ctl: InputDetectionThreshold<Fw1884Protocol>,
     common_ctl: CommonCtl,
     optical_ctl: OpticalCtl,
     console_ctl: ConsoleCtl,
@@ -25,6 +26,7 @@ impl Default for Fw1884Model {
             req: Default::default(),
             image: vec![0u32; 64],
             clock_ctl: Default::default(),
+            input_threshold_ctl: Default::default(),
             meter_ctl: Default::default(),
             common_ctl: Default::default(),
             optical_ctl: Default::default(),
@@ -221,8 +223,11 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1884Model {
 
         self.clock_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.input_threshold_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clock_ctl.load(card_cntr)?;
+        self.input_threshold_ctl.load(card_cntr)?;
 
         self.meter_ctl
             .load_state(card_cntr, &self.image)
@@ -247,6 +252,8 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1884Model {
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
         if self.clock_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read_state(elem_id, elem_value)? {
             Ok(true)
@@ -296,6 +303,14 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1884Model {
     ) -> Result<bool, Error> {
         if self.clock_ctl.write(
             &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_threshold_ctl.write(
             &mut self.req,
             &mut unit.1,
             elem_id,

--- a/runtime/tascam/src/lib.rs
+++ b/runtime/tascam/src/lib.rs
@@ -29,7 +29,7 @@ use {
     isoch_rack_runtime::*,
     protocols::{config_rom::*, *},
     seq_cntr::*,
-    std::convert::TryFrom,
+    std::{convert::TryFrom, marker::PhantomData},
 };
 
 pub enum TascamRuntime {


### PR DESCRIPTION
Current implementation of runtime crate uses the combination of structure and trait
implementation. It is necessarily useful since it can be rewritten by generic structure
with phantom data. This patchset reworks for the controls.

```
Takashi Sakamoto (9):
  protocols/tascam: code cleanup by standard format
  runtime/tascam: add generic structure of controls for sampling and
    media clocks
  runtime/tascam: add generic structure of controls for input signal
    detection
  runtime/tascam: add generic structure of controls for coaxial output
  runtime/tascam: add generic structure of controls for optical
    interfaces
  runtime/tascam: add generic structure of controls for rack inputs
  runtime/tascam: code refactoring for controls specific to FW-1884
  runtime/tascam: add generic structure of controls for hardware
    metering
  runtime/tascam: add generic structure of controls for console surface

 protocols/tascam/src/asynch.rs                |  67 +-
 .../tascam/src/bin/tascam-hardware-info.rs    |   2 +-
 protocols/tascam/src/isoch.rs                 |  75 +-
 runtime/tascam/src/fw1082_model.rs            | 151 ++-
 runtime/tascam/src/fw1804_model.rs            | 200 ++--
 runtime/tascam/src/fw1884_model.rs            | 263 ++----
 runtime/tascam/src/isoch_ctls.rs              | 879 +++++++++++-------
 runtime/tascam/src/lib.rs                     |   2 +-
 8 files changed, 907 insertions(+), 732 deletions(-)
```