### PR TITLE
[PATCH 00/10] runtime/tascam: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2023/03/28
+2023/03/29
 Takashi Sakamoto
 
 Introduction
@@ -284,6 +284,7 @@ Currently this function is available for below executables:
 * snd-fireface-ctl-service
 * snd-fireworks-ctl-service
 * snd-firewire-digi00x-ctl-service
+* snd-firewire-tascam-ctl-service
 
 This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
 `tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.

--- a/runtime/tascam/Cargo.toml
+++ b/runtime/tascam/Cargo.toml
@@ -22,3 +22,5 @@ alsa-ctl-tlv-codec = "0.1"
 firewire-tascam-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
+++ b/runtime/tascam/src/bin/snd-firewire-tascam-ctl-service.rs
@@ -16,11 +16,15 @@ struct Arguments {
     subsystem: String,
     /// The numeric identifier of sound card or firewire character device.
     sysnum: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, (String, u32), TascamRuntime> for TascamServiceCmd {
     fn params(args: &Arguments) -> ((String, u32), Option<LogLevel>) {
-        ((args.subsystem.clone(), args.sysnum), None)
+        ((args.subsystem.clone(), args.sysnum), args.log_level)
     }
 }
 

--- a/runtime/tascam/src/fw1884_model.rs
+++ b/runtime/tascam/src/fw1884_model.rs
@@ -259,7 +259,9 @@ impl SpecificCtl {
     ];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        Fw1884Protocol::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = Fw1884Protocol::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -306,9 +308,10 @@ impl SpecificCtl {
                         let msg = format!("Invalid index for monitor rotary targets: {}", val);
                         Error::new(FileError::Inval, &msg)
                     })?;
-                Fw1884Protocol::update_wholly(req, node, target, timeout_ms)
-                    .map(|_| self.params = *target)?;
-                Ok(true)
+                let res = Fw1884Protocol::update_wholly(req, node, target, timeout_ms)
+                    .map(|_| self.params = *target);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/isoch_console_runtime.rs
+++ b/runtime/tascam/src/isoch_console_runtime.rs
@@ -106,17 +106,24 @@ where
 
         self.seq_cntr.open_port()?;
         self.model.initialize_sequencer(&mut self.unit.1)?;
+
+        let enter = debug_span!("cache").entered();
         self.model.cache(&mut self.unit)?;
+        enter.exit();
+
+        let enter = debug_span!("load").entered();
         self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, TIMER_NAME, 0);
         let _ = self.card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
         self.model.get_measure_elem_list(&mut self.measure_elems);
+        enter.exit();
 
         Ok(())
     }
 
     pub fn run(&mut self) -> Result<(), Error> {
+        let enter = debug_span!("event").entered();
         loop {
             let ev = match self.rx.recv() {
                 Ok(ev) => ev,
@@ -127,9 +134,20 @@ where
                 ConsoleUnitEvent::Shutdown => break,
                 ConsoleUnitEvent::Disconnected => break,
                 ConsoleUnitEvent::BusReset(generation) => {
-                    println!("IEEE 1394 bus is updated: {}", generation);
+                    debug!("IEEE 1394 bus is updated: {}", generation);
                 }
                 ConsoleUnitEvent::Elem((elem_id, events)) => {
+                    let _enter = debug_span!("element").entered();
+
+                    debug!(
+                        numid = elem_id.numid(),
+                        name = elem_id.name().as_str(),
+                        iface = ?elem_id.iface(),
+                        device_id = elem_id.device_id(),
+                        subdevice_id = elem_id.subdevice_id(),
+                        index = elem_id.index(),
+                    );
+
                     if elem_id.name() != TIMER_NAME {
                         let _ = self.card_cntr.dispatch_elem_event(
                             &mut self.unit,
@@ -155,6 +173,7 @@ where
                     }
                 }
                 ConsoleUnitEvent::Interval => {
+                    let _enter = debug_span!("timer").entered();
                     let _ = self.card_cntr.measure_elems(
                         &mut self.unit,
                         &self.measure_elems,
@@ -180,6 +199,8 @@ where
                 }
             }
         }
+
+        enter.exit();
 
         Ok(())
     }

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -827,6 +827,7 @@ where
 {
     pub(crate) fn parse(&mut self, image: &[u32]) -> Result<(), Error> {
         T::parse_image(&mut self.params, image);
+        debug!(params = ?self.params);
         Ok(())
     }
 
@@ -836,7 +837,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -879,8 +882,10 @@ where
             MASTER_FADER_ASSIGN_NAME => {
                 let mut params = self.params.clone();
                 params.master_fader_assign = elem_value.boolean()[0];
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -460,7 +460,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -537,14 +539,18 @@ where
             SIGNAL_DETECTION_THRESHOLD_NAME => {
                 let mut params = self.params.clone();
                 params.signal = elem_value.int()[0] as u16;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             OVER_LEVEL_DETECTION_THRESHOLD_NAME => {
                 let mut params = self.params.clone();
                 params.over_level = elem_value.int()[0] as u16;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -702,7 +702,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -773,8 +775,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|(src, _, _)| params.output_source = *src)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             SPDIF_IN_SRC_NAME => {
                 let pos = elem_value.enumerated()[0] as usize;
@@ -787,8 +791,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&src| params.capture_source = src)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -97,6 +97,7 @@ where
 
     pub(crate) fn parse(&mut self, image: &[u32]) -> Result<(), Error> {
         T::parse_image(&mut self.params, image);
+        debug!(params = ?self.params);
         Ok(())
     }
 
@@ -935,7 +936,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::update_wholly(req, node, &self.params, timeout_ms)
+        let res = T::update_wholly(req, node, &self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1016,7 +1019,8 @@ where
                     .iter_mut()
                     .zip(elem_value.int().iter().map(|&val| val as i16))
                     .for_each(|(o, n)| *o = n);
-                T::update_partially(req, node, &mut self.params, params, timeout_ms)?;
+                let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 Ok(true)
             }
             INPUT_BALANCE_NAME => {
@@ -1026,8 +1030,9 @@ where
                     .iter_mut()
                     .zip(elem_value.int().iter().map(|&val| val as u8))
                     .for_each(|(o, n)| *o = n);
-                T::update_partially(req, node, &mut self.params, params, timeout_ms)?;
-                Ok(true)
+                let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             INPUT_MUTE_NAME => {
                 let mut params = self.params.clone();
@@ -1036,8 +1041,9 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(o, n)| *o = n);
-                T::update_partially(req, node, &mut self.params, params, timeout_ms)?;
-                Ok(true)
+                let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -318,7 +318,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -395,6 +397,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             CLK_RATE_NAME => {
@@ -412,6 +415,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/tascam/src/isoch_ctls.rs
+++ b/runtime/tascam/src/isoch_ctls.rs
@@ -595,7 +595,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -645,8 +647,9 @@ where
                         let msg = format!("Invalid value for index of clock rates: {}", pos);
                         Error::new(FileError::Inval, &msg)
                     })?;
-                T::update_wholly(req, node, &src, timeout_ms).map(|_| self.params = src)?;
-                Ok(true)
+                let res = T::update_wholly(req, node, &src, timeout_ms).map(|_| self.params = src);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/tascam/src/lib.rs
+++ b/runtime/tascam/src/lib.rs
@@ -30,6 +30,7 @@ use {
     protocols::{config_rom::*, *},
     seq_cntr::*,
     std::{convert::TryFrom, marker::PhantomData},
+    tracing::Level,
 };
 
 pub enum TascamRuntime {
@@ -46,7 +47,14 @@ const FW1082_SW_VERSION: u32 = 0x800003;
 const FW1804_SW_VERSION: u32 = 0x800004;
 
 impl RuntimeOperation<(String, u32)> for TascamRuntime {
-    fn new((subsystem, sysnum): (String, u32), _: Option<LogLevel>) -> Result<Self, Error> {
+    fn new((subsystem, sysnum): (String, u32), log_level: Option<LogLevel>) -> Result<Self, Error> {
+        if let Some(level) = log_level {
+            let fmt_level = match level {
+                LogLevel::Debug => Level::DEBUG,
+            };
+            tracing_subscriber::fmt().with_max_level(fmt_level).init();
+        }
+
         match subsystem.as_str() {
             "snd" => {
                 let unit = SndTascam::new();

--- a/runtime/tascam/src/lib.rs
+++ b/runtime/tascam/src/lib.rs
@@ -30,7 +30,7 @@ use {
     protocols::{config_rom::*, *},
     seq_cntr::*,
     std::{convert::TryFrom, marker::PhantomData},
-    tracing::Level,
+    tracing::{debug, debug_span, Level},
 };
 
 pub enum TascamRuntime {


### PR DESCRIPTION
It's really helpful to dump logs for debugging purpose. This patchset utilizes
tracing and tracing-subscriber crates for the purpose. An option is newly added
to fireworks runtime, then implement tracing events.

```
Takashi Sakamoto (10):
  runtime/tascam: use tracing-subscriber crate to dump debug logs
  runtime/tascam: add tracing span and event to runtime structure for
    console model
  runtime/tascam: add tracing span and event to runtime structure for
    rack model
  runtime/tascam: add tracing events for clock controls
  runtime/tascam: add tracing events for input detection controls
  runtime/tascam: add tracing events for coaxial output parameters
  runtime/tascam: add tracing events for optical interface controls
  runtime/tascam: add tracing events for rack input controls
  runtime/tascam: add tracing events for console controls
  runtime/tascam: add tracing events for controls specific to FW-1884

 README.rst                                    |  3 +-
 runtime/tascam/Cargo.toml                     |  2 +
 .../bin/snd-firewire-tascam-ctl-service.rs    |  6 +-
 runtime/tascam/src/fw1884_model.rs            | 11 ++-
 runtime/tascam/src/isoch_console_runtime.rs   | 23 +++++-
 runtime/tascam/src/isoch_ctls.rs              | 76 +++++++++++++------
 runtime/tascam/src/isoch_rack_runtime.rs      | 22 +++++-
 runtime/tascam/src/lib.rs                     | 10 ++-
 8 files changed, 121 insertions(+), 32 deletions(-)
```