### PR TITLE
[PATCH 00/13] runtime/core: remove some argument in methods of CtlModel

### DIFF
--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -143,57 +143,68 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
-        } else if self
-            .convert_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.convert_ctl.write_params(
+            &mut self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .display_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.display_ctl.write_params(
+            &mut self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .input_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_params(&mut self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .output_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.output_ctl.write_params(
+            &mut self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .route_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_params(&mut self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write_params(&mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_params(&mut self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .stream_ctl
-            .write_params(unit, &mut self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.stream_ctl.write_params(
+            unit,
+            &mut self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(true)

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -146,14 +146,10 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/apogee/ensemble_model.rs
+++ b/runtime/bebob/src/apogee/ensemble_model.rs
@@ -106,12 +106,7 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -143,7 +138,6 @@ impl CtlModel<(SndUnit, FwNode)> for EnsembleModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -80,20 +80,22 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -61,12 +61,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -80,7 +75,6 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/behringer.rs
+++ b/runtime/bebob/src/behringer.rs
@@ -83,14 +83,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fca610Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -99,15 +99,14 @@ pub trait SamplingClkSrcCtlOperation<T: SamplingClockSourceOperation> {
         unit: &mut SndUnit,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_SRC_NAME => {
                 unit.lock()?;
                 let mut params = self.state().clone();
-                params.src_idx = new.enumerated()[0] as usize;
+                params.src_idx = elem_value.enumerated()[0] as usize;
                 let res = T::update_src(avc, &params, self.state_mut(), timeout_ms);
                 debug!(params = ?self.state(), ?res);
                 let _ = unit.unlock();

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -35,15 +35,14 @@ pub trait MediaClkFreqCtlOperation<T: MediaClockFrequencyOperation> {
         unit: &mut SndUnit,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             CLK_RATE_NAME => {
                 unit.lock()?;
                 let mut params = self.state().clone();
-                params.freq_idx = new.enumerated()[0] as usize;
+                params.freq_idx = elem_value.enumerated()[0] as usize;
                 let res = T::update_freq(avc, &params, self.state_mut(), timeout_ms);
                 debug!(params = ?self.state(), ?res);
                 let _ = unit.unlock();

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -258,13 +258,12 @@ pub trait AvcLrBalanceCtlOperation<T: AvcLrBalanceOperation> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::BALANCE_NAME {
             let mut params = self.state().clone();
-            let vals = &new.int()[..params.balances.len()];
+            let vals = &elem_value.int()[..params.balances.len()];
             params
                 .balances
                 .iter_mut()

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -310,13 +310,12 @@ pub trait AvcMuteCtlOperation<T: AvcMuteOperation> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::MUTE_NAME {
             let mut params = self.state().clone();
-            let vals = &new.boolean()[..params.mutes.len()];
+            let vals = &elem_value.boolean()[..params.mutes.len()];
             params.mutes.copy_from_slice(&vals);
             let res = T::update_mutes(avc, &params, self.state_mut(), timeout_ms);
             debug!(params = ?self.state(), ?res);

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -183,13 +183,12 @@ pub trait AvcLevelCtlOperation<T: AvcLevelOperation> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::LEVEL_NAME {
             let mut params = self.state().clone();
-            let vals = &new.int()[..params.levels.len()];
+            let vals = &elem_value.int()[..params.levels.len()];
             params
                 .levels
                 .iter_mut()

--- a/runtime/bebob/src/common_ctls.rs
+++ b/runtime/bebob/src/common_ctls.rs
@@ -386,13 +386,12 @@ pub trait AvcSelectorCtlOperation<T: AvcSelectorOperation> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::SELECTOR_NAME {
             let mut params = self.state().clone();
-            let vals = &new.enumerated()[..params.selectors.len()];
+            let vals = &elem_value.enumerated()[..params.selectors.len()];
             params
                 .selectors
                 .iter_mut()

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -93,14 +93,10 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -71,12 +71,7 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -90,7 +85,6 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/digidesign.rs
+++ b/runtime/bebob/src/digidesign.rs
@@ -90,20 +90,22 @@ impl CtlModel<(SndUnit, FwNode)> for Mbox2proModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -170,32 +170,38 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
+            Ok(true)
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .input_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .input_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .output_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -173,14 +173,10 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -145,12 +145,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -170,7 +165,6 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -178,14 +178,10 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .input_ctl

--- a/runtime/bebob/src/esi.rs
+++ b/runtime/bebob/src/esi.rs
@@ -185,7 +185,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
             Ok(true)
         } else if self
             .input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -195,7 +195,7 @@ impl CtlModel<(SndUnit, FwNode)> for Quatafire610Model {
             Ok(true)
         } else if self
             .output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -222,33 +222,35 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .out_ctl
-            .write_params(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_params(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.specific_ctl.write_params(
             &self.req,
             &unit.1,
             elem_id,
-            new,
+            elem_value,
             &mut self.separated_mixer_ctl.1,
             &mut self.paired_mixer_ctl.1,
             TIMEOUT_MS,
@@ -259,7 +261,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
             unit,
             &self.req,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
@@ -268,14 +270,17 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
             unit,
             &self.req,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self
-            .reverb_ctl
-            .write_params(unit, &mut self.req, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.reverb_ctl.write_params(
+            unit,
+            &mut self.req,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -188,12 +188,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -222,7 +217,6 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/focusrite/saffire_model.rs
+++ b/runtime/bebob/src/focusrite/saffire_model.rs
@@ -225,14 +225,10 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -180,46 +180,48 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .out_ctl
-            .write_params(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_params(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .specific_ctl
-            .write_params(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_params(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_low_rate_ctl
-            .write_src_gains(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_src_gains(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_middle_rate_ctl
-            .write_src_gains(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_src_gains(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .through_ctl
-            .write_params(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write_params(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -143,12 +143,7 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -180,7 +175,6 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/focusrite/saffirele_model.rs
+++ b/runtime/bebob/src/focusrite/saffirele_model.rs
@@ -183,14 +183,10 @@ impl CtlModel<(SndUnit, FwNode)> for SaffireLeModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/focusrite/saffireproio_model.rs
+++ b/runtime/bebob/src/focusrite/saffireproio_model.rs
@@ -228,12 +228,7 @@ where
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -259,7 +254,6 @@ where
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -302,7 +302,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -322,7 +322,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -280,14 +280,10 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -297,7 +297,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -317,7 +317,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -277,57 +277,65 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
+            Ok(true)
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .phys_out_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .phys_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .mon_src_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .mon_src_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -285,14 +285,10 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -242,12 +242,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -277,7 +272,6 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/icon.rs
+++ b/runtime/bebob/src/icon.rs
@@ -292,7 +292,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -312,7 +312,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -327,7 +327,7 @@ impl CtlModel<(SndUnit, FwNode)> for FirexonModel {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/maudio.rs
+++ b/runtime/bebob/src/maudio.rs
@@ -362,14 +362,13 @@ pub trait MaudioNormalMixerCtlOperation<O: MaudioNormalMixerOperation> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == Self::MIXER_NAME {
             let dst_idx = elem_id.index() as usize;
             let mut params = self.state().clone();
-            let vals = &new.boolean()[..Self::SRC_COUNT];
+            let vals = &elem_value.boolean()[..Self::SRC_COUNT];
             params.0[dst_idx].copy_from_slice(&vals);
             let res = O::update(avc, &params, self.state_mut(), timeout_ms);
             debug!(params = ?self.state(), ?res);

--- a/runtime/bebob/src/maudio.rs
+++ b/runtime/bebob/src/maudio.rs
@@ -258,15 +258,14 @@ trait MaudioNormalMeterCtlOperation<O: MaudioNormalMeterProtocol> {
         &mut self,
         avc: &BebobAvc,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             SWITCH_NAME => {
                 if O::HAS_SWITCH {
                     if let Some(switch) = &mut self.state_mut().switch {
-                        let pos = new.enumerated()[0] as usize;
+                        let pos = elem_value.enumerated()[0] as usize;
                         let &state = SWITCH_LIST.iter().nth(pos).ok_or_else(|| {
                             let msg = format!("Invalid index for LED switch: {}", pos);
                             Error::new(FileError::Inval, &msg)

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -337,12 +337,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -376,7 +371,6 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -376,70 +376,79 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .meter_ctl
-            .write_meter(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_meter(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.write_balance(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .aux_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .aux_output_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_output_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_output_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .phys_output_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_output_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(false)
         } else if self
             .hp_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_src_state(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -388,7 +388,6 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS * 3,
         )? {

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -422,13 +422,10 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.phys_output_ctl.write_selector(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .phys_output_ctl
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .hp_ctl
@@ -437,7 +434,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(false)
         } else if self
             .hp_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -379,14 +379,10 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -394,7 +394,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self
             .meter_ctl
-            .write_meter(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_meter(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -399,7 +399,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -409,17 +409,17 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self
             .aux_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .aux_output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.phys_output_ctl.write_selector(
@@ -432,7 +432,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(false)
         } else if self

--- a/runtime/bebob/src/maudio/audiophile_model.rs
+++ b/runtime/bebob/src/maudio/audiophile_model.rs
@@ -404,7 +404,7 @@ impl CtlModel<(SndUnit, FwNode)> for AudiophileModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -450,75 +450,86 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.write_balance(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .aux_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .aux_output_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_output_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_output_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.phys_output_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .phys_output_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .hp_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_src_state(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .hp_ctl
-            .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .spdif_input_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.spdif_input_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_src_state(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -468,7 +468,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -478,17 +478,17 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self
             .aux_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .aux_output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.phys_output_ctl.write_selector(
@@ -501,7 +501,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -491,13 +491,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.phys_output_ctl.write_selector(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .phys_output_ctl
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .hp_ctl
@@ -506,7 +503,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -514,13 +511,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.spdif_input_ctl.write_selector(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .spdif_input_ctl
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -462,7 +462,6 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS * 3,
         )? {

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -407,12 +407,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -450,7 +445,6 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -453,14 +453,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/maudio/fw410_model.rs
+++ b/runtime/bebob/src/maudio/fw410_model.rs
@@ -473,7 +473,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fw410Model {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -240,7 +240,6 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS * 3,
         )? {

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -231,14 +231,10 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -251,7 +251,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -228,40 +228,47 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.write_balance(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .stream_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.stream_input_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_src_state(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -246,7 +246,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -256,7 +256,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
             Ok(true)
         } else if self
             .stream_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/ozonic_model.rs
+++ b/runtime/bebob/src/maudio/ozonic_model.rs
@@ -199,12 +199,7 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -228,7 +223,6 @@ impl CtlModel<(SndUnit, FwNode)> for OzonicModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -112,14 +112,10 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -86,12 +86,7 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -109,7 +104,6 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/maudio/profirelightbridge_model.rs
+++ b/runtime/bebob/src/maudio/profirelightbridge_model.rs
@@ -121,7 +121,6 @@ impl CtlModel<(SndUnit, FwNode)> for PflModel {
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS * 3,
         )? {

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -290,13 +290,10 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.spdif_output_ctl.write_selector(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .spdif_output_ctl
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .mixer_ctl

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -228,12 +228,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -259,7 +254,6 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -259,45 +259,54 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
             &self.avc,
             elem_id,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS * 3,
         )? {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_input_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_input_ctl.write_balance(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .stream_input_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.stream_input_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .spdif_output_ctl
-            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.spdif_output_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write_src_state(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_src_state(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -271,7 +271,6 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             &mut unit.0,
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS * 3,
         )? {

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -262,14 +262,10 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -282,7 +282,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/maudio/solo_model.rs
+++ b/runtime/bebob/src/maudio/solo_model.rs
@@ -277,7 +277,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self
             .phys_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -287,7 +287,7 @@ impl CtlModel<(SndUnit, FwNode)> for SoloModel {
             Ok(true)
         } else if self
             .stream_input_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self.spdif_output_ctl.write_selector(

--- a/runtime/bebob/src/maudio/special_model.rs
+++ b/runtime/bebob/src/maudio/special_model.rs
@@ -74,12 +74,7 @@ impl<T: MediaClockFrequencyOperation> CtlModel<(SndUnit, FwNode)> for SpecialMod
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read_params(elem_id, elem_value)? {
@@ -101,7 +96,6 @@ impl<T: MediaClockFrequencyOperation> CtlModel<(SndUnit, FwNode)> for SpecialMod
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/bebob/src/maudio/special_model.rs
+++ b/runtime/bebob/src/maudio/special_model.rs
@@ -101,17 +101,13 @@ impl<T: MediaClockFrequencyOperation> CtlModel<(SndUnit, FwNode)> for SpecialMod
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
+        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.input_ctl.write_params(
             &mut self.cache,

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -453,12 +453,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -507,7 +502,6 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -511,14 +511,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -528,7 +528,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -543,7 +543,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .headphone_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -564,7 +564,6 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {
@@ -577,7 +576,6 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {
@@ -602,7 +600,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -516,14 +516,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -533,7 +533,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -548,7 +548,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .headphone_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -561,29 +561,24 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_mute(
-            &self.avc,
-            elem_id,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .mixer_stream_src_ctl
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.write_mute(
-            &self.avc,
-            elem_id,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_selector(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -556,13 +556,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_balance(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,
@@ -600,7 +597,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/presonus/firebox_model.rs
+++ b/runtime/bebob/src/presonus/firebox_model.rs
@@ -523,7 +523,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -538,7 +538,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .headphone_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -551,13 +551,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_phys_src_ctl.write_balance(
             &self.avc,
@@ -575,13 +572,10 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
@@ -601,7 +595,7 @@ impl CtlModel<(SndUnit, FwNode)> for FireboxModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -162,15 +162,21 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, elem_value, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -167,14 +167,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -162,14 +162,10 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -179,7 +179,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -174,7 +174,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -159,32 +159,32 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+            .write_freq(&mut unit.0, &self.avc, elem_id, elem_value, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
         } else if self
             .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_src(&mut unit.0, &self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_balance(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/presonus/fp10_model.rs
+++ b/runtime/bebob/src/presonus/fp10_model.rs
@@ -134,12 +134,7 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -159,7 +154,6 @@ impl CtlModel<(SndUnit, FwNode)> for Fp10Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -522,12 +522,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -569,7 +564,6 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -605,7 +605,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -628,24 +628,20 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_mute(
-            &self.avc,
-            elem_id,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .mixer_stream_src_ctl
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.write_mute(
-            &self.avc,
-            elem_id,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .input_switch_ctl

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -590,7 +590,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .phys_in_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -600,7 +600,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -615,7 +615,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -631,7 +631,6 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {
@@ -644,7 +643,6 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -573,14 +573,10 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -578,14 +578,10 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_in_ctl

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -623,13 +623,10 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_balance(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_balance(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,

--- a/runtime/bebob/src/presonus/inspire1394_model.rs
+++ b/runtime/bebob/src/presonus/inspire1394_model.rs
@@ -585,7 +585,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .phys_in_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -595,7 +595,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -610,7 +610,7 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -618,13 +618,10 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_phys_src_ctl.write_balance(
             &self.avc,
@@ -642,13 +639,10 @@ impl CtlModel<(SndUnit, FwNode)> for Inspire1394Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -205,7 +205,7 @@ where
             Ok(true)
         } else if self
             .analog_in_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -195,23 +195,28 @@ where
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self
             .analog_in_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .analog_in_ctl
-            .write_balance(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.analog_in_ctl.write_balance(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -42,7 +42,6 @@ impl MediaClkFreqCtlOperation<FaClkProtocol> for ClkCtl {
         _: &BebobAvc,
         elem_id: &ElemId,
         _: &ElemValue,
-        _: &ElemValue,
         _: u32,
     ) -> Result<bool, Error> {
         if elem_id.name().as_str() == CLK_RATE_NAME {
@@ -199,14 +198,10 @@ where
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self
             .analog_in_ctl

--- a/runtime/bebob/src/roland.rs
+++ b/runtime/bebob/src/roland.rs
@@ -174,12 +174,7 @@ where
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.analog_in_ctl.read_levels(elem_id, elem_value)? {
@@ -195,7 +190,6 @@ where
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -148,14 +148,10 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .output_ctl

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -143,14 +143,10 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -117,12 +117,7 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -140,7 +135,6 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/stanton.rs
+++ b/runtime/bebob/src/stanton.rs
@@ -140,27 +140,33 @@ impl CtlModel<(SndUnit, FwNode)> for ScratchampModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .output_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .headphone_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -263,7 +263,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self
             .phys_in_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -273,7 +273,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self
             .mon_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -283,7 +283,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -253,48 +253,53 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
         } else if self
             .phys_in_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mon_src_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mon_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mon_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .spdif_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.spdif_out_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -256,14 +256,10 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self
             .phys_in_ctl

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -278,7 +278,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self
             .mon_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -288,7 +288,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/terratec/aureon_model.rs
+++ b/runtime/bebob/src/terratec/aureon_model.rs
@@ -222,12 +222,7 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.phys_in_ctl.read_levels(elem_id, elem_value)? {
@@ -253,7 +248,6 @@ impl CtlModel<(SndUnit, FwNode)> for AureonModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -338,13 +338,10 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self.mixer_phys_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_phys_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,
@@ -354,13 +351,10 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
-        } else if self.mixer_stream_src_ctl.write_level(
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .mixer_stream_src_ctl
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
@@ -380,7 +374,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -328,14 +328,10 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_in_ctl

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -280,12 +280,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -320,7 +315,6 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -323,14 +323,10 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -320,70 +320,81 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
-            Ok(true)
-        } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .phys_in_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .mixer_phys_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self.mixer_phys_src_ctl.write_mute(
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
             &self.avc,
             elem_id,
-            new,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
+            Ok(true)
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
-            .mixer_stream_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .phys_in_ctl
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
+            Ok(true)
+        } else if self.mixer_phys_src_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.mixer_phys_src_ctl.write_mute(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.mixer_stream_src_ctl.write_level(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self.mixer_stream_src_ctl.write_selector(
             &self.avc,
             elem_id,
-            old,
-            new,
+            elem_value,
             FCP_TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.mixer_out_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/bebob/src/terratec/phase88_model.rs
+++ b/runtime/bebob/src/terratec/phase88_model.rs
@@ -346,7 +346,6 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         } else if self.mixer_phys_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {
@@ -359,7 +358,6 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
         } else if self.mixer_stream_src_ctl.write_mute(
             &self.avc,
             elem_id,
-            old,
             new,
             FCP_TIMEOUT_MS,
         )? {
@@ -379,7 +377,7 @@ impl CtlModel<(SndUnit, FwNode)> for Phase88Model {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -398,52 +398,60 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
             Ok(true)
-        } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .phys_in_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hp_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_selector(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -536,52 +544,60 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
-        if self
-            .clk_ctl
-            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
-        {
+        if self.clk_ctl.write_freq(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS * 3,
+        )? {
+            Ok(true)
+        } else if self.clk_ctl.write_src(
+            &mut unit.0,
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .clk_ctl
-            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .phys_out_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .phys_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
+        } else if self.phys_out_ctl.write_selector(
+            &self.avc,
+            elem_id,
+            elem_value,
+            FCP_TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
-            .phys_out_ctl
-            .write_selector(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .mixer_src_ctl
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
-            .mixer_src_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -365,12 +365,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -398,7 +393,6 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(
@@ -511,12 +505,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read_freq(elem_id, elem_value)? {
             Ok(true)
         } else if self.clk_ctl.read_src(elem_id, elem_value)? {
@@ -544,7 +533,6 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write_freq(

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -401,14 +401,10 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,
@@ -547,14 +543,10 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
         old: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
-        if self.clk_ctl.write_freq(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS * 3,
-        )? {
+        if self
+            .clk_ctl
+            .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
+        {
             Ok(true)
         } else if self.clk_ctl.write_src(
             &mut unit.0,

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -433,7 +433,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -443,7 +443,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -556,7 +556,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -571,7 +571,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -581,7 +581,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_mute(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_mute(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else {

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -406,14 +406,10 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_in_ctl
@@ -548,14 +544,10 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             .write_freq(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS * 3)?
         {
             Ok(true)
-        } else if self.clk_ctl.write_src(
-            &mut unit.0,
-            &self.avc,
-            elem_id,
-            old,
-            new,
-            FCP_TIMEOUT_MS,
-        )? {
+        } else if self
+            .clk_ctl
+            .write_src(&mut unit.0, &self.avc, elem_id, new, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else if self
             .phys_out_ctl

--- a/runtime/bebob/src/yamaha_terratec.rs
+++ b/runtime/bebob/src/yamaha_terratec.rs
@@ -428,7 +428,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -438,7 +438,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24CoaxModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -551,7 +551,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .phys_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -566,7 +566,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .mixer_src_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
@@ -576,7 +576,7 @@ impl CtlModel<(SndUnit, FwNode)> for GoPhase24OptModel {
             Ok(true)
         } else if self
             .mixer_out_ctl
-            .write_level(&self.avc, elem_id, old, new, FCP_TIMEOUT_MS)?
+            .write_level(&self.avc, elem_id, new, FCP_TIMEOUT_MS)?
         {
             Ok(true)
         } else if self

--- a/runtime/core/src/card_cntr.rs
+++ b/runtime/core/src/card_cntr.rs
@@ -17,18 +17,12 @@ pub struct CardCntr {
 pub trait CtlModel<O: Sized> {
     fn cache(&mut self, _: &mut O) -> Result<(), Error>;
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error>;
-    fn read(
-        &mut self,
-        unit: &mut O,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error>;
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error>;
     fn write(
         &mut self,
         unit: &mut O,
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error>;
 }
 
@@ -513,7 +507,7 @@ impl CardCntr {
 
                 let _enter = debug_span!("hardware").entered();
 
-                let res = ctl_model.read(unit, &elem_id, &mut val);
+                let res = ctl_model.read(&elem_id, &mut val);
                 debug!(
                     numid = elem_id.numid(),
                     values = value_array_literal(elem_info, &val),
@@ -583,7 +577,7 @@ impl CardCntr {
 
                 let _enter = debug_span!("hardware").entered();
 
-                let res = ctl_model.write(unit, &elem_id, v, &val);
+                let res = ctl_model.write(unit, &elem_id, &val);
                 debug!(
                     numid = elem_id.numid(),
                     old_values = value_array_literal(elem_info, &v),
@@ -633,7 +627,7 @@ impl CardCntr {
                 .try_for_each(|(elem_info, elem_value)| {
                     let _enter = debug_span!("hardware").entered();
 
-                    let res = ctl_model.read(unit, elem_id, elem_value);
+                    let res = ctl_model.read(elem_id, elem_value);
                     debug!(
                         numid = elem_id.numid(),
                         values = value_array_literal(elem_info, &elem_value),
@@ -681,7 +675,7 @@ impl CardCntr {
                 .filter(|(elem_info, _)| match_elem_id(elem_info, elem_id))
                 .try_for_each(|(elem_info, elem_value)| {
                     let _enter = debug_span!("hardware").entered();
-                    let res = ctl_model.read(unit, elem_id, elem_value);
+                    let res = ctl_model.read(elem_id, elem_value);
                     debug!(
                         numid = elem_id.numid(),
                         values = value_array_literal(elem_info, &elem_value),

--- a/runtime/dice/src/blackbird_model.rs
+++ b/runtime/dice/src/blackbird_model.rs
@@ -65,12 +65,7 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -84,7 +79,6 @@ impl CtlModel<(SndDice, FwNode)> for BlackbirdModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/extension_model.rs
+++ b/runtime/dice/src/extension_model.rs
@@ -66,12 +66,7 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -85,7 +80,6 @@ impl CtlModel<(SndDice, FwNode)> for ExtensionModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/liquids56_model.rs
+++ b/runtime/dice/src/focusrite/liquids56_model.rs
@@ -94,12 +94,7 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -119,7 +114,6 @@ impl CtlModel<(SndDice, FwNode)> for LiquidS56Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/spro14_model.rs
+++ b/runtime/dice/src/focusrite/spro14_model.rs
@@ -79,12 +79,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -102,7 +97,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro14Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/spro24_model.rs
+++ b/runtime/dice/src/focusrite/spro24_model.rs
@@ -79,12 +79,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -102,7 +97,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro24Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/spro24dsp_model.rs
+++ b/runtime/dice/src/focusrite/spro24dsp_model.rs
@@ -124,12 +124,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -155,7 +150,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro24DspModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/spro26_model.rs
+++ b/runtime/dice/src/focusrite/spro26_model.rs
@@ -69,12 +69,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -90,7 +85,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro26Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/focusrite/spro40_model.rs
+++ b/runtime/dice/src/focusrite/spro40_model.rs
@@ -79,12 +79,7 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -102,7 +97,6 @@ impl CtlModel<(SndDice, FwNode)> for SPro40Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/io_fw_model.rs
+++ b/runtime/dice/src/io_fw_model.rs
@@ -78,12 +78,7 @@ where
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -101,7 +96,6 @@ where
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/ionix_model.rs
+++ b/runtime/dice/src/ionix_model.rs
@@ -35,12 +35,7 @@ impl CtlModel<(SndDice, FwNode)> for IonixModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
@@ -56,7 +51,6 @@ impl CtlModel<(SndDice, FwNode)> for IonixModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/mbox3_model.rs
+++ b/runtime/dice/src/mbox3_model.rs
@@ -72,12 +72,7 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -93,7 +88,6 @@ impl CtlModel<(SndDice, FwNode)> for Mbox3Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/minimal_model.rs
+++ b/runtime/dice/src/minimal_model.rs
@@ -26,12 +26,7 @@ impl CtlModel<(SndDice, FwNode)> for MinimalModel {
         self.common_ctl.load(card_cntr)
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         self.common_ctl.read(elem_id, elem_value)
     }
 
@@ -39,7 +34,6 @@ impl CtlModel<(SndDice, FwNode)> for MinimalModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         self.common_ctl.write(

--- a/runtime/dice/src/pfire_model.rs
+++ b/runtime/dice/src/pfire_model.rs
@@ -116,12 +116,7 @@ where
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -137,7 +132,6 @@ where
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/presonus/fstudio_model.rs
+++ b/runtime/dice/src/presonus/fstudio_model.rs
@@ -39,12 +39,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -62,7 +57,6 @@ impl CtlModel<(SndDice, FwNode)> for FStudioModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/presonus/fstudiomobile_model.rs
+++ b/runtime/dice/src/presonus/fstudiomobile_model.rs
@@ -66,12 +66,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -85,7 +80,6 @@ impl CtlModel<(SndDice, FwNode)> for FStudioMobileModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/presonus/fstudioproject_model.rs
+++ b/runtime/dice/src/presonus/fstudioproject_model.rs
@@ -66,12 +66,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -85,7 +80,6 @@ impl CtlModel<(SndDice, FwNode)> for FStudioProjectModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/presonus/fstudiotube_model.rs
+++ b/runtime/dice/src/presonus/fstudiotube_model.rs
@@ -66,12 +66,7 @@ impl CtlModel<(SndDice, FwNode)> for FStudioTubeModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.tcd22xx_ctls.read(elem_id, elem_value)? {
@@ -85,7 +80,6 @@ impl CtlModel<(SndDice, FwNode)> for FStudioTubeModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -76,8 +76,8 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        old: &ElemValue,
-        new: &ElemValue,
+        _: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
             &unit.0,
@@ -85,28 +85,28 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
             &unit.1,
             &mut self.sections,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write(&self.req, &unit.1, elem_id, old, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .panel_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -859,15 +859,14 @@ impl MixerCtl {
         req: &FwReq,
         node: &FwNode,
         elem_id: &ElemId,
-        _: &ElemValue,
-        new: &ElemValue,
+        elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             MIXER_MIC_INST_SRC_LEVEL_NAME => {
                 let mut params = self.0.data.clone();
                 let levels = &mut params.mic_inst_level;
-                let vals = &new.int()[..levels.len()];
+                let vals = &elem_value.int()[..levels.len()];
                 levels.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -881,7 +880,7 @@ impl MixerCtl {
             MIXER_MIC_INST_SRC_BALANCE_NAME => {
                 let mut params = self.0.data.clone();
                 let pans = &mut params.mic_inst_pan;
-                let vals = &new.int()[..pans.len()];
+                let vals = &elem_value.int()[..pans.len()];
                 pans.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -895,7 +894,7 @@ impl MixerCtl {
             MIXER_MIC_INST_SRC_SEND_NAME => {
                 let mut params = self.0.data.clone();
                 let sends = &mut params.mic_inst_send;
-                let vals = &new.int()[..sends.len()];
+                let vals = &elem_value.int()[..sends.len()];
                 sends.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -909,7 +908,7 @@ impl MixerCtl {
             MIXER_DUAL_INST_SRC_LEVEL_NAME => {
                 let mut params = self.0.data.clone();
                 let levels = &mut params.mic_inst_level;
-                let vals = &new.int()[..levels.len()];
+                let vals = &elem_value.int()[..levels.len()];
                 levels.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -923,7 +922,7 @@ impl MixerCtl {
             MIXER_DUAL_INST_SRC_BALANCE_NAME => {
                 let mut params = self.0.data.clone();
                 let pans = &mut params.mic_inst_pan;
-                let vals = &new.int()[..pans.len()];
+                let vals = &elem_value.int()[..pans.len()];
                 pans.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -937,7 +936,7 @@ impl MixerCtl {
             MIXER_DUAL_INST_SRC_SEND_NAME => {
                 let mut params = self.0.data.clone();
                 let sends = &mut params.mic_inst_send;
-                let vals = &new.int()[..sends.len()];
+                let vals = &elem_value.int()[..sends.len()];
                 sends.copy_from_slice(&vals);
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
@@ -950,7 +949,7 @@ impl MixerCtl {
             }
             MIXER_STEREO_IN_SRC_LEVEL_NAME => {
                 let mut params = self.0.data.clone();
-                params.stereo_in_level = new.int()[0];
+                params.stereo_in_level = elem_value.int()[0];
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
                     &node,
@@ -962,7 +961,7 @@ impl MixerCtl {
             }
             MIXER_STEREO_IN_SRC_BALANCE_NAME => {
                 let mut params = self.0.data.clone();
-                params.stereo_in_pan = new.int()[0];
+                params.stereo_in_pan = elem_value.int()[0];
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
                     &node,
@@ -974,7 +973,7 @@ impl MixerCtl {
             }
             MIXER_STEREO_IN_SRC_SEND_NAME => {
                 let mut params = self.0.data.clone();
-                params.stereo_in_send = new.int()[0];
+                params.stereo_in_send = elem_value.int()[0];
                 let res = Desktopk6Protocol::update_partial_segment(
                     req,
                     &node,
@@ -986,7 +985,7 @@ impl MixerCtl {
             }
             HP_SRC_NAME => {
                 let mut params = self.0.data.clone();
-                let pos = new.enumerated()[0] as usize;
+                let pos = elem_value.enumerated()[0] as usize;
                 params.hp_src = Self::HP_SRCS
                     .iter()
                     .nth(pos)

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -49,12 +49,7 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.hw_state_ctl.read(elem_id, elem_value)? {
@@ -76,7 +71,6 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -74,12 +74,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
@@ -109,7 +104,6 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -74,12 +74,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
@@ -109,7 +104,6 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -48,12 +48,7 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
@@ -75,7 +70,6 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -74,12 +74,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.knob_ctl.read(elem_id, elem_value)? {
@@ -109,7 +104,6 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -84,12 +84,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDice, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.lineout_ctl.read(elem_id, elem_value)? {
@@ -123,7 +118,6 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         &mut self,
         unit: &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(

--- a/runtime/digi00x/src/model.rs
+++ b/runtime/digi00x/src/model.rs
@@ -29,12 +29,7 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDigi00x, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         &mut self,
         (unit, node): &mut (SndDigi00x, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
@@ -130,12 +124,7 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi003Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndDigi00x, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -153,7 +142,6 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi003Model {
         &mut self,
         (unit, node): &mut (SndDigi00x, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -47,12 +47,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff400Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndFireface, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_ctl.read(elem_id, elem_value)? {
@@ -74,7 +69,6 @@ impl CtlModel<(SndFireface, FwNode)> for Ff400Model {
         &mut self,
         unit: &mut (SndFireface, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -43,12 +43,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff800Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndFireface, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.out_ctl.read(elem_id, elem_value)? {
@@ -68,7 +63,6 @@ impl CtlModel<(SndFireface, FwNode)> for Ff800Model {
         &mut self,
         unit: &mut (SndFireface, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -37,12 +37,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndFireface, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.dsp_ctl.read(elem_id, elem_value)? {
@@ -60,7 +55,6 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         &mut self,
         unit: &mut (SndFireface, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -37,12 +37,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndFireface, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.dsp_ctl.read(elem_id, elem_value)? {
@@ -60,7 +55,6 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         &mut self,
         unit: &mut (SndFireface, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/fireworks/src/audiofire12_former_model.rs
+++ b/runtime/fireworks/src/audiofire12_former_model.rs
@@ -70,12 +70,7 @@ impl CtlModel<SndEfw> for Audiofire12FormerModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -101,7 +96,6 @@ impl CtlModel<SndEfw> for Audiofire12FormerModel {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/audiofire12_later_model.rs
+++ b/runtime/fireworks/src/audiofire12_later_model.rs
@@ -54,12 +54,7 @@ impl CtlModel<SndEfw> for Audiofire12LaterModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -85,7 +80,6 @@ impl CtlModel<SndEfw> for Audiofire12LaterModel {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/audiofire2_model.rs
+++ b/runtime/fireworks/src/audiofire2_model.rs
@@ -49,12 +49,7 @@ impl CtlModel<SndEfw> for Audiofire2Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -87,7 +82,6 @@ impl CtlModel<SndEfw> for Audiofire2Model {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/audiofire4_model.rs
+++ b/runtime/fireworks/src/audiofire4_model.rs
@@ -52,12 +52,7 @@ impl CtlModel<SndEfw> for Audiofire4Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -92,7 +87,6 @@ impl CtlModel<SndEfw> for Audiofire4Model {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/audiofire8_model.rs
+++ b/runtime/fireworks/src/audiofire8_model.rs
@@ -46,12 +46,7 @@ impl CtlModel<SndEfw> for Audiofire8Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -79,7 +74,6 @@ impl CtlModel<SndEfw> for Audiofire8Model {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/audiofire9_model.rs
+++ b/runtime/fireworks/src/audiofire9_model.rs
@@ -49,12 +49,7 @@ impl CtlModel<SndEfw> for Audiofire9Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -84,7 +79,6 @@ impl CtlModel<SndEfw> for Audiofire9Model {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/onyx1200f_model.rs
+++ b/runtime/fireworks/src/onyx1200f_model.rs
@@ -43,12 +43,7 @@ impl CtlModel<SndEfw> for Onyx1200fModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -74,7 +69,6 @@ impl CtlModel<SndEfw> for Onyx1200fModel {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/onyx400f_model.rs
+++ b/runtime/fireworks/src/onyx400f_model.rs
@@ -52,12 +52,7 @@ impl CtlModel<SndEfw> for Onyx400fModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -81,7 +76,6 @@ impl CtlModel<SndEfw> for Onyx400fModel {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/fireworks/src/rip_model.rs
+++ b/runtime/fireworks/src/rip_model.rs
@@ -40,12 +40,7 @@ impl CtlModel<SndEfw> for RipModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut SndEfw,
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -69,7 +64,6 @@ impl CtlModel<SndEfw> for RipModel {
         &mut self,
         unit: &mut SndEfw,
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clk_ctl.write(unit, elem_id, elem_value, TIMEOUT_MS)? {

--- a/runtime/motu/src/audioexpress_model.rs
+++ b/runtime/motu/src/audioexpress_model.rs
@@ -58,12 +58,7 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpressModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
@@ -89,7 +84,6 @@ impl CtlModel<(SndMotu, FwNode)> for AudioExpressModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f828_model.rs
+++ b/runtime/motu/src/f828_model.rs
@@ -29,12 +29,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.monitor_input_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndMotu, FwNode)> for F828Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f828mk2_model.rs
+++ b/runtime/motu/src/f828mk2_model.rs
@@ -69,12 +69,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
@@ -106,7 +101,6 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk2Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f828mk3_hybrid_model.rs
+++ b/runtime/motu/src/f828mk3_hybrid_model.rs
@@ -63,12 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -110,7 +105,6 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3HybridModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f828mk3_model.rs
+++ b/runtime/motu/src/f828mk3_model.rs
@@ -63,12 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -110,7 +105,6 @@ impl CtlModel<(SndMotu, FwNode)> for F828mk3Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f896_model.rs
+++ b/runtime/motu/src/f896_model.rs
@@ -35,12 +35,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.monitor_input_ctl.read(elem_id, elem_value)? {
@@ -60,7 +55,6 @@ impl CtlModel<(SndMotu, FwNode)> for F896Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f896hd_model.rs
+++ b/runtime/motu/src/f896hd_model.rs
@@ -67,12 +67,7 @@ impl CtlModel<(SndMotu, FwNode)> for F896hdModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
@@ -104,7 +99,6 @@ impl CtlModel<(SndMotu, FwNode)> for F896hdModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/f8pre_model.rs
+++ b/runtime/motu/src/f8pre_model.rs
@@ -56,12 +56,7 @@ impl CtlModel<(SndMotu, FwNode)> for F8preModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
@@ -87,7 +82,6 @@ impl CtlModel<(SndMotu, FwNode)> for F8preModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/h4pre_model.rs
+++ b/runtime/motu/src/h4pre_model.rs
@@ -58,12 +58,7 @@ impl CtlModel<(SndMotu, FwNode)> for H4preModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.phone_assign_ctl.0.read(elem_id, elem_value)? {
@@ -89,7 +84,6 @@ impl CtlModel<(SndMotu, FwNode)> for H4preModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/track16_model.rs
+++ b/runtime/motu/src/track16_model.rs
@@ -60,12 +60,7 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -105,7 +100,6 @@ impl CtlModel<(SndMotu, FwNode)> for Track16Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/traveler_mk3_model.rs
+++ b/runtime/motu/src/traveler_mk3_model.rs
@@ -63,12 +63,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -110,7 +105,6 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerMk3Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/traveler_model.rs
+++ b/runtime/motu/src/traveler_model.rs
@@ -72,12 +72,7 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
@@ -111,7 +106,6 @@ impl CtlModel<(SndMotu, FwNode)> for TravelerModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/ultralite_mk3_hybrid_model.rs
+++ b/runtime/motu/src/ultralite_mk3_hybrid_model.rs
@@ -57,12 +57,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -100,7 +95,6 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3HybridModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/ultralite_mk3_model.rs
+++ b/runtime/motu/src/ultralite_mk3_model.rs
@@ -57,12 +57,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.port_assign_ctl.read(elem_id, elem_value)? {
@@ -100,7 +95,6 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteMk3Model {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/motu/src/ultralite_model.rs
+++ b/runtime/motu/src/ultralite_model.rs
@@ -61,12 +61,7 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndMotu, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clk_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.main_assign_ctl.read(elem_id, elem_value)? {
@@ -94,7 +89,6 @@ impl CtlModel<(SndMotu, FwNode)> for UltraliteModel {
         &mut self,
         (unit, node): &mut (SndMotu, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/apogee_model.rs
+++ b/runtime/oxfw/src/apogee_model.rs
@@ -48,12 +48,7 @@ impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.meter_ctl.read(elem_id, elem_value)? {
@@ -77,7 +72,6 @@ impl CtlModel<(SndUnit, FwNode)> for ApogeeModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/common_model.rs
+++ b/runtime/oxfw/src/common_model.rs
@@ -28,12 +28,7 @@ impl CtlModel<(SndUnit, FwNode)> for CommonModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
@@ -45,7 +40,6 @@ impl CtlModel<(SndUnit, FwNode)> for CommonModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/griffin_model.rs
+++ b/runtime/oxfw/src/griffin_model.rs
@@ -31,12 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndUnit, FwNode)> for GriffinModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/lacie_model.rs
+++ b/runtime/oxfw/src/lacie_model.rs
@@ -31,12 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndUnit, FwNode)> for LacieModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/loud_model.rs
+++ b/runtime/oxfw/src/loud_model.rs
@@ -31,12 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.specific_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndUnit, FwNode)> for LinkFwModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/oxfw/src/tascam_model.rs
+++ b/runtime/oxfw/src/tascam_model.rs
@@ -31,12 +31,7 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndUnit, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.specific_ctl.read(elem_id, elem_value)? {
@@ -50,7 +45,6 @@ impl CtlModel<(SndUnit, FwNode)> for TascamModel {
         &mut self,
         unit: &mut (SndUnit, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self

--- a/runtime/tascam/src/fw1082_model.rs
+++ b/runtime/tascam/src/fw1082_model.rs
@@ -174,12 +174,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndTascam, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clock_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
@@ -199,7 +194,6 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1082Model {
         &mut self,
         unit: &mut (SndTascam, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clock_ctl.write(

--- a/runtime/tascam/src/fw1804_model.rs
+++ b/runtime/tascam/src/fw1804_model.rs
@@ -73,12 +73,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndTascam, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clock_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
@@ -100,7 +95,6 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1804Model {
         &mut self,
         unit: &mut (SndTascam, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clock_ctl.write(

--- a/runtime/tascam/src/fw1884_model.rs
+++ b/runtime/tascam/src/fw1884_model.rs
@@ -160,12 +160,7 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1884Model {
         Ok(())
     }
 
-    fn read(
-        &mut self,
-        _: &mut (SndTascam, FwNode),
-        elem_id: &ElemId,
-        elem_value: &mut ElemValue,
-    ) -> Result<bool, Error> {
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.clock_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_threshold_ctl.read(elem_id, elem_value)? {
@@ -189,7 +184,6 @@ impl CtlModel<(SndTascam, FwNode)> for Fw1884Model {
         &mut self,
         unit: &mut (SndTascam, FwNode),
         elem_id: &ElemId,
-        _: &ElemValue,
         new: &ElemValue,
     ) -> Result<bool, Error> {
         if self.clock_ctl.write(


### PR DESCRIPTION
Some argument in methods of CtlModel is useless nowadays. This patchset
removes them.

```
Takashi Sakamoto (13):
  runtime/bebob: remove unused method parameter to update media clock
    frequency
  runtime/bebob: remove unused method parameter to update sampling clock
    source
  runtime/bebob: remove unused method parameter to update level
    parameters
  runtime/bebob: remove unused method parameter to update L/R balance
    parameters
  runtime/bebob: remove unused method parameter to update mute
    parameters
  runtime/bebob: remove unused method parameter to update selector
    parameters
  runtime/bebob: remove unused method parameter to update meter
    parameters in maudio models
  runtime/bebob: remove unused method parameter to update mixer
    parameters in maudio models
  runtime/bebob: remove unused method parameter to update input
    parameters in M-Audio Profire Light Bridge
  runtime/bebob: remove unused method parameter to update input
    parameters in Presonus Firebox
  runtime/bebob: remove unused method parameter to update input
    parameters in Presonus Inspire 1394
  runtime/dice: remove unused method parameter to update mixer
    parameters in Desktop Konnekt 6
  runtime/core: remove unused argument from trait methods to read/write
    control element

 runtime/bebob/src/apogee/ensemble_model.rs    | 63 +++++++-------
 runtime/bebob/src/behringer.rs                | 16 +---
 runtime/bebob/src/common_ctls.rs              | 30 +++----
 runtime/bebob/src/digidesign.rs               | 16 +---
 runtime/bebob/src/esi.rs                      | 22 ++---
 runtime/bebob/src/focusrite/saffire_model.rs  | 35 ++++----
 .../bebob/src/focusrite/saffirele_model.rs    | 26 ++----
 .../bebob/src/focusrite/saffireproio_model.rs |  8 +-
 runtime/bebob/src/icon.rs                     | 40 ++++-----
 runtime/bebob/src/maudio.rs                   | 10 +--
 runtime/bebob/src/maudio/audiophile_model.rs  | 53 ++++++------
 runtime/bebob/src/maudio/fw410_model.rs       | 56 ++++++-------
 runtime/bebob/src/maudio/ozonic_model.rs      | 40 ++++-----
 .../src/maudio/profirelightbridge_model.rs    | 27 ++----
 runtime/bebob/src/maudio/solo_model.rs        | 43 +++++-----
 runtime/bebob/src/maudio/special_model.rs     | 20 ++---
 runtime/bebob/src/presonus/firebox_model.rs   | 83 +++++++++----------
 runtime/bebob/src/presonus/fp10_model.rs      | 22 ++---
 .../bebob/src/presonus/inspire1394_model.rs   | 66 ++++++---------
 runtime/bebob/src/roland.rs                   | 26 +++---
 runtime/bebob/src/stanton.rs                  | 20 ++---
 runtime/bebob/src/terratec/aureon_model.rs    | 35 ++++----
 runtime/bebob/src/terratec/phase88_model.rs   | 47 ++++-------
 runtime/bebob/src/yamaha_terratec.rs          | 76 +++++++----------
 runtime/core/src/card_cntr.rs                 | 18 ++--
 runtime/dice/src/blackbird_model.rs           |  8 +-
 runtime/dice/src/extension_model.rs           |  8 +-
 runtime/dice/src/focusrite/liquids56_model.rs |  8 +-
 runtime/dice/src/focusrite/spro14_model.rs    |  8 +-
 runtime/dice/src/focusrite/spro24_model.rs    |  8 +-
 runtime/dice/src/focusrite/spro24dsp_model.rs |  8 +-
 runtime/dice/src/focusrite/spro26_model.rs    |  8 +-
 runtime/dice/src/focusrite/spro40_model.rs    |  8 +-
 runtime/dice/src/io_fw_model.rs               |  8 +-
 runtime/dice/src/ionix_model.rs               |  8 +-
 runtime/dice/src/mbox3_model.rs               |  8 +-
 runtime/dice/src/minimal_model.rs             |  8 +-
 runtime/dice/src/pfire_model.rs               |  8 +-
 runtime/dice/src/presonus/fstudio_model.rs    |  8 +-
 .../dice/src/presonus/fstudiomobile_model.rs  |  8 +-
 .../dice/src/presonus/fstudioproject_model.rs |  8 +-
 .../dice/src/presonus/fstudiotube_model.rs    |  8 +-
 .../dice/src/tcelectronic/desktopk6_model.rs  | 43 ++++------
 runtime/dice/src/tcelectronic/itwin_model.rs  |  8 +-
 runtime/dice/src/tcelectronic/k24d_model.rs   |  8 +-
 runtime/dice/src/tcelectronic/k8_model.rs     |  8 +-
 runtime/dice/src/tcelectronic/klive_model.rs  |  8 +-
 .../dice/src/tcelectronic/studiok48_model.rs  |  8 +-
 runtime/digi00x/src/model.rs                  | 16 +---
 runtime/fireface/src/ff400_model.rs           |  8 +-
 runtime/fireface/src/ff800_model.rs           |  8 +-
 runtime/fireface/src/ff802_model.rs           |  8 +-
 runtime/fireface/src/ucx_model.rs             |  8 +-
 .../fireworks/src/audiofire12_former_model.rs |  8 +-
 .../fireworks/src/audiofire12_later_model.rs  |  8 +-
 runtime/fireworks/src/audiofire2_model.rs     |  8 +-
 runtime/fireworks/src/audiofire4_model.rs     |  8 +-
 runtime/fireworks/src/audiofire8_model.rs     |  8 +-
 runtime/fireworks/src/audiofire9_model.rs     |  8 +-
 runtime/fireworks/src/onyx1200f_model.rs      |  8 +-
 runtime/fireworks/src/onyx400f_model.rs       |  8 +-
 runtime/fireworks/src/rip_model.rs            |  8 +-
 runtime/motu/src/audioexpress_model.rs        |  8 +-
 runtime/motu/src/f828_model.rs                |  8 +-
 runtime/motu/src/f828mk2_model.rs             |  8 +-
 runtime/motu/src/f828mk3_hybrid_model.rs      |  8 +-
 runtime/motu/src/f828mk3_model.rs             |  8 +-
 runtime/motu/src/f896_model.rs                |  8 +-
 runtime/motu/src/f896hd_model.rs              |  8 +-
 runtime/motu/src/f8pre_model.rs               |  8 +-
 runtime/motu/src/h4pre_model.rs               |  8 +-
 runtime/motu/src/track16_model.rs             |  8 +-
 runtime/motu/src/traveler_mk3_model.rs        |  8 +-
 runtime/motu/src/traveler_model.rs            |  8 +-
 .../motu/src/ultralite_mk3_hybrid_model.rs    |  8 +-
 runtime/motu/src/ultralite_mk3_model.rs       |  8 +-
 runtime/motu/src/ultralite_model.rs           |  8 +-
 runtime/oxfw/src/apogee_model.rs              |  8 +-
 runtime/oxfw/src/common_model.rs              |  8 +-
 runtime/oxfw/src/griffin_model.rs             |  8 +-
 runtime/oxfw/src/lacie_model.rs               |  8 +-
 runtime/oxfw/src/loud_model.rs                |  8 +-
 runtime/oxfw/src/tascam_model.rs              |  8 +-
 runtime/tascam/src/fw1082_model.rs            |  8 +-
 runtime/tascam/src/fw1804_model.rs            |  8 +-
 runtime/tascam/src/fw1884_model.rs            |  8 +-
 86 files changed, 442 insertions(+), 987 deletions(-)
```