### PR TITLE
[PATCH 00/17] protocols/fireface: break down parameters in latter models

### DIFF
--- a/protocols/fireface/src/former.rs
+++ b/protocols/fireface/src/former.rs
@@ -38,7 +38,7 @@ pub trait RmeFfFormerSpecification {
 ///
 /// Each value of 32 bit integer is between 0x00000000 and 0x7fffff00 to represent -90.03 and
 /// 0.00 dB. When reaching saturation, 1 byte in LSB side represent ratio of overload.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct FormerMeterState {
     /// The detected levels for analog (line and microphone) inputs.
     pub analog_inputs: Vec<i32>,
@@ -139,8 +139,8 @@ fn deserialize_meter(
         });
 }
 
-impl<O: RmeFfFormerSpecification> RmeFfParamsSerialize<FormerMeterState, u8> for O {
-    fn serialize(params: &FormerMeterState) -> Vec<u8> {
+impl<O: RmeFfFormerSpecification> RmeFfOffsetParamsSerialize<FormerMeterState> for O {
+    fn serialize_offsets(params: &FormerMeterState) -> Vec<u8> {
         serialize_meter(
             params,
             Self::PHYS_INPUT_COUNT,
@@ -150,8 +150,8 @@ impl<O: RmeFfFormerSpecification> RmeFfParamsSerialize<FormerMeterState, u8> for
     }
 }
 
-impl<O: RmeFfFormerMeterSpecification> RmeFfParamsDeserialize<FormerMeterState, u8> for O {
-    fn deserialize(params: &mut FormerMeterState, raw: &[u8]) {
+impl<O: RmeFfFormerMeterSpecification> RmeFfOffsetParamsDeserialize<FormerMeterState> for O {
+    fn deserialize_offsets(params: &mut FormerMeterState, raw: &[u8]) {
         deserialize_meter(
             params,
             raw,
@@ -162,7 +162,7 @@ impl<O: RmeFfFormerMeterSpecification> RmeFfParamsDeserialize<FormerMeterState, 
     }
 }
 
-impl<O: RmeFfFormerMeterSpecification + RmeFfParamsDeserialize<FormerMeterState, u8>>
+impl<O: RmeFfFormerMeterSpecification + RmeFfOffsetParamsDeserialize<FormerMeterState>>
     RmeFfCacheableParamsOperation<FormerMeterState> for O
 {
     fn cache_wholly(
@@ -189,7 +189,7 @@ impl<O: RmeFfFormerMeterSpecification + RmeFfParamsDeserialize<FormerMeterState,
             &mut raw,
             timeout_ms,
         )
-        .map(|_| Self::deserialize(params, &raw))
+        .map(|_| Self::deserialize_offsets(params, &raw))
     }
 }
 
@@ -197,7 +197,7 @@ impl<O: RmeFfFormerMeterSpecification + RmeFfParamsDeserialize<FormerMeterState,
 ///
 /// The value for volume is between 0x00000000 and 0x00010000 through 0x00000001 and 0x00080000 to
 /// represent the range from negative infinite to 6.00 dB through -90.30 dB and 0.00 dB.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct FormerOutputVolumeState(pub Vec<i32>);
 
 /// Output protocol specific to former models of RME Fireface.
@@ -235,14 +235,14 @@ fn deserialize_output_volumes(
     });
 }
 
-impl<O: RmeFormerOutputSpecification> RmeFfParamsSerialize<FormerOutputVolumeState, u8> for O {
-    fn serialize(params: &FormerOutputVolumeState) -> Vec<u8> {
+impl<O: RmeFormerOutputSpecification> RmeFfOffsetParamsSerialize<FormerOutputVolumeState> for O {
+    fn serialize_offsets(params: &FormerOutputVolumeState) -> Vec<u8> {
         serialize_output_volumes(params, Self::PHYS_OUTPUT_COUNT)
     }
 }
 
-impl<O: RmeFormerOutputSpecification> RmeFfParamsDeserialize<FormerOutputVolumeState, u8> for O {
-    fn deserialize(params: &mut FormerOutputVolumeState, raw: &[u8]) {
+impl<O: RmeFormerOutputSpecification> RmeFfOffsetParamsDeserialize<FormerOutputVolumeState> for O {
+    fn deserialize_offsets(params: &mut FormerOutputVolumeState, raw: &[u8]) {
         deserialize_output_volumes(params, raw, Self::PHYS_OUTPUT_COUNT)
     }
 }
@@ -251,7 +251,7 @@ impl<O: RmeFormerOutputSpecification> RmeFfParamsDeserialize<FormerOutputVolumeS
 ///
 /// The value is between 0x00000000 and 0x00010000 through 0x00008000 to represent -90.30 and 6.02 dB
 /// through 0x00008000.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct FormerMixerSrc {
     /// Gains of sources from analog inputs.
     pub analog_gains: Vec<i32>,
@@ -264,7 +264,7 @@ pub struct FormerMixerSrc {
 }
 
 /// State of mixer.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
 pub struct FormerMixerState(pub Vec<FormerMixerSrc>);
 
 /// The specification of mixer in former models.
@@ -359,21 +359,21 @@ fn deserialize_mixer(
     });
 }
 
-impl<O: RmeFormerMixerSpecification> RmeFfParamsSerialize<FormerMixerState, u8> for O {
-    fn serialize(params: &FormerMixerState) -> Vec<u8> {
+impl<O: RmeFormerMixerSpecification> RmeFfOffsetParamsSerialize<FormerMixerState> for O {
+    fn serialize_offsets(params: &FormerMixerState) -> Vec<u8> {
         serialize_mixer(params, Self::DST_COUNT, Self::AVAIL_COUNT)
     }
 }
 
-impl<O: RmeFormerMixerSpecification> RmeFfParamsDeserialize<FormerMixerState, u8> for O {
-    fn deserialize(params: &mut FormerMixerState, raw: &[u8]) {
+impl<O: RmeFormerMixerSpecification> RmeFfOffsetParamsDeserialize<FormerMixerState> for O {
+    fn deserialize_offsets(params: &mut FormerMixerState, raw: &[u8]) {
         deserialize_mixer(params, raw, Self::DST_COUNT, Self::AVAIL_COUNT)
     }
 }
 
 impl<O> RmeFfWhollyUpdatableParamsOperation<FormerMixerState> for O
 where
-    O: RmeFormerMixerSpecification + RmeFfParamsDeserialize<FormerMixerState, u8>,
+    O: RmeFormerMixerSpecification + RmeFfOffsetParamsDeserialize<FormerMixerState>,
 {
     fn update_wholly(
         req: &mut FwReq,
@@ -381,7 +381,7 @@ where
         params: &FormerMixerState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let mut raw = Self::serialize(params);
+        let mut raw = Self::serialize_offsets(params);
 
         let mixer_length = calculate_mixer_length(Self::AVAIL_COUNT);
 
@@ -401,7 +401,7 @@ where
 
 impl<O> RmeFfPartiallyUpdatableParamsOperation<FormerMixerState> for O
 where
-    O: RmeFormerMixerSpecification + RmeFfParamsDeserialize<FormerMixerState, u8>,
+    O: RmeFormerMixerSpecification + RmeFfOffsetParamsDeserialize<FormerMixerState>,
 {
     fn update_partially(
         req: &mut FwReq,
@@ -410,8 +410,8 @@ where
         update: FormerMixerState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let old = Self::serialize(params);
-        let mut new = Self::serialize(&update);
+        let old = Self::serialize_offsets(params);
+        let mut new = Self::serialize_offsets(&update);
 
         let mixer_length = calculate_mixer_length(Self::AVAIL_COUNT);
 
@@ -437,14 +437,14 @@ where
 
 const FORMER_CONFIG_SIZE: usize = 12;
 
-fn write_config<T: RmeFfParamsSerialize<U, u8>, U>(
+fn write_config<T: RmeFfOffsetParamsSerialize<U>, U>(
     req: &mut FwReq,
     node: &mut FwNode,
     offset: u64,
     config: &U,
     timeout_ms: u32,
 ) -> Result<(), Error> {
-    let mut raw = T::serialize(config);
+    let mut raw = T::serialize_offsets(config);
 
     req.transaction_sync(
         node,
@@ -458,7 +458,7 @@ fn write_config<T: RmeFfParamsSerialize<U, u8>, U>(
 
 const FORMER_STATUS_SIZE: usize = 8;
 
-fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
+fn read_status<T: RmeFfOffsetParamsDeserialize<U>, U>(
     req: &mut FwReq,
     node: &mut FwNode,
     offset: u64,
@@ -474,11 +474,11 @@ fn read_status<T: RmeFfParamsDeserialize<U, u8>, U>(
         &mut raw,
         timeout_ms,
     )
-    .map(|_| T::deserialize(status, &raw))
+    .map(|_| T::deserialize_offsets(status, &raw))
 }
 
 /// Configuration of S/PDIF output.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct FormerSpdifOutput {
     /// The format of S/PDIF signal.
     pub format: SpdifFormat,
@@ -489,7 +489,7 @@ pub struct FormerSpdifOutput {
 }
 
 /// Nominal level of line inputs.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum FormerLineInNominalLevel {
     Low,
     /// -10 dBV.

--- a/protocols/fireface/src/former/ff400.rs
+++ b/protocols/fireface/src/former/ff400.rs
@@ -1378,10 +1378,24 @@ mod test {
         assert_eq!(target, expected);
 
         let expected = FormerOutputVolumeState(vec![
-            0, 0, 0, 0, 0, 0, // Analog.
-            0, amp_to_vol_value(0x32), // Headphone.
-            0, 0, // S/PDIF.
-            0, 0, 0, 0, 0, 0, 0, 0, // ADAT.
+            0,
+            0,
+            0,
+            0,
+            0,
+            0, // Analog.
+            0,
+            amp_to_vol_value(0x32), // Headphone.
+            0,
+            0, // S/PDIF.
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0, // ADAT.
         ]);
         let msg = KNOB_IS_SIGNAL_LEVEL_FLAG
             | KNOB_IS_RIGHT_CHANNEL_FLAG

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -496,20 +496,6 @@ pub trait RmeFfLatterDspSpecification: RmeFfLatterSpecification {
     fn create_dsp_state() -> FfLatterDspState {
         FfLatterDspState {
             input_ch_strip: FfLatterInputChStripState(FfLatterChStripState {
-                eq: FfLatterEqState {
-                    activates: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    low_types: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    low_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    low_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    low_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    middle_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    middle_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    middle_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    high_types: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    high_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    high_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                    high_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
-                },
                 dynamics: FfLatterDynState {
                     activates: vec![Default::default(); Self::PHYS_INPUT_COUNT],
                     gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
@@ -528,20 +514,6 @@ pub trait RmeFfLatterDspSpecification: RmeFfLatterSpecification {
                 },
             }),
             output_ch_strip: FfLatterOutputChStripState(FfLatterChStripState {
-                eq: FfLatterEqState {
-                    activates: vec![Default::default(); Self::OUTPUT_COUNT],
-                    low_types: vec![Default::default(); Self::OUTPUT_COUNT],
-                    low_gains: vec![Default::default(); Self::OUTPUT_COUNT],
-                    low_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
-                    low_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
-                    middle_gains: vec![Default::default(); Self::OUTPUT_COUNT],
-                    middle_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
-                    middle_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
-                    high_types: vec![Default::default(); Self::OUTPUT_COUNT],
-                    high_gains: vec![Default::default(); Self::OUTPUT_COUNT],
-                    high_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
-                    high_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
-                },
                 dynamics: FfLatterDynState {
                     activates: vec![Default::default(); Self::OUTPUT_COUNT],
                     gains: vec![Default::default(); Self::OUTPUT_COUNT],
@@ -712,6 +684,24 @@ pub trait RmeFfLatterInputSpecification: RmeFfLatterDspSpecification {
             roll_offs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
         })
     }
+
+    /// Instantiate input equalizer parameters.
+    fn create_input_equalizer_parameters() -> FfLatterInputEqualizerParameters {
+        FfLatterInputEqualizerParameters(FfLatterEqState {
+            activates: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            low_types: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            low_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            low_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            low_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            middle_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            middle_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            middle_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            high_types: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            high_gains: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            high_freqs: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+            high_qualities: vec![Default::default(); Self::PHYS_INPUT_COUNT],
+        })
+    }
 }
 
 impl<O: RmeFfLatterDspSpecification> RmeFfLatterInputSpecification for O {}
@@ -843,6 +833,24 @@ pub trait RmeFfLatterOutputSpecification: RmeFfLatterDspSpecification {
             activates: vec![Default::default(); Self::OUTPUT_COUNT],
             cut_offs: vec![Default::default(); Self::OUTPUT_COUNT],
             roll_offs: vec![Default::default(); Self::OUTPUT_COUNT],
+        })
+    }
+
+    /// Instantiate output equalizer parameters.
+    fn create_output_equalizer_parameters() -> FfLatterOutputEqualizerParameters {
+        FfLatterOutputEqualizerParameters(FfLatterEqState {
+            activates: vec![Default::default(); Self::OUTPUT_COUNT],
+            low_types: vec![Default::default(); Self::OUTPUT_COUNT],
+            low_gains: vec![Default::default(); Self::OUTPUT_COUNT],
+            low_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
+            low_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
+            middle_gains: vec![Default::default(); Self::OUTPUT_COUNT],
+            middle_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
+            middle_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
+            high_types: vec![Default::default(); Self::OUTPUT_COUNT],
+            high_gains: vec![Default::default(); Self::OUTPUT_COUNT],
+            high_freqs: vec![Default::default(); Self::OUTPUT_COUNT],
+            high_qualities: vec![Default::default(); Self::OUTPUT_COUNT],
         })
     }
 }
@@ -1117,7 +1125,7 @@ where
 }
 
 /// Type of bandwidth equalizing.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfLatterChStripEqType {
     Peak,
     Shelf,
@@ -1130,18 +1138,16 @@ impl Default for FfLatterChStripEqType {
     }
 }
 
-impl From<FfLatterChStripEqType> for i16 {
-    fn from(eq_type: FfLatterChStripEqType) -> Self {
-        match eq_type {
-            FfLatterChStripEqType::Peak => 0x0000,
-            FfLatterChStripEqType::Shelf => 0x0001,
-            FfLatterChStripEqType::LowPass => 0x0002,
-        }
+fn deserialize_eq_type(eq_type: &FfLatterChStripEqType) -> i16 {
+    match eq_type {
+        FfLatterChStripEqType::Peak => 0x0000,
+        FfLatterChStripEqType::Shelf => 0x0001,
+        FfLatterChStripEqType::LowPass => 0x0002,
     }
 }
 
 /// State of equalizer in channel strip effect.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterEqState {
     /// Whether to activate equalizer.
     pub activates: Vec<bool>,
@@ -1194,7 +1200,7 @@ fn eq_state_to_cmds(state: &FfLatterEqState, ch_offset: u8) -> Vec<u32> {
         cmds.push(create_phys_port_cmd(
             ch,
             EQ_LOW_TYPE_CMD,
-            state.low_types[i] as i16,
+            deserialize_eq_type(&state.low_types[i]),
         ));
         cmds.push(create_phys_port_cmd(
             ch,
@@ -1229,7 +1235,7 @@ fn eq_state_to_cmds(state: &FfLatterEqState, ch_offset: u8) -> Vec<u32> {
         cmds.push(create_phys_port_cmd(
             ch,
             EQ_HIGH_TYPE_CMD,
-            state.high_types[i] as i16,
+            deserialize_eq_type(&state.high_types[i]),
         ));
         cmds.push(create_phys_port_cmd(
             ch,
@@ -1249,6 +1255,82 @@ fn eq_state_to_cmds(state: &FfLatterEqState, ch_offset: u8) -> Vec<u32> {
     });
 
     cmds
+}
+
+/// Parameters of input equalizer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FfLatterInputEqualizerParameters(pub FfLatterEqState);
+
+impl AsRef<FfLatterEqState> for FfLatterInputEqualizerParameters {
+    fn as_ref(&self) -> &FfLatterEqState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterEqState> for FfLatterInputEqualizerParameters {
+    fn as_mut(&mut self) -> &mut FfLatterEqState {
+        &mut self.0
+    }
+}
+
+/// Parameters of output equalizer.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FfLatterOutputEqualizerParameters(pub FfLatterEqState);
+
+impl AsRef<FfLatterEqState> for FfLatterOutputEqualizerParameters {
+    fn as_ref(&self) -> &FfLatterEqState {
+        &self.0
+    }
+}
+
+impl AsMut<FfLatterEqState> for FfLatterOutputEqualizerParameters {
+    fn as_mut(&mut self) -> &mut FfLatterEqState {
+        &mut self.0
+    }
+}
+
+/// The trait for specification of equalizer.
+pub trait RmeFfLatterEqualizerSpecification {
+    /// The minimum value of gain.
+    const EQ_GAIN_MIN: i32 = -20;
+    /// The maximum value of gain.
+    const EQ_GAIN_MAX: i32 = 20;
+    /// The step value of gain.
+    const EQ_GAIN_STEP: i32 = 1;
+
+    /// The minimum value of frequency.
+    const EQ_FREQ_MIN: i32 = 20;
+    /// The maximum value of frequency.
+    const EQ_FREQ_MAX: i32 = 20000;
+    /// The step value of frequency.
+    const EQ_FREQ_STEP: i32 = 1;
+
+    /// The minimum value of quality.
+    const EQ_QUALITY_MIN: i32 = 7;
+    /// The maximum value of quality.
+    const EQ_QUALITY_MAX: i32 = 50;
+    /// The step value of quality.
+    const EQ_QUALITY_STEP: i32 = 1;
+}
+
+impl<O: RmeFfLatterDspSpecification> RmeFfLatterEqualizerSpecification for O {}
+
+impl<O> RmeFfCommandParamsSerialize<FfLatterInputEqualizerParameters> for O
+where
+    O: RmeFfLatterEqualizerSpecification + RmeFfLatterInputSpecification,
+{
+    fn serialize_commands(params: &FfLatterInputEqualizerParameters) -> Vec<u32> {
+        eq_state_to_cmds(&params.0, 0)
+    }
+}
+
+impl<O> RmeFfCommandParamsSerialize<FfLatterOutputEqualizerParameters> for O
+where
+    O: RmeFfLatterEqualizerSpecification + RmeFfLatterOutputSpecification,
+{
+    fn serialize_commands(params: &FfLatterOutputEqualizerParameters) -> Vec<u32> {
+        eq_state_to_cmds(&params.0, Self::PHYS_INPUT_COUNT as u8)
+    }
 }
 
 /// State of dynamics in channel strip effect.
@@ -1380,7 +1462,6 @@ fn autolevel_state_to_cmds(state: &FfLatterAutolevelState, ch_offset: u8) -> Vec
 /// State of channel strip effect.
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterChStripState {
-    pub eq: FfLatterEqState,
     pub dynamics: FfLatterDynState,
     pub autolevel: FfLatterAutolevelState,
 }
@@ -1389,18 +1470,6 @@ pub struct FfLatterChStripState {
 pub trait RmeFfLatterChStripSpecification<T>: RmeFfLatterDspSpecification {
     const CH_COUNT: usize;
     const CH_OFFSET: u8;
-
-    const EQ_GAIN_MIN: i32 = -20;
-    const EQ_GAIN_MAX: i32 = 20;
-    const EQ_GAIN_STEP: i32 = 1;
-
-    const EQ_FREQ_MIN: i32 = 20;
-    const EQ_FREQ_MAX: i32 = 20000;
-    const EQ_FREQ_STEP: i32 = 1;
-
-    const EQ_QUALITY_MIN: i32 = 7;
-    const EQ_QUALITY_MAX: i32 = 50;
-    const EQ_QUALITY_STEP: i32 = 1;
 
     const DYN_GAIN_MIN: i32 = -300;
     const DYN_GAIN_MAX: i32 = 300;
@@ -1468,7 +1537,6 @@ where
 {
     fn serialize_commands(state: &FfLatterInputChStripState) -> Vec<u32> {
         [
-            eq_state_to_cmds(&state.0.eq, 0),
             dyn_state_to_cmds(&state.0.dynamics, 0),
             autolevel_state_to_cmds(&state.0.autolevel, 0),
         ]
@@ -1510,7 +1578,6 @@ impl<O: RmeFfLatterSpecification> RmeFfCommandParamsSerialize<FfLatterOutputChSt
             + Self::ADAT_INPUT_COUNT) as u8;
 
         [
-            eq_state_to_cmds(&state.0.eq, ch_offset),
             dyn_state_to_cmds(&state.0.dynamics, ch_offset),
             autolevel_state_to_cmds(&state.0.autolevel, ch_offset),
         ]

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -1916,6 +1916,12 @@ fn reverb_state_to_cmds(state: &FfLatterFxReverbState) -> Vec<u32> {
     cmds
 }
 
+impl<O: RmeFfLatterFxSpecification> RmeFfCommandParamsSerialize<FfLatterFxReverbState> for O {
+    fn serialize_commands(params: &FfLatterFxReverbState) -> Vec<u32> {
+        reverb_state_to_cmds(params)
+    }
+}
+
 /// State of echo in send effect.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfLatterFxEchoState {
@@ -1980,8 +1986,6 @@ fn echo_state_to_cmds(state: &FfLatterFxEchoState) -> Vec<u32> {
 /// State of send effects (reverb and echo).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterFxState {
-    /// The state of reverb effect.
-    pub reverb: FfLatterFxReverbState,
     /// The state of echo effect.
     pub echo: FfLatterFxEchoState,
 }
@@ -2124,7 +2128,6 @@ pub trait RmeFfLatterFxSpecification: RmeFfLatterDspSpecification {
     /// Instantiate fx parameters.
     fn create_fx_parameters() -> FfLatterFxState {
         FfLatterFxState {
-            reverb: Default::default(),
             echo: Default::default(),
         }
     }
@@ -2136,7 +2139,6 @@ impl<O: RmeFfLatterFxSpecification> RmeFfCommandParamsSerialize<FfLatterFxState>
     fn serialize_commands(state: &FfLatterFxState) -> Vec<u32> {
         let mut cmds = Vec::new();
 
-        cmds.append(&mut reverb_state_to_cmds(&state.reverb));
         cmds.append(&mut echo_state_to_cmds(&state.echo));
 
         cmds

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -356,7 +356,6 @@ where
 /// State of send effects (reverb and echo).
 #[derive(Default, Debug, Clone, Eq, PartialEq)]
 pub struct FfLatterDspState {
-    pub mixer: FfLatterMixerState,
     pub input_ch_strip: FfLatterInputChStripState,
     pub output_ch_strip: FfLatterOutputChStripState,
     pub fx: FfLatterFxState,
@@ -496,16 +495,6 @@ pub trait RmeFfLatterDspSpecification: RmeFfLatterSpecification {
 
     fn create_dsp_state() -> FfLatterDspState {
         FfLatterDspState {
-            mixer: FfLatterMixerState(vec![
-                FfLatterMixer {
-                    line_gains: vec![Default::default(); Self::LINE_INPUT_COUNT],
-                    mic_gains: vec![Default::default(); Self::MIC_INPUT_COUNT],
-                    spdif_gains: vec![Default::default(); Self::SPDIF_INPUT_COUNT],
-                    adat_gains: vec![Default::default(); Self::ADAT_INPUT_COUNT],
-                    stream_gains: vec![Default::default(); Self::STREAM_INPUT_COUNT],
-                };
-                Self::OUTPUT_COUNT
-            ]),
             input_ch_strip: FfLatterInputChStripState(FfLatterChStripState {
                 hpf: FfLatterHpfState {
                     activates: vec![Default::default(); Self::PHYS_INPUT_COUNT],
@@ -924,7 +913,7 @@ impl<O: RmeFfLatterOutputSpecification> RmeFfCommandParamsSerialize<FfLatterOutp
 ///
 /// Each value is between 0x0000 and 0xa000 through 0x9000 to represent -65.00 dB and 6.00 dB
 /// through 0.00 dB.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterMixer {
     /// The gain of sources from line inputs.
     pub line_gains: Vec<u16>,
@@ -939,15 +928,32 @@ pub struct FfLatterMixer {
 }
 
 /// State of mixers.
-#[derive(Default, Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterMixerState(pub Vec<FfLatterMixer>);
 
 /// The specification of mixer.
 pub trait RmeFfLatterMixerSpecification: RmeFfLatterDspSpecification {
+    /// The minimum value of gain for source of mixer.
     const MIXER_INPUT_GAIN_MIN: i32 = 0x0000;
+    /// The zero value of gain for source of mixer.
     const MIXER_INPUT_GAIN_ZERO: i32 = 0x9000;
+    /// The maximum value of gain for source of mixer.
     const MIXER_INPUT_GAIN_MAX: i32 = 0xa000;
+    /// The step value of gain for source of mixer.
     const MIXER_INPUT_GAIN_STEP: i32 = 1;
+
+    fn create_mixer_parameters() -> FfLatterMixerState {
+        FfLatterMixerState(vec![
+            FfLatterMixer {
+                line_gains: vec![Default::default(); Self::LINE_INPUT_COUNT],
+                mic_gains: vec![Default::default(); Self::MIC_INPUT_COUNT],
+                spdif_gains: vec![Default::default(); Self::SPDIF_INPUT_COUNT],
+                adat_gains: vec![Default::default(); Self::ADAT_INPUT_COUNT],
+                stream_gains: vec![Default::default(); Self::STREAM_INPUT_COUNT],
+            };
+            Self::OUTPUT_COUNT
+        ])
+    }
 }
 
 impl<O: RmeFfLatterDspSpecification> RmeFfLatterMixerSpecification for O {}

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -1983,11 +1983,10 @@ fn echo_state_to_cmds(state: &FfLatterFxEchoState) -> Vec<u32> {
     cmds
 }
 
-/// State of send effects (reverb and echo).
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FfLatterFxState {
-    /// The state of echo effect.
-    pub echo: FfLatterFxEchoState,
+impl<O: RmeFfLatterFxSpecification> RmeFfCommandParamsSerialize<FfLatterFxEchoState> for O {
+    fn serialize_commands(params: &FfLatterFxEchoState) -> Vec<u32> {
+        echo_state_to_cmds(params)
+    }
 }
 
 /// The specification of FX.
@@ -2124,26 +2123,9 @@ pub trait RmeFfLatterFxSpecification: RmeFfLatterDspSpecification {
             adat_output_vols: vec![0; Self::ADAT_OUTPUT_COUNT],
         }
     }
-
-    /// Instantiate fx parameters.
-    fn create_fx_parameters() -> FfLatterFxState {
-        FfLatterFxState {
-            echo: Default::default(),
-        }
-    }
 }
 
 impl<O: RmeFfLatterDspSpecification> RmeFfLatterFxSpecification for O {}
-
-impl<O: RmeFfLatterFxSpecification> RmeFfCommandParamsSerialize<FfLatterFxState> for O {
-    fn serialize_commands(state: &FfLatterFxState) -> Vec<u32> {
-        let mut cmds = Vec::new();
-
-        cmds.append(&mut echo_state_to_cmds(&state.echo));
-
-        cmds
-    }
-}
 
 #[cfg(test)]
 mod test {

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -23,7 +23,7 @@ const CFG_AESEBU_OUT_PRO_MASK: u32 = 0x00000020;
 const CFG_WORD_OUT_SINGLE_MASK: u32 = 0x00000010;
 
 /// Signal source of sampling clock.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Ff802ClkSrc {
     Internal,
     AdatA,
@@ -61,7 +61,7 @@ fn deserialize_clock_source(src: &mut Ff802ClkSrc, quad: &u32) {
 }
 
 /// Digital interface of S/PDIF signal for 802.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum Ff802SpdifIface {
     Xlr,
     Optical,
@@ -74,7 +74,7 @@ impl Default for Ff802SpdifIface {
 }
 
 /// Unique protocol for 802.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ff802Config {
     /// The low offset of destination address for MIDI messages.
     midi_tx_low_offset: FfLatterMidiTxLowOffset,
@@ -92,8 +92,8 @@ pub struct Ff802Config {
     pub word_out_single: bool,
 }
 
-impl RmeFfParamsSerialize<Ff802Config, u8> for Ff802Protocol {
-    fn serialize(state: &Ff802Config) -> Vec<u8> {
+impl RmeFfOffsetParamsSerialize<Ff802Config> for Ff802Protocol {
+    fn serialize_offsets(state: &Ff802Config) -> Vec<u8> {
         let mut quad = 0;
 
         serialize_midi_tx_low_offset(&state.midi_tx_low_offset, &mut quad);
@@ -128,8 +128,8 @@ impl RmeFfParamsSerialize<Ff802Config, u8> for Ff802Protocol {
     }
 }
 
-impl RmeFfParamsDeserialize<Ff802Config, u8> for Ff802Protocol {
-    fn deserialize(state: &mut Ff802Config, raw: &[u8]) {
+impl RmeFfOffsetParamsDeserialize<Ff802Config> for Ff802Protocol {
+    fn deserialize_offsets(state: &mut Ff802Config, raw: &[u8]) {
         assert!(raw.len() >= LATTER_CONFIG_SIZE);
 
         let mut r = [0; 4];
@@ -195,7 +195,7 @@ const STATUS_LOCK_SPDIF_MASK: u32 = 0x00000002;
 const STATUS_LOCK_WORD_CLK_MASK: u32 = 0x00000001;
 
 /// Lock status of 802.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ff802ExtLockStatus {
     pub word_clk: bool,
     pub spdif: bool,
@@ -228,7 +228,7 @@ fn deserialize_external_lock_status(status: &mut Ff802ExtLockStatus, quad: &u32)
 }
 
 /// Sync status of 802.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ff802ExtSyncStatus {
     pub word_clk: bool,
     pub spdif: bool,
@@ -261,7 +261,7 @@ fn deserialize_external_sync_status(status: &mut Ff802ExtSyncStatus, quad: &u32)
 }
 
 /// Sync status of 802.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ff802ExtRateStatus {
     pub word_clk: Option<ClkNominalRate>,
     pub spdif: Option<ClkNominalRate>,
@@ -321,7 +321,7 @@ fn deserialize_external_rate_status(status: &mut Ff802ExtRateStatus, quad: &u32)
 }
 
 /// Status of 802.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct Ff802Status {
     pub ext_lock: Ff802ExtLockStatus,
     pub ext_sync: Ff802ExtSyncStatus,
@@ -330,8 +330,8 @@ pub struct Ff802Status {
     pub active_clk_rate: ClkNominalRate,
 }
 
-impl RmeFfParamsSerialize<Ff802Status, u8> for Ff802Protocol {
-    fn serialize(status: &Ff802Status) -> Vec<u8> {
+impl RmeFfOffsetParamsSerialize<Ff802Status> for Ff802Protocol {
+    fn serialize_offsets(status: &Ff802Status) -> Vec<u8> {
         let mut quad = 0;
 
         serialize_external_lock_status(&status.ext_lock, &mut quad);
@@ -355,8 +355,8 @@ impl RmeFfParamsSerialize<Ff802Status, u8> for Ff802Protocol {
     }
 }
 
-impl RmeFfParamsDeserialize<Ff802Status, u8> for Ff802Protocol {
-    fn deserialize(status: &mut Ff802Status, raw: &[u8]) {
+impl RmeFfOffsetParamsDeserialize<Ff802Status> for Ff802Protocol {
+    fn deserialize_offsets(status: &mut Ff802Status, raw: &[u8]) {
         assert!(raw.len() >= LATTER_STATUS_SIZE);
 
         let mut r = [0; 4];
@@ -439,9 +439,9 @@ mod test {
             spdif_out_format: SpdifFormat::Professional,
             word_out_single: true,
         };
-        let quads = Ff802Protocol::serialize(&orig);
+        let quads = Ff802Protocol::serialize_offsets(&orig);
         let mut target = Ff802Config::default();
-        Ff802Protocol::deserialize(&mut target, &quads);
+        Ff802Protocol::deserialize_offsets(&mut target, &quads);
 
         assert_eq!(target, orig);
     }
@@ -518,9 +518,9 @@ mod test {
             active_clk_src: Ff802ClkSrc::AdatA,
             active_clk_rate: ClkNominalRate::R96000,
         };
-        let raw = Ff802Protocol::serialize(&orig);
+        let raw = Ff802Protocol::serialize_offsets(&orig);
         let mut target = Ff802Status::default();
-        Ff802Protocol::deserialize(&mut target, &raw);
+        Ff802Protocol::deserialize_offsets(&mut target, &raw);
 
         assert_eq!(target, orig);
     }

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -22,7 +22,7 @@ const CFG_WORD_INPUT_TERMINATE_MASK: u32 = 0x00000008;
 const CFG_SPDIF_OUT_PRO_MASK: u32 = 0x00000020;
 
 /// Signal source of sampling clock.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FfUcxClkSrc {
     Internal,
     Coax,
@@ -56,7 +56,7 @@ fn deserialize_clock_source(src: &mut FfUcxClkSrc, quad: &u32) {
 }
 
 /// Configuration for UCX.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfUcxConfig {
     /// The low offset of destination address for MIDI messages.
     midi_tx_low_offset: FfLatterMidiTxLowOffset,
@@ -74,8 +74,8 @@ pub struct FfUcxConfig {
     pub spdif_out_format: SpdifFormat,
 }
 
-impl RmeFfParamsSerialize<FfUcxConfig, u8> for FfUcxProtocol {
-    fn serialize(state: &FfUcxConfig) -> Vec<u8> {
+impl RmeFfOffsetParamsSerialize<FfUcxConfig> for FfUcxProtocol {
+    fn serialize_offsets(state: &FfUcxConfig) -> Vec<u8> {
         let mut quad = 0;
 
         serialize_midi_tx_low_offset(&state.midi_tx_low_offset, &mut quad);
@@ -105,8 +105,8 @@ impl RmeFfParamsSerialize<FfUcxConfig, u8> for FfUcxProtocol {
     }
 }
 
-impl RmeFfParamsDeserialize<FfUcxConfig, u8> for FfUcxProtocol {
-    fn deserialize(state: &mut FfUcxConfig, raw: &[u8]) {
+impl RmeFfOffsetParamsDeserialize<FfUcxConfig> for FfUcxProtocol {
+    fn deserialize_offsets(state: &mut FfUcxConfig, raw: &[u8]) {
         assert!(raw.len() >= LATTER_CONFIG_SIZE);
 
         let mut r = [0; 4];
@@ -169,7 +169,7 @@ const STATUS_LOCK_OPT_IFACE_MASK: u32 = 0x00000002;
 const STATUS_LOCK_COAX_IFACE_MASK: u32 = 0x00000001;
 
 /// Lock status of UCX.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfUcxExtLockStatus {
     pub word_clk: bool,
     pub opt_iface: bool,
@@ -196,7 +196,7 @@ fn deserialize_external_lock_status(status: &mut FfUcxExtLockStatus, quad: &u32)
 }
 
 /// Sync status of UCX.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfUcxExtSyncStatus {
     pub word_clk: bool,
     pub opt_iface: bool,
@@ -223,7 +223,7 @@ fn deserialize_external_sync_status(status: &mut FfUcxExtSyncStatus, quad: &u32)
 }
 
 /// Sync status of UCX.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfUcxExtRateStatus {
     pub word_clk: Option<ClkNominalRate>,
     pub opt_iface: Option<ClkNominalRate>,
@@ -271,7 +271,7 @@ fn deserialize_external_rate_status(status: &mut FfUcxExtRateStatus, quad: &u32)
 }
 
 /// Status of UCX.
-#[derive(Default, Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FfUcxStatus {
     pub ext_lock: FfUcxExtLockStatus,
     pub ext_sync: FfUcxExtSyncStatus,
@@ -281,8 +281,8 @@ pub struct FfUcxStatus {
     pub active_clk_rate: ClkNominalRate,
 }
 
-impl RmeFfParamsSerialize<FfUcxStatus, u8> for FfUcxProtocol {
-    fn serialize(state: &FfUcxStatus) -> Vec<u8> {
+impl RmeFfOffsetParamsSerialize<FfUcxStatus> for FfUcxProtocol {
+    fn serialize_offsets(state: &FfUcxStatus) -> Vec<u8> {
         let mut quad = 0;
 
         serialize_external_lock_status(&state.ext_lock, &mut quad);
@@ -309,8 +309,8 @@ impl RmeFfParamsSerialize<FfUcxStatus, u8> for FfUcxProtocol {
     }
 }
 
-impl RmeFfParamsDeserialize<FfUcxStatus, u8> for FfUcxProtocol {
-    fn deserialize(state: &mut FfUcxStatus, raw: &[u8]) {
+impl RmeFfOffsetParamsDeserialize<FfUcxStatus> for FfUcxProtocol {
+    fn deserialize_offsets(state: &mut FfUcxStatus, raw: &[u8]) {
         assert!(raw.len() >= LATTER_STATUS_SIZE);
 
         let mut r = [0; 4];
@@ -397,9 +397,9 @@ mod test {
             word_in_terminate: true,
             spdif_out_format: SpdifFormat::Professional,
         };
-        let quads = FfUcxProtocol::serialize(&orig);
+        let quads = FfUcxProtocol::serialize_offsets(&orig);
         let mut target = FfUcxConfig::default();
-        FfUcxProtocol::deserialize(&mut target, &quads);
+        FfUcxProtocol::deserialize_offsets(&mut target, &quads);
 
         assert_eq!(target, orig);
     }
@@ -471,9 +471,9 @@ mod test {
             active_clk_src: FfUcxClkSrc::Opt,
             active_clk_rate: ClkNominalRate::R88200,
         };
-        let raw = FfUcxProtocol::serialize(&orig);
+        let raw = FfUcxProtocol::serialize_offsets(&orig);
         let mut target = FfUcxStatus::default();
-        FfUcxProtocol::deserialize(&mut target, &raw);
+        FfUcxProtocol::deserialize_offsets(&mut target, &raw);
 
         assert_eq!(target, orig);
     }

--- a/protocols/fireface/src/lib.rs
+++ b/protocols/fireface/src/lib.rs
@@ -39,7 +39,7 @@ impl<'a> FfConfigRom for ConfigRom<'a> {
 }
 
 /// Nominal frequency of sampling clock.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ClkNominalRate {
     R32000,
     R44100,
@@ -59,7 +59,7 @@ impl Default for ClkNominalRate {
 }
 
 /// Format of S/PDIF signal.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SpdifFormat {
     Consumer,
     Professional,
@@ -72,7 +72,7 @@ impl Default for SpdifFormat {
 }
 
 /// Digital interface of S/PDIF signal.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SpdifIface {
     Coaxial,
     Optical,
@@ -85,7 +85,7 @@ impl Default for SpdifIface {
 }
 
 /// Configuration of S/PDIF input.
-#[derive(Default, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct SpdifInput {
     /// The interface of S/PDIF signal.
     pub iface: SpdifIface,
@@ -94,7 +94,7 @@ pub struct SpdifInput {
 }
 
 /// Type of signal to optical output interface.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OpticalOutputSignal {
     Adat,
     Spdif,
@@ -107,7 +107,7 @@ impl Default for OpticalOutputSignal {
 }
 
 /// Nominal level of line outputs.
-#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum LineOutNominalLevel {
     High,
     /// -10 dBV.

--- a/protocols/fireface/src/lib.rs
+++ b/protocols/fireface/src/lib.rs
@@ -122,16 +122,16 @@ impl Default for LineOutNominalLevel {
     }
 }
 
-/// Parameters deserializer.
-pub trait RmeFfParamsDeserialize<T, U> {
-    /// Deserialize parameters into raw data.
-    fn deserialize(params: &mut T, raw: &[U]);
+/// Serialize offsets for parameters.
+pub trait RmeFfOffsetParamsSerialize<T> {
+    /// Serialize parameters from raw data.
+    fn serialize_offsets(params: &T) -> Vec<u8>;
 }
 
-/// Parameters serializer.
-pub trait RmeFfParamsSerialize<T, U> {
-    /// Serialize parameters from raw data.
-    fn serialize(params: &T) -> Vec<U>;
+/// Deserialize offsets for parameters.
+pub trait RmeFfOffsetParamsDeserialize<T> {
+    /// Deserialize parameters into raw data.
+    fn deserialize_offsets(params: &mut T, raw: &[u8]);
 }
 
 /// Operation for parameters which can be updated wholly at once.

--- a/runtime/fireface/src/ff400_model.rs
+++ b/runtime/fireface/src/ff400_model.rs
@@ -476,9 +476,9 @@ impl CfgCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_PAD_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 2, true)?;
 
-        let labels: Vec<String> = Self::LINE_OUTPUT_LEVELS
+        let labels: Vec<&str> = Self::LINE_OUTPUT_LEVELS
             .iter()
-            .map(|l| line_out_nominal_level_to_string(l))
+            .map(|l| line_out_nominal_level_to_str(l))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, LINE_OUTPUT_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;

--- a/runtime/fireface/src/ff800_model.rs
+++ b/runtime/fireface/src/ff800_model.rs
@@ -359,9 +359,9 @@ impl CfgCtl {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, INPUT_INST_SPKR_EMU_NAME, 0);
         let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
 
-        let labels: Vec<String> = Self::OUTPUT_LINE_LEVELS
+        let labels: Vec<&str> = Self::OUTPUT_LINE_LEVELS
             .iter()
-            .map(|l| line_out_nominal_level_to_string(l))
+            .map(|l| line_out_nominal_level_to_str(l))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OUTPUT_LINE_LEVEL_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -23,10 +23,10 @@ pub struct Ff802Model {
     output_dyn_ctl: LatterOutputDynamicsCtl<Ff802Protocol>,
     input_al_ctl: LatterInputAutolevelCtl<Ff802Protocol>,
     output_al_ctl: LatterOutputAutolevelCtl<Ff802Protocol>,
-    fx_ctl: LatterFxCtl<Ff802Protocol>,
     fx_source_ctl: LatterFxSourceCtl<Ff802Protocol>,
     fx_output_ctl: LatterFxOutputCtl<Ff802Protocol>,
     fx_reverb_ctl: LatterFxReverbCtl<Ff802Protocol>,
+    fx_echo_ctl: LatterFxEchoCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -47,10 +47,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_reverb_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_echo_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -70,10 +70,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_dyn_ctl.load(card_cntr)?;
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
-        self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
         self.fx_output_ctl.load(card_cntr)?;
         self.fx_reverb_ctl.load(card_cntr)?;
+        self.fx_echo_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -106,13 +106,13 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.fx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_reverb_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_echo_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -186,11 +186,6 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         {
             Ok(true)
         } else if self
-            .fx_ctl
-            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
             .fx_source_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
@@ -202,6 +197,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .fx_reverb_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_echo_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -13,6 +13,7 @@ pub struct Ff802Model {
     dsp_ctl: LatterDspCtl<Ff802Protocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
+    input_ctl: LatterInputCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -23,6 +24,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -32,6 +34,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
+        self.input_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -43,6 +46,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.status_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -62,6 +67,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .cfg_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -18,6 +18,8 @@ pub struct Ff802Model {
     mixer_ctl: LatterMixerCtl<Ff802Protocol>,
     input_hpf_ctl: LatterInputHpfCtl<Ff802Protocol>,
     output_hpf_ctl: LatterOutputHpfCtl<Ff802Protocol>,
+    input_eq_ctl: LatterInputEqualizerCtl<Ff802Protocol>,
+    output_eq_ctl: LatterOutputEqualizerCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -33,6 +35,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -47,6 +51,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.mixer_ctl.load(card_cntr)?;
         self.input_hpf_ctl.load(card_cntr)?;
         self.output_hpf_ctl.load(card_cntr)?;
+        self.input_eq_ctl.load(card_cntr)?;
+        self.output_eq_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -68,6 +74,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.input_hpf_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_hpf_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -112,6 +122,16 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .output_hpf_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_eq_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_eq_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -26,6 +26,7 @@ pub struct Ff802Model {
     fx_ctl: LatterFxCtl<Ff802Protocol>,
     fx_source_ctl: LatterFxSourceCtl<Ff802Protocol>,
     fx_output_ctl: LatterFxOutputCtl<Ff802Protocol>,
+    fx_reverb_ctl: LatterFxReverbCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -49,6 +50,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_reverb_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -71,6 +73,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
         self.fx_output_ctl.load(card_cntr)?;
+        self.fx_reverb_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -108,6 +111,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_reverb_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -192,6 +197,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .fx_output_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_reverb_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -22,6 +22,8 @@ pub struct Ff802Model {
     output_eq_ctl: LatterOutputEqualizerCtl<Ff802Protocol>,
     input_dyn_ctl: LatterInputDynamicsCtl<Ff802Protocol>,
     output_dyn_ctl: LatterOutputDynamicsCtl<Ff802Protocol>,
+    input_al_ctl: LatterInputAutolevelCtl<Ff802Protocol>,
+    output_al_ctl: LatterOutputAutolevelCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -41,6 +43,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -59,6 +63,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_eq_ctl.load(card_cntr)?;
         self.input_dyn_ctl.load(card_cntr)?;
         self.output_dyn_ctl.load(card_cntr)?;
+        self.input_al_ctl.load(card_cntr)?;
+        self.output_al_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -88,6 +94,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_al_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -152,6 +162,16 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .output_dyn_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_al_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_al_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -20,6 +20,8 @@ pub struct Ff802Model {
     output_hpf_ctl: LatterOutputHpfCtl<Ff802Protocol>,
     input_eq_ctl: LatterInputEqualizerCtl<Ff802Protocol>,
     output_eq_ctl: LatterOutputEqualizerCtl<Ff802Protocol>,
+    input_dyn_ctl: LatterInputDynamicsCtl<Ff802Protocol>,
+    output_dyn_ctl: LatterOutputDynamicsCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -37,6 +39,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -53,6 +57,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_hpf_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
+        self.input_dyn_ctl.load(card_cntr)?;
+        self.output_dyn_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -78,6 +84,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -132,6 +142,16 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .output_eq_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_dyn_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_dyn_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -10,7 +10,6 @@ use {
 pub struct Ff802Model {
     req: FwReq,
     meter_ctl: LatterMeterCtl<Ff802Protocol>,
-    dsp_ctl: LatterDspCtl<Ff802Protocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<Ff802Protocol>,
@@ -24,6 +23,7 @@ pub struct Ff802Model {
     output_dyn_ctl: LatterOutputDynamicsCtl<Ff802Protocol>,
     input_al_ctl: LatterInputAutolevelCtl<Ff802Protocol>,
     output_al_ctl: LatterOutputAutolevelCtl<Ff802Protocol>,
+    fx_ctl: LatterFxCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -31,7 +31,6 @@ const TIMEOUT_MS: u32 = 100;
 impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
     fn cache(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -45,13 +44,13 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
-        self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
@@ -65,13 +64,12 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_dyn_ctl.load(card_cntr)?;
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
+        self.fx_ctl.load(card_cntr)?;
         Ok(())
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -99,6 +97,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
+        } else if self.fx_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -111,11 +111,6 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
-            .dsp_ctl
-            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
             .cfg_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
@@ -172,6 +167,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .output_al_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -16,6 +16,8 @@ pub struct Ff802Model {
     input_ctl: LatterInputCtl<Ff802Protocol>,
     output_ctl: LatterOutputCtl<Ff802Protocol>,
     mixer_ctl: LatterMixerCtl<Ff802Protocol>,
+    input_hpf_ctl: LatterInputHpfCtl<Ff802Protocol>,
+    output_hpf_ctl: LatterOutputHpfCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -29,6 +31,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -41,6 +45,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.input_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
+        self.input_hpf_ctl.load(card_cntr)?;
+        self.output_hpf_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -58,6 +64,10 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_hpf_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_hpf_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -92,6 +102,16 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .mixer_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_hpf_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_hpf_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -24,6 +24,7 @@ pub struct Ff802Model {
     input_al_ctl: LatterInputAutolevelCtl<Ff802Protocol>,
     output_al_ctl: LatterOutputAutolevelCtl<Ff802Protocol>,
     fx_ctl: LatterFxCtl<Ff802Protocol>,
+    fx_source_ctl: LatterFxSourceCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -45,6 +46,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -65,6 +67,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
         self.fx_ctl.load(card_cntr)?;
+        self.fx_source_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -98,6 +101,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -172,6 +177,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .fx_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_source_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -15,6 +15,7 @@ pub struct Ff802Model {
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<Ff802Protocol>,
     output_ctl: LatterOutputCtl<Ff802Protocol>,
+    mixer_ctl: LatterMixerCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -27,6 +28,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -38,6 +40,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -53,6 +56,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -82,6 +87,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .output_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .mixer_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -18,13 +18,11 @@ pub struct Ff802Model {
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
-    fn cache(&mut self, unit: &mut (SndFireface, FwNode)) -> Result<(), Error> {
-        self.meter_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.cfg_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.status_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -53,18 +51,18 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
 
     fn write(
         &mut self,
-        unit: &mut (SndFireface, FwNode),
+        (_, node): &mut (SndFireface, FwNode),
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .dsp_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .cfg_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -79,11 +77,9 @@ impl MeasureModel<(SndFireface, FwNode)> for Ff802Model {
         elem_id_list.extend_from_slice(&self.status_ctl.0);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndFireface, FwNode)) -> Result<(), Error> {
-        self.meter_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.status_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+    fn measure_states(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 }

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -25,6 +25,7 @@ pub struct Ff802Model {
     output_al_ctl: LatterOutputAutolevelCtl<Ff802Protocol>,
     fx_ctl: LatterFxCtl<Ff802Protocol>,
     fx_source_ctl: LatterFxSourceCtl<Ff802Protocol>,
+    fx_output_ctl: LatterFxOutputCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -47,6 +48,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -68,6 +70,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.output_al_ctl.load(card_cntr)?;
         self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
+        self.fx_output_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -103,6 +106,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.fx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -182,6 +187,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .fx_source_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_output_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ff802_model.rs
+++ b/runtime/fireface/src/ff802_model.rs
@@ -14,6 +14,7 @@ pub struct Ff802Model {
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<Ff802Protocol>,
+    output_ctl: LatterOutputCtl<Ff802Protocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -25,6 +26,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -35,6 +37,7 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
+        self.output_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -48,6 +51,8 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
         } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -72,6 +77,11 @@ impl CtlModel<(SndFireface, FwNode)> for Ff802Model {
             Ok(true)
         } else if self
             .input_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -2453,27 +2453,6 @@ where
     const CH_COUNT: usize = T::OUTPUT_COUNT;
 }
 
-fn fx_reverb_type_to_string(reverb_type: &FfLatterFxReverbType) -> String {
-    match reverb_type {
-        FfLatterFxReverbType::SmallRoom => "Small-room",
-        FfLatterFxReverbType::MediumRoom => "Medium-room",
-        FfLatterFxReverbType::LargeRoom => "Large-room",
-        FfLatterFxReverbType::Walls => "Walls",
-        FfLatterFxReverbType::Shorty => "Shorty",
-        FfLatterFxReverbType::Attack => "Attack",
-        FfLatterFxReverbType::Swagger => "Swagger",
-        FfLatterFxReverbType::OldSchool => "Old-school",
-        FfLatterFxReverbType::Echoistic => "Echoistic",
-        FfLatterFxReverbType::EightPlusNine => "8-plus-9",
-        FfLatterFxReverbType::GrandWide => "Grand-wide",
-        FfLatterFxReverbType::Thicker => "Thicker",
-        FfLatterFxReverbType::Envelope => "Envelope",
-        FfLatterFxReverbType::Gated => "Gated",
-        FfLatterFxReverbType::Space => "Space",
-    }
-    .to_string()
-}
-
 fn fx_echo_type_to_string(echo_type: &FfLatterFxEchoType) -> String {
     match echo_type {
         FfLatterFxEchoType::StereoEcho => "Stereo-echo",
@@ -2930,49 +2909,43 @@ const REVERB_SMOOTH_NAME: &str = "fx:reverb-smooth";
 const REVERB_VOL_NAME: &str = "fx:reverb-volume";
 const REVERB_STEREO_WIDTH_NAME: &str = "fx:reverb-stereo-width";
 
-const ECHO_ACTIVATE_NAME: &str = "fx:echo-activate";
-const ECHO_TYPE_NAME: &str = "fx:echo-type";
-const ECHO_DELAY_NAME: &str = "fx:echo-delay";
-const ECHO_FEEDBACK_NAME: &str = "fx:echo-feedback";
-const ECHO_LPF_FREQ_NAME: &str = "fx:echo-lpf-freq";
-const ECHO_VOL_NAME: &str = "fx:echo-volume";
-const ECHO_STEREO_WIDTH_NAME: &str = "fx:echo-stereo-width";
-
-#[derive(Debug)]
-pub struct LatterFxCtl<T>
+#[derive(Default, Debug)]
+pub struct LatterFxReverbCtl<T>
 where
-    T: RmeFfLatterDspSpecification
-        + RmeFfLatterFxSpecification
-        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
+    T: RmeFfLatterFxSpecification
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxReverbState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxReverbState>,
 {
     pub elem_id_list: Vec<ElemId>,
-    params: FfLatterFxState,
+    params: FfLatterFxReverbState,
     _phantom: PhantomData<T>,
 }
 
-impl<T> Default for LatterFxCtl<T>
-where
-    T: RmeFfLatterDspSpecification
-        + RmeFfLatterFxSpecification
-        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
-{
-    fn default() -> Self {
-        Self {
-            elem_id_list: Default::default(),
-            params: T::create_fx_parameters(),
-            _phantom: Default::default(),
-        }
+fn fx_reverb_type_to_str(reverb_type: &FfLatterFxReverbType) -> &str {
+    match reverb_type {
+        FfLatterFxReverbType::SmallRoom => "Small-room",
+        FfLatterFxReverbType::MediumRoom => "Medium-room",
+        FfLatterFxReverbType::LargeRoom => "Large-room",
+        FfLatterFxReverbType::Walls => "Walls",
+        FfLatterFxReverbType::Shorty => "Shorty",
+        FfLatterFxReverbType::Attack => "Attack",
+        FfLatterFxReverbType::Swagger => "Swagger",
+        FfLatterFxReverbType::OldSchool => "Old-school",
+        FfLatterFxReverbType::Echoistic => "Echoistic",
+        FfLatterFxReverbType::EightPlusNine => "8-plus-9",
+        FfLatterFxReverbType::GrandWide => "Grand-wide",
+        FfLatterFxReverbType::Thicker => "Thicker",
+        FfLatterFxReverbType::Envelope => "Envelope",
+        FfLatterFxReverbType::Gated => "Gated",
+        FfLatterFxReverbType::Space => "Space",
     }
 }
 
-impl<T> LatterFxCtl<T>
+impl<T> LatterFxReverbCtl<T>
 where
-    T: RmeFfLatterDspSpecification
-        + RmeFfLatterFxSpecification
-        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
+    T: RmeFfLatterFxSpecification
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxReverbState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxReverbState>,
 {
     const REVERB_TYPES: &'static [FfLatterFxReverbType] = &[
         FfLatterFxReverbType::SmallRoom,
@@ -2992,21 +2965,6 @@ where
         FfLatterFxReverbType::Space,
     ];
 
-    const ECHO_TYPES: &[FfLatterFxEchoType] = &[
-        FfLatterFxEchoType::StereoEcho,
-        FfLatterFxEchoType::StereoCross,
-        FfLatterFxEchoType::PongEcho,
-    ];
-
-    const ECHO_LPF_FREQS: &[FfLatterFxEchoLpfFreq] = &[
-        FfLatterFxEchoLpfFreq::Off,
-        FfLatterFxEchoLpfFreq::H2000,
-        FfLatterFxEchoLpfFreq::H4000,
-        FfLatterFxEchoLpfFreq::H8000,
-        FfLatterFxEchoLpfFreq::H12000,
-        FfLatterFxEchoLpfFreq::H16000,
-    ];
-
     pub fn cache(
         &mut self,
         req: &mut FwReq,
@@ -3024,9 +2982,9 @@ where
             .add_bool_elems(&elem_id, 1, 1, true)
             .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = Self::REVERB_TYPES
+        let labels: Vec<&str> = Self::REVERB_TYPES
             .iter()
-            .map(|t| fx_reverb_type_to_string(t))
+            .map(|t| fx_reverb_type_to_str(t))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, REVERB_TYPE_NAME, 0);
         card_cntr
@@ -3183,6 +3141,266 @@ where
             )
             .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
+        Ok(())
+    }
+
+    pub fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            REVERB_ACTIVATE_NAME => {
+                elem_value.set_bool(&[self.params.activate]);
+                Ok(true)
+            }
+            REVERB_TYPE_NAME => {
+                let val = Self::REVERB_TYPES
+                    .iter()
+                    .position(|t| self.params.reverb_type.eq(t))
+                    .unwrap();
+                elem_value.set_enum(&[val as u32]);
+                Ok(true)
+            }
+            REVERB_PRE_DELAY_NAME => {
+                elem_value.set_int(&[self.params.pre_delay as i32]);
+                Ok(true)
+            }
+            REVERB_PRE_HPF_FREQ_NAME => {
+                elem_value.set_int(&[self.params.pre_hpf as i32]);
+                Ok(true)
+            }
+            REVERB_ROOM_SCALE_NAME => {
+                elem_value.set_int(&[self.params.room_scale as i32]);
+                Ok(true)
+            }
+            REVERB_ATTACK_NAME => {
+                elem_value.set_int(&[self.params.attack as i32]);
+                Ok(true)
+            }
+            REVERB_HOLD_NAME => {
+                elem_value.set_int(&[self.params.hold as i32]);
+                Ok(true)
+            }
+            REVERB_RELEASE_NAME => {
+                elem_value.set_int(&[self.params.release as i32]);
+                Ok(true)
+            }
+            REVERB_POST_LPF_FREQ_NAME => {
+                elem_value.set_int(&[self.params.post_lpf as i32]);
+                Ok(true)
+            }
+            REVERB_TIME_NAME => {
+                elem_value.set_int(&[self.params.time as i32]);
+                Ok(true)
+            }
+            REVERB_DAMPING_NAME => {
+                elem_value.set_int(&[self.params.damping as i32]);
+                Ok(true)
+            }
+            REVERB_SMOOTH_NAME => {
+                elem_value.set_int(&[self.params.smooth as i32]);
+                Ok(true)
+            }
+            REVERB_VOL_NAME => {
+                elem_value.set_int(&[self.params.volume as i32]);
+                Ok(true)
+            }
+            REVERB_STEREO_WIDTH_NAME => {
+                elem_value.set_int(&[self.params.stereo_width as i32]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    pub fn write(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            REVERB_ACTIVATE_NAME => {
+                let mut params = self.params.clone();
+                params.activate = elem_value.boolean()[0];
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_TYPE_NAME => {
+                let mut params = self.params.clone();
+                let pos = elem_value.enumerated()[0] as usize;
+                Self::REVERB_TYPES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid index of type of reverb effect: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|&t| params.reverb_type = t)?;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_PRE_DELAY_NAME => {
+                let mut params = self.params.clone();
+                params.pre_delay = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_PRE_HPF_FREQ_NAME => {
+                let mut params = self.params.clone();
+                params.pre_hpf = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_ROOM_SCALE_NAME => {
+                let mut params = self.params.clone();
+                params.room_scale = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_ATTACK_NAME => {
+                let mut params = self.params.clone();
+                params.attack = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_HOLD_NAME => {
+                let mut params = self.params.clone();
+                params.hold = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_RELEASE_NAME => {
+                let mut params = self.params.clone();
+                params.release = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_POST_LPF_FREQ_NAME => {
+                let mut params = self.params.clone();
+                params.post_lpf = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_TIME_NAME => {
+                let mut params = self.params.clone();
+                params.time = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_DAMPING_NAME => {
+                let mut params = self.params.clone();
+                params.damping = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_SMOOTH_NAME => {
+                let mut params = self.params.clone();
+                params.smooth = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_VOL_NAME => {
+                let mut params = self.params.clone();
+                params.volume = elem_value.int()[0] as i16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            REVERB_STEREO_WIDTH_NAME => {
+                let mut params = self.params.clone();
+                params.stereo_width = elem_value.int()[0] as u16;
+                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
+                debug!(params = ?self.params, ?res);
+                res.map(|_| true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+const ECHO_ACTIVATE_NAME: &str = "fx:echo-activate";
+const ECHO_TYPE_NAME: &str = "fx:echo-type";
+const ECHO_DELAY_NAME: &str = "fx:echo-delay";
+const ECHO_FEEDBACK_NAME: &str = "fx:echo-feedback";
+const ECHO_LPF_FREQ_NAME: &str = "fx:echo-lpf-freq";
+const ECHO_VOL_NAME: &str = "fx:echo-volume";
+const ECHO_STEREO_WIDTH_NAME: &str = "fx:echo-stereo-width";
+
+#[derive(Debug)]
+pub struct LatterFxCtl<T>
+where
+    T: RmeFfLatterDspSpecification
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
+{
+    pub elem_id_list: Vec<ElemId>,
+    params: FfLatterFxState,
+    _phantom: PhantomData<T>,
+}
+
+impl<T> Default for LatterFxCtl<T>
+where
+    T: RmeFfLatterDspSpecification
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
+{
+    fn default() -> Self {
+        Self {
+            elem_id_list: Default::default(),
+            params: T::create_fx_parameters(),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<T> LatterFxCtl<T>
+where
+    T: RmeFfLatterDspSpecification
+        + RmeFfLatterFxSpecification
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
+{
+    const ECHO_TYPES: &[FfLatterFxEchoType] = &[
+        FfLatterFxEchoType::StereoEcho,
+        FfLatterFxEchoType::StereoCross,
+        FfLatterFxEchoType::PongEcho,
+    ];
+
+    const ECHO_LPF_FREQS: &[FfLatterFxEchoLpfFreq] = &[
+        FfLatterFxEchoLpfFreq::Off,
+        FfLatterFxEchoLpfFreq::H2000,
+        FfLatterFxEchoLpfFreq::H4000,
+        FfLatterFxEchoLpfFreq::H8000,
+        FfLatterFxEchoLpfFreq::H12000,
+        FfLatterFxEchoLpfFreq::H16000,
+    ];
+
+    pub fn cache(
+        &mut self,
+        req: &mut FwReq,
+        node: &mut FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let res = T::command_wholly(req, node, &mut self.params, timeout_ms);
+        debug!(params = ?self.params, ?res);
+        res
+    }
+
+    pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ECHO_ACTIVATE_NAME, 0);
         card_cntr
             .add_bool_elems(&elem_id, 1, 1, true)
@@ -3267,66 +3485,6 @@ where
 
     pub fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            REVERB_ACTIVATE_NAME => {
-                elem_value.set_bool(&[self.params.reverb.activate]);
-                Ok(true)
-            }
-            REVERB_TYPE_NAME => {
-                let val = Self::REVERB_TYPES
-                    .iter()
-                    .position(|t| self.params.reverb.reverb_type.eq(t))
-                    .unwrap();
-                elem_value.set_enum(&[val as u32]);
-                Ok(true)
-            }
-            REVERB_PRE_DELAY_NAME => {
-                elem_value.set_int(&[self.params.reverb.pre_delay as i32]);
-                Ok(true)
-            }
-            REVERB_PRE_HPF_FREQ_NAME => {
-                elem_value.set_int(&[self.params.reverb.pre_hpf as i32]);
-                Ok(true)
-            }
-            REVERB_ROOM_SCALE_NAME => {
-                elem_value.set_int(&[self.params.reverb.room_scale as i32]);
-                Ok(true)
-            }
-            REVERB_ATTACK_NAME => {
-                elem_value.set_int(&[self.params.reverb.attack as i32]);
-                Ok(true)
-            }
-            REVERB_HOLD_NAME => {
-                elem_value.set_int(&[self.params.reverb.hold as i32]);
-                Ok(true)
-            }
-            REVERB_RELEASE_NAME => {
-                elem_value.set_int(&[self.params.reverb.release as i32]);
-                Ok(true)
-            }
-            REVERB_POST_LPF_FREQ_NAME => {
-                elem_value.set_int(&[self.params.reverb.post_lpf as i32]);
-                Ok(true)
-            }
-            REVERB_TIME_NAME => {
-                elem_value.set_int(&[self.params.reverb.time as i32]);
-                Ok(true)
-            }
-            REVERB_DAMPING_NAME => {
-                elem_value.set_int(&[self.params.reverb.damping as i32]);
-                Ok(true)
-            }
-            REVERB_SMOOTH_NAME => {
-                elem_value.set_int(&[self.params.reverb.smooth as i32]);
-                Ok(true)
-            }
-            REVERB_VOL_NAME => {
-                elem_value.set_int(&[self.params.reverb.volume as i32]);
-                Ok(true)
-            }
-            REVERB_STEREO_WIDTH_NAME => {
-                elem_value.set_int(&[self.params.reverb.stereo_width as i32]);
-                Ok(true)
-            }
             ECHO_ACTIVATE_NAME => {
                 elem_value.set_bool(&[self.params.echo.activate]);
                 Ok(true)
@@ -3376,112 +3534,6 @@ where
         timeout_ms: u32,
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
-            REVERB_ACTIVATE_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.activate = elem_value.boolean()[0];
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_TYPE_NAME => {
-                let mut params = self.params.clone();
-                let pos = elem_value.enumerated()[0] as usize;
-                Self::REVERB_TYPES
-                    .iter()
-                    .nth(pos)
-                    .ok_or_else(|| {
-                        let msg = format!("Invalid index of type of reverb effect: {}", pos);
-                        Error::new(FileError::Inval, &msg)
-                    })
-                    .map(|&t| params.reverb.reverb_type = t)?;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_PRE_DELAY_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.pre_delay = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_PRE_HPF_FREQ_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.pre_hpf = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_ROOM_SCALE_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.room_scale = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_ATTACK_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.attack = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_HOLD_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.hold = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_RELEASE_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.release = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_POST_LPF_FREQ_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.post_lpf = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_TIME_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.time = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_DAMPING_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.damping = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_SMOOTH_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.smooth = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_VOL_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.volume = elem_value.int()[0] as i16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
-            REVERB_STEREO_WIDTH_NAME => {
-                let mut params = self.params.clone();
-                params.reverb.stereo_width = elem_value.int()[0] as u16;
-                let res = T::command_partially(req, node, &mut self.params, params, timeout_ms);
-                debug!(params = ?self.params, ?res);
-                res.map(|_| true)
-            }
             ECHO_ACTIVATE_NAME => {
                 let mut params = self.params.clone();
                 params.echo.activate = elem_value.boolean()[0];

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -128,45 +128,45 @@ pub struct LatterDspCtl<T>(FfLatterDspState, PhantomData<T>)
 where
     T: RmeFfLatterDspSpecification
         + RmeFfLatterInputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterMixerState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterMixerState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterMixerState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>
         + RmeFfLatterChStripSpecification<FfLatterInputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputChStripState>
         + RmeFfLatterFxSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>;
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>;
 
 impl<T> Default for LatterDspCtl<T>
 where
     T: RmeFfLatterDspSpecification
         + RmeFfLatterInputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterMixerState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterMixerState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterMixerState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>
         + RmeFfLatterChStripSpecification<FfLatterInputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputChStripState>
         + RmeFfLatterFxSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
 {
     fn default() -> Self {
         let mut state = T::create_dsp_state();
@@ -192,23 +192,23 @@ impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterDspSpecification
         + RmeFfLatterInputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputState>
         + RmeFfLatterOutputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputState>
         + RmeFfLatterMixerSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterMixerState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterMixerState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterMixerState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>
         + RmeFfLatterChStripSpecification<FfLatterInputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputChStripState>
         + RmeFfLatterChStripSpecification<FfLatterOutputChStripState>
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputChStripState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputChStripState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputChStripState>
         + RmeFfLatterFxSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
 {
     pub fn cache(
         &mut self,
@@ -324,8 +324,8 @@ const INPUT_INVERT_PHASE_NAME: &str = "input:invert-phase";
 impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterInputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterInputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterInputState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterInputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterInputState>,
 {
     const INPUT_GAIN_TLV: DbInterval = DbInterval {
         min: 0,
@@ -345,7 +345,7 @@ where
         params: &mut FfLatterInputState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::update_wholly(req, node, params, timeout_ms);
+        let res = T::command_wholly(req, node, params, timeout_ms);
         debug!(?params, ?res);
         res
     }
@@ -447,7 +447,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -458,7 +458,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -479,7 +479,7 @@ where
                             })
                             .map(|&l| *level = l)
                     })?;
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -490,7 +490,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -501,7 +501,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -512,7 +512,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -530,8 +530,8 @@ const LINE_LEVEL_NAME: &str = "output:line-level";
 impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterOutputSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterOutputState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterOutputState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterOutputState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterOutputState>,
 {
     const VOL_TLV: DbInterval = DbInterval {
         min: -6500,
@@ -552,7 +552,7 @@ where
         params: &mut FfLatterOutputState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::update_wholly(req, node, params, timeout_ms);
+        let res = T::command_wholly(req, node, params, timeout_ms);
         debug!(?params, ?res);
         res
     }
@@ -661,7 +661,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -672,7 +672,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -683,7 +683,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -694,7 +694,7 @@ where
                     .iter_mut()
                     .zip(elem_value.boolean())
                     .for_each(|(d, s)| *d = s);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -716,7 +716,7 @@ where
                             })
                             .map(|&l| *level = l)
                     })?;
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -734,8 +734,8 @@ const MIXER_STREAM_SRC_GAIN_NAME: &str = "mixer:stream-source-gain";
 impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterMixerSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterMixerState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterMixerState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterMixerState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>,
 {
     const SRC_GAIN_TLV: DbInterval = DbInterval {
         min: -6500,
@@ -750,7 +750,7 @@ where
         params: &mut FfLatterMixerState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::update_wholly(req, node, params, timeout_ms);
+        let res = T::command_wholly(req, node, params, timeout_ms);
         debug!(?params, ?res);
         res
     }
@@ -901,7 +901,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -917,7 +917,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -933,7 +933,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -949,7 +949,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -965,7 +965,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -996,8 +996,8 @@ fn eq_type_to_string(eq_type: &FfLatterChStripEqType) -> String {
 pub trait FfLatterChStripCtlOperation<T, U>
 where
     T: RmeFfLatterChStripSpecification<U>
-        + RmeFfWhollyUpdatableParamsOperation<U>
-        + RmeFfPartiallyUpdatableParamsOperation<U>,
+        + RmeFfWhollyCommandableParamsOperation<U>
+        + RmeFfPartiallyCommandableParamsOperation<U>,
     U: std::fmt::Debug + Clone + AsRef<FfLatterChStripState> + AsMut<FfLatterChStripState>,
 {
     const HPF_ACTIVATE_NAME: &'static str;
@@ -1050,7 +1050,7 @@ where
         params: &mut U,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::update_wholly(req, node, params, timeout_ms);
+        let res = T::command_wholly(req, node, params, timeout_ms);
         debug!(?params, ?res);
         res
     }
@@ -1632,7 +1632,7 @@ where
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().hpf, ?res);
             res.map(|_| true)
         } else if n == Self::HPF_CUT_OFF_NAME {
@@ -1644,7 +1644,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(dst, &val)| *dst = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().hpf, ?res);
             res.map(|_| true)
         } else if n == Self::HPF_ROLL_OFF_NAME {
@@ -1666,7 +1666,7 @@ where
                         })
                         .map(|&l| *level = l)
                 })?;
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().hpf, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_ACTIVATE_NAME {
@@ -1678,7 +1678,7 @@ where
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_LOW_TYPE_NAME {
@@ -1700,7 +1700,7 @@ where
                         })
                         .map(|&t| *eq_type = t)
                 })?;
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_HIGH_TYPE_NAME {
@@ -1722,7 +1722,7 @@ where
                         })
                         .map(|&t| *eq_type = t)
                 })?;
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_LOW_GAIN_NAME {
@@ -1734,7 +1734,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_GAIN_NAME {
@@ -1746,7 +1746,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_HIGH_GAIN_NAME {
@@ -1758,7 +1758,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_LOW_FREQ_NAME {
@@ -1770,7 +1770,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_FREQ_NAME {
@@ -1782,7 +1782,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_HIGH_FREQ_NAME {
@@ -1794,7 +1794,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(freq, &val)| *freq = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_LOW_QUALITY_NAME {
@@ -1806,7 +1806,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_MIDDLE_QUALITY_NAME {
@@ -1818,7 +1818,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::EQ_HIGH_QUALITY_NAME {
@@ -1830,7 +1830,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(quality, &val)| *quality = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().eq, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_ACTIVATE_NAME {
@@ -1842,7 +1842,7 @@ where
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_GAIN_NAME {
@@ -1854,7 +1854,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_ATTACK_NAME {
@@ -1866,7 +1866,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(attack, &val)| *attack = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_RELEASE_NAME {
@@ -1878,7 +1878,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(release, &val)| *release = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_COMP_THRESHOLD_NAME {
@@ -1890,7 +1890,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(threshold, &val)| *threshold = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_COMP_RATIO_NAME {
@@ -1902,7 +1902,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(ratio, &val)| *ratio = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_EX_THRESHOLD_NAME {
@@ -1914,7 +1914,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(threshold, &val)| *threshold = val as i16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::DYN_EX_RATIO_NAME {
@@ -1926,7 +1926,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(ratio, &val)| *ratio = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().dynamics, ?res);
             res.map(|_| true)
         } else if n == Self::AUTOLEVEL_ACTIVATE_NAME {
@@ -1938,7 +1938,7 @@ where
                 .iter_mut()
                 .zip(elem_value.boolean())
                 .for_each(|(activate, val)| *activate = val);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().autolevel, ?res);
             res.map(|_| true)
         } else if n == Self::AUTOLEVEL_MAX_GAIN_NAME {
@@ -1950,7 +1950,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(gain, &val)| *gain = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().autolevel, ?res);
             res.map(|_| true)
         } else if n == Self::AUTOLEVEL_HEAD_ROOM_NAME {
@@ -1962,7 +1962,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(headroom, &val)| *headroom = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().autolevel, ?res);
             res.map(|_| true)
         } else if n == Self::AUTOLEVEL_RISE_TIME_NAME {
@@ -1974,7 +1974,7 @@ where
                 .iter_mut()
                 .zip(elem_value.int())
                 .for_each(|(time, &val)| *time = val as u16);
-            let res = T::update_partially(req, node, state, params, timeout_ms);
+            let res = T::command_partially(req, node, state, params, timeout_ms);
             debug!(params = ?state.as_ref().autolevel, ?res);
             res.map(|_| true)
         } else {
@@ -2134,8 +2134,8 @@ const ECHO_STEREO_WIDTH_NAME: &str = "fx:echo-stereo-width";
 impl<T> LatterDspCtl<T>
 where
     T: RmeFfLatterFxSpecification
-        + RmeFfWhollyUpdatableParamsOperation<FfLatterFxState>
-        + RmeFfPartiallyUpdatableParamsOperation<FfLatterFxState>,
+        + RmeFfWhollyCommandableParamsOperation<FfLatterFxState>
+        + RmeFfPartiallyCommandableParamsOperation<FfLatterFxState>,
 {
     const PHYS_LEVEL_TLV: DbInterval = DbInterval {
         min: -6500,
@@ -2189,7 +2189,7 @@ where
         params: &mut FfLatterFxState,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        let res = T::update_wholly(req, node, params, timeout_ms);
+        let res = T::command_wholly(req, node, params, timeout_ms);
         debug!(?params, ?res);
         res
     }
@@ -2660,7 +2660,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -2671,7 +2671,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -2682,7 +2682,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -2693,7 +2693,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -2704,7 +2704,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as u16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state, ?res);
                 res.map(|_| true)
             }
@@ -2715,7 +2715,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state);
                 res.map(|_| true)
             }
@@ -2726,7 +2726,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state);
                 res.map(|_| true)
             }
@@ -2737,7 +2737,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state);
                 res.map(|_| true)
             }
@@ -2748,7 +2748,7 @@ where
                     .iter_mut()
                     .zip(elem_value.int())
                     .for_each(|(d, s)| *d = *s as i16);
-                let res = T::update_partially(req, node, state, params, timeout_ms);
+                let res = T::command_partially(req, node, state, params, timeout_ms);
                 debug!(params = ?state);
                 res.map(|_| true)
             }
@@ -2912,7 +2912,7 @@ where
     {
         let mut params = state.clone();
         cb(&mut params.reverb)?;
-        let res = T::update_partially(req, node, state, params, timeout_ms);
+        let res = T::command_partially(req, node, state, params, timeout_ms);
         debug!(params = ?state, ?res);
         res
     }
@@ -2929,7 +2929,7 @@ where
     {
         let mut params = state.clone();
         cb(&mut params.echo)?;
-        let res = T::update_partially(req, node, state, params, timeout_ms);
+        let res = T::command_partially(req, node, state, params, timeout_ms);
         debug!(params = ?state, ?res);
         res
     }

--- a/runtime/fireface/src/lib.rs
+++ b/runtime/fireface/src/lib.rs
@@ -173,11 +173,3 @@ fn optional_clk_nominal_rate_to_string(rate: &Option<ClkNominalRate>) -> String 
         "not-detected".to_string()
     }
 }
-
-fn latter_line_in_nominal_level_to_string(level: &LatterInNominalLevel) -> String {
-    match level {
-        LatterInNominalLevel::Low => "Low",
-        LatterInNominalLevel::Professional => "+4dBu",
-    }
-    .to_string()
-}

--- a/runtime/fireface/src/lib.rs
+++ b/runtime/fireface/src/lib.rs
@@ -142,13 +142,12 @@ fn former_line_in_nominal_level_to_string(level: &FormerLineInNominalLevel) -> S
     .to_string()
 }
 
-fn line_out_nominal_level_to_string(level: &LineOutNominalLevel) -> String {
+fn line_out_nominal_level_to_str(level: &LineOutNominalLevel) -> &str {
     match level {
         LineOutNominalLevel::High => "High",
         LineOutNominalLevel::Consumer => "-10dBV",
         LineOutNominalLevel::Professional => "+4dBu",
     }
-    .to_string()
 }
 
 fn clk_nominal_rate_to_string(rate: &ClkNominalRate) -> String {

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -18,6 +18,8 @@ pub struct UcxModel {
     mixer_ctl: LatterMixerCtl<FfUcxProtocol>,
     input_hpf_ctl: LatterInputHpfCtl<FfUcxProtocol>,
     output_hpf_ctl: LatterOutputHpfCtl<FfUcxProtocol>,
+    input_eq_ctl: LatterInputEqualizerCtl<FfUcxProtocol>,
+    output_eq_ctl: LatterOutputEqualizerCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -33,6 +35,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -47,6 +51,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.mixer_ctl.load(card_cntr)?;
         self.input_hpf_ctl.load(card_cntr)?;
         self.output_hpf_ctl.load(card_cntr)?;
+        self.input_eq_ctl.load(card_cntr)?;
+        self.output_eq_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -68,6 +74,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.input_hpf_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_hpf_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -112,6 +122,16 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .output_hpf_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_eq_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_eq_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -24,6 +24,7 @@ pub struct UcxModel {
     input_al_ctl: LatterInputAutolevelCtl<FfUcxProtocol>,
     output_al_ctl: LatterOutputAutolevelCtl<FfUcxProtocol>,
     fx_ctl: LatterFxCtl<FfUcxProtocol>,
+    fx_source_ctl: LatterFxSourceCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -45,6 +46,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -65,6 +67,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
         self.fx_ctl.load(card_cntr)?;
+        self.fx_source_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -98,6 +101,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -172,6 +177,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .fx_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_source_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -25,6 +25,7 @@ pub struct UcxModel {
     output_al_ctl: LatterOutputAutolevelCtl<FfUcxProtocol>,
     fx_ctl: LatterFxCtl<FfUcxProtocol>,
     fx_source_ctl: LatterFxSourceCtl<FfUcxProtocol>,
+    fx_output_ctl: LatterFxOutputCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -47,6 +48,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -68,6 +70,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_al_ctl.load(card_cntr)?;
         self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
+        self.fx_output_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -103,6 +106,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.fx_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -182,6 +187,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .fx_source_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_output_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -22,6 +22,8 @@ pub struct UcxModel {
     output_eq_ctl: LatterOutputEqualizerCtl<FfUcxProtocol>,
     input_dyn_ctl: LatterInputDynamicsCtl<FfUcxProtocol>,
     output_dyn_ctl: LatterOutputDynamicsCtl<FfUcxProtocol>,
+    input_al_ctl: LatterInputAutolevelCtl<FfUcxProtocol>,
+    output_al_ctl: LatterOutputAutolevelCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -41,6 +43,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -59,6 +63,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_eq_ctl.load(card_cntr)?;
         self.input_dyn_ctl.load(card_cntr)?;
         self.output_dyn_ctl.load(card_cntr)?;
+        self.input_al_ctl.load(card_cntr)?;
+        self.output_al_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -88,6 +94,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_al_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -152,6 +162,16 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .output_dyn_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_al_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_al_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -16,6 +16,8 @@ pub struct UcxModel {
     input_ctl: LatterInputCtl<FfUcxProtocol>,
     output_ctl: LatterOutputCtl<FfUcxProtocol>,
     mixer_ctl: LatterMixerCtl<FfUcxProtocol>,
+    input_hpf_ctl: LatterInputHpfCtl<FfUcxProtocol>,
+    output_hpf_ctl: LatterOutputHpfCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -29,6 +31,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -41,6 +45,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.input_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
         self.mixer_ctl.load(card_cntr)?;
+        self.input_hpf_ctl.load(card_cntr)?;
+        self.output_hpf_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -58,6 +64,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.mixer_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_hpf_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_hpf_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -92,6 +102,16 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .mixer_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_hpf_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_hpf_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -13,6 +13,7 @@ pub struct UcxModel {
     dsp_ctl: LatterDspCtl<FfUcxProtocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
+    input_ctl: LatterInputCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -23,6 +24,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -32,6 +34,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
+        self.input_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -43,6 +46,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.status_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -62,6 +67,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .cfg_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -10,7 +10,6 @@ use {
 pub struct UcxModel {
     req: FwReq,
     meter_ctl: LatterMeterCtl<FfUcxProtocol>,
-    dsp_ctl: LatterDspCtl<FfUcxProtocol>,
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<FfUcxProtocol>,
@@ -24,6 +23,7 @@ pub struct UcxModel {
     output_dyn_ctl: LatterOutputDynamicsCtl<FfUcxProtocol>,
     input_al_ctl: LatterInputAutolevelCtl<FfUcxProtocol>,
     output_al_ctl: LatterOutputAutolevelCtl<FfUcxProtocol>,
+    fx_ctl: LatterFxCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -31,7 +31,6 @@ const TIMEOUT_MS: u32 = 100;
 impl CtlModel<(SndFireface, FwNode)> for UcxModel {
     fn cache(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -45,13 +44,13 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.meter_ctl.load(card_cntr)?;
-        self.dsp_ctl.load(card_cntr)?;
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
@@ -65,13 +64,12 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_dyn_ctl.load(card_cntr)?;
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
+        self.fx_ctl.load(card_cntr)?;
         Ok(())
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.meter_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.dsp_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.cfg_ctl.read(elem_id, elem_value)? {
             Ok(true)
@@ -99,6 +97,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
+        } else if self.fx_ctl.read(elem_id, elem_value)? {
+            Ok(true)
         } else {
             Ok(false)
         }
@@ -111,11 +111,6 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
-            .dsp_ctl
-            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
             .cfg_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
@@ -172,6 +167,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .output_al_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -18,13 +18,11 @@ pub struct UcxModel {
 const TIMEOUT_MS: u32 = 100;
 
 impl CtlModel<(SndFireface, FwNode)> for UcxModel {
-    fn cache(&mut self, unit: &mut (SndFireface, FwNode)) -> Result<(), Error> {
-        self.meter_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.dsp_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.cfg_ctl.cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.status_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.dsp_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -53,18 +51,18 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
 
     fn write(
         &mut self,
-        unit: &mut (SndFireface, FwNode),
+        (_, node): &mut (SndFireface, FwNode),
         elem_id: &ElemId,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self
             .dsp_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .cfg_ctl
-            .write(&mut self.req, &mut unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -79,11 +77,9 @@ impl MeasureModel<(SndFireface, FwNode)> for UcxModel {
         elem_id_list.extend_from_slice(&self.status_ctl.0);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndFireface, FwNode)) -> Result<(), Error> {
-        self.meter_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
-        self.status_ctl
-            .cache(&mut self.req, &mut unit.1, TIMEOUT_MS)?;
+    fn measure_states(&mut self, (_, node): &mut (SndFireface, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 }

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -20,6 +20,8 @@ pub struct UcxModel {
     output_hpf_ctl: LatterOutputHpfCtl<FfUcxProtocol>,
     input_eq_ctl: LatterInputEqualizerCtl<FfUcxProtocol>,
     output_eq_ctl: LatterOutputEqualizerCtl<FfUcxProtocol>,
+    input_dyn_ctl: LatterInputDynamicsCtl<FfUcxProtocol>,
+    output_dyn_ctl: LatterOutputDynamicsCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -37,6 +39,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_hpf_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_eq_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.input_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -53,6 +57,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_hpf_ctl.load(card_cntr)?;
         self.input_eq_ctl.load(card_cntr)?;
         self.output_eq_ctl.load(card_cntr)?;
+        self.input_dyn_ctl.load(card_cntr)?;
+        self.output_dyn_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -78,6 +84,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.input_eq_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -132,6 +142,16 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .output_eq_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .input_dyn_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_dyn_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -15,6 +15,7 @@ pub struct UcxModel {
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<FfUcxProtocol>,
     output_ctl: LatterOutputCtl<FfUcxProtocol>,
+    mixer_ctl: LatterMixerCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -27,6 +28,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -38,6 +40,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
         self.output_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -53,6 +56,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.input_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -82,6 +87,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .output_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .mixer_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -26,6 +26,7 @@ pub struct UcxModel {
     fx_ctl: LatterFxCtl<FfUcxProtocol>,
     fx_source_ctl: LatterFxSourceCtl<FfUcxProtocol>,
     fx_output_ctl: LatterFxOutputCtl<FfUcxProtocol>,
+    fx_reverb_ctl: LatterFxReverbCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -49,6 +50,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_reverb_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -71,6 +73,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
         self.fx_output_ctl.load(card_cntr)?;
+        self.fx_reverb_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -108,6 +111,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_reverb_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -192,6 +197,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .fx_output_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_reverb_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -14,6 +14,7 @@ pub struct UcxModel {
     cfg_ctl: CfgCtl,
     status_ctl: StatusCtl,
     input_ctl: LatterInputCtl<FfUcxProtocol>,
+    output_ctl: LatterOutputCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -25,6 +26,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.cfg_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.status_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -35,6 +37,7 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.cfg_ctl.load(card_cntr)?;
         self.status_ctl.load(card_cntr)?;
         self.input_ctl.load(card_cntr)?;
+        self.output_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -48,6 +51,8 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         } else if self.status_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.input_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -72,6 +77,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .input_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .output_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)

--- a/runtime/fireface/src/ucx_model.rs
+++ b/runtime/fireface/src/ucx_model.rs
@@ -23,10 +23,10 @@ pub struct UcxModel {
     output_dyn_ctl: LatterOutputDynamicsCtl<FfUcxProtocol>,
     input_al_ctl: LatterInputAutolevelCtl<FfUcxProtocol>,
     output_al_ctl: LatterOutputAutolevelCtl<FfUcxProtocol>,
-    fx_ctl: LatterFxCtl<FfUcxProtocol>,
     fx_source_ctl: LatterFxSourceCtl<FfUcxProtocol>,
     fx_output_ctl: LatterFxOutputCtl<FfUcxProtocol>,
     fx_reverb_ctl: LatterFxReverbCtl<FfUcxProtocol>,
+    fx_echo_ctl: LatterFxEchoCtl<FfUcxProtocol>,
 }
 
 const TIMEOUT_MS: u32 = 100;
@@ -47,10 +47,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_dyn_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.input_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.output_al_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.fx_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_source_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_output_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.fx_reverb_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.fx_echo_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -70,10 +70,10 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         self.output_dyn_ctl.load(card_cntr)?;
         self.input_al_ctl.load(card_cntr)?;
         self.output_al_ctl.load(card_cntr)?;
-        self.fx_ctl.load(card_cntr)?;
         self.fx_source_ctl.load(card_cntr)?;
         self.fx_output_ctl.load(card_cntr)?;
         self.fx_reverb_ctl.load(card_cntr)?;
+        self.fx_echo_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -106,13 +106,13 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self.output_al_ctl.read(elem_id, elem_value)? {
             Ok(true)
-        } else if self.fx_ctl.read(elem_id, elem_value)? {
-            Ok(true)
         } else if self.fx_source_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_output_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.fx_reverb_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.fx_echo_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -186,11 +186,6 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
         {
             Ok(true)
         } else if self
-            .fx_ctl
-            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self
             .fx_source_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
@@ -202,6 +197,11 @@ impl CtlModel<(SndFireface, FwNode)> for UcxModel {
             Ok(true)
         } else if self
             .fx_reverb_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self
+            .fx_echo_ctl
             .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)


### PR DESCRIPTION
Current implementation aggregates several parameters for latter models. It is
convenient, while forces runtime to duplicate larger parameters.

This patchset is to break down the aggregated parameters per each.

```
Takashi Sakamoto (17):
  runtime/fireface: code refactoring for latter models
  protocols/fireface: add serializer/deserializer specific to command
    parameters in latter models
  protocols/fireface: code refactoring for serializer/deserializer of
    offset parameters in models
  protocols/fireface: use generic trait implementation to operate
    command parameters in latter models
  runtime/fireface: isolate input parameters in latter models
  runtime/fireface: isolate output parameters in latter models
  runtime/fireface: isolate mixer parameters in latter models
  runtime/fireface: isolate input and output high pass filter parameters
    in latter models
  runtime/fireface: isolate input and output equalizer parameters in
    latter models
  runtime/fireface: isolate input and output dynamics parameters in
    latter models
  runtime/fireface: isolate input and output autolevel parameters in
    latter models
  runtime/fireface: isolate fx parameters in latter models
  runtime/fireface: isolate fx sources parameters in latter models
  runtime/fireface: isolate fx output parameters in latter models
  runtime/fireface: isolate fx reverb parameters in latter models
  runtime/fireface: isolate fx echo parameters in latter models
  protocols/fireface: minor code refactoring for common parameters

 protocols/fireface/src/former.rs       |   58 +-
 protocols/fireface/src/former/ff400.rs |   72 +-
 protocols/fireface/src/former/ff800.rs |  194 +-
 protocols/fireface/src/latter.rs       | 1422 ++++----
 protocols/fireface/src/latter/ff802.rs |   38 +-
 protocols/fireface/src/latter/ucx.rs   |   36 +-
 protocols/fireface/src/lib.rs          |   28 +-
 runtime/fireface/src/ff400_model.rs    |    4 +-
 runtime/fireface/src/ff800_model.rs    |    4 +-
 runtime/fireface/src/ff802_model.rs    |  178 +-
 runtime/fireface/src/latter_ctls.rs    | 4391 ++++++++++++++----------
 runtime/fireface/src/lib.rs            |   11 +-
 runtime/fireface/src/ucx_model.rs      |  180 +-
 13 files changed, 3826 insertions(+), 2790 deletions(-)
```