### PR TITLE
[PATCH 00/17] runtime/motu: rework for runtime of Register DSP models

### DIFF
--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -980,7 +980,7 @@ pub trait RegisterDspOutputOperation {
 }
 
 /// State of inputs in 828mkII.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspLineInputState {
     pub level: Vec<NominalSignalLevel>,
     /// + 6dB.

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -56,7 +56,7 @@ const MIXER_OUTPUT_DESTINATION_MASK: u32 = 0x00000f00;
 const MIXER_OUTPUT_VOLUME_MASK: u32 = 0x000000ff;
 
 /// State of mixer output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspMixerOutputState {
     pub volume: [u8; MIXER_COUNT],
     pub mute: [bool; MIXER_COUNT],

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -529,7 +529,7 @@ const MIXER_STEREO_SOURCE_COUNT: usize = 6;
 const MIXER_STEREO_SOURCE_PAIR_COUNT: usize = MIXER_STEREO_SOURCE_COUNT / 2;
 
 /// State of sources in mixer entiry.
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RegisterDspMixerStereoSourceEntry {
     pub gain: [u8; MIXER_STEREO_SOURCE_COUNT],
     pub pan: [u8; MIXER_STEREO_SOURCE_COUNT],
@@ -540,7 +540,7 @@ pub struct RegisterDspMixerStereoSourceEntry {
 }
 
 /// State of mixer sources.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspMixerStereoSourceState(pub [RegisterDspMixerStereoSourceEntry; MIXER_COUNT]);
 
 const MIXER_SOURCE_PAIRED_WIDTH_FLAG: u32 = 0x00400000;

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -1125,7 +1125,7 @@ pub trait Traveler828mk2LineInputOperation {
 const MONAURAL_INPUT_COUNT: usize = 10;
 
 /// State of input in Ultralite.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspMonauralInputState {
     pub gain: [u8; MONAURAL_INPUT_COUNT],
     pub invert: [bool; MONAURAL_INPUT_COUNT],

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -1579,7 +1579,7 @@ pub trait RegisterDspStereoInputOperation {
 }
 
 /// Information of meter.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspMeterState {
     pub inputs: Vec<u8>,
     pub outputs: Vec<u8>,

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -1134,7 +1134,7 @@ pub struct RegisterDspMonauralInputState {
 const STEREO_INPUT_COUNT: usize = 6;
 
 /// State of input in Audio Express, and 4 pre.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspStereoInputState {
     pub gain: [u8; STEREO_INPUT_COUNT],
     pub invert: [bool; STEREO_INPUT_COUNT],

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -262,7 +262,7 @@ pub trait RegisterDspMixerReturnOperation {
 }
 
 /// State of sources in mixer entiry.
-#[derive(Default, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct RegisterDspMixerMonauralSourceEntry {
     pub gain: Vec<u8>,
     pub pan: Vec<u8>,
@@ -271,7 +271,7 @@ pub struct RegisterDspMixerMonauralSourceEntry {
 }
 
 /// State of mixer sources.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspMixerMonauralSourceState(
     pub [RegisterDspMixerMonauralSourceEntry; MIXER_COUNT],
 );

--- a/protocols/motu/src/register_dsp.rs
+++ b/protocols/motu/src/register_dsp.rs
@@ -891,7 +891,7 @@ const MASTER_VOLUME_OFFSET: usize = 0x0c0c;
 const PHONE_VOLUME_OFFSET: usize = 0x0c10;
 
 /// State of output.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RegisterDspOutputState {
     pub master_volume: u8,
     pub phone_volume: u8,

--- a/protocols/motu/src/version_2.rs
+++ b/protocols/motu/src/version_2.rs
@@ -598,7 +598,7 @@ impl RegisterDspMeterOperation for TravelerProtocol {
 }
 
 /// State of inputs in Traveler.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct TravelerMicInputState {
     pub gain: [u8; TravelerProtocol::MIC_INPUT_COUNT],
     pub pad: [bool; TravelerProtocol::MIC_INPUT_COUNT],

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -16,8 +16,7 @@ pub struct AudioExpress {
     mixer_source_ctl: RegisterDspMixerStereoSourceCtl<AudioExpressProtocol>,
     output_ctl: RegisterDspOutputCtl<AudioExpressProtocol>,
     input_ctl: RegisterDspStereoInputCtl<AudioExpressProtocol>,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
+    meter_ctl: RegisterDspMeterCtl<AudioExpressProtocol>,
 }
 
 #[derive(Default)]
@@ -25,53 +24,33 @@ struct ClkCtl;
 
 impl V3ClkCtlOperation<AudioExpressProtocol> for ClkCtl {}
 
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(
-            AudioExpressProtocol::create_meter_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl RegisterDspMeterCtlOperation<AudioExpressProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
-}
-
 impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
         self.input_ctl.parse_dsp_parameter(&self.params);
 
+        self.meter_ctl.read_dsp_meter(unit)?;
+
         self.phone_assign_ctl
             .0
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.input_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
@@ -80,9 +59,8 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
         self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.meter_ctl.1 = elem_id_list)?;
+        self.meter_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -172,7 +150,7 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
             Ok(true)
         } else if self
             .meter_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -210,11 +188,11 @@ impl NotifyModel<(SndMotu, FwNode), bool> for AudioExpress {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, _): &mut (SndMotu, FwNode),
         is_locked: &bool,
     ) -> Result<(), Error> {
         if *is_locked {
-            unit.0.read_parameter(&mut self.params).map(|_| {
+            unit.read_parameter(&mut self.params).map(|_| {
                 self.phone_assign_ctl.parse_dsp_parameter(&self.params);
                 self.mixer_output_ctl.parse_dsp_parameter(&self.params);
                 self.mixer_source_ctl.parse_dsp_parameter(&self.params);
@@ -291,11 +269,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for AudioExpress {
 
 impl MeasureModel<(SndMotu, FwNode)> for AudioExpress {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -11,11 +11,11 @@ pub struct AudioExpress {
     clk_ctls: ClkCtl,
     phone_assign_ctl: RegisterDspPhoneAssignCtl<AudioExpressProtocol>,
     mixer_return_ctl: RegisterDspMixerReturnCtl<AudioExpressProtocol>,
-    mixer_output_ctl: MixerOutputCtl,
+    params: SndMotuRegisterDspParameter,
+    mixer_output_ctl: RegisterDspMixerOutputCtl<AudioExpressProtocol>,
     mixer_source_ctl: MixerSourceCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
-    params: SndMotuRegisterDspParameter,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
 }
@@ -24,19 +24,6 @@ pub struct AudioExpress {
 struct ClkCtl;
 
 impl V3ClkCtlOperation<AudioExpressProtocol> for ClkCtl {}
-
-#[derive(Default)]
-struct MixerOutputCtl(RegisterDspMixerOutputState, Vec<ElemId>);
-
-impl RegisterDspMixerOutputCtlOperation<AudioExpressProtocol> for MixerOutputCtl {
-    fn state(&self) -> &RegisterDspMixerOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerOutputState {
-        &mut self.0
-    }
-}
 
 struct MixerSourceCtl(RegisterDspMixerStereoSourceState, Vec<ElemId>);
 
@@ -122,19 +109,20 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
     ) -> Result<(), Error> {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_output_ctl.parse_dsp_parameter(&self.params);
 
         self.phone_assign_ctl
             .0
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_return_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_output_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
-        self.mixer_output_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
+        self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl
             .load(card_cntr, unit, &mut self.req, &self.params, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
@@ -208,10 +196,13 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_output_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_output_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_source_ctl
@@ -260,7 +251,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for AudioExpress {
 impl NotifyModel<(SndMotu, FwNode), bool> for AudioExpress {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_output_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -19,12 +19,8 @@ pub struct AudioExpress {
     meter_ctl: RegisterDspMeterCtl<AudioExpressProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for AudioExpress {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -47,6 +43,12 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;

--- a/runtime/motu/src/audioexpress.rs
+++ b/runtime/motu/src/audioexpress.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v3_ctls::*};
+use super::{register_dsp_ctls::*, register_dsp_runtime::*, v3_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct AudioExpress {
     req: FwReq,
     clk_ctls: ClkCtl,
-    phone_assign_ctl: PhoneAssignCtl,
+    phone_assign_ctl: RegisterDspPhoneAssignCtl<AudioExpressProtocol>,
     mixer_output_ctl: MixerOutputCtl,
     mixer_return_ctl: MixerReturnCtl,
     mixer_source_ctl: MixerSourceCtl,
@@ -19,21 +19,6 @@ pub struct AudioExpress {
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct PhoneAssignCtl(usize, Vec<ElemId>);
-
-impl PhoneAssignCtlOperation<AudioExpressProtocol> for PhoneAssignCtl {
-    fn state(&self) -> &usize {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
-}
-
-impl RegisterDspPhoneAssignCtlOperation<AudioExpressProtocol> for PhoneAssignCtl {}
 
 #[derive(Default)]
 struct ClkCtl;
@@ -149,10 +134,14 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
         unit.0.read_parameter(&mut self.params)?;
+        self.phone_assign_ctl.parse_dsp_parameter(&self.params);
+
+        self.phone_assign_ctl
+            .0
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
-        self.phone_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
+        self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
@@ -184,7 +173,7 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
             .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        } else if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -215,10 +204,13 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpress {
             .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phone_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.phone_assign_ctl.0.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_output_ctl
@@ -276,7 +268,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for AudioExpress {
 
 impl NotifyModel<(SndMotu, FwNode), bool> for AudioExpress {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.phone_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
@@ -307,7 +299,7 @@ impl NotifyModel<(SndMotu, FwNode), bool> for AudioExpress {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -348,7 +340,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for AudioExpress {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -13,26 +13,13 @@ pub struct F828mk2 {
     phone_assign_ctl: RegisterDspPhoneAssignCtl<F828mk2Protocol>,
     word_clk_ctl: WordClockCtl<F828mk2Protocol>,
     mixer_return_ctl: RegisterDspMixerReturnCtl<F828mk2Protocol>,
-    mixer_output_ctl: MixerOutputCtl,
+    params: SndMotuRegisterDspParameter,
+    mixer_output_ctl: RegisterDspMixerOutputCtl<F828mk2Protocol>,
     mixer_source_ctl: MixerSourceCtl,
     output_ctl: OutputCtl,
     line_input_ctl: LineInputCtl,
-    params: SndMotuRegisterDspParameter,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MixerOutputCtl(RegisterDspMixerOutputState, Vec<ElemId>);
-
-impl RegisterDspMixerOutputCtlOperation<F828mk2Protocol> for MixerOutputCtl {
-    fn state(&self) -> &RegisterDspMixerOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerOutputState {
-        &mut self.0
-    }
 }
 
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
@@ -116,6 +103,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
     ) -> Result<(), Error> {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_output_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -128,15 +116,15 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_return_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_output_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
-        self.mixer_output_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
+        self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
@@ -229,10 +217,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_output_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_output_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_source_ctl
@@ -291,7 +282,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk2 {
 impl NotifyModel<(SndMotu, FwNode), bool> for F828mk2 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_output_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.line_input_ctl.1);

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -12,8 +12,8 @@ pub struct F828mk2 {
     opt_iface_ctl: V2OptIfaceCtl<F828mk2Protocol>,
     phone_assign_ctl: RegisterDspPhoneAssignCtl<F828mk2Protocol>,
     word_clk_ctl: WordClockCtl<F828mk2Protocol>,
+    mixer_return_ctl: RegisterDspMixerReturnCtl<F828mk2Protocol>,
     mixer_output_ctl: MixerOutputCtl,
-    mixer_return_ctl: MixerReturnCtl,
     mixer_source_ctl: MixerSourceCtl,
     output_ctl: OutputCtl,
     line_input_ctl: LineInputCtl,
@@ -31,19 +31,6 @@ impl RegisterDspMixerOutputCtlOperation<F828mk2Protocol> for MixerOutputCtl {
     }
 
     fn state_mut(&mut self) -> &mut RegisterDspMixerOutputState {
-        &mut self.0
-    }
-}
-
-#[derive(Default)]
-struct MixerReturnCtl(bool, Vec<ElemId>);
-
-impl RegisterDspMixerReturnCtlOperation<F828mk2Protocol> for MixerReturnCtl {
-    fn state(&self) -> &bool {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut bool {
         &mut self.0
     }
 }
@@ -139,16 +126,17 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
         self.phone_assign_ctl
             .0
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_return_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
+        self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
-        self.mixer_return_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
         self.mixer_source_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
@@ -178,9 +166,9 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
             Ok(true)
         } else if self.word_clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.mixer_return_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -233,13 +221,16 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
             .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_output_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_return_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .mixer_return_ctl
+            .mixer_output_ctl
             .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/motu/src/f828mk2.rs
+++ b/runtime/motu/src/f828mk2.rs
@@ -21,12 +21,8 @@ pub struct F828mk2 {
     meter_ctl: RegisterDspMeterCtl<F828mk2Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for F828mk2 {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -52,6 +48,12 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
         self.line_input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F828mk2 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct F828mk3 {
     req: FwReq,
     resp: FwResp,
-    clk_ctls: ClkCtl,
+    clk_ctls: V3ClkCtl<F828mk3Protocol>,
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl<F828mk3Protocol>,
@@ -24,11 +24,6 @@ pub struct F828mk3 {
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V3ClkCtlOperation<F828mk3Protocol> for ClkCtl {}
 
 #[derive(Default)]
 struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
@@ -165,6 +160,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.word_clk_ctl
@@ -219,10 +216,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -269,10 +263,14 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .port_assign_ctl

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -18,57 +18,37 @@ pub struct F896hd {
     mixer_output_ctl: RegisterDspMixerOutputCtl<F896hdProtocol>,
     mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<F896hdProtocol>,
     output_ctl: RegisterDspOutputCtl<F896hdProtocol>,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(F896hdProtocol::create_meter_state(), Default::default())
-    }
-}
-
-impl RegisterDspMeterCtlOperation<F896hdProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: RegisterDspMeterCtl<F896hdProtocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for F896hd {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
 
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.word_clk_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.meter_ctl.read_dsp_meter(unit)?;
+
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.aesebu_rate_convert_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.level_meters_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -79,9 +59,8 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
         self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.meter_ctl.1 = elem_id_list)?;
+        self.meter_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -118,82 +97,78 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.aesebu_rate_convert_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.level_meters_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_return_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_output_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_source_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .meter_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -313,11 +288,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for F896hd {
 
 impl MeasureModel<(SndMotu, FwNode)> for F896hd {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -16,31 +16,10 @@ pub struct F896hd {
     mixer_return_ctl: RegisterDspMixerReturnCtl<F896hdProtocol>,
     params: SndMotuRegisterDspParameter,
     mixer_output_ctl: RegisterDspMixerOutputCtl<F896hdProtocol>,
-    mixer_source_ctl: MixerSourceCtl,
+    mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<F896hdProtocol>,
     output_ctl: OutputCtl,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
-
-impl Default for MixerSourceCtl {
-    fn default() -> Self {
-        Self(
-            F896hdProtocol::create_mixer_monaural_source_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl RegisterDspMixerMonauralSourceCtlOperation<F896hdProtocol> for MixerSourceCtl {
-    fn state(&self) -> &RegisterDspMixerMonauralSourceState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerMonauralSourceState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -82,6 +61,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
     ) -> Result<(), Error> {
         unit.0.read_parameter(&mut self.params)?;
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_source_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -97,6 +77,8 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_output_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_source_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -105,9 +87,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
         self.level_meters_ctl.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl.load(card_cntr)?;
-        self.mixer_source_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
+        self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.output_ctl.1 = elem_id_list)?;
@@ -210,10 +190,13 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_source_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_source_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .output_ctl
@@ -266,7 +249,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F896hd {
 impl NotifyModel<(SndMotu, FwNode), bool> for F896hd {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_source_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
     }
 

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -21,12 +21,8 @@ pub struct F896hd {
     meter_ctl: RegisterDspMeterCtl<F896hdProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F896hd {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for F896hd {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
@@ -50,6 +46,12 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F896hd {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;

--- a/runtime/motu/src/f896hd.rs
+++ b/runtime/motu/src/f896hd.rs
@@ -17,22 +17,9 @@ pub struct F896hd {
     params: SndMotuRegisterDspParameter,
     mixer_output_ctl: RegisterDspMixerOutputCtl<F896hdProtocol>,
     mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<F896hdProtocol>,
-    output_ctl: OutputCtl,
+    output_ctl: RegisterDspOutputCtl<F896hdProtocol>,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct OutputCtl(RegisterDspOutputState, Vec<ElemId>);
-
-impl RegisterDspOutputCtlOperation<F896hdProtocol> for OutputCtl {
-    fn state(&self) -> &RegisterDspOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspOutputState {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
@@ -62,6 +49,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
         unit.0.read_parameter(&mut self.params)?;
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
+        self.output_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -79,6 +67,8 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_source_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.output_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -88,9 +78,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
         self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.output_ctl.1 = elem_id_list)?;
+        self.output_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.meter_ctl.1 = elem_id_list)?;
@@ -200,7 +188,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hd {
             Ok(true)
         } else if self
             .output_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -250,7 +238,7 @@ impl NotifyModel<(SndMotu, FwNode), bool> for F896hd {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.output_ctl.1);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -16,53 +16,34 @@ pub struct F8pre {
     mixer_output_ctl: RegisterDspMixerOutputCtl<F8preProtocol>,
     mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<F8preProtocol>,
     output_ctl: RegisterDspOutputCtl<F8preProtocol>,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(F8preProtocol::create_meter_state(), Default::default())
-    }
-}
-
-impl RegisterDspMeterCtlOperation<F8preProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: RegisterDspMeterCtl<F8preProtocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for F8pre {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
 
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.meter_ctl.read_dsp_meter(unit)?;
+
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .0
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -71,6 +52,8 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
         self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -101,64 +84,60 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.0.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_return_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_output_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_source_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -267,11 +246,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for F8pre {
 
 impl MeasureModel<(SndMotu, FwNode)> for F8pre {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&mut unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -14,31 +14,10 @@ pub struct F8pre {
     mixer_return_ctl: RegisterDspMixerReturnCtl<F8preProtocol>,
     params: SndMotuRegisterDspParameter,
     mixer_output_ctl: RegisterDspMixerOutputCtl<F8preProtocol>,
-    mixer_source_ctl: MixerSourceCtl,
+    mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<F8preProtocol>,
     output_ctl: OutputCtl,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
-
-impl Default for MixerSourceCtl {
-    fn default() -> Self {
-        Self(
-            F8preProtocol::create_mixer_monaural_source_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl RegisterDspMixerMonauralSourceCtlOperation<F8preProtocol> for MixerSourceCtl {
-    fn state(&self) -> &RegisterDspMixerMonauralSourceState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerMonauralSourceState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -81,6 +60,7 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_source_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -91,15 +71,15 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_return_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_source_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl.load(card_cntr)?;
-        self.mixer_source_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
+        self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.output_ctl.1 = elem_id_list)?;
@@ -180,10 +160,13 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_source_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_source_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .output_ctl
@@ -216,7 +199,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F8pre {
 impl NotifyModel<(SndMotu, FwNode), bool> for F8pre {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_source_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
     }
 

--- a/runtime/motu/src/f8pre.rs
+++ b/runtime/motu/src/f8pre.rs
@@ -19,12 +19,8 @@ pub struct F8pre {
     meter_ctl: RegisterDspMeterCtl<F8preProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F8pre {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for F8pre {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -45,6 +41,12 @@ impl CtlModel<(SndMotu, FwNode)> for F8pre {
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F8pre {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -16,8 +16,7 @@ pub struct H4pre {
     mixer_source_ctl: RegisterDspMixerStereoSourceCtl<H4preProtocol>,
     output_ctl: RegisterDspOutputCtl<H4preProtocol>,
     input_ctl: RegisterDspStereoInputCtl<H4preProtocol>,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
+    meter_ctl: RegisterDspMeterCtl<H4preProtocol>,
 }
 
 #[derive(Default)]
@@ -25,50 +24,33 @@ struct ClkCtl;
 
 impl V3ClkCtlOperation<H4preProtocol> for ClkCtl {}
 
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(H4preProtocol::create_meter_state(), Default::default())
-    }
-}
-
-impl RegisterDspMeterCtlOperation<H4preProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
-}
-
 impl CtlModel<(SndMotu, FwNode)> for H4pre {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
         self.input_ctl.parse_dsp_parameter(&self.params);
 
+        self.meter_ctl.read_dsp_meter(unit)?;
+
         self.phone_assign_ctl
             .0
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.input_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
@@ -77,9 +59,8 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
         self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.meter_ctl.1 = elem_id_list)?;
+        self.meter_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -169,7 +150,7 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
             Ok(true)
         } else if self
             .meter_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -287,11 +268,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for H4pre {
 
 impl MeasureModel<(SndMotu, FwNode)> for H4pre {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -8,7 +8,7 @@ const TIMEOUT_MS: u32 = 100;
 #[derive(Default)]
 pub struct H4pre {
     req: FwReq,
-    clk_ctls: ClkCtl,
+    clk_ctls: V3ClkCtl<H4preProtocol>,
     phone_assign_ctl: RegisterDspPhoneAssignCtl<H4preProtocol>,
     mixer_return_ctl: RegisterDspMixerReturnCtl<H4preProtocol>,
     params: SndMotuRegisterDspParameter,
@@ -18,11 +18,6 @@ pub struct H4pre {
     input_ctl: RegisterDspStereoInputCtl<H4preProtocol>,
     meter_ctl: RegisterDspMeterCtl<H4preProtocol>,
 }
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V3ClkCtlOperation<H4preProtocol> for ClkCtl {}
 
 impl CtlModel<(SndMotu, FwNode)> for H4pre {
     fn load(
@@ -66,14 +61,11 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
 
     fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        _: &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
@@ -96,61 +88,61 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.phone_assign_ctl.0.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_return_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_output_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_source_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .input_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .meter_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -19,12 +19,8 @@ pub struct H4pre {
     meter_ctl: RegisterDspMeterCtl<H4preProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for H4pre {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for H4pre {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -47,6 +43,12 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for H4pre {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;

--- a/runtime/motu/src/h4pre.rs
+++ b/runtime/motu/src/h4pre.rs
@@ -13,7 +13,7 @@ pub struct H4pre {
     mixer_return_ctl: RegisterDspMixerReturnCtl<H4preProtocol>,
     params: SndMotuRegisterDspParameter,
     mixer_output_ctl: RegisterDspMixerOutputCtl<H4preProtocol>,
-    mixer_source_ctl: MixerSourceCtl,
+    mixer_source_ctl: RegisterDspMixerStereoSourceCtl<H4preProtocol>,
     output_ctl: OutputCtl,
     input_ctl: InputCtl,
     meter: RegisterDspMeterImage,
@@ -24,27 +24,6 @@ pub struct H4pre {
 struct ClkCtl;
 
 impl V3ClkCtlOperation<H4preProtocol> for ClkCtl {}
-
-struct MixerSourceCtl(RegisterDspMixerStereoSourceState, Vec<ElemId>);
-
-impl Default for MixerSourceCtl {
-    fn default() -> Self {
-        Self(
-            H4preProtocol::create_mixer_stereo_source_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl RegisterDspMixerStereoSourceCtlOperation<H4preProtocol> for MixerSourceCtl {
-    fn state(&self) -> &RegisterDspMixerStereoSourceState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerStereoSourceState {
-        &mut self.0
-    }
-}
 
 #[derive(Default)]
 struct OutputCtl(RegisterDspOutputState, Vec<ElemId>);
@@ -107,6 +86,7 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_source_ctl.parse_dsp_parameter(&self.params);
 
         self.phone_assign_ctl
             .0
@@ -115,14 +95,14 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_output_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_source_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl.load(card_cntr)?;
-        self.mixer_source_ctl
-            .load(card_cntr, unit, &mut self.req, &self.params, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
+        self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.output_ctl.1 = elem_id_list)?;
@@ -201,10 +181,13 @@ impl CtlModel<(SndMotu, FwNode)> for H4pre {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_source_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_source_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .output_ctl
@@ -248,7 +231,7 @@ impl NotifyModel<(SndMotu, FwNode), bool> for H4pre {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_source_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
     }

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -419,13 +419,27 @@ impl<T: RegisterDspMixerMonauralSourceOperation> RegisterDspMixerMonauralSourceC
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct RegisterDspMixerStereoSourceCtl<T: RegisterDspMixerStereoSourceOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    state: RegisterDspMixerStereoSourceState,
+    _phantom: PhantomData<T>,
+}
+
 const MIXER_SOURCE_STEREO_BALANCE_NAME: &str = "mixer-source-stereo-balance";
 const MIXER_SOURCE_STEREO_WIDTH_NAME: &str = "mixer-source-stereo-width";
 
-pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSourceOperation> {
-    fn state(&self) -> &RegisterDspMixerStereoSourceState;
-    fn state_mut(&mut self) -> &mut RegisterDspMixerStereoSourceState;
+impl<T: RegisterDspMixerStereoSourceOperation> Default for RegisterDspMixerStereoSourceCtl<T> {
+    fn default() -> Self {
+        Self {
+            elem_id_list: Default::default(),
+            state: T::create_mixer_stereo_source_state(),
+            _phantom: Default::default(),
+        }
+    }
+}
 
+impl<T: RegisterDspMixerStereoSourceOperation> RegisterDspMixerStereoSourceCtl<T> {
     const GAIN_TLV: DbInterval = DbInterval {
         min: -6400,
         max: 0,
@@ -433,19 +447,16 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
         mute_avail: false,
     };
 
-    fn load(
+    pub(crate) fn cache(
         &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
-        params: &SndMotuRegisterDspParameter,
+        node: &mut FwNode,
         timeout_ms: u32,
-    ) -> Result<Vec<ElemId>, Error> {
-        self.parse_dsp_parameter(params);
-        T::read_mixer_stereo_source_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
+    ) -> Result<(), Error> {
+        T::read_mixer_stereo_source_state(req, node, &mut self.state, timeout_ms)
+    }
 
-        let mut notified_elem_id_list = Vec::new();
-
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SOURCE_GAIN_NAME, 0);
         card_cntr
             .add_int_elems(
@@ -458,7 +469,7 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SOURCE_PAN_NAME, 0);
         card_cntr
@@ -472,17 +483,17 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SOURCE_MUTE_NAME, 0);
         card_cntr
             .add_bool_elems(&elem_id, T::MIXER_COUNT, T::MIXER_SOURCES.len(), true)
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SOURCE_SOLO_NAME, 0);
         card_cntr
             .add_bool_elems(&elem_id, T::MIXER_COUNT, T::MIXER_SOURCES.len(), true)
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Mixer,
@@ -502,7 +513,7 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Mixer,
@@ -522,51 +533,55 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        Ok(notified_elem_id_list)
+        Ok(())
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    pub(crate) fn read(
+        &mut self,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_SOURCE_GAIN_NAME => {
                 let mixer = elem_id.index() as usize;
-                copy_int_to_elem_value(elem_value, &self.state().0[mixer].gain);
+                copy_int_to_elem_value(elem_value, &self.state.0[mixer].gain);
                 Ok(true)
             }
             MIXER_SOURCE_PAN_NAME => {
                 let mixer = elem_id.index() as usize;
-                copy_int_to_elem_value(elem_value, &self.state().0[mixer].pan);
+                copy_int_to_elem_value(elem_value, &self.state.0[mixer].pan);
                 Ok(true)
             }
             MIXER_SOURCE_MUTE_NAME => {
                 let mixer = elem_id.index() as usize;
-                elem_value.set_bool(&self.state().0[mixer].mute);
+                elem_value.set_bool(&self.state.0[mixer].mute);
                 Ok(true)
             }
             MIXER_SOURCE_SOLO_NAME => {
                 let mixer = elem_id.index() as usize;
-                elem_value.set_bool(&self.state().0[mixer].solo);
+                elem_value.set_bool(&self.state.0[mixer].solo);
                 Ok(true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
                 let mixer = elem_id.index() as usize;
-                copy_int_to_elem_value(elem_value, &self.state().0[mixer].balance);
+                copy_int_to_elem_value(elem_value, &self.state.0[mixer].balance);
                 Ok(true)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
                 let mixer = elem_id.index() as usize;
-                copy_int_to_elem_value(elem_value, &self.state().0[mixer].width);
+                copy_int_to_elem_value(elem_value, &self.state.0[mixer].width);
                 Ok(true)
             }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -578,10 +593,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_gain(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &gain,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -592,10 +607,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_pan(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &pan,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -605,10 +620,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_mute(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &mute,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -618,10 +633,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_mute(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &solo,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -632,10 +647,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_balance(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &balance,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -646,10 +661,10 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
                 let mixer = elem_id.index() as usize;
                 T::write_mixer_stereo_source_width(
                     req,
-                    &mut unit.1,
+                    node,
                     mixer,
                     &width,
-                    self.state_mut(),
+                    &mut self.state,
                     timeout_ms,
                 )
                 .map(|_| true)
@@ -658,12 +673,12 @@ pub trait RegisterDspMixerStereoSourceCtlOperation<T: RegisterDspMixerStereoSour
         }
     }
 
-    fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
-        T::parse_dsp_parameter(self.state_mut(), params)
+    pub(crate) fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
+        T::parse_dsp_parameter(&mut self.state, params)
     }
 
-    fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_dsp_event(self.state_mut(), event)
+    pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
+        T::parse_dsp_event(&mut self.state, event)
     }
 }
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -1,15 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2021 Takashi Sakamoto
 
-pub(crate) use super::{common_ctls::PhoneAssignCtlOperation, register_dsp_runtime::*};
+pub(crate) use super::{common_ctls::PhoneAssignCtl, register_dsp_runtime::*};
 
-pub trait RegisterDspPhoneAssignCtlOperation<T: AssignOperation>:
-    PhoneAssignCtlOperation<T>
-{
-    fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
+#[derive(Default, Debug)]
+pub(crate) struct RegisterDspPhoneAssignCtl<T: AssignOperation>(pub PhoneAssignCtl<T>);
+
+impl<T: AssignOperation> RegisterDspPhoneAssignCtl<T> {
+    pub(crate) fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
         let idx = params.headphone_output_paired_assignment() as usize;
         if idx < T::ASSIGN_PORTS.len() {
-            *self.state_mut() = idx;
+            self.0.assign = idx;
         }
     }
 }

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -15,6 +15,13 @@ impl<T: AssignOperation> RegisterDspPhoneAssignCtl<T> {
     }
 }
 
+#[derive(Default, Debug)]
+pub(crate) struct RegisterDspMixerOutputCtl<T: RegisterDspMixerOutputOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    state: RegisterDspMixerOutputState,
+    _phantom: PhantomData<T>,
+}
+
 const MIXER_OUTPUT_VOLUME_NAME: &str = "mixer-output-volume";
 const MIXER_OUTPUT_MUTE_NAME: &str = "mixer-output-mute";
 const MIXER_OUTPUT_DST_NAME: &str = "mixer-output-destination";
@@ -24,10 +31,7 @@ fn copy_int_to_elem_value<T: Copy + Into<i32>>(elem_value: &mut ElemValue, data:
     elem_value.set_int(&vals);
 }
 
-pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation> {
-    fn state(&self) -> &RegisterDspMixerOutputState;
-    fn state_mut(&mut self) -> &mut RegisterDspMixerOutputState;
-
+impl<T: RegisterDspMixerOutputOperation> RegisterDspMixerOutputCtl<T> {
     const VOL_TLV: DbInterval = DbInterval {
         min: 0,
         max: 63,
@@ -35,17 +39,16 @@ pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation>
         mute_avail: false,
     };
 
-    fn load(
+    pub(crate) fn cache(
         &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
-    ) -> Result<Vec<ElemId>, Error> {
-        T::read_mixer_output_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
+    ) -> Result<(), Error> {
+        T::read_mixer_output_state(req, node, &mut self.state, timeout_ms)
+    }
 
-        let mut notified_elem_id_list = Vec::new();
-
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_OUTPUT_VOLUME_NAME, 0);
         card_cntr
             .add_int_elems(
@@ -58,12 +61,12 @@ pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation>
                 Some(&Vec::<u32>::from(&Self::VOL_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_OUTPUT_MUTE_NAME, 0);
         card_cntr
             .add_bool_elems(&elem_id, 1, T::MIXER_COUNT, true)
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         if T::OUTPUT_DESTINATIONS.len() > 0 {
             let labels: Vec<String> = T::OUTPUT_DESTINATIONS
@@ -73,88 +76,99 @@ pub trait RegisterDspMixerOutputCtlOperation<T: RegisterDspMixerOutputOperation>
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_OUTPUT_DST_NAME, 0);
             card_cntr
                 .add_enum_elems(&elem_id, 1, T::MIXER_COUNT, &labels, None, true)
-                .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+                .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
         }
 
-        Ok(notified_elem_id_list)
+        Ok(())
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    pub(crate) fn read(
+        &mut self,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_OUTPUT_VOLUME_NAME => {
-                copy_int_to_elem_value(elem_value, &self.state().volume);
+                copy_int_to_elem_value(elem_value, &self.state.volume);
                 Ok(true)
             }
             MIXER_OUTPUT_MUTE_NAME => {
-                elem_value.set_bool(&self.state().mute);
+                elem_value.set_bool(&self.state.mute);
                 Ok(true)
             }
             MIXER_OUTPUT_DST_NAME => {
-                ElemValueAccessor::<u32>::set_vals(elem_value, T::MIXER_COUNT, |idx| {
-                    let val = T::OUTPUT_DESTINATIONS
-                        .iter()
-                        .position(|p| self.state().destination[idx].eq(p))
-                        .unwrap();
-                    Ok(val as u32)
-                })
-                .map(|_| true)
+                let vals: Vec<u32> = self
+                    .state
+                    .destination
+                    .iter()
+                    .map(|dst| {
+                        T::OUTPUT_DESTINATIONS
+                            .iter()
+                            .position(|p| dst.eq(p))
+                            .map(|p| p as u32)
+                            .unwrap()
+                    })
+                    .collect();
+                elem_value.set_enum(&vals);
+                Ok(true)
             }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_OUTPUT_VOLUME_NAME => {
-                let vals = &elem_value.int()[..T::MIXER_COUNT];
-                let vols: Vec<u8> = vals.iter().map(|&vol| vol as u8).collect();
-                T::write_mixer_output_volume(req, &mut unit.1, &vols, self.state_mut(), timeout_ms)
+                let vols: Vec<u8> = elem_value
+                    .int()
+                    .iter()
+                    .take(T::MIXER_COUNT)
+                    .map(|&vol| vol as u8)
+                    .collect();
+                T::write_mixer_output_volume(req, node, &vols, &mut self.state, timeout_ms)
                     .map(|_| true)
             }
             MIXER_OUTPUT_MUTE_NAME => {
                 let mute = &elem_value.boolean()[..T::MIXER_COUNT];
-                T::write_mixer_output_mute(req, &mut unit.1, &mute, self.state_mut(), timeout_ms)
+                T::write_mixer_output_mute(req, node, &mute, &mut self.state, timeout_ms)
                     .map(|_| true)
             }
             MIXER_OUTPUT_DST_NAME => {
-                let vals = &elem_value.enumerated()[..T::MIXER_COUNT];
                 let mut dst = Vec::new();
-                vals.iter().try_for_each(|&val| {
-                    T::OUTPUT_DESTINATIONS
-                        .iter()
-                        .nth(val as usize)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index for ourput destination: {}", val);
-                            Error::new(FileError::Inval, &msg)
-                        })
-                        .map(|&port| dst.push(port))
-                })?;
-                T::write_mixer_output_destination(
-                    req,
-                    &mut unit.1,
-                    &dst,
-                    self.state_mut(),
-                    timeout_ms,
-                )
-                .map(|_| true)
+                elem_value
+                    .enumerated()
+                    .iter()
+                    .take(T::MIXER_COUNT)
+                    .try_for_each(|&val| {
+                        T::OUTPUT_DESTINATIONS
+                            .iter()
+                            .nth(val as usize)
+                            .ok_or_else(|| {
+                                let msg = format!("Invalid index for ourput destination: {}", val);
+                                Error::new(FileError::Inval, &msg)
+                            })
+                            .map(|&port| dst.push(port))
+                    })?;
+                T::write_mixer_output_destination(req, node, &dst, &mut self.state, timeout_ms)
+                    .map(|_| true)
             }
             _ => Ok(false),
         }
     }
 
-    fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
-        T::parse_dsp_parameter(self.state_mut(), params)
+    pub(crate) fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
+        T::parse_dsp_parameter(&mut self.state, params)
     }
 
-    fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_dsp_event(self.state_mut(), event)
+    pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
+        T::parse_dsp_event(&mut self.state, event)
     }
 }
 

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -894,6 +894,13 @@ pub trait RegisterDspLineInputCtlOperation<T: Traveler828mk2LineInputOperation> 
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct RegisterDspMonauralInputCtl<T: RegisterDspMonauralInputOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    state: RegisterDspMonauralInputState,
+    _phantom: PhantomData<T>,
+}
+
 const INPUT_GAIN_NAME: &str = "input-gain";
 const INPUT_INVERT_NAME: &str = "input-invert";
 const MIC_PHANTOM_NAME: &str = "mic-phantom";
@@ -901,10 +908,17 @@ const MIC_PAD_NAME: &str = "mic-pad";
 const INPUT_JACK_NAME: &str = "input-jack";
 const INPUT_PAIRED_NAME: &str = "input-paired";
 
-pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperation> {
-    fn state(&self) -> &RegisterDspMonauralInputState;
-    fn state_mut(&mut self) -> &mut RegisterDspMonauralInputState;
+impl<T: RegisterDspMonauralInputOperation> Default for RegisterDspMonauralInputCtl<T> {
+    fn default() -> Self {
+        Self {
+            elem_id_list: Default::default(),
+            state: T::create_monaural_input_state(),
+            _phantom: Default::default(),
+        }
+    }
+}
 
+impl<T: RegisterDspMonauralInputOperation> RegisterDspMonauralInputCtl<T> {
     const GAIN_TLV: DbInterval = DbInterval {
         min: 0,
         max: 2400,
@@ -912,17 +926,16 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
         mute_avail: false,
     };
 
-    fn load(
+    pub(crate) fn cache(
         &mut self,
-        card_cntr: &mut CardCntr,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
-    ) -> Result<Vec<ElemId>, Error> {
-        T::read_monaural_input_state(req, &mut unit.1, self.state_mut(), timeout_ms)?;
+    ) -> Result<(), Error> {
+        T::read_monaural_input_state(req, node, &mut self.state, timeout_ms)
+    }
 
-        let mut notified_elem_id_list = Vec::new();
-
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_GAIN_NAME, 0);
         card_cntr
             .add_int_elems(
@@ -935,34 +948,38 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
                 Some(&Vec::<u32>::from(&Self::GAIN_TLV)),
                 true,
             )
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, INPUT_INVERT_NAME, 0);
         card_cntr
             .add_bool_elems(&elem_id, 1, T::INPUT_COUNT, true)
-            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        Ok(notified_elem_id_list)
+        Ok(())
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    pub(crate) fn read(
+        &mut self,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             INPUT_GAIN_NAME => {
-                copy_int_to_elem_value(elem_value, &self.state().gain);
+                copy_int_to_elem_value(elem_value, &self.state.gain);
                 Ok(true)
             }
             INPUT_INVERT_NAME => {
-                elem_value.set_bool(&self.state().invert);
+                elem_value.set_bool(&self.state.invert);
                 Ok(true)
             }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -971,30 +988,24 @@ pub trait RegisterDspMonauralInputCtlOperation<T: RegisterDspMonauralInputOperat
             INPUT_GAIN_NAME => {
                 let vals = &elem_value.int()[..T::INPUT_COUNT];
                 let gain: Vec<u8> = vals.iter().map(|&val| val as u8).collect();
-                T::write_monaural_input_gain(req, &mut unit.1, &gain, self.state_mut(), timeout_ms)
-                    .map(|_| true)
+                T::write_monaural_input_gain(req, node, &gain, &mut self.state, timeout_ms)?;
+                Ok(true)
             }
             INPUT_INVERT_NAME => {
                 let invert = &elem_value.boolean()[..T::INPUT_COUNT];
-                T::write_monaural_input_invert(
-                    req,
-                    &mut unit.1,
-                    &invert,
-                    self.state_mut(),
-                    timeout_ms,
-                )
-                .map(|_| true)
+                T::write_monaural_input_invert(req, node, &invert, &mut self.state, timeout_ms)?;
+                Ok(true)
             }
             _ => Ok(false),
         }
     }
 
-    fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
-        T::parse_dsp_parameter(self.state_mut(), params)
+    pub(crate) fn parse_dsp_parameter(&mut self, params: &SndMotuRegisterDspParameter) {
+        T::parse_dsp_parameter(&mut self.state, params)
     }
 
-    fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_dsp_event(self.state_mut(), event)
+    pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
+        T::parse_dsp_event(&mut self.state, event)
     }
 }
 

--- a/runtime/motu/src/register_dsp_runtime.rs
+++ b/runtime/motu/src/register_dsp_runtime.rs
@@ -23,9 +23,14 @@ pub type UltraliteRuntime = RegisterDspRuntime<UltraLite>;
 pub type AudioExpressRuntime = RegisterDspRuntime<AudioExpress>;
 pub type H4preRuntime = RegisterDspRuntime<H4pre>;
 
+pub trait RegisterDspCtlModel {
+    fn cache(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error>;
+}
+
 pub struct RegisterDspRuntime<T>
 where
     T: Default
+        + RegisterDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), bool>
@@ -48,6 +53,7 @@ where
 impl<T> Drop for RegisterDspRuntime<T>
 where
     T: Default
+        + RegisterDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), bool>
@@ -89,6 +95,7 @@ const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100
 impl<T> RegisterDspRuntime<T>
 where
     T: Default
+        + RegisterDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), bool>
@@ -120,6 +127,7 @@ where
         self.launch_node_event_dispatcher()?;
         self.launch_system_event_dispatcher()?;
 
+        self.model.cache(&mut self.unit)?;
         self.model.load(&mut self.unit, &mut self.card_cntr)?;
 
         NotifyModel::<(SndMotu, FwNode), u32>::get_notified_elem_list(

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -12,7 +12,7 @@ pub struct Track16 {
     clk_ctls: ClkCtl,
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
-    phone_assign_ctl: PhoneAssignCtl,
+    phone_assign_ctl: PhoneAssignCtl<Track16Protocol>,
     sequence_number: u8,
     reverb_ctl: ReverbCtl,
     monitor_ctl: MonitorCtl,
@@ -22,19 +22,6 @@ pub struct Track16 {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct PhoneAssignCtl(usize, Vec<ElemId>);
-
-impl PhoneAssignCtlOperation<Track16Protocol> for PhoneAssignCtl {
-    fn state(&self) -> &usize {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -177,14 +164,15 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.phone_assign_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|mut elem_id_list| self.port_assign_ctl.1.append(&mut elem_id_list))?;
         self.opt_iface_ctl.load(card_cntr)?;
-        self.phone_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.phone_assign_ctl.1.append(&mut elem_id_list))?;
+        self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
@@ -290,10 +278,13 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phone_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.phone_assign_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
@@ -385,7 +376,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
 impl NotifyModel<(SndMotu, FwNode), u32> for Track16 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.port_assign_ctl.1);
-        elem_id_list.extend_from_slice(&self.phone_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndMotu, FwNode), msg: &u32) -> Result<(), Error> {
@@ -393,7 +384,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for Track16 {
             self.port_assign_ctl
                 .cache(unit, &mut self.req, TIMEOUT_MS)?;
             self.phone_assign_ctl
-                .cache(unit, &mut self.req, TIMEOUT_MS)?;
+                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct Track16 {
     req: FwReq,
     resp: FwResp,
-    clk_ctls: ClkCtl,
+    clk_ctls: V3ClkCtl<Track16Protocol>,
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl<Track16Protocol>,
@@ -23,11 +23,6 @@ pub struct Track16 {
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V3ClkCtlOperation<Track16Protocol> for ClkCtl {}
 
 #[derive(Default)]
 struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
@@ -164,6 +159,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
@@ -215,10 +212,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -263,10 +257,14 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .port_assign_ctl

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -19,62 +19,47 @@ pub struct Traveler {
     output_ctl: RegisterDspOutputCtl<TravelerProtocol>,
     line_input_ctl: RegisterDspLineInputCtl<TravelerProtocol>,
     mic_input_ctl: MicInputCtl,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(TravelerProtocol::create_meter_state(), Default::default())
-    }
-}
-
-impl RegisterDspMeterCtlOperation<TravelerProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: RegisterDspMeterCtl<TravelerProtocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for Traveler {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
         self.line_input_ctl.parse_dsp_parameter(&self.params);
 
+        self.meter_ctl.read_dsp_meter(unit)?;
+
         self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.word_clk_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .0
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.line_input_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mic_input_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -86,9 +71,8 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
         self.output_ctl.load(card_cntr)?;
         self.line_input_ctl.load(card_cntr)?;
         self.mic_input_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.meter_ctl.1 = elem_id_list)?;
+        self.meter_ctl.load(card_cntr)?;
+
         Ok(())
     }
 
@@ -127,84 +111,80 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.0.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.mixer_return_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_output_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_source_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .line_input_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mic_input_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .meter_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -353,11 +333,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for Traveler {
 
 impl MeasureModel<(SndMotu, FwNode)> for Traveler {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(
@@ -435,8 +415,8 @@ impl MicInputCtl {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -449,18 +429,12 @@ impl MicInputCtl {
                     .take(TravelerProtocol::MIC_INPUT_COUNT)
                     .map(|&val| val as u8)
                     .collect();
-                TravelerProtocol::write_mic_gain(
-                    req,
-                    &mut unit.1,
-                    &gain,
-                    &mut self.state,
-                    timeout_ms,
-                )
-                .map(|_| true)
+                TravelerProtocol::write_mic_gain(req, node, &gain, &mut self.state, timeout_ms)
+                    .map(|_| true)
             }
             MIC_PAD_NAME => {
                 let pad = &elem_value.boolean()[..TravelerProtocol::MIC_INPUT_COUNT];
-                TravelerProtocol::write_mic_pad(req, &mut unit.1, &pad, &mut self.state, timeout_ms)
+                TravelerProtocol::write_mic_pad(req, node, &pad, &mut self.state, timeout_ms)
                     .map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -22,12 +22,8 @@ pub struct Traveler {
     meter_ctl: RegisterDspMeterCtl<TravelerProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for Traveler {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for Traveler {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -54,6 +50,12 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
         self.mic_input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for Traveler {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -37,12 +37,9 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
-        self.clk_ctls
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.word_clk_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .0
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -52,14 +49,10 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
             .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.line_input_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.mic_input_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.meter_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.line_input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mic_input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -15,33 +15,12 @@ pub struct Traveler {
     mixer_return_ctl: RegisterDspMixerReturnCtl<TravelerProtocol>,
     params: SndMotuRegisterDspParameter,
     mixer_output_ctl: RegisterDspMixerOutputCtl<TravelerProtocol>,
-    mixer_source_ctl: MixerSourceCtl,
+    mixer_source_ctl: RegisterDspMixerMonauralSourceCtl<TravelerProtocol>,
     output_ctl: OutputCtl,
     line_input_ctl: LineInputCtl,
     mic_input_ctl: MicInputCtl,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
-
-impl Default for MixerSourceCtl {
-    fn default() -> Self {
-        Self(
-            TravelerProtocol::create_mixer_monaural_source_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl RegisterDspMixerMonauralSourceCtlOperation<TravelerProtocol> for MixerSourceCtl {
-    fn state(&self) -> &RegisterDspMixerMonauralSourceState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerMonauralSourceState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -108,6 +87,7 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_source_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -122,6 +102,8 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_output_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_source_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
@@ -129,9 +111,7 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
         self.word_clk_ctl.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
         self.mixer_output_ctl.load(card_cntr)?;
-        self.mixer_source_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
+        self.mixer_source_ctl.load(card_cntr)?;
         self.output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.output_ctl.1 = elem_id_list)?;
@@ -234,10 +214,13 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_source_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_source_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .output_ctl
@@ -315,7 +298,7 @@ impl NotifyModel<(SndMotu, FwNode), bool> for Traveler {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_source_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.line_input_ctl.1);
     }

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -13,27 +13,14 @@ pub struct Traveler {
     phone_assign_ctl: RegisterDspPhoneAssignCtl<TravelerProtocol>,
     word_clk_ctl: WordClockCtl<TravelerProtocol>,
     mixer_return_ctl: RegisterDspMixerReturnCtl<TravelerProtocol>,
-    mixer_output_ctl: MixerOutputCtl,
+    params: SndMotuRegisterDspParameter,
+    mixer_output_ctl: RegisterDspMixerOutputCtl<TravelerProtocol>,
     mixer_source_ctl: MixerSourceCtl,
     output_ctl: OutputCtl,
     line_input_ctl: LineInputCtl,
     mic_input_ctl: MicInputCtl,
-    params: SndMotuRegisterDspParameter,
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MixerOutputCtl(RegisterDspMixerOutputState, Vec<ElemId>);
-
-impl RegisterDspMixerOutputCtlOperation<TravelerProtocol> for MixerOutputCtl {
-    fn state(&self) -> &RegisterDspMixerOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMixerOutputState {
-        &mut self.0
-    }
 }
 
 struct MixerSourceCtl(RegisterDspMixerMonauralSourceState, Vec<ElemId>);
@@ -120,6 +107,7 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
     ) -> Result<(), Error> {
         unit.0.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
+        self.mixer_output_ctl.parse_dsp_parameter(&self.params);
 
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
@@ -132,15 +120,15 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.mixer_return_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.mixer_output_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;
-        self.mixer_output_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
+        self.mixer_output_ctl.load(card_cntr)?;
         self.mixer_source_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_source_ctl.1 = elem_id_list)?;
@@ -238,10 +226,13 @@ impl CtlModel<(SndMotu, FwNode)> for Traveler {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .mixer_output_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_output_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_source_ctl
@@ -323,7 +314,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for Traveler {
 impl NotifyModel<(SndMotu, FwNode), bool> for Traveler {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_output_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.line_input_ctl.1);

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct TravelerMk3 {
     req: FwReq,
     resp: FwResp,
-    clk_ctls: ClkCtl,
+    clk_ctls: V3ClkCtl<TravelerMk3Protocol>,
     port_assign_ctl: PortAssignCtl,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl<TravelerMk3Protocol>,
@@ -24,11 +24,6 @@ pub struct TravelerMk3 {
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V3ClkCtlOperation<TravelerMk3Protocol> for ClkCtl {}
 
 #[derive(Default)]
 struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
@@ -177,6 +172,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.word_clk_ctl
@@ -231,10 +228,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -281,10 +275,14 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .port_assign_ctl

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use super::{common_ctls::*, register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
+use super::{register_dsp_ctls::*, register_dsp_runtime::*, v2_ctls::*};
 
 const TIMEOUT_MS: u32 = 100;
 
@@ -10,7 +10,7 @@ pub struct UltraLite {
     req: FwReq,
     clk_ctls: V2ClkCtl<UltraliteProtocol>,
     main_assign_ctl: MainAssignCtl,
-    phone_assign_ctl: PhoneAssignCtl,
+    phone_assign_ctl: RegisterDspPhoneAssignCtl<UltraliteProtocol>,
     mixer_output_ctl: MixerOutputCtl,
     mixer_return_ctl: MixerReturnCtl,
     mixer_source_ctl: MixerSourceCtl,
@@ -20,21 +20,6 @@ pub struct UltraLite {
     meter: RegisterDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct PhoneAssignCtl(usize, Vec<ElemId>);
-
-impl PhoneAssignCtlOperation<UltraliteProtocol> for PhoneAssignCtl {
-    fn state(&self) -> &usize {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
-}
-
-impl RegisterDspPhoneAssignCtlOperation<UltraliteProtocol> for PhoneAssignCtl {}
 
 #[derive(Default)]
 struct MainAssignCtl(usize, Vec<ElemId>);
@@ -144,15 +129,19 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        unit.0.read_parameter(&mut self.params)?;
+        self.phone_assign_ctl.parse_dsp_parameter(&self.params);
+
         self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.phone_assign_ctl
+            .0
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.main_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
-        self.phone_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.phone_assign_ctl.1.append(&mut elem_id_list))?;
+        self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_output_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|elem_id_list| self.mixer_output_ctl.1 = elem_id_list)?;
@@ -180,7 +169,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
             Ok(true)
         } else if self.main_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        } else if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -218,10 +207,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
             .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phone_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.phone_assign_ctl.0.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_output_ctl
@@ -285,7 +277,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraLite {
 
 impl NotifyModel<(SndMotu, FwNode), bool> for UltraLite {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.phone_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.0.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_output_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_source_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
@@ -316,7 +308,7 @@ impl NotifyModel<(SndMotu, FwNode), bool> for UltraLite {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -357,7 +349,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for UltraLite {
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self.phone_assign_ctl.read(elem_id, elem_value)? {
+        if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_output_ctl.read(elem_id, elem_value)? {
             Ok(true)

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -35,8 +35,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
-        self.clk_ctls
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .0
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -44,14 +43,11 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
             .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.output_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.input_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.main_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.meter_ctl
-            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
@@ -100,14 +96,10 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
         _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            unit,
-            &mut self.req,
-            node,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.phone_assign_ctl.0.write(
             &mut self.req,

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -8,7 +8,7 @@ const TIMEOUT_MS: u32 = 100;
 #[derive(Default)]
 pub struct UltraLite {
     req: FwReq,
-    clk_ctls: ClkCtl,
+    clk_ctls: V2ClkCtl<UltraliteProtocol>,
     main_assign_ctl: MainAssignCtl,
     phone_assign_ctl: PhoneAssignCtl,
     mixer_output_ctl: MixerOutputCtl,
@@ -35,11 +35,6 @@ impl PhoneAssignCtlOperation<UltraliteProtocol> for PhoneAssignCtl {
 }
 
 impl RegisterDspPhoneAssignCtlOperation<UltraliteProtocol> for PhoneAssignCtl {}
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V2ClkCtlOperation<UltraliteProtocol> for ClkCtl {}
 
 #[derive(Default)]
 struct MainAssignCtl(usize, Vec<ElemId>);
@@ -149,6 +144,9 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
         self.clk_ctls.load(card_cntr)?;
         self.main_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)?;
@@ -174,14 +172,11 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
 
     fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        _: &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.main_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -209,10 +204,14 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
         _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .main_assign_ctl

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -20,12 +20,8 @@ pub struct UltraLite {
     meter_ctl: RegisterDspMeterCtl<UltraliteProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for UltraLite {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl RegisterDspCtlModel for UltraLite {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
@@ -49,6 +45,12 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
             .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for UltraLite {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
         self.mixer_return_ctl.load(card_cntr)?;

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -17,56 +17,41 @@ pub struct UltraLite {
     output_ctl: RegisterDspOutputCtl<UltraliteProtocol>,
     input_ctl: RegisterDspMonauralInputCtl<UltraliteProtocol>,
     main_assign_ctl: MainAssignCtl,
-    meter: RegisterDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(RegisterDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(UltraliteProtocol::create_meter_state(), Default::default())
-    }
-}
-
-impl RegisterDspMeterCtlOperation<UltraliteProtocol> for MeterCtl {
-    fn state(&self) -> &RegisterDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut RegisterDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: RegisterDspMeterCtl<UltraliteProtocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for UltraLite {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        unit.0.read_parameter(&mut self.params)?;
+        unit.read_parameter(&mut self.params)?;
         self.phone_assign_ctl.parse_dsp_parameter(&self.params);
         self.mixer_output_ctl.parse_dsp_parameter(&self.params);
         self.mixer_source_ctl.parse_dsp_parameter(&self.params);
         self.output_ctl.parse_dsp_parameter(&self.params);
         self.input_ctl.parse_dsp_parameter(&self.params);
 
+        self.meter_ctl.read_dsp_meter(unit)?;
+
         self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .0
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_return_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_source_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.main_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.phone_assign_ctl.0.load(card_cntr)?;
@@ -76,6 +61,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
         self.output_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.main_assign_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
 
         Ok(())
     }
@@ -109,67 +95,67 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLite {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctls.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.0.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_return_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_output_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_source_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .input_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.main_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -304,11 +290,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<RegisterDspEvent>> for UltraLite {
 
 impl MeasureModel<(SndMotu, FwNode)> for UltraLite {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(&mut unit.0, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -11,7 +11,7 @@ pub struct UltraliteMk3Hybrid {
     resp: FwResp,
     clk_ctls: ClkCtl,
     port_assign_ctl: PortAssignCtl,
-    phone_assign_ctl: PhoneAssignCtl,
+    phone_assign_ctl: PhoneAssignCtl<UltraliteMk3HybridProtocol>,
     sequence_number: u8,
     reverb_ctl: ReverbCtl,
     monitor_ctl: MonitorCtl,
@@ -21,19 +21,6 @@ pub struct UltraliteMk3Hybrid {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct PhoneAssignCtl(usize, Vec<ElemId>);
-
-impl PhoneAssignCtlOperation<UltraliteMk3HybridProtocol> for PhoneAssignCtl {
-    fn state(&self) -> &usize {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut usize {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -183,13 +170,14 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.phone_assign_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl
             .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
             .map(|mut elem_id_list| self.port_assign_ctl.1.append(&mut elem_id_list))?;
-        self.phone_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.phone_assign_ctl.1.append(&mut elem_id_list))?;
+        self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
@@ -285,10 +273,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phone_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.phone_assign_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
@@ -380,7 +371,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
 impl NotifyModel<(SndMotu, FwNode), u32> for UltraliteMk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.port_assign_ctl.1);
-        elem_id_list.extend_from_slice(&self.phone_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
     }
 
     fn parse_notification(&mut self, unit: &mut (SndMotu, FwNode), msg: &u32) -> Result<(), Error> {
@@ -388,7 +379,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraliteMk3Hybrid {
             self.port_assign_ctl
                 .cache(unit, &mut self.req, TIMEOUT_MS)?;
             self.phone_assign_ctl
-                .cache(unit, &mut self.req, TIMEOUT_MS)?;
+                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -9,7 +9,7 @@ const TIMEOUT_MS: u32 = 100;
 pub struct UltraliteMk3Hybrid {
     req: FwReq,
     resp: FwResp,
-    clk_ctls: ClkCtl,
+    clk_ctls: V3ClkCtl<UltraliteMk3HybridProtocol>,
     port_assign_ctl: PortAssignCtl,
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3HybridProtocol>,
     sequence_number: u8,
@@ -22,11 +22,6 @@ pub struct UltraliteMk3Hybrid {
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct ClkCtl;
-
-impl V3ClkCtlOperation<UltraliteMk3HybridProtocol> for ClkCtl {}
 
 #[derive(Default)]
 struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
@@ -170,6 +165,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         unit: &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
+        self.clk_ctls
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
@@ -216,14 +213,11 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
 
     fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        _: &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -263,10 +257,14 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctls
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        if self.clk_ctls.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .port_assign_ctl

--- a/runtime/motu/src/v1_runtime.rs
+++ b/runtime/motu/src/v1_runtime.rs
@@ -18,7 +18,10 @@ pub trait Version1CtlModel {
 
 pub struct Version1Runtime<T>
 where
-    T: Version1CtlModel + CtlModel<(SndMotu, FwNode)> + NotifyModel<(SndMotu, FwNode), u32> + Default,
+    T: Version1CtlModel
+        + CtlModel<(SndMotu, FwNode)>
+        + NotifyModel<(SndMotu, FwNode), u32>
+        + Default,
 {
     unit: (SndMotu, FwNode),
     model: T,
@@ -33,7 +36,10 @@ where
 
 impl<T> Drop for Version1Runtime<T>
 where
-    T: Version1CtlModel + CtlModel<(SndMotu, FwNode)> + NotifyModel<(SndMotu, FwNode), u32> + Default,
+    T: Version1CtlModel
+        + CtlModel<(SndMotu, FwNode)>
+        + NotifyModel<(SndMotu, FwNode), u32>
+        + Default,
 {
     fn drop(&mut self) {
         // At first, stop event loop in all of dispatchers to avoid queueing new events.
@@ -62,7 +68,10 @@ const SYSTEM_DISPATCHER_NAME: &str = "system event dispatcher";
 
 impl<T> Version1Runtime<T>
 where
-    T: Version1CtlModel + CtlModel<(SndMotu, FwNode)> + NotifyModel<(SndMotu, FwNode), u32> + Default,
+    T: Version1CtlModel
+        + CtlModel<(SndMotu, FwNode)>
+        + NotifyModel<(SndMotu, FwNode), u32>
+        + Default,
 {
     pub fn new(unit: SndMotu, node: FwNode, card_id: u32, version: u32) -> Result<Self, Error> {
         let card_cntr = CardCntr::default();

--- a/runtime/motu/src/v2_ctls.rs
+++ b/runtime/motu/src/v2_ctls.rs
@@ -3,6 +3,14 @@
 
 pub(crate) use super::{protocols::version_2::*, register_dsp_runtime::*};
 
+#[derive(Default, Debug)]
+pub(crate) struct V2ClkCtl<T: V2ClkOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    rate: usize,
+    source: usize,
+    _phantom: PhantomData<T>,
+}
+
 fn clk_src_to_str(src: &V2ClkSrc) -> &'static str {
     match src {
         V2ClkSrc::Internal => "Internal",
@@ -18,77 +26,92 @@ fn clk_src_to_str(src: &V2ClkSrc) -> &'static str {
 const RATE_NAME: &str = "sampling- rate";
 const SRC_NAME: &str = "clock-source";
 
-pub trait V2ClkCtlOperation<T: V2ClkOperation> {
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+impl<T: V2ClkOperation> V2ClkCtl<T> {
+    pub(crate) fn cache(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        T::get_clk_rate(req, node, timeout_ms).map(|idx| self.rate = idx)?;
+        T::get_clk_src(req, node, timeout_ms).and_then(|idx| {
+            if T::HAS_LCD {
+                let label = clk_src_to_str(&T::CLK_SRCS[idx].0);
+                T::update_clk_display(req, node, &label, timeout_ms)?;
+            }
+            self.source = idx;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<&str> = T::CLK_RATES.iter().map(|e| clk_rate_to_str(&e.0)).collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = T::CLK_SRCS.iter().map(|e| clk_src_to_str(&e.0)).collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SRC_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn read(
+    pub(crate) fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
-        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
-        timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|idx| idx as u32)
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                T::get_clk_src(req, &mut unit.1, timeout_ms).and_then(|idx| {
-                    if T::HAS_LCD {
-                        let label = clk_src_to_str(&T::CLK_SRCS[idx].0);
-                        T::update_clk_display(req, &mut unit.1, &label, timeout_ms)?;
-                    }
-                    Ok(idx as u32)
-                })
-            })
-            .map(|_| true),
+            RATE_NAME => {
+                elem_value.set_enum(&[self.rate as u32]);
+                Ok(true)
+            }
+            SRC_NAME => {
+                elem_value.set_enum(&[self.source as u32]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        unit: &mut SndMotu,
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                unit.0.lock()?;
-                let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                let prev_src = T::get_clk_src(req, &mut unit.1, timeout_ms)?;
-                unit.0.lock()?;
-                let mut res = T::set_clk_src(req, &mut unit.1, val as usize, timeout_ms);
-                if res.is_ok() && T::HAS_LCD {
-                    let label = clk_src_to_str(&T::CLK_SRCS[val as usize].0);
-                    res = T::update_clk_display(req, &mut unit.1, &label, timeout_ms);
-                    if res.is_err() {
-                        let _ = T::set_clk_src(req, &mut unit.1, prev_src, timeout_ms);
+            RATE_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_rate(req, node, val, timeout_ms).map(|_| self.rate = val);
+                let _ = unit.unlock();
+                res.map(|_| true)
+            }
+            SRC_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_src(req, node, val, timeout_ms).and_then(|_| {
+                    if T::HAS_LCD {
+                        let label = clk_src_to_str(&T::CLK_SRCS[val].0);
+                        if T::update_clk_display(req, node, &label, timeout_ms).is_err() {
+                            let _ = T::set_clk_src(req, node, self.source, timeout_ms);
+                        }
                     }
-                }
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
+                    self.source = val;
+                    Ok(())
+                });
+                let _ = unit.unlock();
+                res.map(|_| true)
+            }
             _ => Ok(false),
         }
     }

--- a/runtime/motu/src/v3_ctls.rs
+++ b/runtime/motu/src/v3_ctls.rs
@@ -3,6 +3,14 @@
 
 pub(crate) use super::{command_dsp_runtime::*, protocols::version_3::*};
 
+#[derive(Default, Debug)]
+pub(crate) struct V3ClkCtl<T: V3ClkOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    rate: usize,
+    source: usize,
+    _phantom: PhantomData<T>,
+}
+
 fn clk_src_to_str(src: &V3ClkSrc) -> &'static str {
     match src {
         V3ClkSrc::Internal => "Internal",
@@ -17,76 +25,92 @@ fn clk_src_to_str(src: &V3ClkSrc) -> &'static str {
 const RATE_NAME: &str = "sampling-rate";
 const SRC_NAME: &str = "clock-source";
 
-pub trait V3ClkCtlOperation<T: V3ClkOperation> {
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+impl<T: V3ClkOperation> V3ClkCtl<T> {
+    pub(crate) fn cache(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        T::get_clk_rate(req, node, timeout_ms).map(|idx| self.rate = idx)?;
+        T::get_clk_src(req, node, timeout_ms).and_then(|idx| {
+            if T::HAS_LCD {
+                let label = clk_src_to_str(&T::CLK_SRCS[idx].0);
+                T::update_clk_display(req, node, &label, timeout_ms)?;
+            }
+            self.source = idx;
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let labels: Vec<&str> = T::CLK_RATES.iter().map(|e| clk_rate_to_str(&e.0)).collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = T::CLK_SRCS.iter().map(|e| clk_src_to_str(&e.0)).collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, SRC_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+        card_cntr
+            .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
         Ok(())
     }
 
-    fn read(
+    pub(crate) fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
-        req: &mut FwReq,
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
-        timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                T::get_clk_rate(req, &mut unit.1, timeout_ms).map(|val| val as u32)
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::set_val(elem_value, || {
-                let val = T::get_clk_src(req, &mut unit.1, timeout_ms)?;
-                if T::HAS_LCD {
-                    let label = clk_src_to_str(&T::CLK_SRCS[val].0);
-                    let _ = T::update_clk_display(req, &mut unit.1, &label, timeout_ms);
-                }
-                Ok(val as u32)
-            })
-            .map(|_| true),
+            RATE_NAME => {
+                elem_value.set_enum(&[self.rate as u32]);
+                Ok(true)
+            }
+            SRC_NAME => {
+                elem_value.set_enum(&[self.source as u32]);
+                Ok(true)
+            }
             _ => Ok(false),
         }
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        unit: &mut SndMotu,
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            RATE_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                unit.0.lock()?;
-                let res = T::set_clk_rate(req, &mut unit.1, val as usize, timeout_ms);
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
-            SRC_NAME => ElemValueAccessor::<u32>::get_val(elem_value, |val| {
-                let prev_src = T::get_clk_src(req, &mut unit.1, timeout_ms)?;
-                unit.0.lock()?;
-                let mut res = T::set_clk_src(req, &mut unit.1, val as usize, timeout_ms);
-                if res.is_ok() && T::HAS_LCD {
-                    let label = clk_src_to_str(&T::CLK_SRCS[val as usize].0);
-                    res = T::update_clk_display(req, &mut unit.1, &label, timeout_ms);
-                    if res.is_err() {
-                        let _ = T::set_clk_src(req, &mut unit.1, prev_src, timeout_ms);
+            RATE_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_rate(req, node, val, timeout_ms).map(|_| self.rate = val);
+                let _ = unit.unlock();
+                res.map(|_| true)
+            }
+            SRC_NAME => {
+                let val = elem_value.enumerated()[0] as usize;
+                unit.lock()?;
+                let res = T::set_clk_src(req, node, val, timeout_ms).and_then(|_| {
+                    if T::HAS_LCD {
+                        let label = clk_src_to_str(&T::CLK_SRCS[val].0);
+                        if T::update_clk_display(req, node, &label, timeout_ms).is_err() {
+                            let _ = T::set_clk_src(req, node, self.source, timeout_ms);
+                        }
                     }
-                }
-                let _ = unit.0.unlock();
-                res
-            })
-            .map(|_| true),
+                    self.source = val;
+                    Ok(())
+                });
+                let _ = unit.unlock();
+                res.map(|_| true)
+            }
             _ => Ok(false),
         }
     }


### PR DESCRIPTION
This patchset reworks current implementation of runtime for Register DSP models so that
cache function is split from load function following to the other runtime implementations.

```
Takashi Sakamoto (17):
  runtime/motu: use generic structure for controls specific to version 2
    models
  runtime/motu: use generic structure for optical interface controls
    specific to version 2 model
  runtime/motu: use generic structure for phone controls
  runtime/motu: use generic structure for phone controls in Register DSP
    models
  runtime/motu: use generic structure for mixer return controls in
    Register DSP models
  runtime/motu: use generic structure for mixer output controls in
    Register DSP models
  runtime/motu: use generic structure for mixer monaural source control
    in Register DSP models
  runtime/motu: use generic structure for mixer stereo source control in
    Register DSP models
  runtime/motu: use generic structure for output control in Register DSP
    models
  runtime/motu: use generic structure for monaural input control in
    Register DSP models
  runtime/motu: use generic structure for stereo input control in
    Register DSP models
  runtime/motu: use generic structure for line input control in 828mk2
    and Traveler
  runtime/motu: use generic structure for mic input control in Traveler
  runtime/motu: use generic structure for phone assignment control in
    Ultralite
  runtime/motu: use generic structure for meter control in Register DSP
    models
  runtime/motu: use generic structure for clock controls in version 3
    models
  runtime/motu: split cache function from load function in Register DSP
    models

 protocols/motu/src/register_dsp.rs       |  20 +-
 protocols/motu/src/version_2.rs          |   2 +-
 runtime/motu/src/audioexpress.rs         | 287 +++-----
 runtime/motu/src/common_ctls.rs          |  65 +-
 runtime/motu/src/f828mk2.rs              | 333 ++++------
 runtime/motu/src/f828mk3.rs              |  62 +-
 runtime/motu/src/f828mk3_hybrid.rs       |  62 +-
 runtime/motu/src/f896hd.rs               | 253 +++----
 runtime/motu/src/f8pre.rs                | 268 +++-----
 runtime/motu/src/h4pre.rs                | 279 +++-----
 runtime/motu/src/register_dsp_ctls.rs    | 810 +++++++++++++----------
 runtime/motu/src/register_dsp_runtime.rs |   8 +
 runtime/motu/src/track16.rs              |  63 +-
 runtime/motu/src/traveler.rs             | 409 ++++--------
 runtime/motu/src/traveler_mk3.rs         |  58 +-
 runtime/motu/src/ultralite.rs            | 352 ++++------
 runtime/motu/src/ultralite_mk3.rs        |  65 +-
 runtime/motu/src/ultralite_mk3_hybrid.rs |  65 +-
 runtime/motu/src/v1_runtime.rs           |  15 +-
 runtime/motu/src/v2_ctls.rs              | 211 +++---
 runtime/motu/src/v3_ctls.rs              | 112 ++--
 21 files changed, 1600 insertions(+), 2199 deletions(-)
```