### PR TITLE
[PATCH 00/12] runtime/motu: rework for runtime of Command DSP models

### DIFF
--- a/protocols/motu/src/command_dsp.rs
+++ b/protocols/motu/src/command_dsp.rs
@@ -2996,7 +2996,7 @@ pub trait CommandDspOutputOperation: CommandDspOperation {
 }
 
 /// Information of Meter.
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct CommandDspMeterState {
     pub inputs: Vec<f32>,
     pub outputs: Vec<f32>,

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -1522,14 +1522,18 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     ) -> Result<bool, Error> {
         assert_eq!(levels.len(), Self::CH_COUNT);
 
-        ElemValueAccessor::<u32>::set_vals(elem_value, Self::CH_COUNT, |idx| {
-            let pos = Self::ROLL_OFF_LEVELS
-                .iter()
-                .position(|l| levels[idx].eq(l))
-                .unwrap();
-            Ok(pos as u32)
-        })
-        .map(|_| true)
+        let vals: Vec<u32> = levels
+            .iter()
+            .map(|level| {
+                let pos = Self::ROLL_OFF_LEVELS
+                    .iter()
+                    .position(|l| level.eq(l))
+                    .unwrap();
+                pos as u32
+            })
+            .collect();
+        elem_value.set_enum(&vals);
+        Ok(true)
     }
 
     fn read_filter_type_5(
@@ -1538,14 +1542,18 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     ) -> Result<bool, Error> {
         assert_eq!(filter_types.len(), Self::CH_COUNT);
 
-        ElemValueAccessor::<u32>::set_vals(elem_value, Self::CH_COUNT, |idx| {
-            let pos = Self::FILTER_TYPE_5
-                .iter()
-                .position(|f| filter_types[idx].eq(f))
-                .unwrap();
-            Ok(pos as u32)
-        })
-        .map(|_| true)
+        let vals: Vec<u32> = filter_types
+            .iter()
+            .map(|filter_type| {
+                let pos = Self::FILTER_TYPE_5
+                    .iter()
+                    .position(|f| filter_type.eq(f))
+                    .unwrap();
+                pos as u32
+            })
+            .collect();
+        elem_value.set_enum(&vals);
+        Ok(true)
     }
 
     fn read_filter_type_4(
@@ -1554,14 +1562,18 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     ) -> Result<bool, Error> {
         assert_eq!(filter_types.len(), Self::CH_COUNT);
 
-        ElemValueAccessor::<u32>::set_vals(elem_value, Self::CH_COUNT, |idx| {
-            let pos = Self::FILTER_TYPE_4
-                .iter()
-                .position(|f| filter_types[idx].eq(f))
-                .unwrap();
-            Ok(pos as u32)
-        })
-        .map(|_| true)
+        let vals: Vec<u32> = filter_types
+            .iter()
+            .map(|filter_type| {
+                let pos = Self::FILTER_TYPE_4
+                    .iter()
+                    .position(|f| filter_type.eq(f))
+                    .unwrap();
+                pos as u32
+            })
+            .collect();
+        elem_value.set_enum(&vals);
+        Ok(true)
     }
 
     fn read_equalizer(
@@ -1643,8 +1655,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_bool_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1653,7 +1665,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         F: Fn(&mut CommandDspEqualizerState, &[bool]),
     {
         let vals = &elem_value.boolean()[..Self::CH_COUNT];
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
         })
@@ -1662,8 +1674,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_int_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1672,7 +1684,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         F: Fn(&mut CommandDspEqualizerState, &[i32]),
     {
         let vals = &elem_value.int()[..Self::CH_COUNT];
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
         })
@@ -1681,8 +1693,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_u32_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1692,7 +1704,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     {
         let vals = &elem_value.int()[..Self::CH_COUNT];
         let raw: Vec<u32> = vals.iter().map(|&val| val as u32).collect();
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &raw);
             Ok(())
         })
@@ -1701,8 +1713,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_f32_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1715,7 +1727,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
             .iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
             .collect();
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &raw);
             Ok(())
         })
@@ -1724,8 +1736,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_roll_off_level<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1745,7 +1757,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
                 })
                 .map(|&l| levels.push(l))
         })?;
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &levels);
             Ok(())
         })
@@ -1754,8 +1766,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_filter_type_5<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1775,7 +1787,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
                 })
                 .map(|&filter_type| filter_types.push(filter_type))
         })?;
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &filter_types);
             Ok(())
         })
@@ -1784,8 +1796,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_filter_type_4<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -1805,7 +1817,7 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
                 })
                 .map(|&filter_type| filter_types.push(filter_type))
         })?;
-        self.write_equalizer_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_equalizer_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &filter_types);
             Ok(())
         })
@@ -1814,8 +1826,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_equalizer(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -1825,8 +1837,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         if name == Self::ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1836,8 +1848,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HPF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1847,8 +1859,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HPF_SLOPE_NAME {
             self.write_roll_off_level(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.hpf_slope.copy_from_slice(vals),
@@ -1856,8 +1868,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HPF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1867,8 +1879,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LPF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1878,8 +1890,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LPF_SLOPE_NAME {
             self.write_roll_off_level(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.lpf_slope.copy_from_slice(vals),
@@ -1887,8 +1899,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LPF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1898,8 +1910,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1909,8 +1921,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LF_TYPE_NAME {
             self.write_filter_type_5(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.lf_type.copy_from_slice(vals),
@@ -1918,8 +1930,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1929,8 +1941,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LF_GAIN_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1940,8 +1952,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LF_WIDTH_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1951,8 +1963,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LMF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1962,8 +1974,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LMF_TYPE_NAME {
             self.write_filter_type_4(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.lmf_type.copy_from_slice(vals),
@@ -1971,8 +1983,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LMF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1982,8 +1994,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LMF_GAIN_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -1993,8 +2005,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::LMF_WIDTH_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2004,8 +2016,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::MF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2015,8 +2027,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::MF_TYPE_NAME {
             self.write_filter_type_4(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.mf_type.copy_from_slice(vals),
@@ -2024,8 +2036,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::MF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2035,8 +2047,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::MF_GAIN_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2046,8 +2058,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::MF_WIDTH_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2057,8 +2069,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HMF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2068,8 +2080,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HMF_TYPE_NAME {
             self.write_filter_type_4(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.hmf_type.copy_from_slice(vals),
@@ -2077,8 +2089,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HMF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2088,8 +2100,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HMF_GAIN_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2099,8 +2111,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HMF_WIDTH_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2110,8 +2122,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HF_ENABLE_NAME {
             self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2121,8 +2133,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HF_TYPE_NAME {
             self.write_filter_type_5(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| state.hf_type.copy_from_slice(vals),
@@ -2130,8 +2142,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HF_FREQ_NAME {
             self.write_u32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2141,8 +2153,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HF_GAIN_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2152,8 +2164,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
         } else if name == Self::HF_WIDTH_NAME {
             self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -2168,8 +2180,8 @@ pub trait CommandDspEqualizerCtlOperation<T: CommandDspOperation, U: Default> {
     fn write_equalizer_state<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
         func: F,
     ) -> Result<bool, Error>
@@ -3153,8 +3165,8 @@ where
     fn write_equalizer_state<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
         func: F,
     ) -> Result<bool, Error>
@@ -3165,7 +3177,7 @@ where
         func(&mut state.equalizer)?;
         T::write_input_state(
             req,
-            &mut unit.1,
+            node,
             sequence_number,
             state,
             self.state_mut(),
@@ -3525,8 +3537,8 @@ where
     fn write_equalizer_state<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
         func: F,
     ) -> Result<bool, Error>
@@ -3537,7 +3549,7 @@ where
         func(&mut state.equalizer)?;
         T::write_output_state(
             req,
-            &mut unit.1,
+            node,
             sequence_number,
             state,
             self.state_mut(),

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -3262,21 +3262,33 @@ where
     }
 }
 
+#[derive(Debug)]
+pub(crate) struct CommandDspOutputCtl<T: CommandDspOutputOperation> {
+    pub elem_id_list: Vec<ElemId>,
+    state: CommandDspOutputState,
+    _phantom: PhantomData<T>,
+}
+
 const OUTPUT_REVERB_SEND_NAME: &str = "output-reverb-send";
 const OUTPUT_REVERB_RETURN_NAME: &str = "output-reverb-return";
 const OUTPUT_MASTER_MONITOR_NAME: &str = "output-master-monitor";
 const OUTPUT_MASTER_TALKBACK_NAME: &str = "output-master-talkback";
 const OUTPUT_MASTER_LISTENBACK_NAME: &str = "output-master-listenback";
 
-pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
-    fn state(&self) -> &CommandDspOutputState;
-    fn state_mut(&mut self) -> &mut CommandDspOutputState;
+impl<T: CommandDspOutputOperation> Default for CommandDspOutputCtl<T> {
+    fn default() -> Self {
+        Self {
+            elem_id_list: Default::default(),
+            state: T::create_output_state(),
+            _phantom: Default::default(),
+        }
+    }
+}
 
+impl<T: CommandDspOutputOperation> CommandDspOutputCtl<T> {
     const F32_CONVERT_SCALE: f32 = 1000000.0;
 
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        let mut notified_elem_id_list = Vec::new();
-
+    pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         [
             (OUTPUT_REVERB_SEND_NAME, T::GAIN_MIN, T::GAIN_MAX),
             (OUTPUT_REVERB_RETURN_NAME, T::VOLUME_MIN, T::VOLUME_MAX),
@@ -3295,7 +3307,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
                     None,
                     true,
                 )
-                .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))
+                .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))
         })?;
 
         [
@@ -3308,19 +3320,14 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
             card_cntr
                 .add_bool_elems(&elem_id, 1, T::OUTPUT_PORTS.len(), true)
-                .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))
+                .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))
         })?;
 
-        Ok(notified_elem_id_list)
+        Ok(())
     }
 
     fn read_bool_values(elem_value: &mut ElemValue, vals: &[bool]) -> Result<bool, Error> {
         elem_value.set_bool(&vals);
-        Ok(true)
-    }
-
-    fn read_int_values(elem_value: &mut ElemValue, vals: &[i32]) -> Result<bool, Error> {
-        elem_value.set_int(&vals);
         Ok(true)
     }
 
@@ -3334,20 +3341,24 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
         Ok(true)
     }
 
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    pub(crate) fn read(
+        &mut self,
+        elem_id: &ElemId,
+        elem_value: &mut ElemValue,
+    ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            OUTPUT_REVERB_SEND_NAME => Self::read_f32_values(elem_value, &self.state().reverb_send),
+            OUTPUT_REVERB_SEND_NAME => Self::read_f32_values(elem_value, &self.state.reverb_send),
             OUTPUT_REVERB_RETURN_NAME => {
-                Self::read_f32_values(elem_value, &self.state().reverb_return)
+                Self::read_f32_values(elem_value, &self.state.reverb_return)
             }
             OUTPUT_MASTER_MONITOR_NAME => {
-                Self::read_bool_values(elem_value, &self.state().master_monitor)
+                Self::read_bool_values(elem_value, &self.state.master_monitor)
             }
             OUTPUT_MASTER_TALKBACK_NAME => {
-                Self::read_bool_values(elem_value, &self.state().master_talkback)
+                Self::read_bool_values(elem_value, &self.state.master_talkback)
             }
             OUTPUT_MASTER_LISTENBACK_NAME => {
-                Self::read_bool_values(elem_value, &self.state().master_listenback)
+                Self::read_bool_values(elem_value, &self.state.master_listenback)
             }
             _ => Ok(false),
         }
@@ -3356,8 +3367,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     fn write_bool_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -3366,26 +3377,7 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
         F: Fn(&mut CommandDspOutputState, &[bool]),
     {
         let vals = &elem_value.boolean()[..T::OUTPUT_PORTS.len()];
-        self.write_state(sequence_number, unit, req, timeout_ms, |state| {
-            func(state, &vals);
-            Ok(())
-        })
-    }
-
-    fn write_int_values<F>(
-        &mut self,
-        sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
-        req: &mut FwReq,
-        elem_value: &ElemValue,
-        timeout_ms: u32,
-        func: F,
-    ) -> Result<bool, Error>
-    where
-        F: Fn(&mut CommandDspOutputState, &[i32]),
-    {
-        let vals = &elem_value.int()[..T::OUTPUT_PORTS.len()];
-        self.write_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &vals);
             Ok(())
         })
@@ -3394,8 +3386,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
     fn write_f32_values<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_value: &ElemValue,
         timeout_ms: u32,
         func: F,
@@ -3408,17 +3400,17 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             .iter()
             .map(|&val| (val as f32) / Self::F32_CONVERT_SCALE)
             .collect();
-        self.write_state(sequence_number, unit, req, timeout_ms, |state| {
+        self.write_state(sequence_number, req, node, timeout_ms, |state| {
             func(state, &raw);
             Ok(())
         })
     }
 
-    fn write(
+    pub(crate) fn write(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         elem_id: &ElemId,
         elem_value: &ElemValue,
         timeout_ms: u32,
@@ -3426,8 +3418,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
         match elem_id.name().as_str() {
             OUTPUT_REVERB_SEND_NAME => self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -3436,8 +3428,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             ),
             OUTPUT_REVERB_RETURN_NAME => self.write_f32_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -3446,8 +3438,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             ),
             OUTPUT_MASTER_MONITOR_NAME => self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -3456,8 +3448,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             ),
             OUTPUT_MASTER_TALKBACK_NAME => self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -3466,8 +3458,8 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
             ),
             OUTPUT_MASTER_LISTENBACK_NAME => self.write_bool_values(
                 sequence_number,
-                unit,
                 req,
+                node,
                 elem_value,
                 timeout_ms,
                 |state, vals| {
@@ -3478,38 +3470,37 @@ pub trait CommandDspOutputCtlOperation<T: CommandDspOutputOperation> {
         }
     }
 
-    fn parse_commands(&mut self, cmds: &[DspCmd]) {
-        T::parse_output_commands(self.state_mut(), cmds);
+    pub(crate) fn parse_commands(&mut self, cmds: &[DspCmd]) {
+        T::parse_output_commands(&mut self.state, cmds);
     }
 
     fn write_state<F>(
         &mut self,
         sequence_number: &mut u8,
-        unit: &mut (SndMotu, FwNode),
         req: &mut FwReq,
+        node: &mut FwNode,
         timeout_ms: u32,
         func: F,
     ) -> Result<bool, Error>
     where
         F: Fn(&mut CommandDspOutputState) -> Result<(), Error>,
     {
-        let mut state = self.state().clone();
+        let mut state = self.state.clone();
         func(&mut state)?;
         T::write_output_state(
             req,
-            &mut unit.1,
+            node,
             sequence_number,
             state,
-            self.state_mut(),
+            &mut self.state,
             timeout_ms,
         )
         .map(|_| true)
     }
 }
 
-impl<O, T> CommandDspEqualizerCtlOperation<T, CommandDspOutputState> for O
+impl<T> CommandDspEqualizerCtlOperation<T, CommandDspOutputState> for CommandDspOutputCtl<T>
 where
-    O: CommandDspOutputCtlOperation<T>,
     T: CommandDspOutputOperation,
 {
     const CH_COUNT: usize = T::OUTPUT_PORTS.len();
@@ -3555,7 +3546,7 @@ where
     const HF_WIDTH_NAME: &'static str = "output-equalizer-hf-width";
 
     fn state(&self) -> &CommandDspEqualizerState {
-        &self.state().equalizer
+        &self.state.equalizer
     }
 
     fn write_equalizer_state<F>(
@@ -3569,23 +3560,22 @@ where
     where
         F: Fn(&mut CommandDspEqualizerState) -> Result<(), Error>,
     {
-        let mut state = self.state().clone();
+        let mut state = self.state.clone();
         func(&mut state.equalizer)?;
         T::write_output_state(
             req,
             node,
             sequence_number,
             state,
-            self.state_mut(),
+            &mut self.state,
             timeout_ms,
         )
         .map(|_| true)
     }
 }
 
-impl<O, T> CommandDspDynamicsCtlOperation<T, CommandDspOutputState> for O
+impl<T> CommandDspDynamicsCtlOperation<T, CommandDspOutputState> for CommandDspOutputCtl<T>
 where
-    O: CommandDspOutputCtlOperation<T>,
     T: CommandDspOutputOperation,
 {
     const CH_COUNT: usize = T::OUTPUT_PORTS.len();
@@ -3606,7 +3596,7 @@ where
     const LEVELER_REDUCE_NAME: &'static str = "output-dynamics-leveler-reduce";
 
     fn state(&self) -> &CommandDspDynamicsState {
-        &self.state().dynamics
+        &self.state.dynamics
     }
 
     fn write_dynamics_state<F>(
@@ -3620,14 +3610,14 @@ where
     where
         F: Fn(&mut CommandDspDynamicsState) -> Result<(), Error>,
     {
-        let mut state = self.state().clone();
+        let mut state = self.state.clone();
         func(&mut state.dynamics)?;
         T::write_output_state(
             req,
             node,
             sequence_number,
             state,
-            self.state_mut(),
+            &mut self.state,
             timeout_ms,
         )
         .map(|_| true)

--- a/runtime/motu/src/command_dsp_runtime.rs
+++ b/runtime/motu/src/command_dsp_runtime.rs
@@ -30,9 +30,14 @@ pub type F828mk3HybridRuntime = Version3Runtime<F828mk3Hybrid>;
 pub type TravelerMk3Runtime = Version3Runtime<TravelerMk3>;
 pub type Track16Runtime = Version3Runtime<Track16>;
 
+pub trait CommandDspCtlModel {
+    fn cache(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error>;
+}
+
 pub struct Version3Runtime<T>
 where
     for<'a> T: Default
+        + CommandDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), Vec<DspCmd>>
@@ -57,6 +62,7 @@ where
 impl<T> Drop for Version3Runtime<T>
 where
     for<'a> T: Default
+        + CommandDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), Vec<DspCmd>>
@@ -99,6 +105,7 @@ const TIMER_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100
 impl<T> Version3Runtime<T>
 where
     for<'a> T: Default
+        + CommandDspCtlModel
         + CtlModel<(SndMotu, FwNode)>
         + NotifyModel<(SndMotu, FwNode), u32>
         + NotifyModel<(SndMotu, FwNode), Vec<DspCmd>>
@@ -184,6 +191,7 @@ where
             Err(Error::new(FileError::Io, "No message for state arrived."))?;
         }
 
+        self.model.cache(&mut self.unit)?;
         self.model.load(&mut self.unit, &mut self.card_cntr)?;
         NotifyModel::<(SndMotu, FwNode), u32>::get_notified_elem_list(
             &mut self.model,

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -17,30 +17,12 @@ pub struct F828mk3 {
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<F828mk3Protocol>,
     monitor_ctl: CommandDspMonitorCtl<F828mk3Protocol>,
-    mixer_ctl: MixerCtl,
+    mixer_ctl: CommandDspMixerCtl<F828mk3Protocol>,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
-
-impl Default for MixerCtl {
-    fn default() -> Self {
-        Self(F828mk3Protocol::create_mixer_state(), Default::default())
-    }
-}
-
-impl CommandDspMixerCtlOperation<F828mk3Protocol> for MixerCtl {
-    fn state(&self) -> &CommandDspMixerState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMixerState {
-        &mut self.0
-    }
 }
 
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
@@ -134,9 +116,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
-        self.mixer_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
+        self.mixer_ctl.load(card_cntr)?;
         self.input_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
@@ -273,8 +253,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -385,7 +365,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -280,8 +280,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -307,8 +307,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -20,22 +20,9 @@ pub struct F828mk3 {
     mixer_ctl: CommandDspMixerCtl<F828mk3Protocol>,
     input_ctl: CommandDspInputCtl<F828mk3Protocol>,
     output_ctl: CommandDspOutputCtl<F828mk3Protocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -95,9 +82,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -328,7 +313,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3 {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -271,8 +271,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -298,8 +298,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -21,44 +21,24 @@ pub struct F828mk3 {
     input_ctl: CommandDspInputCtl<F828mk3Protocol>,
     output_ctl: CommandDspOutputCtl<F828mk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
-    meter: CommandDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(F828mk3Protocol::create_meter_state(), Default::default())
-    }
-}
-
-impl CommandDspMeterCtlOperation<F828mk3Protocol> for MeterCtl {
-    fn state(&self) -> &CommandDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: CommandDspMeterCtl<F828mk3Protocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.word_clk_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
@@ -83,9 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -134,128 +112,124 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.port_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -364,11 +338,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3 {
 
 impl MeasureModel<(SndMotu, FwNode)> for F828mk3 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(unit, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -24,12 +24,8 @@ pub struct F828mk3 {
     meter_ctl: CommandDspMeterCtl<F828mk3Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for F828mk3 {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -40,6 +36,12 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -15,7 +15,7 @@ pub struct F828mk3 {
     phone_assign_ctl: PhoneAssignCtl<F828mk3Protocol>,
     word_clk_ctl: WordClockCtl<F828mk3Protocol>,
     sequence_number: u8,
-    reverb_ctl: ReverbCtl,
+    reverb_ctl: CommandDspReverbCtl<F828mk3Protocol>,
     monitor_ctl: MonitorCtl,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
@@ -23,19 +23,6 @@ pub struct F828mk3 {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ReverbCtl(CommandDspReverbState, Vec<ElemId>);
-
-impl CommandDspReverbCtlOperation<F828mk3Protocol> for ReverbCtl {
-    fn state(&self) -> &CommandDspReverbState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspReverbState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -158,9 +145,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
-        self.reverb_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
+        self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
@@ -285,8 +270,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -413,7 +398,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3 {
 
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.reverb_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);

--- a/runtime/motu/src/f828mk3.rs
+++ b/runtime/motu/src/f828mk3.rs
@@ -18,29 +18,11 @@ pub struct F828mk3 {
     reverb_ctl: CommandDspReverbCtl<F828mk3Protocol>,
     monitor_ctl: CommandDspMonitorCtl<F828mk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<F828mk3Protocol>,
-    input_ctl: InputCtl,
+    input_ctl: CommandDspInputCtl<F828mk3Protocol>,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct InputCtl(CommandDspInputState, Vec<ElemId>);
-
-impl Default for InputCtl {
-    fn default() -> Self {
-        Self(F828mk3Protocol::create_input_state(), Default::default())
-    }
-}
-
-impl CommandDspInputCtlOperation<F828mk3Protocol> for InputCtl {
-    fn state(&self) -> &CommandDspInputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspInputState {
-        &mut self.0
-    }
 }
 
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
@@ -117,15 +99,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+        self.input_ctl.load(card_cntr)?;
         self.input_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.input_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
@@ -262,8 +242,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3 {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -366,7 +346,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3 {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.input_ctl.1);
+        elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -20,22 +20,9 @@ pub struct F828mk3Hybrid {
     mixer_ctl: CommandDspMixerCtl<F828mk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<F828mk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<F828mk3HybridProtocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -98,9 +85,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -331,7 +316,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Hybrid {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -24,12 +24,8 @@ pub struct F828mk3Hybrid {
     meter_ctl: CommandDspMeterCtl<F828mk3HybridProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for F828mk3Hybrid {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -40,6 +36,12 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -19,31 +19,10 @@ pub struct F828mk3Hybrid {
     monitor_ctl: CommandDspMonitorCtl<F828mk3HybridProtocol>,
     mixer_ctl: CommandDspMixerCtl<F828mk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<F828mk3HybridProtocol>,
-    output_ctl: OutputCtl,
+    output_ctl: CommandDspOutputCtl<F828mk3HybridProtocol>,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
-
-impl Default for OutputCtl {
-    fn default() -> Self {
-        Self(
-            F828mk3HybridProtocol::create_output_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspOutputCtlOperation<F828mk3HybridProtocol> for OutputCtl {
-    fn state(&self) -> &CommandDspOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspOutputState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -112,15 +91,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.output_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+        self.output_ctl.load(card_cntr)?;
         self.output_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
@@ -275,8 +252,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -353,7 +330,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Hybrid {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.output_ctl.1);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }
 

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -16,26 +16,13 @@ pub struct F828mk3Hybrid {
     word_clk_ctl: WordClockCtl<F828mk3HybridProtocol>,
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<F828mk3HybridProtocol>,
-    monitor_ctl: MonitorCtl,
+    monitor_ctl: CommandDspMonitorCtl<F828mk3HybridProtocol>,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MonitorCtl(CommandDspMonitorState, Vec<ElemId>);
-
-impl CommandDspMonitorCtlOperation<F828mk3HybridProtocol> for MonitorCtl {
-    fn state(&self) -> &CommandDspMonitorState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMonitorState {
-        &mut self.0
-    }
 }
 
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
@@ -158,9 +145,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         self.phone_assign_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
-        self.monitor_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
+        self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
@@ -291,8 +276,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -411,7 +396,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3Hybrid {
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.1);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -17,33 +17,12 @@ pub struct F828mk3Hybrid {
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<F828mk3HybridProtocol>,
     monitor_ctl: CommandDspMonitorCtl<F828mk3HybridProtocol>,
-    mixer_ctl: MixerCtl,
+    mixer_ctl: CommandDspMixerCtl<F828mk3HybridProtocol>,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
-
-impl Default for MixerCtl {
-    fn default() -> Self {
-        Self(
-            F828mk3HybridProtocol::create_mixer_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMixerCtlOperation<F828mk3HybridProtocol> for MixerCtl {
-    fn state(&self) -> &CommandDspMixerState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMixerState {
-        &mut self.0
-    }
 }
 
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
@@ -146,9 +125,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
         self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
-        self.mixer_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
+        self.mixer_ctl.load(card_cntr)?;
         self.input_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
@@ -285,8 +262,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -397,7 +374,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -289,8 +289,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -316,8 +316,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -10,7 +10,7 @@ pub struct F828mk3Hybrid {
     req: FwReq,
     resp: FwResp,
     clk_ctls: V3ClkCtl<F828mk3HybridProtocol>,
-    port_assign_ctl: PortAssignCtl,
+    port_assign_ctl: V3PortAssignCtl<F828mk3HybridProtocol>,
     opt_iface_ctl: OptIfaceCtl,
     phone_assign_ctl: PhoneAssignCtl<F828mk3HybridProtocol>,
     word_clk_ctl: WordClockCtl<F828mk3HybridProtocol>,
@@ -23,19 +23,6 @@ pub struct F828mk3Hybrid {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
-
-impl V3PortAssignCtlOperation<F828mk3HybridProtocol> for PortAssignCtl {
-    fn state(&self) -> &V3PortAssignState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut V3PortAssignState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -174,15 +161,15 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
     ) -> Result<(), Error> {
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.port_assign_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.word_clk_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
-        self.port_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.port_assign_ctl.1.append(&mut elem_id_list))?;
+        self.port_assign_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
@@ -284,10 +271,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .port_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.port_assign_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .opt_iface_ctl
@@ -396,19 +386,22 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
 
 impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
-        elem_id_list.extend_from_slice(&self.port_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.port_assign_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.word_clk_ctl.elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &mut (SndMotu, FwNode), msg: &u32) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndMotu, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
         if *msg & F828mk3HybridProtocol::NOTIFY_PORT_CHANGE > 0 {
             self.port_assign_ctl
-                .cache(unit, &mut self.req, TIMEOUT_MS)?;
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
             self.phone_assign_ctl
-                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-            self.word_clk_ctl
-                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         }
         // TODO: what kind of event is preferable for NOTIFY_FOOTSWITCH_MASK?
         Ok(())

--- a/runtime/motu/src/f828mk3_hybrid.rs
+++ b/runtime/motu/src/f828mk3_hybrid.rs
@@ -280,8 +280,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -307,8 +307,8 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/register_dsp_runtime.rs
+++ b/runtime/motu/src/register_dsp_runtime.rs
@@ -7,7 +7,7 @@ pub(crate) use {
     },
     alsa_ctl_tlv_codec::DbInterval,
     alsactl::{prelude::*, *},
-    core::{card_cntr::*, elem_value_accessor::*},
+    core::card_cntr::*,
     hinawa::FwReq,
     protocols::register_dsp::*,
 };

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -260,8 +260,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -287,8 +287,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -15,26 +15,13 @@ pub struct Track16 {
     phone_assign_ctl: PhoneAssignCtl<Track16Protocol>,
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<Track16Protocol>,
-    monitor_ctl: MonitorCtl,
+    monitor_ctl: CommandDspMonitorCtl<Track16Protocol>,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MonitorCtl(CommandDspMonitorState, Vec<ElemId>);
-
-impl CommandDspMonitorCtlOperation<Track16Protocol> for MonitorCtl {
-    fn state(&self) -> &CommandDspMonitorState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMonitorState {
-        &mut self.0
-    }
 }
 
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
@@ -142,9 +129,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
-        self.monitor_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
+        self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
@@ -268,8 +253,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -383,7 +368,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for Track16 {
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.1);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -23,12 +23,8 @@ pub struct Track16 {
     meter_ctl: CommandDspMeterCtl<Track16Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for Track16 {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for Track16 {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -38,6 +34,12 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for Track16 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -269,8 +269,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -296,8 +296,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -17,29 +17,11 @@ pub struct Track16 {
     reverb_ctl: CommandDspReverbCtl<Track16Protocol>,
     monitor_ctl: CommandDspMonitorCtl<Track16Protocol>,
     mixer_ctl: CommandDspMixerCtl<Track16Protocol>,
-    input_ctl: InputCtl,
+    input_ctl: CommandDspInputCtl<Track16Protocol>,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct InputCtl(CommandDspInputState, Vec<ElemId>);
-
-impl Default for InputCtl {
-    fn default() -> Self {
-        Self(Track16Protocol::create_input_state(), Default::default())
-    }
-}
-
-impl CommandDspInputCtlOperation<Track16Protocol> for InputCtl {
-    fn state(&self) -> &CommandDspInputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspInputState {
-        &mut self.0
-    }
 }
 
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
@@ -113,15 +95,13 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+        self.input_ctl.load(card_cntr)?;
         self.input_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.input_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
@@ -251,8 +231,8 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -350,7 +330,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16 {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.input_ctl.1);
+        elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -20,42 +20,23 @@ pub struct Track16 {
     input_ctl: CommandDspInputCtl<Track16Protocol>,
     output_ctl: CommandDspOutputCtl<Track16Protocol>,
     resource_ctl: CommandDspResourceCtl,
-    meter: CommandDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(Track16Protocol::create_meter_state(), Default::default())
-    }
-}
-
-impl CommandDspMeterCtlOperation<Track16Protocol> for MeterCtl {
-    fn state(&self) -> &CommandDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: CommandDspMeterCtl<Track16Protocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for Track16 {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
@@ -79,9 +60,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -128,123 +107,119 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.port_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -348,11 +323,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16 {
 
 impl MeasureModel<(SndMotu, FwNode)> for Track16 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(unit, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/track16.rs
+++ b/runtime/motu/src/track16.rs
@@ -19,22 +19,9 @@ pub struct Track16 {
     mixer_ctl: CommandDspMixerCtl<Track16Protocol>,
     input_ctl: CommandDspInputCtl<Track16Protocol>,
     output_ctl: CommandDspOutputCtl<Track16Protocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -91,9 +78,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16 {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -312,7 +297,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16 {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -20,22 +20,9 @@ pub struct TravelerMk3 {
     mixer_ctl: CommandDspMixerCtl<TravelerMk3Protocol>,
     input_ctl: CommandDspInputCtl<TravelerMk3Protocol>,
     output_ctl: CommandDspOutputCtl<TravelerMk3Protocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -98,9 +85,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -307,7 +292,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3 {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -289,8 +289,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -316,8 +316,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -15,7 +15,7 @@ pub struct TravelerMk3 {
     phone_assign_ctl: PhoneAssignCtl<TravelerMk3Protocol>,
     word_clk_ctl: WordClockCtl<TravelerMk3Protocol>,
     sequence_number: u8,
-    reverb_ctl: ReverbCtl,
+    reverb_ctl: CommandDspReverbCtl<TravelerMk3Protocol>,
     monitor_ctl: MonitorCtl,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
@@ -23,19 +23,6 @@ pub struct TravelerMk3 {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ReverbCtl(CommandDspReverbState, Vec<ElemId>);
-
-impl CommandDspReverbCtlOperation<TravelerMk3Protocol> for ReverbCtl {
-    fn state(&self) -> &CommandDspReverbState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspReverbState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -170,9 +157,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         self.opt_iface_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
-        self.reverb_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
+        self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
@@ -297,8 +282,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -401,7 +386,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for TravelerMk3 {
 
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.reverb_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -21,47 +21,24 @@ pub struct TravelerMk3 {
     input_ctl: CommandDspInputCtl<TravelerMk3Protocol>,
     output_ctl: CommandDspOutputCtl<TravelerMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
-    meter: CommandDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(
-            TravelerMk3Protocol::create_meter_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMeterCtlOperation<TravelerMk3Protocol> for MeterCtl {
-    fn state(&self) -> &CommandDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: CommandDspMeterCtl<TravelerMk3Protocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.opt_iface_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.word_clk_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
@@ -86,9 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -137,128 +112,124 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.port_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.opt_iface_ctl.write(
-            &mut unit.0,
+            unit,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .word_clk_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -343,11 +314,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3 {
 
 impl MeasureModel<(SndMotu, FwNode)> for TravelerMk3 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(unit, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -280,8 +280,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -307,8 +307,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -11,7 +11,7 @@ pub struct TravelerMk3 {
     resp: FwResp,
     clk_ctls: V3ClkCtl<TravelerMk3Protocol>,
     port_assign_ctl: V3PortAssignCtl<TravelerMk3Protocol>,
-    opt_iface_ctl: OptIfaceCtl,
+    opt_iface_ctl: V3OptIfaceCtl<TravelerMk3Protocol>,
     phone_assign_ctl: PhoneAssignCtl<TravelerMk3Protocol>,
     word_clk_ctl: WordClockCtl<TravelerMk3Protocol>,
     sequence_number: u8,
@@ -24,11 +24,6 @@ pub struct TravelerMk3 {
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
 }
-
-#[derive(Default)]
-struct OptIfaceCtl;
-
-impl V3OptIfaceCtlOperation<TravelerMk3Protocol> for OptIfaceCtl {}
 
 #[derive(Default)]
 struct ReverbCtl(CommandDspReverbState, Vec<ElemId>);
@@ -163,6 +158,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.opt_iface_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.word_clk_ctl
@@ -211,7 +208,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
 
     fn read(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        _: &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         elem_value: &mut ElemValue,
     ) -> Result<bool, Error> {
@@ -219,10 +216,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self
-            .opt_iface_ctl
-            .read(unit, &mut self.req, elem_id, elem_value, TIMEOUT_MS)?
-        {
+        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.phone_assign_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -259,7 +253,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         &mut self,
         unit: &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctls.write(
@@ -279,10 +273,14 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .opt_iface_ctl
-            .write(unit, &mut self.req, elem_id, old, new, TIMEOUT_MS)?
-        {
+        } else if self.opt_iface_ctl.write(
+            &mut unit.0,
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -16,26 +16,13 @@ pub struct TravelerMk3 {
     word_clk_ctl: WordClockCtl<TravelerMk3Protocol>,
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<TravelerMk3Protocol>,
-    monitor_ctl: MonitorCtl,
+    monitor_ctl: CommandDspMonitorCtl<TravelerMk3Protocol>,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MonitorCtl(CommandDspMonitorState, Vec<ElemId>);
-
-impl CommandDspMonitorCtlOperation<TravelerMk3Protocol> for MonitorCtl {
-    fn state(&self) -> &CommandDspMonitorState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMonitorState {
-        &mut self.0
-    }
 }
 
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
@@ -158,9 +145,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
         self.phone_assign_ctl.load(card_cntr)?;
         self.word_clk_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
-        self.monitor_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
+        self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
@@ -291,8 +276,8 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -387,7 +372,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for TravelerMk3 {
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.1);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/traveler_mk3.rs
+++ b/runtime/motu/src/traveler_mk3.rs
@@ -24,12 +24,8 @@ pub struct TravelerMk3 {
     meter_ctl: CommandDspMeterCtl<TravelerMk3Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for TravelerMk3 {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -40,6 +36,12 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for TravelerMk3 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.opt_iface_ctl.load(card_cntr)?;

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -16,32 +16,11 @@ pub struct UltraLiteMk3 {
     reverb_ctl: CommandDspReverbCtl<UltraliteMk3Protocol>,
     monitor_ctl: CommandDspMonitorCtl<UltraliteMk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3Protocol>,
-    input_ctl: InputCtl,
+    input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct InputCtl(CommandDspInputState, Vec<ElemId>);
-
-impl Default for InputCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3Protocol::create_input_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspInputCtlOperation<UltraliteMk3Protocol> for InputCtl {
-    fn state(&self) -> &CommandDspInputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspInputState {
-        &mut self.0
-    }
 }
 
 struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
@@ -118,15 +97,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+        self.input_ctl.load(card_cntr)?;
         self.input_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.input_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
@@ -245,8 +222,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -344,7 +321,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.input_ctl.1);
+        elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -22,12 +22,8 @@ pub struct UltraLiteMk3 {
     meter_ctl: CommandDspMeterCtl<UltraliteMk3Protocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for UltraLiteMk3 {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -36,6 +32,12 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -15,33 +15,12 @@ pub struct UltraLiteMk3 {
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<UltraliteMk3Protocol>,
     monitor_ctl: CommandDspMonitorCtl<UltraliteMk3Protocol>,
-    mixer_ctl: MixerCtl,
+    mixer_ctl: CommandDspMixerCtl<UltraliteMk3Protocol>,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
-
-impl Default for MixerCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3Protocol::create_mixer_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMixerCtlOperation<UltraliteMk3Protocol> for MixerCtl {
-    fn state(&self) -> &CommandDspMixerState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMixerState {
-        &mut self.0
-    }
 }
 
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
@@ -138,9 +117,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
-        self.mixer_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
+        self.mixer_ctl.load(card_cntr)?;
         self.input_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
@@ -259,8 +236,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -366,7 +343,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -263,8 +263,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -290,8 +290,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -18,22 +18,9 @@ pub struct UltraLiteMk3 {
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3Protocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3Protocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -90,9 +77,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -300,7 +285,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -14,26 +14,13 @@ pub struct UltraLiteMk3 {
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3Protocol>,
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<UltraliteMk3Protocol>,
-    monitor_ctl: MonitorCtl,
+    monitor_ctl: CommandDspMonitorCtl<UltraliteMk3Protocol>,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MonitorCtl(CommandDspMonitorState, Vec<ElemId>);
-
-impl CommandDspMonitorCtlOperation<UltraliteMk3Protocol> for MonitorCtl {
-    fn state(&self) -> &CommandDspMonitorState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMonitorState {
-        &mut self.0
-    }
 }
 
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
@@ -150,9 +137,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
-        self.monitor_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
+        self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
@@ -265,8 +250,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -380,7 +365,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraLiteMk3 {
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.1);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -19,43 +19,22 @@ pub struct UltraLiteMk3 {
     input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
-    meter: CommandDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3Protocol::create_meter_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMeterCtlOperation<UltraliteMk3Protocol> for MeterCtl {
-    fn state(&self) -> &CommandDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: CommandDspMeterCtl<UltraliteMk3Protocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
@@ -78,9 +57,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -125,114 +102,110 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.port_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -336,11 +309,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
 
 impl MeasureModel<(SndMotu, FwNode)> for UltraLiteMk3 {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(unit, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -254,8 +254,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -281,8 +281,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -13,7 +13,7 @@ pub struct UltraLiteMk3 {
     port_assign_ctl: V3PortAssignCtl<UltraliteMk3Protocol>,
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3Protocol>,
     sequence_number: u8,
-    reverb_ctl: ReverbCtl,
+    reverb_ctl: CommandDspReverbCtl<UltraliteMk3Protocol>,
     monitor_ctl: MonitorCtl,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
@@ -21,19 +21,6 @@ pub struct UltraLiteMk3 {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ReverbCtl(CommandDspReverbState, Vec<ElemId>);
-
-impl CommandDspReverbCtlOperation<UltraliteMk3Protocol> for ReverbCtl {
-    fn state(&self) -> &CommandDspReverbState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspReverbState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -162,9 +149,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
-        self.reverb_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
+        self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
@@ -271,8 +256,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -394,7 +379,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraLiteMk3 {
 
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.reverb_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -17,31 +17,10 @@ pub struct UltraLiteMk3 {
     monitor_ctl: CommandDspMonitorCtl<UltraliteMk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3Protocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
-    output_ctl: OutputCtl,
+    output_ctl: CommandDspOutputCtl<UltraliteMk3Protocol>,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
-
-impl Default for OutputCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3Protocol::create_output_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspOutputCtlOperation<UltraliteMk3Protocol> for OutputCtl {
-    fn state(&self) -> &CommandDspOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspOutputState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -104,15 +83,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.output_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+        self.output_ctl.load(card_cntr)?;
         self.output_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
@@ -249,8 +226,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -322,7 +299,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraLiteMk3 {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.output_ctl.1);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }
 

--- a/runtime/motu/src/ultralite_mk3.rs
+++ b/runtime/motu/src/ultralite_mk3.rs
@@ -10,7 +10,7 @@ pub struct UltraLiteMk3 {
     req: FwReq,
     resp: FwResp,
     clk_ctls: V3ClkCtl<UltraliteMk3Protocol>,
-    port_assign_ctl: PortAssignCtl,
+    port_assign_ctl: V3PortAssignCtl<UltraliteMk3Protocol>,
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3Protocol>,
     sequence_number: u8,
     reverb_ctl: ReverbCtl,
@@ -21,19 +21,6 @@ pub struct UltraLiteMk3 {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct PortAssignCtl(V3PortAssignState, Vec<ElemId>);
-
-impl V3PortAssignCtlOperation<UltraliteMk3Protocol> for PortAssignCtl {
-    fn state(&self) -> &V3PortAssignState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut V3PortAssignState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -167,13 +154,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
     ) -> Result<(), Error> {
         self.clk_ctls
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.port_assign_ctl
+            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
         self.phone_assign_ctl
             .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
 
         self.clk_ctls.load(card_cntr)?;
-        self.port_assign_ctl
-            .load(card_cntr, unit, &mut self.req, TIMEOUT_MS)
-            .map(|mut elem_id_list| self.port_assign_ctl.1.append(&mut elem_id_list))?;
+        self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl
             .load(card_cntr)
@@ -266,10 +253,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .port_assign_ctl
-            .write(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.port_assign_ctl.write(
+            &mut self.req,
+            &mut unit.1,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
@@ -368,16 +358,20 @@ impl CtlModel<(SndMotu, FwNode)> for UltraLiteMk3 {
 
 impl NotifyModel<(SndMotu, FwNode), u32> for UltraLiteMk3 {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.port_assign_ctl.1);
+        elem_id_list.extend_from_slice(&self.port_assign_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
     }
 
-    fn parse_notification(&mut self, unit: &mut (SndMotu, FwNode), msg: &u32) -> Result<(), Error> {
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndMotu, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
         if *msg & UltraliteMk3Protocol::NOTIFY_PORT_CHANGE > 0 {
             self.port_assign_ctl
-                .cache(unit, &mut self.req, TIMEOUT_MS)?;
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
             self.phone_assign_ctl
-                .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -13,7 +13,7 @@ pub struct UltraliteMk3Hybrid {
     port_assign_ctl: V3PortAssignCtl<UltraliteMk3HybridProtocol>,
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3HybridProtocol>,
     sequence_number: u8,
-    reverb_ctl: ReverbCtl,
+    reverb_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
     monitor_ctl: MonitorCtl,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
@@ -21,19 +21,6 @@ pub struct UltraliteMk3Hybrid {
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ReverbCtl(CommandDspReverbState, Vec<ElemId>);
-
-impl CommandDspReverbCtlOperation<UltraliteMk3HybridProtocol> for ReverbCtl {
-    fn state(&self) -> &CommandDspReverbState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspReverbState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -162,9 +149,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
-        self.reverb_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.reverb_ctl.1.append(&mut elem_id_list))?;
+        self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
@@ -271,8 +256,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -394,7 +379,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraliteMk3Hybrid {
 
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.reverb_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -17,31 +17,10 @@ pub struct UltraliteMk3Hybrid {
     monitor_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3HybridProtocol>,
-    output_ctl: OutputCtl,
+    output_ctl: CommandDspOutputCtl<UltraliteMk3HybridProtocol>,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct OutputCtl(CommandDspOutputState, Vec<ElemId>);
-
-impl Default for OutputCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3HybridProtocol::create_output_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspOutputCtlOperation<UltraliteMk3HybridProtocol> for OutputCtl {
-    fn state(&self) -> &CommandDspOutputState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspOutputState {
-        &mut self.0
-    }
 }
 
 #[derive(Default)]
@@ -104,15 +83,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.output_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+        self.output_ctl.load(card_cntr)?;
         self.output_ctl
             .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl
             .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.1.append(&mut elem_id_list))?;
+            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
@@ -249,8 +226,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -322,7 +299,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.output_ctl.1);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);
     }
 

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -14,26 +14,13 @@ pub struct UltraliteMk3Hybrid {
     phone_assign_ctl: PhoneAssignCtl<UltraliteMk3HybridProtocol>,
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
-    monitor_ctl: MonitorCtl,
+    monitor_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
     mixer_ctl: MixerCtl,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct MonitorCtl(CommandDspMonitorState, Vec<ElemId>);
-
-impl CommandDspMonitorCtlOperation<UltraliteMk3HybridProtocol> for MonitorCtl {
-    fn state(&self) -> &CommandDspMonitorState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMonitorState {
-        &mut self.0
-    }
 }
 
 struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
@@ -150,9 +137,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
-        self.monitor_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.monitor_ctl.1.append(&mut elem_id_list))?;
+        self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
@@ -265,8 +250,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -380,7 +365,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for UltraliteMk3Hybrid {
 impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.1);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.1);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -15,33 +15,12 @@ pub struct UltraliteMk3Hybrid {
     sequence_number: u8,
     reverb_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
     monitor_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
-    mixer_ctl: MixerCtl,
+    mixer_ctl: CommandDspMixerCtl<UltraliteMk3HybridProtocol>,
     input_ctl: InputCtl,
     output_ctl: OutputCtl,
     resource_ctl: ResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-struct MixerCtl(CommandDspMixerState, Vec<ElemId>);
-
-impl Default for MixerCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3HybridProtocol::create_mixer_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMixerCtlOperation<UltraliteMk3HybridProtocol> for MixerCtl {
-    fn state(&self) -> &CommandDspMixerState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMixerState {
-        &mut self.0
-    }
 }
 
 struct InputCtl(CommandDspInputState, Vec<ElemId>);
@@ -138,9 +117,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         self.phone_assign_ctl.load(card_cntr)?;
         self.reverb_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
-        self.mixer_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.mixer_ctl.1.append(&mut elem_id_list))?;
+        self.mixer_ctl.load(card_cntr)?;
         self.input_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.1.append(&mut elem_id_list))?;
@@ -259,8 +236,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -366,7 +343,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.1);
         elem_id_list.extend_from_slice(&self.output_ctl.1);
         elem_id_list.extend_from_slice(&self.resource_ctl.1);

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -263,8 +263,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -290,8 +290,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -18,22 +18,9 @@ pub struct UltraliteMk3Hybrid {
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3HybridProtocol>,
-    resource_ctl: ResourceCtl,
+    resource_ctl: CommandDspResourceCtl,
     meter: CommandDspMeterImage,
     meter_ctl: MeterCtl,
-}
-
-#[derive(Default)]
-struct ResourceCtl(u32, Vec<ElemId>);
-
-impl CommandDspResourcebCtlOperation for ResourceCtl {
-    fn state(&self) -> &u32 {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut u32 {
-        &mut self.0
-    }
 }
 
 struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
@@ -90,9 +77,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
-        self.resource_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.resource_ctl.1.append(&mut elem_id_list))?;
+        self.resource_ctl.load(card_cntr)?;
         self.meter_ctl
             .load(card_cntr)
             .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
@@ -300,7 +285,7 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.resource_ctl.1);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
     fn parse_notification(

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -254,8 +254,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,
@@ -281,8 +281,8 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
-            unit,
             &mut self.req,
+            &mut unit.1,
             elem_id,
             new,
             TIMEOUT_MS,

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -22,12 +22,8 @@ pub struct UltraliteMk3Hybrid {
     meter_ctl: CommandDspMeterCtl<UltraliteMk3HybridProtocol>,
 }
 
-impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
-    fn load(
-        &mut self,
-        (unit, node): &mut (SndMotu, FwNode),
-        card_cntr: &mut CardCntr,
-    ) -> Result<(), Error> {
+impl CommandDspCtlModel for UltraliteMk3Hybrid {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
         self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
             .cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -36,6 +32,12 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
 
         self.meter_ctl.read_dsp_meter(unit)?;
 
+        Ok(())
+    }
+}
+
+impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
+    fn load(&mut self, _: &mut (SndMotu, FwNode), card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
         self.phone_assign_ctl.load(card_cntr)?;

--- a/runtime/motu/src/ultralite_mk3_hybrid.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid.rs
@@ -19,43 +19,22 @@ pub struct UltraliteMk3Hybrid {
     input_ctl: CommandDspInputCtl<UltraliteMk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3HybridProtocol>,
     resource_ctl: CommandDspResourceCtl,
-    meter: CommandDspMeterImage,
-    meter_ctl: MeterCtl,
-}
-
-struct MeterCtl(CommandDspMeterState, Vec<ElemId>);
-
-impl Default for MeterCtl {
-    fn default() -> Self {
-        Self(
-            UltraliteMk3HybridProtocol::create_meter_state(),
-            Default::default(),
-        )
-    }
-}
-
-impl CommandDspMeterCtlOperation<UltraliteMk3HybridProtocol> for MeterCtl {
-    fn state(&self) -> &CommandDspMeterState {
-        &self.0
-    }
-
-    fn state_mut(&mut self) -> &mut CommandDspMeterState {
-        &mut self.0
-    }
+    meter_ctl: CommandDspMeterCtl<UltraliteMk3HybridProtocol>,
 }
 
 impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
     fn load(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         card_cntr: &mut CardCntr,
     ) -> Result<(), Error> {
-        self.clk_ctls
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.port_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.phone_assign_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
 
         self.clk_ctls.load(card_cntr)?;
         self.port_assign_ctl.load(card_cntr)?;
@@ -78,9 +57,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.resource_ctl.load(card_cntr)?;
-        self.meter_ctl
-            .load(card_cntr)
-            .map(|mut elem_id_list| self.meter_ctl.1.append(&mut elem_id_list))?;
+        self.meter_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -125,114 +102,110 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
 
     fn write(
         &mut self,
-        unit: &mut (SndMotu, FwNode),
+        (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
         _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctls.write(
-            &mut unit.0,
-            &mut self.req,
-            &mut unit.1,
-            elem_id,
-            new,
-            TIMEOUT_MS,
-        )? {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.port_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.phone_assign_ctl.write(
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.reverb_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.monitor_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.input_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_equalizer(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.output_ctl.write_dynamics(
             &mut self.sequence_number,
             &mut self.req,
-            &mut unit.1,
+            node,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -336,11 +309,11 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Hybrid {
 
 impl MeasureModel<(SndMotu, FwNode)> for UltraliteMk3Hybrid {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.read_dsp_meter(unit, &mut self.meter)
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
     }
 
     fn measure_elem(


### PR DESCRIPTION
This patchset reworks current implementation of runtime for Command DSP models so that
cache function is split from load function following to the other runtime implementations.

```
Takashi Sakamoto (12):
  runtime/motu: use generic structure for port assign controls in
    version 3 models
  runtime/motu: use generic structure for optical interface controls in
    version 3 models
  runtime/motu: use generic structure for reverb controls in Command DSP
    models
  runtime/motu: use generic structure for monitor controls in Command
    DSP models
  runtime/motu: use generic structure for mixer controls in Command DSP
    models
  runtime/motu: code refactoring for equalizer controls in Command DSP
    models
  runtime/motu: code refactoring for dynamics controls in Command DSP
    models
  runtime/motu: use generic structure for input controls in Command DSP
    models
  runtime/motu: use generic structure for output controls in Command DSP
    models
  runtime/motu: use common structure for resource controls in Command
    DSP models
  runtime/motu: use generic structure for meter controls in Command DSP
    models
  runtime/motu: split cache function from load function in command DSP
    model

 protocols/motu/src/command_dsp.rs        |    2 +-
 runtime/motu/src/command_dsp_ctls.rs     | 1642 +++++++++++++---------
 runtime/motu/src/command_dsp_runtime.rs  |    8 +
 runtime/motu/src/f828mk3.rs              |  324 ++---
 runtime/motu/src/f828mk3_hybrid.rs       |  336 ++---
 runtime/motu/src/register_dsp_runtime.rs |    2 +-
 runtime/motu/src/track16.rs              |  316 ++---
 runtime/motu/src/traveler_mk3.rs         |  321 ++---
 runtime/motu/src/ultralite_mk3.rs        |  299 +---
 runtime/motu/src/ultralite_mk3_hybrid.rs |  299 +---
 runtime/motu/src/v3_ctls.rs              |  240 ++--
 11 files changed, 1611 insertions(+), 2178 deletions(-)
```