### PR TITLE
[PATCH 0/5] protocols/motu: split equalizer/dynamics parameters from input/output parameters

### DIFF
--- a/protocols/motu/src/command_dsp.rs
+++ b/protocols/motu/src/command_dsp.rs
@@ -2905,6 +2905,51 @@ pub trait MotuCommandDspInputSpecification {
             nominal_level: vec![Default::default(); Self::LINE_INPUT_COUNT],
         }
     }
+
+    /// Instantiate input equalizer parameters.
+    fn create_input_equalizer_state() -> CommandDspInputEqualizerState {
+        CommandDspInputEqualizerState(CommandDspEqualizerState {
+            enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            hpf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hpf_slope: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hpf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            lpf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lpf_slope: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lpf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            lf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lf_type: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lf_gain: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lf_width: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            lmf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lmf_type: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lmf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lmf_gain: vec![Default::default(); Self::INPUT_PORTS.len()],
+            lmf_width: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            mf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            mf_type: vec![Default::default(); Self::INPUT_PORTS.len()],
+            mf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+            mf_gain: vec![Default::default(); Self::INPUT_PORTS.len()],
+            mf_width: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            hmf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hmf_type: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hmf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hmf_gain: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hmf_width: vec![Default::default(); Self::INPUT_PORTS.len()],
+
+            hf_enable: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hf_type: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hf_freq: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hf_gain: vec![Default::default(); Self::INPUT_PORTS.len()],
+            hf_width: vec![Default::default(); Self::INPUT_PORTS.len()],
+        })
+    }
 }
 
 impl<O> MotuCommandDspParametersOperation<CommandDspInputState> for O
@@ -2989,6 +3034,51 @@ where
                 }
                 _ => (),
             };
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// State of input equalizers.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct CommandDspInputEqualizerState(pub CommandDspEqualizerState);
+
+impl AsRef<CommandDspEqualizerState> for CommandDspInputEqualizerState {
+    fn as_ref(&self) -> &CommandDspEqualizerState {
+        &self.0
+    }
+}
+
+impl AsMut<CommandDspEqualizerState> for CommandDspInputEqualizerState {
+    fn as_mut(&mut self) -> &mut CommandDspEqualizerState {
+        &mut self.0
+    }
+}
+
+impl<O> MotuCommandDspParametersOperation<CommandDspInputEqualizerState> for O
+where
+    O: MotuCommandDspInputSpecification + MotuCommandDspEqualizerSpecification,
+{
+    fn build_commands(params: &CommandDspInputEqualizerState) -> Vec<DspCmd> {
+        let mut cmds = Vec::new();
+
+        (0..Self::INPUT_PORTS.len()).for_each(|ch| {
+            Self::create_equalizer_parameters(&params.0, ch)
+                .into_iter()
+                .for_each(|param| {
+                    let cmd = DspCmd::Input(InputCmd::Equalizer(ch, param));
+                    cmds.push(cmd);
+                });
+        });
+
+        cmds
+    }
+
+    fn parse_command(params: &mut CommandDspInputEqualizerState, command: &DspCmd) -> bool {
+        if let DspCmd::Input(InputCmd::Equalizer(ch, param)) = command {
+            Self::parse_equalizer_parameter(&mut params.0, param, *ch);
             true
         } else {
             false
@@ -3122,6 +3212,50 @@ pub trait MotuCommandDspOutputSpecification {
             master_listenback: vec![Default::default(); Self::OUTPUT_PORTS.len()],
         }
     }
+
+    fn create_output_equalizer_state() -> CommandDspOutputEqualizerState {
+        CommandDspOutputEqualizerState(CommandDspEqualizerState {
+            enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            hpf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hpf_slope: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hpf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            lpf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lpf_slope: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lpf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            lf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lf_type: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lf_gain: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lf_width: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            lmf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lmf_type: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lmf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lmf_gain: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            lmf_width: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            mf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            mf_type: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            mf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            mf_gain: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            mf_width: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            hmf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hmf_type: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hmf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hmf_gain: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hmf_width: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+
+            hf_enable: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hf_type: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hf_freq: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hf_gain: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+            hf_width: vec![Default::default(); Self::OUTPUT_PORTS.len()],
+        })
+    }
 }
 
 impl<O> MotuCommandDspParametersOperation<CommandDspOutputState> for O
@@ -3184,6 +3318,51 @@ where
                 OutputCmd::MasterListenback(ch, val) => params.master_listenback[*ch] = *val,
                 _ => (),
             };
+            true
+        } else {
+            false
+        }
+    }
+}
+
+/// State of output equalizers.
+#[derive(Default, Debug, Clone, PartialEq)]
+pub struct CommandDspOutputEqualizerState(pub CommandDspEqualizerState);
+
+impl AsRef<CommandDspEqualizerState> for CommandDspOutputEqualizerState {
+    fn as_ref(&self) -> &CommandDspEqualizerState {
+        &self.0
+    }
+}
+
+impl AsMut<CommandDspEqualizerState> for CommandDspOutputEqualizerState {
+    fn as_mut(&mut self) -> &mut CommandDspEqualizerState {
+        &mut self.0
+    }
+}
+
+impl<O> MotuCommandDspParametersOperation<CommandDspOutputEqualizerState> for O
+where
+    O: MotuCommandDspOutputSpecification + MotuCommandDspEqualizerSpecification,
+{
+    fn build_commands(params: &CommandDspOutputEqualizerState) -> Vec<DspCmd> {
+        let mut cmds = Vec::new();
+
+        (0..Self::OUTPUT_PORTS.len()).for_each(|ch| {
+            Self::create_equalizer_parameters(&params.0, ch)
+                .into_iter()
+                .for_each(|param| {
+                    let cmd = DspCmd::Output(OutputCmd::Equalizer(ch, param));
+                    cmds.push(cmd);
+                });
+        });
+
+        cmds
+    }
+
+    fn parse_command(params: &mut CommandDspOutputEqualizerState, command: &DspCmd) -> bool {
+        if let DspCmd::Output(OutputCmd::Equalizer(ch, param)) = command {
+            Self::parse_equalizer_parameter(&mut params.0, param, *ch);
             true
         } else {
             false

--- a/runtime/motu/src/f828mk3_hybrid_model.rs
+++ b/runtime/motu/src/f828mk3_hybrid_model.rs
@@ -20,8 +20,10 @@ pub struct F828mk3HybridModel {
     mixer_ctl: CommandDspMixerCtl<F828mk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<F828mk3HybridProtocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<F828mk3HybridProtocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<F828mk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<F828mk3HybridProtocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<F828mk3HybridProtocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<F828mk3HybridProtocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<F828mk3HybridProtocol>,
 }
@@ -52,14 +54,10 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_dyn_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_dyn_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -195,7 +193,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -222,7 +220,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -268,8 +266,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3HybridModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -284,8 +284,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3HybridModel {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/f828mk3_hybrid_model.rs
+++ b/runtime/motu/src/f828mk3_hybrid_model.rs
@@ -19,7 +19,9 @@ pub struct F828mk3HybridModel {
     monitor_ctl: CommandDspMonitorCtl<F828mk3HybridProtocol>,
     mixer_ctl: CommandDspMixerCtl<F828mk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<F828mk3HybridProtocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<F828mk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<F828mk3HybridProtocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<F828mk3HybridProtocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<F828mk3HybridProtocol>,
 }
@@ -49,16 +51,12 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -188,7 +186,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -215,7 +213,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -269,7 +267,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3HybridModel {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -283,7 +283,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3HybridModel {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/f828mk3_hybrid_model.rs
+++ b/runtime/motu/src/f828mk3_hybrid_model.rs
@@ -320,7 +320,7 @@ impl CommandDspModel for F828mk3HybridModel {
     }
 
     fn begin_messaging(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        UltraliteMk3Protocol::begin_messaging(
+        F828mk3HybridProtocol::begin_messaging(
             &mut self.req,
             &mut unit.1,
             &mut self.sequence_number,
@@ -329,7 +329,7 @@ impl CommandDspModel for F828mk3HybridModel {
     }
 
     fn release_message_handler(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        UltraliteMk3Protocol::cancel_messaging(
+        F828mk3HybridProtocol::cancel_messaging(
             &mut self.req,
             &mut unit.1,
             &mut self.sequence_number,

--- a/runtime/motu/src/f828mk3_model.rs
+++ b/runtime/motu/src/f828mk3_model.rs
@@ -20,8 +20,10 @@ pub struct F828mk3Model {
     mixer_ctl: CommandDspMixerCtl<F828mk3Protocol>,
     input_ctl: CommandDspInputCtl<F828mk3Protocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<F828mk3Protocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<F828mk3Protocol>,
     output_ctl: CommandDspOutputCtl<F828mk3Protocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<F828mk3Protocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<F828mk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<F828mk3Protocol>,
 }
@@ -52,14 +54,10 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -195,7 +193,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -222,7 +220,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -268,8 +266,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -284,8 +284,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Model {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/f828mk3_model.rs
+++ b/runtime/motu/src/f828mk3_model.rs
@@ -19,7 +19,9 @@ pub struct F828mk3Model {
     monitor_ctl: CommandDspMonitorCtl<F828mk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<F828mk3Protocol>,
     input_ctl: CommandDspInputCtl<F828mk3Protocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<F828mk3Protocol>,
     output_ctl: CommandDspOutputCtl<F828mk3Protocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<F828mk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<F828mk3Protocol>,
 }
@@ -49,16 +51,12 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -188,7 +186,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -215,7 +213,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -269,7 +267,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Model {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -283,7 +283,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F828mk3Model {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/f828mk3_model.rs
+++ b/runtime/motu/src/f828mk3_model.rs
@@ -251,7 +251,7 @@ impl NotifyModel<(SndMotu, FwNode), u32> for F828mk3Model {
         (_, node): &mut (SndMotu, FwNode),
         msg: &u32,
     ) -> Result<(), Error> {
-        if *msg & F828mk3HybridProtocol::NOTIFY_PORT_CHANGE > 0 {
+        if *msg & F828mk3Protocol::NOTIFY_PORT_CHANGE > 0 {
             self.port_assign_ctl
                 .cache(&mut self.req, node, TIMEOUT_MS)?;
             self.phone_assign_ctl
@@ -320,7 +320,7 @@ impl CommandDspModel for F828mk3Model {
     }
 
     fn begin_messaging(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        UltraliteMk3Protocol::begin_messaging(
+        F828mk3Protocol::begin_messaging(
             &mut self.req,
             &mut unit.1,
             &mut self.sequence_number,
@@ -329,7 +329,7 @@ impl CommandDspModel for F828mk3Model {
     }
 
     fn release_message_handler(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
-        UltraliteMk3Protocol::cancel_messaging(
+        F828mk3Protocol::cancel_messaging(
             &mut self.req,
             &mut unit.1,
             &mut self.sequence_number,

--- a/runtime/motu/src/track16_model.rs
+++ b/runtime/motu/src/track16_model.rs
@@ -18,7 +18,9 @@ pub struct Track16Model {
     monitor_ctl: CommandDspMonitorCtl<Track16Protocol>,
     mixer_ctl: CommandDspMixerCtl<Track16Protocol>,
     input_ctl: CommandDspInputCtl<Track16Protocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<Track16Protocol>,
     output_ctl: CommandDspOutputCtl<Track16Protocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<Track16Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<Track16Protocol>,
 }
@@ -46,16 +48,12 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -86,13 +84,13 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -178,7 +176,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -205,7 +203,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -256,7 +254,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16Model {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -270,7 +270,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16Model {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/track16_model.rs
+++ b/runtime/motu/src/track16_model.rs
@@ -19,8 +19,10 @@ pub struct Track16Model {
     mixer_ctl: CommandDspMixerCtl<Track16Protocol>,
     input_ctl: CommandDspInputCtl<Track16Protocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<Track16Protocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<Track16Protocol>,
     output_ctl: CommandDspOutputCtl<Track16Protocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<Track16Protocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<Track16Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<Track16Protocol>,
 }
@@ -49,14 +51,10 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_dyn_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_dyn_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -86,13 +84,13 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -185,7 +183,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -212,7 +210,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -255,8 +253,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -271,8 +271,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for Track16Model {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/traveler_mk3_model.rs
+++ b/runtime/motu/src/traveler_mk3_model.rs
@@ -20,8 +20,10 @@ pub struct TravelerMk3Model {
     mixer_ctl: CommandDspMixerCtl<TravelerMk3Protocol>,
     input_ctl: CommandDspInputCtl<TravelerMk3Protocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<TravelerMk3Protocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<TravelerMk3Protocol>,
     output_ctl: CommandDspOutputCtl<TravelerMk3Protocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<TravelerMk3Protocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<TravelerMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<TravelerMk3Protocol>,
 }
@@ -52,14 +54,10 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_dyn_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_dyn_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -195,7 +193,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -222,7 +220,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -252,8 +250,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -268,8 +268,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3Model {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/traveler_mk3_model.rs
+++ b/runtime/motu/src/traveler_mk3_model.rs
@@ -19,7 +19,9 @@ pub struct TravelerMk3Model {
     monitor_ctl: CommandDspMonitorCtl<TravelerMk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<TravelerMk3Protocol>,
     input_ctl: CommandDspInputCtl<TravelerMk3Protocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<TravelerMk3Protocol>,
     output_ctl: CommandDspOutputCtl<TravelerMk3Protocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<TravelerMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<TravelerMk3Protocol>,
 }
@@ -49,16 +51,12 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -91,13 +89,13 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -188,7 +186,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -215,7 +213,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -253,7 +251,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3Model {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -267,7 +267,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for TravelerMk3Model {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/ultralite_mk3_hybrid_model.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid_model.rs
@@ -18,8 +18,10 @@ pub struct UltraliteMk3HybridModel {
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3HybridProtocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<UltraliteMk3HybridProtocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<UltraliteMk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3HybridProtocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<UltraliteMk3HybridProtocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<UltraliteMk3HybridProtocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<UltraliteMk3HybridProtocol>,
 }
@@ -46,14 +48,10 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_dyn_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_dyn_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -81,13 +79,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -171,7 +169,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -198,7 +196,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -241,8 +239,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3HybridModel {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -257,8 +257,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3HybridModel {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/ultralite_mk3_hybrid_model.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid_model.rs
@@ -17,7 +17,9 @@ pub struct UltraliteMk3HybridModel {
     monitor_ctl: CommandDspReverbCtl<UltraliteMk3HybridProtocol>,
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3HybridProtocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3HybridProtocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<UltraliteMk3HybridProtocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3HybridProtocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<UltraliteMk3HybridProtocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<UltraliteMk3HybridProtocol>,
 }
@@ -43,16 +45,12 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -81,13 +79,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -164,7 +162,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -191,7 +189,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -242,7 +240,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3HybridModel {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -256,7 +256,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3HybridModel {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/ultralite_mk3_model.rs
+++ b/runtime/motu/src/ultralite_mk3_model.rs
@@ -19,7 +19,9 @@ pub struct UltraliteMk3Model {
     input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
     input_eq_ctl: CommandDspInputEqualizerCtl<UltraliteMk3Protocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3Protocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<UltraliteMk3Protocol>,
     output_eq_ctl: CommandDspOutputEqualizerCtl<UltraliteMk3Protocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<UltraliteMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<UltraliteMk3Protocol>,
 }
@@ -46,14 +48,10 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_dyn_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_dynamics(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_dyn_ctl.load(card_cntr)?;
         self.resource_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         Ok(())
@@ -81,13 +79,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             Ok(true)
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.resource_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -171,7 +169,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_dynamics(
+        } else if self.input_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -198,7 +196,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_dynamics(
+        } else if self.output_dyn_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -241,8 +239,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Model {
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -257,8 +257,10 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Model {
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
                 || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
                 || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())

--- a/runtime/motu/src/ultralite_mk3_model.rs
+++ b/runtime/motu/src/ultralite_mk3_model.rs
@@ -17,7 +17,9 @@ pub struct UltraliteMk3Model {
     monitor_ctl: CommandDspMonitorCtl<UltraliteMk3Protocol>,
     mixer_ctl: CommandDspMixerCtl<UltraliteMk3Protocol>,
     input_ctl: CommandDspInputCtl<UltraliteMk3Protocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<UltraliteMk3Protocol>,
     output_ctl: CommandDspOutputCtl<UltraliteMk3Protocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<UltraliteMk3Protocol>,
     resource_ctl: CommandDspResourceCtl,
     meter_ctl: CommandDspMeterCtl<UltraliteMk3Protocol>,
 }
@@ -43,16 +45,12 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
         self.monitor_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
-        self.input_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.input_eq_ctl.load(card_cntr)?;
         self.input_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.input_ctl.elem_id_list.append(&mut elem_id_list))?;
         self.output_ctl.load(card_cntr)?;
-        self.output_ctl
-            .load_equalizer(card_cntr)
-            .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
+        self.output_eq_ctl.load(card_cntr)?;
         self.output_ctl
             .load_dynamics(card_cntr)
             .map(|mut elem_id_list| self.output_ctl.elem_id_list.append(&mut elem_id_list))?;
@@ -81,13 +79,13 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.input_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.output_ctl.read_equalizer(elem_id, elem_value)? {
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read_dynamics(elem_id, elem_value)? {
             Ok(true)
@@ -164,7 +162,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.input_ctl.write_equalizer(
+        } else if self.input_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -191,7 +189,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.output_ctl.write_equalizer(
+        } else if self.output_eq_ctl.write(
             &mut self.sequence_number,
             &mut self.req,
             node,
@@ -242,7 +240,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Model {
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
     }
 
@@ -256,7 +256,9 @@ impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for UltraliteMk3Model {
                 || self.monitor_ctl.parse_command(cmd)
                 || self.mixer_ctl.parse_command(cmd)
                 || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
                 || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
                 || self.resource_ctl.parse_command(cmd);
         }
         Ok(())


### PR DESCRIPTION
The size of structures for input and output parameters is enough large since they
include equalizer and dynamics parameters. It brings overhead to operate them.

This patchset split equalizer and dynamcis parameters from them.

```
Takashi Sakamoto (5):
  runtime/motu: fix invalid binding for protocol
  protocols/motu: implement traits for input and output equalizer
    parameters in Command DSP models
  runtime/motu: use structures specific to equalizer effect parameters
    in Command DSP models
  protocols/motu: implement traits for input and output dynamics
    parameters in Command DSP models
  runtime/motu: use structures specific to dynamics effect parameters in
    Command DSP models

 protocols/motu/src/command_dsp.rs             | 512 +++++++++++-------
 runtime/motu/src/command_dsp_ctls.rs          | 212 ++++++--
 runtime/motu/src/f828mk3_hybrid_model.rs      |  48 +-
 runtime/motu/src/f828mk3_model.rs             |  50 +-
 runtime/motu/src/track16_model.rs             |  44 +-
 runtime/motu/src/traveler_mk3_model.rs        |  44 +-
 .../motu/src/ultralite_mk3_hybrid_model.rs    |  44 +-
 runtime/motu/src/ultralite_mk3_model.rs       |  44 +-
 8 files changed, 627 insertions(+), 371 deletions(-)
```