### PR TITLE
[PATCH 00/13] runtime/motu: support debug logging by tracing crate

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2023/03/29
+2023/04/12
 Takashi Sakamoto
 
 Introduction
@@ -85,7 +85,8 @@ Execute temporarily ::
     & cargo run --bin (the executable name) -- (the arguments of executable)
 
 All of executables can print help when either ``--help`` or ``-h`` is given as an argument of
-command line.
+command line. Additionally, either ``--log-level`` or ``-l`` is also available for runtime
+debugging. For further information, please refer to ``Runtime debugging`` clause.
 
 Install executables ::
 
@@ -177,6 +178,7 @@ your device, please contact to developer.
   * Griffin FireWave
   * Lacie FireWire Speakers
   * Mackie Tapco Link.FireWire 4x6
+  * For the others, common controls are available.
 
 * snd-bebob-ctl-service
 
@@ -272,19 +274,9 @@ Supported protocols
 Runtime debugging
 =================
 
-Some executables support an option for log level for debugging. When either ``-l`` or
+All executables support an option for log level for debugging. When either ``-l`` or
 ``--log-level`` is given with log level, they prints verbose logs to standard output.
 At present, ``debug`` is just supported for the log level.
-
-Currently this function is available for below executables:
-
-* snd-bebob-ctl-service
-* snd-dice-ctl-service
-* snd-oxfw-ctl-service
-* snd-fireface-ctl-service
-* snd-fireworks-ctl-service
-* snd-firewire-digi00x-ctl-service
-* snd-firewire-tascam-ctl-service
 
 This function is implemented by `tracing <https://crates.io/crates/tracing>`_ and
 `tracing-subscriber <https://crates.io/crates/tracing-subscriber>`_ crates.

--- a/runtime/motu/Cargo.toml
+++ b/runtime/motu/Cargo.toml
@@ -21,3 +21,5 @@ ieee1212-config-rom = "0.1"
 firewire-motu-protocols = "0.1"
 clap = { version = "3.2", features = ["derive"] }
 core = { path = "../core" }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
+++ b/runtime/motu/src/bin/snd-firewire-motu-ctl-service.rs
@@ -14,11 +14,15 @@ struct MotuServiceCmd;
 struct Arguments {
     /// The numeric identifier of sound card in Linux sound subsystem.
     card_id: u32,
+
+    /// The level to debug runtime, disabled as a default.
+    #[clap(long, short, arg_enum)]
+    log_level: Option<LogLevel>,
 }
 
 impl ServiceCmd<Arguments, u32, MotuRuntime> for MotuServiceCmd {
     fn params(args: &Arguments) -> (u32, Option<LogLevel>) {
-        (args.card_id, None)
+        (args.card_id, args.log_level)
     }
 }
 

--- a/runtime/motu/src/command_dsp_ctls.rs
+++ b/runtime/motu/src/command_dsp_ctls.rs
@@ -237,7 +237,11 @@ where
     ];
 
     pub(crate) fn parse_command(&mut self, cmd: &DspCmd) -> bool {
-        T::parse_command(&mut self.params, cmd)
+        let res = T::parse_command(&mut self.params, cmd);
+        if res {
+            debug!(params = ?self.params);
+        }
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -478,6 +482,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_SPLIT_POINT_NAME => {
@@ -491,6 +496,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_PRE_DELAY_NAME => {
@@ -504,6 +510,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_SHELF_FILTER_FREQ_NAME => {
@@ -517,6 +524,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_SHELF_FILTER_ATTR_NAME => {
@@ -530,6 +538,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_DECAY_TIME_NAME => {
@@ -543,6 +552,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_FREQ_TIME_NAME => {
@@ -556,6 +566,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_FREQ_CROSSOVER_NAME => {
@@ -569,6 +580,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_WIDTH_NAME => {
@@ -582,6 +594,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_REFLECTION_MODE_NAME => {
@@ -595,6 +608,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_REFLECTION_SIZE_NAME => {
@@ -608,6 +622,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             REVERB_REFLECTION_LEVEL_NAME => {
@@ -621,6 +636,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -653,7 +669,11 @@ where
         + MotuCommandDspUpdatableParamsOperation<CommandDspMonitorState>,
 {
     pub(crate) fn parse_command(&mut self, cmd: &DspCmd) -> bool {
-        T::parse_command(&mut self.params, cmd)
+        let res = T::parse_command(&mut self.params, cmd);
+        if res {
+            debug!(params = ?self.params);
+        }
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -742,6 +762,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             TALKBACK_ENABLE_NAME => {
@@ -755,6 +776,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             LISTENBACK_ENABLE_NAME => {
@@ -768,6 +790,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             TALKBACK_VOLUME_NAME => {
@@ -781,6 +804,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             LISTENBACK_VOLUME_NAME => {
@@ -794,6 +818,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -860,7 +885,11 @@ where
         [SourceStereoPairMode::Width, SourceStereoPairMode::LrBalance];
 
     pub(crate) fn parse_command(&mut self, cmd: &DspCmd) -> bool {
-        T::parse_command(&mut self.params, cmd)
+        let res = T::parse_command(&mut self.params, cmd);
+        if res {
+            debug!(params = ?self.params);
+        }
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1142,6 +1171,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_OUTPUT_MUTE_NAME => {
@@ -1155,6 +1185,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_OUTPUT_VOLUME_NAME => {
@@ -1168,6 +1199,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_REVERB_SEND_NAME => {
@@ -1181,6 +1213,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_REVERB_RETURN_NAME => {
@@ -1194,6 +1227,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_MUTE_NAME => {
@@ -1212,6 +1246,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_SOLO_NAME => {
@@ -1230,6 +1265,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_PAN_NAME => {
@@ -1248,6 +1284,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_GAIN_NAME => {
@@ -1266,6 +1303,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_STEREO_PAIR_MODE_NAME => {
@@ -1288,6 +1326,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
@@ -1306,6 +1345,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
@@ -1324,6 +1364,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -1746,6 +1787,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HPF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -1759,6 +1801,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HPF_SLOPE_NAME {
             let mut params = self.params().clone();
@@ -1772,6 +1815,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HPF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -1785,6 +1829,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LPF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -1798,6 +1843,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LPF_SLOPE_NAME {
             let mut params = self.params().clone();
@@ -1811,6 +1857,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LPF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -1824,6 +1871,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -1837,6 +1885,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LF_TYPE_NAME {
             let mut params = self.params().clone();
@@ -1850,6 +1899,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -1863,6 +1913,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LF_GAIN_NAME {
             let mut params = self.params().clone();
@@ -1876,6 +1927,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LF_WIDTH_NAME {
             let mut params = self.params().clone();
@@ -1889,6 +1941,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LMF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -1902,6 +1955,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LMF_TYPE_NAME {
             let mut params = self.params().clone();
@@ -1915,6 +1969,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LMF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -1928,6 +1983,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LMF_GAIN_NAME {
             let mut params = self.params().clone();
@@ -1941,6 +1997,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LMF_WIDTH_NAME {
             let mut params = self.params().clone();
@@ -1954,6 +2011,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::MF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -1967,6 +2025,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::MF_TYPE_NAME {
             let mut params = self.params().clone();
@@ -1980,6 +2039,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::MF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -1993,6 +2053,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::MF_GAIN_NAME {
             let mut params = self.params().clone();
@@ -2006,6 +2067,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::MF_WIDTH_NAME {
             let mut params = self.params().clone();
@@ -2019,6 +2081,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HMF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -2032,6 +2095,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HMF_TYPE_NAME {
             let mut params = self.params().clone();
@@ -2045,6 +2109,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HMF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -2058,6 +2123,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HMF_GAIN_NAME {
             let mut params = self.params().clone();
@@ -2071,6 +2137,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HMF_WIDTH_NAME {
             let mut params = self.params().clone();
@@ -2084,6 +2151,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HF_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -2097,6 +2165,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HF_TYPE_NAME {
             let mut params = self.params().clone();
@@ -2110,6 +2179,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HF_FREQ_NAME {
             let mut params = self.params().clone();
@@ -2123,6 +2193,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HF_GAIN_NAME {
             let mut params = self.params().clone();
@@ -2136,6 +2207,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::HF_WIDTH_NAME {
             let mut params = self.params().clone();
@@ -2149,6 +2221,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else {
             Ok(false)
@@ -2426,6 +2499,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -2439,6 +2513,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_DETECT_MODE_NAME {
             let mut params = self.params().clone();
@@ -2456,6 +2531,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_THRESHOLD_NAME {
             let mut params = self.params().clone();
@@ -2469,6 +2545,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_RATIO_NAME {
             let mut params = self.params().clone();
@@ -2482,6 +2559,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_ATTACK_NAME {
             let mut params = self.params().clone();
@@ -2495,6 +2573,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_RELEASE_NAME {
             let mut params = self.params().clone();
@@ -2508,6 +2587,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::COMP_GAIN_NAME {
             let mut params = self.params().clone();
@@ -2521,6 +2601,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LEVELER_ENABLE_NAME {
             let mut params = self.params().clone();
@@ -2534,6 +2615,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LEVELER_MODE_NAME {
             let mut params = self.params().clone();
@@ -2547,6 +2629,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LEVELER_MAKEUP_NAME {
             let mut params = self.params().clone();
@@ -2560,6 +2643,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else if name == Self::LEVELER_REDUCE_NAME {
             let mut params = self.params().clone();
@@ -2573,6 +2657,7 @@ where
                 params,
                 timeout_ms,
             );
+            debug!(params = ?self.params().as_ref(), ?res);
             res.map(|_| true)
         } else {
             Ok(false)
@@ -2846,6 +2931,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_PAIR_NAME => {
@@ -2859,6 +2945,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_GAIN_NAME => {
@@ -2872,6 +2959,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_SWAP_NAME => {
@@ -2885,6 +2973,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_STEREO_MODE_NAME => {
@@ -2902,6 +2991,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_WIDTH_NAME => {
@@ -2915,6 +3005,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_REVERB_SEND_NAME => {
@@ -2928,6 +3019,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_REVERB_BALANCE_NAME => {
@@ -2941,6 +3033,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_PAD_NAME => {
@@ -2954,6 +3047,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_PHANTOM_NAME => {
@@ -2967,6 +3061,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_LIMITTER_NAME => {
@@ -2980,6 +3075,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_LOOKAHEAD_NAME => {
@@ -2993,6 +3089,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_SOFT_CLIP_NAME => {
@@ -3006,6 +3103,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -3013,7 +3111,11 @@ where
     }
 
     pub(crate) fn parse_command(&mut self, cmd: &DspCmd) -> bool {
-        T::parse_command(&mut self.params, cmd)
+        let res = T::parse_command(&mut self.params, cmd);
+        if res {
+            debug!(params = ?self.params);
+        }
+        res
     }
 }
 
@@ -3252,6 +3354,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OUTPUT_REVERB_RETURN_NAME => {
@@ -3265,6 +3368,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OUTPUT_MASTER_MONITOR_NAME => {
@@ -3278,6 +3382,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OUTPUT_MASTER_TALKBACK_NAME => {
@@ -3291,6 +3396,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OUTPUT_MASTER_LISTENBACK_NAME => {
@@ -3304,6 +3410,7 @@ where
                     params,
                     timeout_ms,
                 );
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -3311,7 +3418,11 @@ where
     }
 
     pub(crate) fn parse_command(&mut self, cmd: &DspCmd) -> bool {
-        T::parse_command(&mut self.params, cmd)
+        let res = T::parse_command(&mut self.params, cmd);
+        if res {
+            debug!(params = ?self.params);
+        }
+        res
     }
 }
 
@@ -3411,7 +3522,7 @@ where
 #[derive(Default, Debug)]
 pub(crate) struct CommandDspResourceCtl {
     pub elem_id_list: Vec<ElemId>,
-    state: u32,
+    params: u32,
 }
 
 const RESOURCE_USAGE_NAME: &str = "resource-usage";
@@ -3440,7 +3551,7 @@ impl CommandDspResourceCtl {
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             RESOURCE_USAGE_NAME => {
-                read_u32_to_i32_value(elem_value, &self.state)?;
+                read_u32_to_i32_value(elem_value, &self.params)?;
                 Ok(true)
             }
             _ => Ok(false),
@@ -3453,10 +3564,11 @@ impl CommandDspResourceCtl {
                 // TODO: flag?
                 ResourceCmd::Usage(usage, _) => {
                     let val = f32_to_i32(*usage).unwrap();
-                    self.state = val as u32;
+                    self.params = val as u32;
                 }
                 _ => (),
             }
+            debug!(params = ?self.params);
             true
         } else {
             false
@@ -3548,6 +3660,7 @@ where
     pub(crate) fn read_dsp_meter(&mut self, unit: &mut SndMotu) -> Result<(), Error> {
         unit.read_float_meter(&mut self.image)?;
         T::parse_image(&mut self.params, &self.image);
+        debug!(params = ?self.params);
         Ok(())
     }
 }

--- a/runtime/motu/src/common_ctls.rs
+++ b/runtime/motu/src/common_ctls.rs
@@ -29,7 +29,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -83,6 +85,7 @@ where
                     .map(|&p| params.0 = p)?;
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -123,7 +126,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -175,8 +180,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -218,7 +225,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -267,8 +276,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -332,7 +343,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -436,8 +449,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.peak_hold_time = mode)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             CLIP_HOLD_TIME_MODE_NAME => {
                 let mut params = self.params.clone();
@@ -453,8 +468,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.clip_hold_time = mode)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             AESEBU_MODE_NAME => {
                 let mut params = self.params.clone();
@@ -468,8 +485,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.aesebu_mode = mode)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             PROGRAMMABLE_MODE_NAME => {
                 let mut params = self.params.clone();
@@ -485,8 +504,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.programmable_mode = mode)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/motu/src/f828.rs
+++ b/runtime/motu/src/f828.rs
@@ -118,7 +118,9 @@ const OPT_OUT_IFACE_MODE_NAME: &str = "optical-iface-out-mode";
 
 impl SpecificCtl {
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        F828Protocol::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = F828Protocol::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -187,6 +189,7 @@ impl SpecificCtl {
                 let res = F828Protocol::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.params = params);
                 unit.unlock()?;
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OPT_OUT_IFACE_MODE_NAME => {
@@ -204,6 +207,7 @@ impl SpecificCtl {
                 let res = F828Protocol::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.params = params);
                 unit.unlock()?;
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/lib.rs
+++ b/runtime/motu/src/lib.rs
@@ -42,7 +42,7 @@ use {
     ieee1212_config_rom::*,
     protocols::{config_rom::*, *},
     std::{convert::TryFrom, marker::PhantomData},
-    tracing::Level,
+    tracing::{debug, debug_span, Level},
 };
 
 pub enum MotuRuntime {

--- a/runtime/motu/src/lib.rs
+++ b/runtime/motu/src/lib.rs
@@ -42,6 +42,7 @@ use {
     ieee1212_config_rom::*,
     protocols::{config_rom::*, *},
     std::{convert::TryFrom, marker::PhantomData},
+    tracing::Level,
 };
 
 pub enum MotuRuntime {
@@ -63,7 +64,14 @@ pub enum MotuRuntime {
 }
 
 impl RuntimeOperation<u32> for MotuRuntime {
-    fn new(card_id: u32, _: Option<LogLevel>) -> Result<Self, Error> {
+    fn new(card_id: u32, log_level: Option<LogLevel>) -> Result<Self, Error> {
+        if let Some(level) = log_level {
+            let fmt_level = match level {
+                LogLevel::Debug => Level::DEBUG,
+            };
+            tracing_subscriber::fmt().with_max_level(fmt_level).init();
+        }
+
         let cdev = format!("/dev/snd/hwC{}D0", card_id);
         let unit = SndMotu::new();
         unit.open(&cdev, 0)?;

--- a/runtime/motu/src/register_dsp_ctls.rs
+++ b/runtime/motu/src/register_dsp_ctls.rs
@@ -25,7 +25,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.0.params, event)
+        let res = T::parse_event(&mut self.0.params, event);
+        if res {
+            debug!(params = ?self.0.params, ?event);
+        }
+        res
     }
 }
 
@@ -73,7 +77,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -161,6 +167,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(vol, &val)| *vol = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_OUTPUT_MUTE_NAME => {
@@ -168,6 +175,7 @@ where
                 let vals = &elem_value.boolean()[..T::MIXER_COUNT];
                 params.mute.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_OUTPUT_DST_NAME => {
@@ -188,6 +196,7 @@ where
                             .map(|&port| *dest = port)
                     })?;
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -199,7 +208,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -229,7 +242,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -267,6 +282,7 @@ where
                 params.0 = elem_value.boolean()[0];
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -357,7 +373,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -454,6 +472,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_PAN_NAME => {
@@ -465,6 +484,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(pan, &val)| *pan = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_MUTE_NAME => {
@@ -474,6 +494,7 @@ where
                 let vals = &elem_value.boolean()[..src.mute.len()];
                 src.mute.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_SOLO_NAME => {
@@ -483,6 +504,7 @@ where
                 let vals = &elem_value.boolean()[..src.mute.len()];
                 src.solo.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -494,7 +516,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -560,7 +586,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -709,6 +737,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_PAN_NAME => {
@@ -720,6 +749,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(pan, &val)| *pan = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_MUTE_NAME => {
@@ -729,6 +759,7 @@ where
                 let vals = &elem_value.boolean()[..src.mute.len()];
                 src.mute.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_SOLO_NAME => {
@@ -738,6 +769,7 @@ where
                 let vals = &elem_value.boolean()[..src.solo.len()];
                 src.solo.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_STEREO_BALANCE_NAME => {
@@ -749,6 +781,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(balance, &val)| *balance = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIXER_SOURCE_STEREO_WIDTH_NAME => {
@@ -760,6 +793,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(width, &val)| *width = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -771,7 +805,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -813,7 +851,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -880,6 +920,7 @@ where
                 params.master_volume = elem_value.int()[0] as u8;
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms)
                     .map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             PHONE_VOLUME_NAME => {
@@ -887,6 +928,7 @@ where
                 params.phone_volume = elem_value.int()[0] as u8;
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms)
                     .map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -898,7 +940,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -955,7 +1001,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1033,6 +1081,7 @@ where
                             .map(|&l| *level = l)
                     })?;
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_BOOST_NAME => {
@@ -1040,6 +1089,7 @@ where
                 let vals = &elem_value.boolean()[..params.boost.len()];
                 params.boost.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -1051,7 +1101,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -1097,7 +1151,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1158,6 +1214,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_INVERT_NAME => {
@@ -1165,6 +1222,7 @@ where
                 let vals = &elem_value.boolean()[..params.invert.len()];
                 params.invert.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -1176,7 +1234,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -1232,7 +1294,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1329,6 +1393,7 @@ where
                     .zip(elem_value.int())
                     .for_each(|(gain, &val)| *gain = val as u8);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_INVERT_NAME => {
@@ -1336,6 +1401,7 @@ where
                 let vals = &elem_value.boolean()[..params.invert.len()];
                 params.invert.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_PHANTOM_NAME => {
@@ -1343,6 +1409,7 @@ where
                 let vals = &elem_value.boolean()[..params.phantom.len()];
                 params.phantom.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_PAD_NAME => {
@@ -1350,6 +1417,7 @@ where
                 let vals = &elem_value.boolean()[..params.pad.len()];
                 params.pad.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             INPUT_PAIRED_NAME => {
@@ -1357,6 +1425,7 @@ where
                 let vals = &elem_value.boolean()[..params.paired.len()];
                 params.paired.copy_from_slice(vals);
                 let res = T::update_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -1368,7 +1437,11 @@ where
     }
 
     pub(crate) fn parse_dsp_event(&mut self, event: &RegisterDspEvent) -> bool {
-        T::parse_event(&mut self.params, event)
+        let res = T::parse_event(&mut self.params, event);
+        if res {
+            debug!(params = ?self.params, ?event);
+        }
+        res
     }
 }
 
@@ -1456,6 +1529,7 @@ where
     pub(crate) fn read_dsp_meter(&mut self, unit: &SndMotu) -> Result<(), Error> {
         unit.read_byte_meter(&mut self.image)?;
         T::parse_image(&mut self.params, &self.image);
+        debug!(params = ?self.params);
         Ok(())
     }
 }
@@ -1484,7 +1558,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::update_wholly(req, node, &self.params, timeout_ms)
+        let res = T::update_wholly(req, node, &self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -1522,6 +1598,7 @@ where
                 params.0 = elem_value.enumerated()[0] as usize;
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/traveler.rs
+++ b/runtime/motu/src/traveler.rs
@@ -376,7 +376,9 @@ impl MicInputCtl {
     };
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        TravelerProtocol::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = TravelerProtocol::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -435,6 +437,7 @@ impl MicInputCtl {
                     .for_each(|(gain, &val)| *gain = val as u8);
                 let res = TravelerProtocol::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             MIC_PAD_NAME => {
@@ -443,6 +446,7 @@ impl MicInputCtl {
                 params.pad.copy_from_slice(vals);
                 let res = TravelerProtocol::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/ultralite.rs
+++ b/runtime/motu/src/ultralite.rs
@@ -317,7 +317,9 @@ const MAIN_ASSIGNMENT_NAME: &str = "main-assign";
 
 impl MainAssignCtl {
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        UltraliteProtocol::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = UltraliteProtocol::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -367,6 +369,7 @@ impl MainAssignCtl {
                     .map(|&p| params.0 = p)?;
                 let res = UltraliteProtocol::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/v1_ctls.rs
+++ b/runtime/motu/src/v1_ctls.rs
@@ -41,7 +41,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -111,6 +113,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 unit.unlock()?;
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             SRC_NAME => {
@@ -128,6 +131,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 unit.unlock()?;
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -161,7 +165,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -213,8 +219,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&mode| params.0 = mode)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }

--- a/runtime/motu/src/v2_ctls.rs
+++ b/runtime/motu/src/v2_ctls.rs
@@ -30,7 +30,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -100,6 +102,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             SRC_NAME => {
@@ -117,6 +120,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -162,11 +166,15 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)?;
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res?;
+
         let label = clk_src_to_str(&self.params.source);
         let params = ClockNameDisplayParameters(label.to_string());
-        T::update_wholly(req, node, &params, timeout_ms)?;
-        Ok(())
+        let res = T::update_wholly(req, node, &params, timeout_ms);
+        debug!(?params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -236,6 +244,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             SRC_NAME => {
@@ -258,6 +267,7 @@ where
                         .or_else(|_| T::update_wholly(req, node, &self.params, timeout_ms))
                 });
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -300,7 +310,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -374,6 +386,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OPT_OUT_IFACE_MODE_NAME => {
@@ -392,6 +405,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),

--- a/runtime/motu/src/v3_ctls.rs
+++ b/runtime/motu/src/v3_ctls.rs
@@ -30,7 +30,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -100,6 +102,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             SRC_NAME => {
@@ -117,6 +120,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -161,11 +165,14 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)?;
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res?;
         let label = clk_src_to_str(&self.params.source);
         let params = ClockNameDisplayParameters(label.to_string());
-        T::update_wholly(req, node, &params, timeout_ms)?;
-        Ok(())
+        let res = T::update_wholly(req, node, &params, timeout_ms);
+        debug!(?params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -235,6 +242,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             SRC_NAME => {
@@ -257,6 +265,7 @@ where
                         .or_else(|_| T::update_wholly(req, node, &self.params, timeout_ms))
                 });
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
@@ -291,7 +300,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -359,8 +370,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&p| params.main = p)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             RETURN_ASSIGN_NAME => {
                 let mut params = self.params.clone();
@@ -373,8 +386,10 @@ where
                         Error::new(FileError::Inval, &msg)
                     })
                     .map(|&p| params.mixer_return = p)?;
-                T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params)?;
-                Ok(true)
+                let res =
+                    T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
             }
             _ => Ok(false),
         }
@@ -437,7 +452,9 @@ where
         node: &mut FwNode,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        T::cache_wholly(req, node, &mut self.params, timeout_ms)
+        let res = T::cache_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        Ok(())
     }
 
     pub(crate) fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -523,6 +540,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             OPT_IFACE_OUT_MODE_NAME => {
@@ -547,6 +565,7 @@ where
                 let res =
                     T::update_wholly(req, node, &params, timeout_ms).map(|_| self.params = params);
                 let _ = unit.unlock();
+                debug!(params = ?self.params, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),


### PR DESCRIPTION
It's really helpful to dump logs for debugging purpose. This patchset utilizes
tracing and tracing-subscriber crates for the purpose. An option is newly added
to motu runtime, then implement tracing events.

```
Takashi Sakamoto (13):
  runtime/motu: use tracing-subscriber crate to dump debug logs
  runtime/motu: add tracing span and event to runtime for version 1
    models
  runtime/motu: add tracing span and event to runtime for Register DSP
    models
  runtime/motu: add tracing span and event to runtime for Command DSP
    models
  runtime/motu: add tracing event to common controls
  runtime/motu: add tracing event to controls specific to version 1
    models
  runtime/motu: add tracing event to controls specific to version 2
    models
  runtime/motu: add tracing event to controls specific to version 3
    models
  runtime/motu: add tracing event to controls specific to Register DSP
    models
  runtime/motu: add tracing event to controls specific to Command DSP
    models
  runtime/motu: add tracing event to controls specific to 828
  runtime/motu: add tracing event to controls specific to Traveler
  runtime/motu: add tracing event to controls specific to Ultralite

 README.rst                                    |  18 +--
 runtime/motu/Cargo.toml                       |   2 +
 .../src/bin/snd-firewire-motu-ctl-service.rs  |   6 +-
 runtime/motu/src/command_dsp_ctls.rs          | 129 ++++++++++++++++--
 runtime/motu/src/command_dsp_runtime.rs       |  25 +++-
 runtime/motu/src/common_ctls.rs               |  53 ++++---
 runtime/motu/src/f828.rs                      |   6 +-
 runtime/motu/src/lib.rs                       |  10 +-
 runtime/motu/src/register_dsp_ctls.rs         | 111 ++++++++++++---
 runtime/motu/src/register_dsp_runtime.rs      |  26 +++-
 runtime/motu/src/traveler.rs                  |   6 +-
 runtime/motu/src/ultralite.rs                 |   5 +-
 runtime/motu/src/v1_ctls.rs                   |  16 ++-
 runtime/motu/src/v1_runtime.rs                |  24 +++-
 runtime/motu/src/v2_ctls.rs                   |  24 +++-
 runtime/motu/src/v3_ctls.rs                   |  39 ++++--
 16 files changed, 419 insertions(+), 81 deletions(-)
```