### PR TITLE
[PATCH 0/8] runtime/motu: rework for runtime of version 1 models

### DIFF
--- a/protocols/motu/src/lib.rs
+++ b/protocols/motu/src/lib.rs
@@ -12,7 +12,10 @@ pub mod version_3;
 
 use {
     glib::{Error, FileError},
-    hinawa::{prelude::{FwNodeExt, FwReqExtManual}, FwNode, FwReq, FwTcode},
+    hinawa::{
+        prelude::{FwNodeExt, FwReqExtManual},
+        FwNode, FwReq, FwTcode,
+    },
     std::{thread, time},
 };
 

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -81,14 +81,10 @@ pub trait RegisterDspMixerOutputOperation {
         state.volume.copy_from_slice(vols);
 
         let flags = param.mixer_output_paired_flag();
-        state
-            .mute
-            .iter_mut()
-            .zip(flags)
-            .for_each(|(mute, &flag)| {
-                let val = (flag as u32) << 8;
-                *mute = val & MIXER_OUTPUT_MUTE_FLAG > 0;
-            });
+        state.mute.iter_mut().zip(flags).for_each(|(mute, &flag)| {
+            let val = (flag as u32) << 8;
+            *mute = val & MIXER_OUTPUT_MUTE_FLAG > 0;
+        });
         state
             .destination
             .iter_mut()

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 
@@ -125,7 +125,10 @@ struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
 
 impl Default for MeterCtl {
     fn default() -> Self {
-        Self(AudioExpressProtocol::create_meter_state(), Default::default())
+        Self(
+            AudioExpressProtocol::create_meter_state(),
+            Default::default(),
+        )
     }
 }
 

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+pub(crate) use super::command_dsp_runtime::*;
 
 const REVERB_ENABLE: &str = "reverb-enable";
 const REVERB_SPLIT_POINT_NAME: &str = "reverb-split-point";

--- a/runtime/motu/src/command_dsp_runtime.rs
+++ b/runtime/motu/src/command_dsp_runtime.rs
@@ -1,17 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-pub use {
+pub(crate) use {
     super::{
-        command_dsp_ctls::*, f828mk3::*, f828mk3_hybrid::*, track16::*, traveler_mk3::*,
-        ultralite_mk3::*, ultralite_mk3_hybrid::*, *,
+        f828mk3::*, f828mk3_hybrid::*, track16::*, traveler_mk3::*, ultralite_mk3::*,
+        ultralite_mk3_hybrid::*, *,
     },
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*},
-    glib::source,
+    core::card_cntr::*,
     hinawa::{prelude::FwRespExtManual, FwRcode, FwResp, FwTcode},
+    protocols::command_dsp::*,
+};
+
+use {
+    core::dispatcher::*,
+    glib::source,
     nix::sys::signal::Signal,
-    protocols::{command_dsp::*, version_3::*},
     std::{
         sync::{mpsc, Arc, Mutex},
         thread,

--- a/runtime/motu/src/common_ctls.rs
+++ b/runtime/motu/src/common_ctls.rs
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use {
+pub(crate) use {
     super::*,
     alsactl::*,
-    core::{card_cntr::CardCntr, elem_value_accessor::ElemValueAccessor},
+    core::{card_cntr::*, elem_value_accessor::*},
     hinawa::FwReq,
 };
 

--- a/runtime/motu/src/f828.rs
+++ b/runtime/motu/src/f828.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::v1_runtime::*;
+use super::{v1_ctls::*, v1_runtime::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f828.rs
+++ b/runtime/motu/src/f828.rs
@@ -13,17 +13,18 @@ pub struct F828 {
     specific_ctls: SpecificCtl,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F828 {
-    fn load(
-        &mut self,
-        (_, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl Version1CtlModel for F828 {
+    fn cache(&mut self, (_, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.monitor_input_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.specific_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        Ok(())
+    }
+}
 
+impl CtlModel<(SndMotu, FwNode)> for F828 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.monitor_input_ctl.load(card_cntr)?;
         self.specific_ctls.load(card_cntr)?;

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -13,7 +13,7 @@ pub struct F828mk3Hybrid {
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl,
-    word_clk_ctl: WordClkCtl,
+    word_clk_ctl: WordClockCtl<F828mk3HybridProtocol>,
     sequence_number: u8,
     reverb_ctl: ReverbCtl,
     monitor_ctl: MonitorCtl,
@@ -34,19 +34,6 @@ impl PhoneAssignCtlOperation<F828mk3HybridProtocol> for PhoneAssignCtl {
     }
 
     fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
-}
-
-#[derive(Default)]
-struct WordClkCtl(WordClkSpeedMode, Vec<ElemId>);
-
-impl WordClkCtlOperation<F828mk3HybridProtocol> for WordClkCtl {
-    fn state(&self) -> &WordClkSpeedMode {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut WordClkSpeedMode {
         &mut self.0
     }
 }
@@ -203,6 +190,9 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.word_clk_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
@@ -211,9 +201,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         self.phone_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|mut elem_id_list| self.phone_assign_ctl.1.append(&mut elem_id_list))?;
-        self.word_clk_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.word_clk_ctl.1.append(&mut elem_id_list))?;
+        self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
@@ -328,7 +316,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.reverb_ctl.write(
@@ -422,7 +410,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
         elem_id_list.extend_from_slice(&self.port_assign_ctl.1);
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.1);
-        elem_id_list.extend_from_slice(&self.word_clk_ctl.1);
+        elem_id_list.extend_from_slice(&self.word_clk_ctl.elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndMotu, FwNode), msg: &u32) -> Result<(), Error> {
@@ -431,7 +419,8 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3Hybrid {
                 .cache(unit, &mut self.req, TIMEOUT_MS)?;
             self.phone_assign_ctl
                 .cache(unit, &mut self.req, TIMEOUT_MS)?;
-            self.word_clk_ctl.cache(unit, &mut self.req, TIMEOUT_MS)?;
+            self.word_clk_ctl
+                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         }
         // TODO: what kind of event is preferable for NOTIFY_FOOTSWITCH_MASK?
         Ok(())

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f896.rs
+++ b/runtime/motu/src/f896.rs
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct F896 {
     req: FwReq,
     clk_ctls: V1ClkCtl<F896Protocol>,
-    monitor_input_ctl: MonitorInputCtl,
+    monitor_input_ctl: V1MonitorInputCtl<F896Protocol>,
     word_clk_ctl: WordClkCtl,
     aesebu_rate_convert_ctl: AesebuRateConvertCtl,
     level_meters_ctl: LevelMetersCtl,
@@ -46,11 +46,6 @@ impl LevelMetersCtlOperation<F896Protocol> for LevelMetersCtl {
     }
 }
 
-#[derive(Default)]
-struct MonitorInputCtl;
-
-impl V1MonitorInputCtlOperation<F896Protocol> for MonitorInputCtl {}
-
 impl CtlModel<(SndMotu, FwNode)> for F896 {
     fn load(
         &mut self,
@@ -80,13 +75,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896 {
     ) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.monitor_input_ctl.read(
-            unit,
-            &mut self.req,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.monitor_input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.word_clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -127,10 +116,13 @@ impl CtlModel<(SndMotu, FwNode)> for F896 {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .monitor_input_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.monitor_input_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .word_clk_ctl

--- a/runtime/motu/src/f896.rs
+++ b/runtime/motu/src/f896.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::v1_runtime::*;
+use super::{common_ctls::*, v1_ctls::*, v1_runtime::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f896.rs
+++ b/runtime/motu/src/f896.rs
@@ -15,21 +15,20 @@ pub struct F896 {
     level_meters_ctl: LevelMetersCtl<F896Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F896 {
-    fn load(
-        &mut self,
-        (_, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.word_clk_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+impl Version1CtlModel for F896 {
+    fn cache(&mut self, (_, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.aesebu_rate_convert_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.level_meters_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
+        Ok(())
+    }
+}
 
+impl CtlModel<(SndMotu, FwNode)> for F896 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.monitor_input_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;

--- a/runtime/motu/src/f896.rs
+++ b/runtime/motu/src/f896.rs
@@ -11,14 +11,9 @@ pub struct F896 {
     clk_ctls: V1ClkCtl<F896Protocol>,
     monitor_input_ctl: V1MonitorInputCtl<F896Protocol>,
     word_clk_ctl: WordClockCtl<F896Protocol>,
-    aesebu_rate_convert_ctl: AesebuRateConvertCtl,
+    aesebu_rate_convert_ctl: AesebuRateConvertCtl<F896Protocol>,
     level_meters_ctl: LevelMetersCtl,
 }
-
-#[derive(Default)]
-struct AesebuRateConvertCtl;
-
-impl AesebuRateConvertCtlOperation<F896Protocol> for AesebuRateConvertCtl {}
 
 #[derive(Default)]
 struct LevelMetersCtl(LevelMeterState);
@@ -43,6 +38,8 @@ impl CtlModel<(SndMotu, FwNode)> for F896 {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.word_clk_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.aesebu_rate_convert_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.monitor_input_ctl.load(card_cntr)?;
@@ -66,13 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896 {
             Ok(true)
         } else if self.word_clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.aesebu_rate_convert_ctl.read(
-            unit,
-            &mut self.req,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        } else if self.aesebu_rate_convert_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.level_meters_ctl.read(
             unit,
@@ -117,8 +108,8 @@ impl CtlModel<(SndMotu, FwNode)> for F896 {
         {
             Ok(true)
         } else if self.aesebu_rate_convert_ctl.write(
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/lib.rs
+++ b/runtime/motu/src/lib.rs
@@ -41,7 +41,7 @@ use {
     hitaki::{prelude::*, *},
     ieee1212_config_rom::*,
     protocols::{config_rom::*, *},
-    std::convert::TryFrom,
+    std::{convert::TryFrom, marker::PhantomData},
 };
 
 pub enum MotuRuntime {

--- a/runtime/motu/src/lib.rs
+++ b/runtime/motu/src/lib.rs
@@ -176,7 +176,7 @@ impl RuntimeOperation<u32> for MotuRuntime {
     }
 }
 
-pub fn clk_rate_to_str(rate: &ClkRate) -> &'static str {
+pub(crate) fn clk_rate_to_str(rate: &ClkRate) -> &'static str {
     match rate {
         ClkRate::R44100 => "44100",
         ClkRate::R48000 => "48000",
@@ -187,7 +187,7 @@ pub fn clk_rate_to_str(rate: &ClkRate) -> &'static str {
     }
 }
 
-pub fn target_port_to_string(port: &TargetPort) -> String {
+pub(crate) fn target_port_to_string(port: &TargetPort) -> String {
     match port {
         TargetPort::Disabled => "Disabled".to_string(),
         TargetPort::AnalogPair(ch) => format!("Analog-{}/{}", *ch * 2 + 1, *ch * 2 + 2),
@@ -211,7 +211,7 @@ pub fn target_port_to_string(port: &TargetPort) -> String {
     }
 }
 
-pub fn nominal_signal_level_to_str(level: &NominalSignalLevel) -> &'static str {
+pub(crate) fn nominal_signal_level_to_str(level: &NominalSignalLevel) -> &'static str {
     match level {
         NominalSignalLevel::Consumer => "-10dBu",
         NominalSignalLevel::Professional => "+4dBV",

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+pub(crate) use super::{common_ctls::PhoneAssignCtlOperation, register_dsp_runtime::*};
 
 pub trait RegisterDspPhoneAssignCtlOperation<T: AssignOperation>:
     PhoneAssignCtlOperation<T>

--- a/runtime/motu/src/register_dsp_runtime.rs
+++ b/runtime/motu/src/register_dsp_runtime.rs
@@ -1,20 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-pub use {
+pub(crate) use {
     super::{
-        audioexpress::*, common_ctls::*, f828mk2::*, f896hd::*, f8pre::*, h4pre::*,
-        register_dsp_ctls::*, traveler::*, ultralite::*, v2_ctls::*, v3_ctls::*, *,
+        audioexpress::*, f828mk2::*, f896hd::*, f8pre::*, h4pre::*, traveler::*, ultralite::*, *,
     },
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*, elem_value_accessor::*},
-    glib::source,
+    core::{card_cntr::*, elem_value_accessor::*},
     hinawa::FwReq,
-    nix::sys::signal::Signal,
-    protocols::{register_dsp::*, version_2::*, version_3::*},
-    std::sync::mpsc,
+    protocols::register_dsp::*,
 };
+
+use {core::dispatcher::*, glib::source, nix::sys::signal::Signal, std::sync::mpsc};
 
 pub type F828mk2Runtime = RegisterDspRuntime<F828mk2>;
 pub type F896hdRuntime = RegisterDspRuntime<F896hd>;

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -13,7 +13,7 @@ pub struct TravelerMk3 {
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl,
-    word_clk_ctl: WordClkCtl,
+    word_clk_ctl: WordClockCtl<TravelerMk3Protocol>,
     sequence_number: u8,
     reverb_ctl: ReverbCtl,
     monitor_ctl: MonitorCtl,
@@ -34,19 +34,6 @@ impl PhoneAssignCtlOperation<TravelerMk3Protocol> for PhoneAssignCtl {
     }
 
     fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
-}
-
-#[derive(Default)]
-struct WordClkCtl(WordClkSpeedMode, Vec<ElemId>);
-
-impl WordClkCtlOperation<TravelerMk3Protocol> for WordClkCtl {
-    fn state(&self) -> &WordClkSpeedMode {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut WordClkSpeedMode {
         &mut self.0
     }
 }
@@ -203,6 +190,9 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.word_clk_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
@@ -211,9 +201,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         self.phone_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|mut elem_id_list| self.phone_assign_ctl.1.append(&mut elem_id_list))?;
-        self.word_clk_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.word_clk_ctl.1.append(&mut elem_id_list))?;
+        self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
@@ -328,7 +316,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.reverb_ctl.write(

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 

--- a/runtime/motu/src/v1_ctls.rs
+++ b/runtime/motu/src/v1_ctls.rs
@@ -3,6 +3,14 @@
 
 pub(crate) use super::{protocols::version_1::*, v1_runtime::*};
 
+#[derive(Default, Debug)]
+pub(crate) struct V1ClkCtl<T: V1ClkOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    rate: usize,
+    source: usize,
+    _phantom: PhantomData<T>,
+}
+
 fn clk_src_to_str(src: &V1ClkSrc) -> &'static str {
     match src {
         V1ClkSrc::Internal => "Internal",
@@ -17,69 +25,82 @@ fn clk_src_to_str(src: &V1ClkSrc) -> &'static str {
 const RATE_NAME: &str = "sampling- rate";
 const SRC_NAME: &str = "clock-source";
 
-pub trait V1ClkCtlOperation<T: V1ClkOperation> {
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+impl<T: V1ClkOperation> V1ClkCtl<T> {
+    pub(crate) fn cache(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        T::get_clk_rate(req, node, timeout_ms).map(|idx| self.rate = idx)?;
+        T::get_clk_src(req, node, timeout_ms).map(|idx| self.source = idx)?;
+        Ok(())
+    }
+
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<&str> = T::CLK_RATE_LABELS
             .iter()
             .map(|l| clk_rate_to_str(l))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = T::CLK_SRC_LABELS
             .iter()
             .map(|l| clk_src_to_str(l))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SRC_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn read(
+    pub(crate) fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
-        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
-        timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                T::get_clk_src(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
-            })
-            .map(|_| true),
+            RATE_NAME => {
+                elem_value.set_enum(&[self.rate as u32]);
+                Ok(true)
+            }
+            SRC_NAME => {
+                elem_value.set_enum(&[self.source as u32]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        unit: &mut SndMotu,
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                unit.0.lock()?;
-                let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                unit.0.lock()?;
-                let res = T::set_clk_src(req, &mut unit.1, val as usize, timeout_ms);
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
+            RATE_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_rate(req, node, val, timeout_ms).map(|_| self.rate = val);
+                unit.unlock()?;
+                res.map(|_| true)
+            }
+            SRC_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_src(req, node, val, timeout_ms).map(|_| self.source = val);
+                unit.unlock()?;
+                res.map(|_| true)
+            }
             _ => Ok(false),
         }
     }

--- a/runtime/motu/src/v1_ctls.rs
+++ b/runtime/motu/src/v1_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::v1_runtime::*;
+pub(crate) use super::{protocols::version_1::*, v1_runtime::*};
 
 fn clk_src_to_str(src: &V1ClkSrc) -> &'static str {
     match src {

--- a/runtime/motu/src/v1_runtime.rs
+++ b/runtime/motu/src/v1_runtime.rs
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-pub use {
-    super::{f828::*, f896::*, v1_ctls::*, *},
+pub(crate) use {
+    super::{f828::*, f896::*, *},
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, dispatcher::*},
-    glib::source,
-    nix::sys::signal::Signal,
-    protocols::version_1::*,
-    std::sync::mpsc,
+    core::card_cntr::*,
 };
+
+use {core::dispatcher::*, glib::source, nix::sys::signal::Signal, std::sync::mpsc};
 
 pub type F828Runtime = Version1Runtime<F828>;
 pub type F896Runtime = Version1Runtime<F896>;

--- a/runtime/motu/src/v2_ctls.rs
+++ b/runtime/motu/src/v2_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::register_dsp_runtime::*;
+pub(crate) use super::{protocols::version_2::*, register_dsp_runtime::*};
 
 fn clk_src_to_str(src: &V2ClkSrc) -> &'static str {
     match src {

--- a/runtime/motu/src/v3_ctls.rs
+++ b/runtime/motu/src/v3_ctls.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-use super::command_dsp_runtime::*;
+pub(crate) use super::{command_dsp_runtime::*, protocols::version_3::*};
 
 fn clk_src_to_str(src: &V3ClkSrc) -> &'static str {
     match src {


### PR DESCRIPTION
This patchset reworks current implementation of runtime for version 1 models so that
cache function is split from load function following to the other runtime implementations.

```
Takashi Sakamoto (8):
  runtime/motu: code refactoring for use statements
  runtime/motu: use generic structure for clock controls in version 1
    models
  runtime/motu: use generic structure for controls specific to version 1
    models
  runtime/motu: code refactoring for controls specific to 828
  runtime/motu: use generic structure for word clock output controls
  runtime/motu: use generic structure for AES/EBU converter controls
  runtime/motu: use generic structure for level meter controls
  runtime/motu: split cache function from load function in version 1
    model

 protocols/motu/src/lib.rs                |   5 +-
 protocols/motu/src/register_dsp.rs       |  12 +-
 runtime/motu/src/audioexpress.rs         |   7 +-
 runtime/motu/src/command_dsp_ctls.rs     |   2 +-
 runtime/motu/src/command_dsp_runtime.rs  |  16 +-
 runtime/motu/src/common_ctls.rs          | 284 ++++++++++++-----------
 runtime/motu/src/f828.rs                 | 167 +++++++------
 runtime/motu/src/f828mk2.rs              |  31 +--
 runtime/motu/src/f828mk3.rs              |  31 +--
 runtime/motu/src/f828mk3_hybrid.rs       |  31 +--
 runtime/motu/src/f896.rs                 | 138 ++++-------
 runtime/motu/src/f896hd.rs               |  97 +++-----
 runtime/motu/src/f8pre.rs                |   2 +-
 runtime/motu/src/h4pre.rs                |   2 +-
 runtime/motu/src/lib.rs                  |   8 +-
 runtime/motu/src/register_dsp_ctls.rs    |   2 +-
 runtime/motu/src/register_dsp_runtime.rs |  14 +-
 runtime/motu/src/track16.rs              |   2 +-
 runtime/motu/src/traveler.rs             |  31 +--
 runtime/motu/src/traveler_mk3.rs         |  26 +--
 runtime/motu/src/ultralite.rs            |   2 +-
 runtime/motu/src/ultralite_mk3.rs        |   2 +-
 runtime/motu/src/ultralite_mk3_hybrid.rs |   2 +-
 runtime/motu/src/v1_ctls.rs              | 140 ++++++-----
 runtime/motu/src/v1_runtime.rs           |  23 +-
 runtime/motu/src/v2_ctls.rs              |   2 +-
 runtime/motu/src/v3_ctls.rs              |   2 +-
 27 files changed, 495 insertions(+), 586 deletions(-)
```