### PR TITLE
[PATCH 00/12] protocols/tascam: add traits to cache and update parameters

### DIFF
--- a/protocols/tascam/src/asynch.rs
+++ b/protocols/tascam/src/asynch.rs
@@ -19,6 +19,8 @@ use {
     std::{cell::RefCell, sync::Mutex},
 };
 
+const ASYNCH_IMAGE_QUADLET_COUNT: usize = TascamExpander::QUADLET_COUNT;
+
 glib::wrapper! {
     /// The implementation of `hitaki::TascamProtocol` so that it can cache status of hardware
     /// from message in asynchronous packet from the hardware as ALSA firewire-tascam driver does

--- a/protocols/tascam/src/asynch/fe8.rs
+++ b/protocols/tascam/src/asynch/fe8.rs
@@ -23,6 +23,10 @@ use super::*;
 #[derive(Default)]
 pub struct Fe8Protocol;
 
+impl TascamHardwareImageSpecification for Fe8Protocol {
+    const IMAGE_QUADLET_COUNT: usize = ASYNCH_IMAGE_QUADLET_COUNT;
+}
+
 impl MachineStateOperation for Fe8Protocol {
     const BOOL_ITEMS: &'static [MachineItem] = &[
         MachineItem::Rec(0),

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -46,6 +46,12 @@ pub trait TascamIsochPartiallyUpdatableParamsOperation<T> {
     ) -> Result<(), Error>;
 }
 
+/// Operation to parse parameters in the image of hardware state.
+pub trait TascamIsochImageParamsOperation<T> {
+    /// Parse the image of hardware state.
+    fn parse_image(params: &mut T, image: &[u32]);
+}
+
 /// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkSrc {

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -293,6 +293,8 @@ where
     }
 }
 
+const ISOCH_IMAGE_QUADLET_COUNT: usize = 64;
+
 /// Mode of monitor.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MonitorMode {

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -12,6 +12,40 @@ pub mod fw1884;
 
 use super::*;
 
+/// Operation to cache whole parameters at once.
+pub trait TascamIsochWhollyCachableParamsOperation<T> {
+    /// Cache whole parameters.
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        states: &mut T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+/// Operation to update whole parameters at once.
+pub trait TascamIsochWhollyUpdatableParamsOperation<T> {
+    /// Update whole parameters.
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        states: &T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
+/// Operation to update the part of parameters.
+pub trait TascamIsochPartiallyUpdatableParamsOperation<T> {
+    /// Update the part of parameters.
+    fn update_partially(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        params: &mut T,
+        update: T,
+        timeout_ms: u32,
+    ) -> Result<(), Error>;
+}
+
 /// Signal source of sampling clock.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkSrc {

--- a/protocols/tascam/src/isoch.rs
+++ b/protocols/tascam/src/isoch.rs
@@ -329,8 +329,8 @@ pub struct IsochMeterState {
     pub monitor_mode: MonitorMode,
 }
 
-/// The trait for meter operation.
-pub trait IsochMeterOperation {
+/// The specification of metering.
+pub trait TascamIsochMeterSpecification: TascamHardwareImageSpecification {
     const INPUT_COUNT: usize;
     const OUTPUT_COUNT: usize;
     const HAS_SOLO: bool;
@@ -360,8 +360,15 @@ pub trait IsochMeterOperation {
             monitor_mode: Default::default(),
         }
     }
+}
 
-    fn parse_meter_state(state: &mut IsochMeterState, image: &[u32]) -> Result<(), Error> {
+impl<O> TascamIsochImageParamsOperation<IsochMeterState> for O
+where
+    O: TascamIsochMeterSpecification,
+{
+    fn parse_image(state: &mut IsochMeterState, image: &[u32]) {
+        assert_eq!(image.len(), Self::IMAGE_QUADLET_COUNT);
+
         let monitor = (image[5] & 0x0000ffff) as i16;
         if (state.monitor - monitor).abs() > Self::ROTARY_STEP {
             state.monitor = monitor;
@@ -443,8 +450,6 @@ pub trait IsochMeterOperation {
                 _ => MonitorMode::Computer,
             };
         }
-
-        Ok(())
     }
 }
 

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -41,7 +41,7 @@ impl TascamIsochMeterSpecification for Fw1082Protocol {
     const HAS_SOLO: bool = true;
 }
 
-impl IsochConsoleOperation for Fw1082Protocol {}
+impl TascamIsochConsoleSpecification for Fw1082Protocol {}
 
 impl MachineStateOperation for Fw1082Protocol {
     const BOOL_ITEMS: &'static [MachineItem] = &[

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -27,6 +27,8 @@ impl TascamIsochClockSpecification for Fw1082Protocol {
     const SAMPLING_CLOCK_SOURCES: &'static [ClkSrc] = &[ClkSrc::Internal, ClkSrc::Spdif];
 }
 
+impl TascamIsochInputDetectionSpecification for Fw1082Protocol {}
+
 impl IsochMeterOperation for Fw1082Protocol {
     const INPUT_COUNT: usize = 10;
     const OUTPUT_COUNT: usize = 4;

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -35,7 +35,7 @@ impl TascamHardwareImageSpecification for Fw1082Protocol {
     const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
 }
 
-impl IsochMeterOperation for Fw1082Protocol {
+impl TascamIsochMeterSpecification for Fw1082Protocol {
     const INPUT_COUNT: usize = 10;
     const OUTPUT_COUNT: usize = 4;
     const HAS_SOLO: bool = true;

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -23,15 +23,17 @@ use super::*;
 #[derive(Default)]
 pub struct Fw1082Protocol;
 
+impl TascamIsochClockSpecification for Fw1082Protocol {
+    const SAMPLING_CLOCK_SOURCES: &'static [ClkSrc] = &[ClkSrc::Internal, ClkSrc::Spdif];
+}
+
 impl IsochMeterOperation for Fw1082Protocol {
     const INPUT_COUNT: usize = 10;
     const OUTPUT_COUNT: usize = 4;
     const HAS_SOLO: bool = true;
 }
 
-impl IsochCommonOperation for Fw1082Protocol {
-    const SAMPLING_CLOCK_SOURCES: &'static [ClkSrc] = &[ClkSrc::Internal, ClkSrc::Spdif];
-}
+impl IsochCommonOperation for Fw1082Protocol {}
 
 impl IsochConsoleOperation for Fw1082Protocol {}
 

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -29,13 +29,13 @@ impl TascamIsochClockSpecification for Fw1082Protocol {
 
 impl TascamIsochInputDetectionSpecification for Fw1082Protocol {}
 
+impl TascamIsochCoaxialOutputSpecification for Fw1082Protocol {}
+
 impl IsochMeterOperation for Fw1082Protocol {
     const INPUT_COUNT: usize = 10;
     const OUTPUT_COUNT: usize = 4;
     const HAS_SOLO: bool = true;
 }
-
-impl IsochCommonOperation for Fw1082Protocol {}
 
 impl IsochConsoleOperation for Fw1082Protocol {}
 

--- a/protocols/tascam/src/isoch/fw1082.rs
+++ b/protocols/tascam/src/isoch/fw1082.rs
@@ -31,6 +31,10 @@ impl TascamIsochInputDetectionSpecification for Fw1082Protocol {}
 
 impl TascamIsochCoaxialOutputSpecification for Fw1082Protocol {}
 
+impl TascamHardwareImageSpecification for Fw1082Protocol {
+    const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
+}
+
 impl IsochMeterOperation for Fw1082Protocol {
     const INPUT_COUNT: usize = 10;
     const OUTPUT_COUNT: usize = 4;

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -32,6 +32,8 @@ impl TascamIsochClockSpecification for Fw1804Protocol {
     ];
 }
 
+impl TascamIsochInputDetectionSpecification for Fw1804Protocol {}
+
 impl IsochMeterOperation for Fw1804Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -34,13 +34,13 @@ impl TascamIsochClockSpecification for Fw1804Protocol {
 
 impl TascamIsochInputDetectionSpecification for Fw1804Protocol {}
 
+impl TascamIsochCoaxialOutputSpecification for Fw1804Protocol {}
+
 impl IsochMeterOperation for Fw1804Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;
     const HAS_SOLO: bool = false;
 }
-
-impl IsochCommonOperation for Fw1804Protocol {}
 
 impl IsochOpticalOperation for Fw1804Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -56,13 +56,13 @@ impl TascamIsochOpticalIfaceSpecification for Fw1804Protocol {
     ];
 }
 
+impl TascamIsochRackInputSpecification for Fw1804Protocol {}
+
 impl IsochMeterOperation for Fw1804Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;
     const HAS_SOLO: bool = false;
 }
-
-impl IsochRackOperation for Fw1804Protocol {}
 
 impl FireWireLedOperation for Fw1804Protocol {
     const POSITIONS: &'static [u16] = &[0x8e];

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -36,13 +36,7 @@ impl TascamIsochInputDetectionSpecification for Fw1804Protocol {}
 
 impl TascamIsochCoaxialOutputSpecification for Fw1804Protocol {}
 
-impl IsochMeterOperation for Fw1804Protocol {
-    const INPUT_COUNT: usize = 18;
-    const OUTPUT_COUNT: usize = 18;
-    const HAS_SOLO: bool = false;
-}
-
-impl IsochOpticalOperation for Fw1804Protocol {
+impl TascamIsochOpticalIfaceSpecification for Fw1804Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[
         (
             OpticalOutputSource::StreamInputPairs,
@@ -60,6 +54,12 @@ impl IsochOpticalOperation for Fw1804Protocol {
             0x00048800,
         ),
     ];
+}
+
+impl IsochMeterOperation for Fw1804Protocol {
+    const INPUT_COUNT: usize = 18;
+    const OUTPUT_COUNT: usize = 18;
+    const HAS_SOLO: bool = false;
 }
 
 impl IsochRackOperation for Fw1804Protocol {}

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -58,6 +58,10 @@ impl TascamIsochOpticalIfaceSpecification for Fw1804Protocol {
 
 impl TascamIsochRackInputSpecification for Fw1804Protocol {}
 
+impl TascamHardwareImageSpecification for Fw1804Protocol {
+    const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
+}
+
 impl IsochMeterOperation for Fw1804Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -23,13 +23,7 @@ use super::*;
 #[derive(Default)]
 pub struct Fw1804Protocol;
 
-impl IsochMeterOperation for Fw1804Protocol {
-    const INPUT_COUNT: usize = 18;
-    const OUTPUT_COUNT: usize = 18;
-    const HAS_SOLO: bool = false;
-}
-
-impl IsochCommonOperation for Fw1804Protocol {
+impl TascamIsochClockSpecification for Fw1804Protocol {
     const SAMPLING_CLOCK_SOURCES: &'static [ClkSrc] = &[
         ClkSrc::Internal,
         ClkSrc::Wordclock,
@@ -37,6 +31,14 @@ impl IsochCommonOperation for Fw1804Protocol {
         ClkSrc::Adat,
     ];
 }
+
+impl IsochMeterOperation for Fw1804Protocol {
+    const INPUT_COUNT: usize = 18;
+    const OUTPUT_COUNT: usize = 18;
+    const HAS_SOLO: bool = false;
+}
+
+impl IsochCommonOperation for Fw1804Protocol {}
 
 impl IsochOpticalOperation for Fw1804Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[

--- a/protocols/tascam/src/isoch/fw1804.rs
+++ b/protocols/tascam/src/isoch/fw1804.rs
@@ -62,7 +62,7 @@ impl TascamHardwareImageSpecification for Fw1804Protocol {
     const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
 }
 
-impl IsochMeterOperation for Fw1804Protocol {
+impl TascamIsochMeterSpecification for Fw1804Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;
     const HAS_SOLO: bool = false;

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -71,7 +71,7 @@ impl TascamIsochMeterSpecification for Fw1884Protocol {
     const HAS_SOLO: bool = true;
 }
 
-impl IsochConsoleOperation for Fw1884Protocol {}
+impl TascamIsochConsoleSpecification for Fw1884Protocol {}
 
 /// The target of monitor knob.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -104,22 +104,29 @@ const MONITOR_KNOB_TARGETS: [(Fw1884MonitorKnobTarget, u32, u32); 3] = [
     ),
 ];
 
-impl Fw1884Protocol {
-    pub fn get_monitor_knob_target(
+impl TascamIsochWhollyCachableParamsOperation<Fw1884MonitorKnobTarget> for Fw1884Protocol {
+    fn cache_wholly(
         req: &mut FwReq,
         node: &mut FwNode,
-        timeout_ms: u32,
-    ) -> Result<Fw1884MonitorKnobTarget, Error> {
-        read_config_flag(req, node, &MONITOR_KNOB_TARGETS, timeout_ms)
-    }
-
-    pub fn set_monitor_knob_target(
-        req: &mut FwReq,
-        node: &mut FwNode,
-        target: Fw1884MonitorKnobTarget,
+        states: &mut Fw1884MonitorKnobTarget,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        write_config_flag(req, node, &MONITOR_KNOB_TARGETS, target, timeout_ms)
+        let mut config = 0;
+        read_config(req, node, &mut config, timeout_ms)?;
+        deserialize_config_flag(states, &MONITOR_KNOB_TARGETS, config)
+    }
+}
+
+impl TascamIsochWhollyUpdatableParamsOperation<Fw1884MonitorKnobTarget> for Fw1884Protocol {
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        states: &Fw1884MonitorKnobTarget,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut config = 0;
+        serialize_config_flag(states, &MONITOR_KNOB_TARGETS, &mut config)?;
+        write_config(req, node, config, timeout_ms)
     }
 }
 

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -23,13 +23,7 @@ use super::*;
 #[derive(Default)]
 pub struct Fw1884Protocol;
 
-impl IsochMeterOperation for Fw1884Protocol {
-    const INPUT_COUNT: usize = 18;
-    const OUTPUT_COUNT: usize = 18;
-    const HAS_SOLO: bool = true;
-}
-
-impl IsochCommonOperation for Fw1884Protocol {
+impl TascamIsochClockSpecification for Fw1884Protocol {
     const SAMPLING_CLOCK_SOURCES: &'static [ClkSrc] = &[
         ClkSrc::Internal,
         ClkSrc::Wordclock,
@@ -37,6 +31,14 @@ impl IsochCommonOperation for Fw1884Protocol {
         ClkSrc::Adat,
     ];
 }
+
+impl IsochMeterOperation for Fw1884Protocol {
+    const INPUT_COUNT: usize = 18;
+    const OUTPUT_COUNT: usize = 18;
+    const HAS_SOLO: bool = true;
+}
+
+impl IsochCommonOperation for Fw1884Protocol {}
 
 impl IsochOpticalOperation for Fw1884Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -34,13 +34,13 @@ impl TascamIsochClockSpecification for Fw1884Protocol {
 
 impl TascamIsochInputDetectionSpecification for Fw1884Protocol {}
 
+impl TascamIsochCoaxialOutputSpecification for Fw1884Protocol {}
+
 impl IsochMeterOperation for Fw1884Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;
     const HAS_SOLO: bool = true;
 }
-
-impl IsochCommonOperation for Fw1884Protocol {}
 
 impl IsochOpticalOperation for Fw1884Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -32,6 +32,8 @@ impl TascamIsochClockSpecification for Fw1884Protocol {
     ];
 }
 
+impl TascamIsochInputDetectionSpecification for Fw1884Protocol {}
+
 impl IsochMeterOperation for Fw1884Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -61,6 +61,10 @@ impl TascamIsochOpticalIfaceSpecification for Fw1884Protocol {
     ];
 }
 
+impl TascamHardwareImageSpecification for Fw1884Protocol {
+    const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
+}
+
 impl IsochMeterOperation for Fw1884Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -65,7 +65,7 @@ impl TascamHardwareImageSpecification for Fw1884Protocol {
     const IMAGE_QUADLET_COUNT: usize = ISOCH_IMAGE_QUADLET_COUNT;
 }
 
-impl IsochMeterOperation for Fw1884Protocol {
+impl TascamIsochMeterSpecification for Fw1884Protocol {
     const INPUT_COUNT: usize = 18;
     const OUTPUT_COUNT: usize = 18;
     const HAS_SOLO: bool = true;

--- a/protocols/tascam/src/isoch/fw1884.rs
+++ b/protocols/tascam/src/isoch/fw1884.rs
@@ -36,13 +36,7 @@ impl TascamIsochInputDetectionSpecification for Fw1884Protocol {}
 
 impl TascamIsochCoaxialOutputSpecification for Fw1884Protocol {}
 
-impl IsochMeterOperation for Fw1884Protocol {
-    const INPUT_COUNT: usize = 18;
-    const OUTPUT_COUNT: usize = 18;
-    const HAS_SOLO: bool = true;
-}
-
-impl IsochOpticalOperation for Fw1884Protocol {
+impl TascamIsochOpticalIfaceSpecification for Fw1884Protocol {
     const OPTICAL_OUTPUT_SOURCES: &'static [(OpticalOutputSource, u32, u32)] = &[
         (
             OpticalOutputSource::StreamInputPairs,
@@ -65,6 +59,12 @@ impl IsochOpticalOperation for Fw1884Protocol {
             0x00840800,
         ),
     ];
+}
+
+impl IsochMeterOperation for Fw1884Protocol {
+    const INPUT_COUNT: usize = 18;
+    const OUTPUT_COUNT: usize = 18;
+    const HAS_SOLO: bool = true;
 }
 
 impl IsochConsoleOperation for Fw1884Protocol {}

--- a/protocols/tascam/src/lib.rs
+++ b/protocols/tascam/src/lib.rs
@@ -143,6 +143,15 @@ impl HardwareInformationProtocol {
     }
 }
 
+/// The specification of hardware image.
+pub trait TascamHardwareImageSpecification {
+    const IMAGE_QUADLET_COUNT: usize;
+
+    fn create_hardware_image() -> Vec<u32> {
+        vec![0; Self::IMAGE_QUADLET_COUNT]
+    }
+}
+
 /// Items of surface.
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum MachineItem {

--- a/runtime/tascam/src/fe8_model.rs
+++ b/runtime/tascam/src/fe8_model.rs
@@ -16,7 +16,7 @@ impl Default for Fe8Model {
     fn default() -> Self {
         Self {
             req: Default::default(),
-            image: vec![0; TascamExpander::QUADLET_COUNT],
+            image: Fe8Protocol::create_hardware_image(),
             seq_state: Default::default(),
         }
     }

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -35,6 +35,23 @@ impl Default for Fw1082Model {
 
 const TIMEOUT_MS: u32 = 50;
 
+impl IsochConsoleCtlModel<Fw1082Protocol, Fw1082SurfaceState> for Fw1082Model {
+    fn cache(&mut self, (unit, node): &mut (SndTascam, FwNode)) -> Result<(), Error> {
+        unit.read_state(&mut self.image)?;
+        self.meter_ctl.parse(&self.image)?;
+        self.console_ctl.parse(&self.image)?;
+
+        self.clock_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_threshold_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.coax_output_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.console_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+}
+
 impl SequencerCtlOperation<SndTascam, Fw1082Protocol, Fw1082SurfaceState> for Fw1082Model {
     fn state(&self) -> &SequencerState<Fw1082SurfaceState> {
         &self.seq_state
@@ -124,30 +141,12 @@ impl MeasureModel<(SndTascam, FwNode)> for Fw1082Model {
 }
 
 impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndTascam, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        unit.0.read_state(&mut self.image)?;
-        self.meter_ctl.parse(&self.image)?;
-        self.console_ctl.parse(&self.image)?;
-
-        self.clock_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.input_threshold_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.coax_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.console_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-
+    fn load(&mut self, _: &mut (SndTascam, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clock_ctl.load(card_cntr)?;
         self.input_threshold_ctl.load(card_cntr)?;
         self.coax_output_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         self.console_ctl.load(card_cntr)?;
-
         Ok(())
     }
 

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -22,7 +22,7 @@ impl Default for Fw1082Model {
     fn default() -> Self {
         Self {
             req: Default::default(),
-            image: vec![0u32; 64],
+            image: Fw1082Protocol::create_hardware_image(),
             clock_ctl: Default::default(),
             input_threshold_ctl: Default::default(),
             coax_output_ctl: Default::default(),

--- a/runtime/tascam/src/fw1804_model.rs
+++ b/runtime/tascam/src/fw1804_model.rs
@@ -22,7 +22,7 @@ impl Default for Fw1804Model {
     fn default() -> Self {
         Self {
             req: Default::default(),
-            image: vec![0u32; 64],
+            image: Fw1804Protocol::create_hardware_image(),
             clock_ctl: Default::default(),
             coax_output_ctl: Default::default(),
             input_threshold_ctl: Default::default(),

--- a/runtime/tascam/src/fw1804_model.rs
+++ b/runtime/tascam/src/fw1804_model.rs
@@ -35,6 +35,23 @@ impl Default for Fw1804Model {
 
 const TIMEOUT_MS: u32 = 50;
 
+impl IsochRackCtlModel for Fw1804Model {
+    fn cache(&mut self, (unit, node): &mut (SndTascam, FwNode)) -> Result<(), Error> {
+        unit.read_state(&mut self.image)?;
+        self.meter_ctl.parse(&self.image)?;
+
+        self.clock_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_threshold_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.coax_output_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.rack_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+}
+
 impl MeasureModel<(SndTascam, FwNode)> for Fw1804Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
@@ -61,32 +78,13 @@ impl MeasureModel<(SndTascam, FwNode)> for Fw1804Model {
 }
 
 impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
-    fn load(
-        &mut self,
-        unit: &mut (SndTascam, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        unit.0.read_state(&mut self.image)?;
-        self.meter_ctl.parse(&self.image)?;
-
-        self.clock_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.input_threshold_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.coax_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.rack_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-
+    fn load(&mut self, _: &mut (SndTascam, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clock_ctl.load(card_cntr)?;
         self.input_threshold_ctl.load(card_cntr)?;
         self.coax_output_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.rack_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
-
         Ok(())
     }
 

--- a/runtime/tascam/src/fw1884_model.rs
+++ b/runtime/tascam/src/fw1884_model.rs
@@ -24,7 +24,7 @@ impl Default for Fw1884Model {
     fn default() -> Self {
         Self {
             req: Default::default(),
-            image: vec![0u32; 64],
+            image: Fw1884Protocol::create_hardware_image(),
             clock_ctl: Default::default(),
             input_threshold_ctl: Default::default(),
             coax_output_ctl: Default::default(),

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -11,7 +11,7 @@ use {
 #[derive(Debug)]
 pub(crate) struct MeterCtl<T>
 where
-    T: IsochMeterOperation,
+    T: TascamIsochMeterSpecification + TascamIsochImageParamsOperation<IsochMeterState>,
 {
     pub elem_id_list: Vec<ElemId>,
     params: IsochMeterState,
@@ -20,7 +20,7 @@ where
 
 impl<T> Default for MeterCtl<T>
 where
-    T: IsochMeterOperation,
+    T: TascamIsochMeterSpecification + TascamIsochImageParamsOperation<IsochMeterState>,
 {
     fn default() -> Self {
         Self {
@@ -71,7 +71,7 @@ fn monitor_mode_to_str(mode: &MonitorMode) -> &'static str {
 
 impl<T> MeterCtl<T>
 where
-    T: IsochMeterOperation,
+    T: TascamIsochMeterSpecification + TascamIsochImageParamsOperation<IsochMeterState>,
 {
     const CLK_SRCS: [Option<ClkSrc>; 5] = [
         Some(ClkSrc::Internal),
@@ -96,7 +96,8 @@ where
     ];
 
     pub(crate) fn parse(&mut self, image: &[u32]) -> Result<(), Error> {
-        T::parse_meter_state(&mut self.params, image)
+        T::parse_image(&mut self.params, image);
+        Ok(())
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {


### PR DESCRIPTION
Current implementation has ad-hoc implementations for control operations, while it is not necessarily convenient in a point of code maintenance, especially for the case that the device includes out-of-specification behaviour.

This patchset introduces a trait to express hardware specification, then implements the
trait for each model. Some trait is added for cache and update operation for hardware
parameters, and they are implemented for operations.

```
Takashi Sakamoto (12):
  runtime/tascam: add model-level cache function splitted from load
    function
  protocols/tascam: add traits to cache and update parameters for isoch
    models
  protocols/tascam: implement traits to cache and update parameters of
    sampling and media clocks
  protocols/tascam: implement traits to cache and update parameters of
    input signal detection
  protocols/tascam: implement traits to cache and update parameters of
    coaxial output interface
  protocols/tascam: implement traits to cache and update parameters of
    optical interfaces
  protocols/tascam: implement traits to update parameters of rack inputs
  protocols/tascam: implement traits to cache and update parameters
    specific to FW-1884
  protocols/tascam: add trait to express specification of hardware image
  protocols/tascam: add trait to parse image of hardware state
  protocols/tascam: implement traits to parse image for meter parameters
  protocols/tascam: implement traits to cache and update parameters of
    console

 protocols/tascam/src/asynch.rs              |   2 +
 protocols/tascam/src/asynch/fe8.rs          |   4 +
 protocols/tascam/src/isoch.rs               | 869 ++++++++++++--------
 protocols/tascam/src/isoch/fw1082.rs        |  20 +-
 protocols/tascam/src/isoch/fw1804.rs        |  26 +-
 protocols/tascam/src/isoch/fw1884.rs        |  47 +-
 protocols/tascam/src/lib.rs                 |   9 +
 runtime/tascam/src/fe8_model.rs             |   2 +-
 runtime/tascam/src/fw1082_model.rs          |  39 +-
 runtime/tascam/src/fw1804_model.rs          |  40 +-
 runtime/tascam/src/fw1884_model.rs          |  68 +-
 runtime/tascam/src/isoch_console_runtime.rs |  27 +-
 runtime/tascam/src/isoch_ctls.rs            | 214 +++--
 runtime/tascam/src/isoch_rack_runtime.rs    |  24 +-
 14 files changed, 785 insertions(+), 606 deletions(-)
```