### PR TITLE
 [PATCH 00/35] protocols/dice: tcelectronic: implement AsRef/AsMut to data of segment

### DIFF
--- a/protocols/dice/src/tcelectronic/desktop.rs
+++ b/protocols/dice/src/tcelectronic/desktop.rs
@@ -433,6 +433,18 @@ impl TcKonnektNotifiedSegmentOperation<DesktopPanel> for Desktopk6Protocol {
     const NOTIFY_FLAG: u32 = DESKTOP_PANEL_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for DesktopPanel {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for DesktopPanel {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.firewire_led
+    }
+}
+
 /// Hardware metering.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct DesktopMeter {

--- a/protocols/dice/src/tcelectronic/desktop.rs
+++ b/protocols/dice/src/tcelectronic/desktop.rs
@@ -253,6 +253,18 @@ impl TcKonnektNotifiedSegmentOperation<DesktopConfig> for Desktopk6Protocol {
     const NOTIFY_FLAG: u32 = DESKTOP_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for DesktopConfig {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for DesktopConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// Source of headphone.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DesktopHpSrc {

--- a/protocols/dice/src/tcelectronic/shell.rs
+++ b/protocols/dice/src/tcelectronic/shell.rs
@@ -235,7 +235,7 @@ impl ShellMixerState {
 
 /// The type of monitor source.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum ShellMixerMonitorSrcType {
+pub enum ShellMixerMonitorSrcType {
     /// Stream input.
     Stream,
     /// Analog input.
@@ -248,22 +248,35 @@ enum ShellMixerMonitorSrcType {
     AdatSpdif,
 }
 
-trait ShellMixerStateSpecification {
+/// The trait for specification of mixer.
+pub trait ShellMixerStateSpecification {
+    /// The sources of monitor.
     const MONITOR_SRC_MAP: [Option<ShellMixerMonitorSrcType>; SHELL_MIXER_MONITOR_SRC_COUNT];
 
-    fn create_mixer_state() -> ShellMixerState {
-        let analog_input_pair_count = Self::MONITOR_SRC_MAP
+    /// The number of analog input pairs.
+    fn analog_input_pair_count() -> usize {
+        Self::MONITOR_SRC_MAP
             .iter()
             .filter(|&&m| m == Some(ShellMixerMonitorSrcType::Analog))
-            .count();
-        let digital_input_pair_count = Self::MONITOR_SRC_MAP
+            .count()
+    }
+
+    /// The number of digital input pairs.
+    fn digital_input_pair_count() -> usize {
+        Self::MONITOR_SRC_MAP
             .iter()
             .filter(|&&m| {
                 m != Some(ShellMixerMonitorSrcType::Analog)
                     && m != Some(ShellMixerMonitorSrcType::Stream)
                     && m.is_some()
             })
-            .count();
+            .count()
+    }
+
+    /// Instantiate state of mixer.
+    fn create_mixer_state() -> ShellMixerState {
+        let analog_input_pair_count = Self::analog_input_pair_count();
+        let digital_input_pair_count = Self::digital_input_pair_count();
 
         ShellMixerState {
             stream: Default::default(),

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -441,6 +441,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinReverbState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
 }
 
+impl AsRef<ReverbState> for ItwinReverbState {
+    fn as_ref(&self) -> &ReverbState {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbState> for ItwinReverbState {
+    fn as_mut(&mut self) -> &mut ReverbState {
+        &mut self.0
+    }
+}
+
 /// Configuration for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinChStripStates(pub [ChStripState; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -353,6 +353,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinConfig> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellStandaloneClockSource> for ItwinConfig {
+    fn as_ref(&self) -> &ShellStandaloneClockSource {
+        &self.standalone_src
+    }
+}
+
+impl AsMut<ShellStandaloneClockSource> for ItwinConfig {
+    fn as_mut(&mut self) -> &mut ShellStandaloneClockSource {
+        &mut self.standalone_src
+    }
+}
+
 impl AsRef<TcKonnektStandaloneClockRate> for ItwinConfig {
     fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
         &self.standalone_rate

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -590,6 +590,18 @@ impl TcKonnektSegmentSerdes<ItwinReverbMeter> for ItwinProtocol {
     }
 }
 
+impl AsRef<ReverbMeter> for ItwinReverbMeter {
+    fn as_ref(&self) -> &ReverbMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbMeter> for ItwinReverbMeter {
+    fn as_mut(&mut self) -> &mut ReverbMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -191,6 +191,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinKnob> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellKnob0Target> for ItwinKnob {
+    fn as_ref(&self) -> &ShellKnob0Target {
+        &self.target
+    }
+}
+
+impl AsMut<ShellKnob0Target> for ItwinKnob {
+    fn as_mut(&mut self) -> &mut ShellKnob0Target {
+        &mut self.target
+    }
+}
+
 /// The number of pair for physical output.
 pub const ITWIN_PHYS_OUT_PAIR_COUNT: usize = 7;
 

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -477,6 +477,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinChStripStates> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
 }
 
+impl AsRef<[ChStripState]> for ItwinChStripStates {
+    fn as_ref(&self) -> &[ChStripState] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripState]> for ItwinChStripStates {
+    fn as_mut(&mut self) -> &mut [ChStripState] {
+        &mut self.0
+    }
+}
+
 /// The mode to listen for analog outputs.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ListeningMode {

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -353,6 +353,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinConfig> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for ItwinConfig {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for ItwinConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// State of mixer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItwinMixerState {

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -417,6 +417,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinMixerState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellMixerState> for ItwinMixerState {
+    fn as_ref(&self) -> &ShellMixerState {
+        &self.mixer
+    }
+}
+
+impl AsMut<ShellMixerState> for ItwinMixerState {
+    fn as_mut(&mut self) -> &mut ShellMixerState {
+        &mut self.mixer
+    }
+}
+
 /// Configuration for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinReverbState(pub ReverbState);

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -631,3 +631,15 @@ impl TcKonnektSegmentSerdes<ItwinChStripMeters> for ItwinProtocol {
         deserialize_ch_strip_meters(&mut params.0, raw)
     }
 }
+
+impl AsRef<[ChStripMeter]> for ItwinChStripMeters {
+    fn as_ref(&self) -> &[ChStripMeter] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripMeter]> for ItwinChStripMeters {
+    fn as_mut(&mut self) -> &mut [ChStripMeter] {
+        &mut self.0
+    }
+}

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -377,6 +377,18 @@ impl AsMut<TcKonnektStandaloneClockRate> for ItwinConfig {
     }
 }
 
+impl AsRef<ShellMixerStreamSourcePair> for ItwinConfig {
+    fn as_ref(&self) -> &ShellMixerStreamSourcePair {
+        &self.mixer_stream_src_pair
+    }
+}
+
+impl AsMut<ShellMixerStreamSourcePair> for ItwinConfig {
+    fn as_mut(&mut self) -> &mut ShellMixerStreamSourcePair {
+        &mut self.mixer_stream_src_pair
+    }
+}
+
 /// State of mixer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItwinMixerState {

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -567,6 +567,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinHwState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for ItwinHwState {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.hw_state.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for ItwinHwState {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.hw_state.firewire_led
+    }
+}
+
 /// Hardware metering for mixer function.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ItwinMixerMeter(pub ShellMixerMeter);

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -567,6 +567,18 @@ impl TcKonnektNotifiedSegmentOperation<ItwinHwState> for ItwinProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellHwState> for ItwinHwState {
+    fn as_ref(&self) -> &ShellHwState {
+        &self.hw_state
+    }
+}
+
+impl AsMut<ShellHwState> for ItwinHwState {
+    fn as_mut(&mut self) -> &mut ShellHwState {
+        &mut self.hw_state
+    }
+}
+
 impl AsRef<FireWireLedState> for ItwinHwState {
     fn as_ref(&self) -> &FireWireLedState {
         &self.hw_state.firewire_led

--- a/protocols/dice/src/tcelectronic/shell/itwin.rs
+++ b/protocols/dice/src/tcelectronic/shell/itwin.rs
@@ -584,6 +584,18 @@ impl TcKonnektSegmentSerdes<ItwinMixerMeter> for ItwinProtocol {
     }
 }
 
+impl AsRef<ShellMixerMeter> for ItwinMixerMeter {
+    fn as_ref(&self) -> &ShellMixerMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ShellMixerMeter> for ItwinMixerMeter {
+    fn as_mut(&mut self) -> &mut ShellMixerMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct ItwinReverbMeter(pub ReverbMeter);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -497,3 +497,15 @@ impl TcKonnektSegmentSerdes<K24dChStripMeters> for K24dProtocol {
         deserialize_ch_strip_meters(&mut params.0, raw)
     }
 }
+
+impl AsRef<[ChStripMeter]> for K24dChStripMeters {
+    fn as_ref(&self) -> &[ChStripMeter] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripMeter]> for K24dChStripMeters {
+    fn as_mut(&mut self) -> &mut [ChStripMeter] {
+        &mut self.0
+    }
+}

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -249,6 +249,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellStandaloneClockSource> for K24dConfig {
+    fn as_ref(&self) -> &ShellStandaloneClockSource {
+        &self.standalone_src
+    }
+}
+
+impl AsMut<ShellStandaloneClockSource> for K24dConfig {
+    fn as_mut(&mut self) -> &mut ShellStandaloneClockSource {
+        &mut self.standalone_src
+    }
+}
+
 impl AsRef<TcKonnektStandaloneClockRate> for K24dConfig {
     fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
         &self.standalone_rate

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -190,6 +190,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dKnob> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellKnob0Target> for K24dKnob {
+    fn as_ref(&self) -> &ShellKnob0Target {
+        &self.knob0_target
+    }
+}
+
+impl AsMut<ShellKnob0Target> for K24dKnob {
+    fn as_mut(&mut self) -> &mut ShellKnob0Target {
+        &mut self.knob0_target
+    }
+}
+
 impl AsRef<TcKonnektLoadedProgram> for K24dKnob {
     fn as_ref(&self) -> &TcKonnektLoadedProgram {
         &self.prog

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -261,6 +261,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellOptIfaceConfig> for K24dConfig {
+    fn as_ref(&self) -> &ShellOptIfaceConfig {
+        &self.opt
+    }
+}
+
+impl AsMut<ShellOptIfaceConfig> for K24dConfig {
+    fn as_mut(&mut self) -> &mut ShellOptIfaceConfig {
+        &mut self.opt
+    }
+}
+
 impl AsRef<ShellCoaxOutPairSrc> for K24dConfig {
     fn as_ref(&self) -> &ShellCoaxOutPairSrc {
         &self.coax_out_src

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -450,6 +450,18 @@ impl TcKonnektSegmentSerdes<K24dMixerMeter> for K24dProtocol {
     }
 }
 
+impl AsRef<ShellMixerMeter> for K24dMixerMeter {
+    fn as_ref(&self) -> &ShellMixerMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ShellMixerMeter> for K24dMixerMeter {
+    fn as_mut(&mut self) -> &mut ShellMixerMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbMeter(pub ReverbMeter);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -382,6 +382,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dChStripStates> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
 }
 
+impl AsRef<[ChStripState]> for K24dChStripStates {
+    fn as_ref(&self) -> &[ChStripState] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripState]> for K24dChStripStates {
+    fn as_mut(&mut self) -> &mut [ChStripState] {
+        &mut self.0
+    }
+}
+
 /// Hardware state.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dHwState(pub ShellHwState);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -346,6 +346,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dReverbState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
 }
 
+impl AsRef<ReverbState> for K24dReverbState {
+    fn as_ref(&self) -> &ReverbState {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbState> for K24dReverbState {
+    fn as_mut(&mut self) -> &mut ReverbState {
+        &mut self.0
+    }
+}
+
 /// Configuration for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dChStripStates(pub [ChStripState; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -430,6 +430,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dHwState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for K24dHwState {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.0.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for K24dHwState {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.0.firewire_led
+    }
+}
+
 const K24D_METER_ANALOG_INPUT_COUNT: usize = 2;
 const K24D_METER_DIGITAL_INPUT_COUNT: usize = 2;
 

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -202,6 +202,18 @@ impl AsMut<ShellKnob0Target> for K24dKnob {
     }
 }
 
+impl AsRef<ShellKnob1Target> for K24dKnob {
+    fn as_ref(&self) -> &ShellKnob1Target {
+        &self.knob1_target
+    }
+}
+
+impl AsMut<ShellKnob1Target> for K24dKnob {
+    fn as_mut(&mut self) -> &mut ShellKnob1Target {
+        &mut self.knob1_target
+    }
+}
+
 impl AsRef<TcKonnektLoadedProgram> for K24dKnob {
     fn as_ref(&self) -> &TcKonnektLoadedProgram {
         &self.prog

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -370,6 +370,18 @@ impl AsMut<ShellMixerState> for K24dMixerState {
     }
 }
 
+impl AsRef<ShellReverbReturn> for K24dMixerState {
+    fn as_ref(&self) -> &ShellReverbReturn {
+        &self.reverb_return
+    }
+}
+
+impl AsMut<ShellReverbReturn> for K24dMixerState {
+    fn as_mut(&mut self) -> &mut ShellReverbReturn {
+        &mut self.reverb_return
+    }
+}
+
 /// Configuration for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbState(pub ReverbState);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -190,6 +190,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dKnob> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektLoadedProgram> for K24dKnob {
+    fn as_ref(&self) -> &TcKonnektLoadedProgram {
+        &self.prog
+    }
+}
+
+impl AsMut<TcKonnektLoadedProgram> for K24dKnob {
+    fn as_mut(&mut self) -> &mut TcKonnektLoadedProgram {
+        &mut self.prog
+    }
+}
+
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dConfig {

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -430,6 +430,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dHwState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellHwState> for K24dHwState {
+    fn as_ref(&self) -> &ShellHwState {
+        &self.0
+    }
+}
+
+impl AsMut<ShellHwState> for K24dHwState {
+    fn as_mut(&mut self) -> &mut ShellHwState {
+        &mut self.0
+    }
+}
+
 impl AsRef<FireWireLedState> for K24dHwState {
     fn as_ref(&self) -> &FireWireLedState {
         &self.0.firewire_led

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -249,6 +249,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for K24dConfig {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for K24dConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// State of mixer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct K24dMixerState {

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -322,6 +322,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dMixerState> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellMixerState> for K24dMixerState {
+    fn as_ref(&self) -> &ShellMixerState {
+        &self.mixer
+    }
+}
+
+impl AsMut<ShellMixerState> for K24dMixerState {
+    fn as_mut(&mut self) -> &mut ShellMixerState {
+        &mut self.mixer
+    }
+}
+
 /// Configuration for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dReverbState(pub ReverbState);

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -261,6 +261,18 @@ impl TcKonnektNotifiedSegmentOperation<K24dConfig> for K24dProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellCoaxOutPairSrc> for K24dConfig {
+    fn as_ref(&self) -> &ShellCoaxOutPairSrc {
+        &self.coax_out_src
+    }
+}
+
+impl AsMut<ShellCoaxOutPairSrc> for K24dConfig {
+    fn as_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
+        &mut self.coax_out_src
+    }
+}
+
 impl AsRef<ShellStandaloneClockSource> for K24dConfig {
     fn as_ref(&self) -> &ShellStandaloneClockSource {
         &self.standalone_src

--- a/protocols/dice/src/tcelectronic/shell/k24d.rs
+++ b/protocols/dice/src/tcelectronic/shell/k24d.rs
@@ -456,6 +456,18 @@ impl TcKonnektSegmentSerdes<K24dReverbMeter> for K24dProtocol {
     }
 }
 
+impl AsRef<ReverbMeter> for K24dReverbMeter {
+    fn as_ref(&self) -> &ReverbMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbMeter> for K24dReverbMeter {
+    fn as_mut(&mut self) -> &mut ReverbMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K24dChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -133,6 +133,18 @@ impl TcKonnektNotifiedSegmentOperation<K8Knob> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellKnob0Target> for K8Knob {
+    fn as_ref(&self) -> &ShellKnob0Target {
+        &self.knob0_target
+    }
+}
+
+impl AsMut<ShellKnob0Target> for K8Knob {
+    fn as_mut(&mut self) -> &mut ShellKnob0Target {
+        &mut self.knob0_target
+    }
+}
+
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8Config {

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -145,6 +145,18 @@ impl AsMut<ShellKnob0Target> for K8Knob {
     }
 }
 
+impl AsRef<ShellKnob1Target> for K8Knob {
+    fn as_ref(&self) -> &ShellKnob1Target {
+        &self.knob1_target
+    }
+}
+
+impl AsMut<ShellKnob1Target> for K8Knob {
+    fn as_mut(&mut self) -> &mut ShellKnob1Target {
+        &mut self.knob1_target
+    }
+}
+
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8Config {

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -180,6 +180,18 @@ impl TcKonnektNotifiedSegmentOperation<K8Config> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellStandaloneClockSource> for K8Config {
+    fn as_ref(&self) -> &ShellStandaloneClockSource {
+        &self.standalone_src
+    }
+}
+
+impl AsMut<ShellStandaloneClockSource> for K8Config {
+    fn as_mut(&mut self) -> &mut ShellStandaloneClockSource {
+        &mut self.standalone_src
+    }
+}
+
 impl AsRef<TcKonnektStandaloneClockRate> for K8Config {
     fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
         &self.standalone_rate

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -180,6 +180,18 @@ impl TcKonnektNotifiedSegmentOperation<K8Config> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for K8Config {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for K8Config {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// State of mixer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct K8MixerState {

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -237,6 +237,18 @@ impl TcKonnektNotifiedSegmentOperation<K8MixerState> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellMixerState> for K8MixerState {
+    fn as_ref(&self) -> &ShellMixerState {
+        &self.mixer
+    }
+}
+
+impl AsMut<ShellMixerState> for K8MixerState {
+    fn as_mut(&mut self) -> &mut ShellMixerState {
+        &mut self.mixer
+    }
+}
+
 /// General state of hardware.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct K8HwState {

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -282,6 +282,18 @@ impl TcKonnektNotifiedSegmentOperation<K8HwState> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for K8HwState {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.hw_state.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for K8HwState {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.hw_state.firewire_led
+    }
+}
+
 const K8_METER_ANALOG_INPUT_COUNT: usize = 2;
 const K8_METER_DIGITAL_INPUT_COUNT: usize = 2;
 

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -180,6 +180,18 @@ impl TcKonnektNotifiedSegmentOperation<K8Config> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellCoaxOutPairSrc> for K8Config {
+    fn as_ref(&self) -> &ShellCoaxOutPairSrc {
+        &self.coax_out_src
+    }
+}
+
+impl AsMut<ShellCoaxOutPairSrc> for K8Config {
+    fn as_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
+        &mut self.coax_out_src
+    }
+}
+
 impl AsRef<ShellStandaloneClockSource> for K8Config {
     fn as_ref(&self) -> &ShellStandaloneClockSource {
         &self.standalone_src

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -282,6 +282,18 @@ impl TcKonnektNotifiedSegmentOperation<K8HwState> for K8Protocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellHwState> for K8HwState {
+    fn as_ref(&self) -> &ShellHwState {
+        &self.hw_state
+    }
+}
+
+impl AsMut<ShellHwState> for K8HwState {
+    fn as_mut(&mut self) -> &mut ShellHwState {
+        &mut self.hw_state
+    }
+}
+
 impl AsRef<FireWireLedState> for K8HwState {
     fn as_ref(&self) -> &FireWireLedState {
         &self.hw_state.firewire_led

--- a/protocols/dice/src/tcelectronic/shell/k8.rs
+++ b/protocols/dice/src/tcelectronic/shell/k8.rs
@@ -301,3 +301,15 @@ impl TcKonnektSegmentSerdes<K8MixerMeter> for K8Protocol {
         deserialize_mixer_meter::<K8Protocol>(&mut params.0, raw)
     }
 }
+
+impl AsRef<ShellMixerMeter> for K8MixerMeter {
+    fn as_ref(&self) -> &ShellMixerMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ShellMixerMeter> for K8MixerMeter {
+    fn as_mut(&mut self) -> &mut ShellMixerMeter {
+        &mut self.0
+    }
+}

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -576,6 +576,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveChStripStates> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CH_STRIP_NOTIFY_FLAG;
 }
 
+impl AsRef<[ChStripState]> for KliveChStripStates {
+    fn as_ref(&self) -> &[ChStripState] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripState]> for KliveChStripStates {
+    fn as_mut(&mut self) -> &mut [ChStripState] {
+        &mut self.0
+    }
+}
+
 /// Hardware state.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveHwState(pub ShellHwState);

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -378,6 +378,18 @@ impl AsMut<TcKonnektMidiSender> for KliveConfig {
     }
 }
 
+impl AsRef<ShellMixerStreamSourcePair> for KliveConfig {
+    fn as_ref(&self) -> &ShellMixerStreamSourcePair {
+        &self.mixer_stream_src_pair
+    }
+}
+
+impl AsMut<ShellMixerStreamSourcePair> for KliveConfig {
+    fn as_mut(&mut self) -> &mut ShellMixerStreamSourcePair {
+        &mut self.mixer_stream_src_pair
+    }
+}
+
 /// The source of channel strip effect.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChStripSrc {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -254,6 +254,18 @@ impl AsMut<ShellKnob0Target> for KliveKnob {
     }
 }
 
+impl AsRef<ShellKnob1Target> for KliveKnob {
+    fn as_ref(&self) -> &ShellKnob1Target {
+        &self.knob1_target
+    }
+}
+
+impl AsMut<ShellKnob1Target> for KliveKnob {
+    fn as_mut(&mut self) -> &mut ShellKnob1Target {
+        &mut self.knob1_target
+    }
+}
+
 impl AsRef<TcKonnektLoadedProgram> for KliveKnob {
     fn as_ref(&self) -> &TcKonnektLoadedProgram {
         &self.prog

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -366,6 +366,18 @@ impl AsMut<TcKonnektStandaloneClockRate> for KliveConfig {
     }
 }
 
+impl AsRef<TcKonnektMidiSender> for KliveConfig {
+    fn as_ref(&self) -> &TcKonnektMidiSender {
+        &self.midi_sender
+    }
+}
+
+impl AsMut<TcKonnektMidiSender> for KliveConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektMidiSender {
+        &mut self.midi_sender
+    }
+}
+
 /// The source of channel strip effect.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChStripSrc {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -330,6 +330,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveConfig> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for KliveConfig {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for KliveConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// The source of channel strip effect.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ChStripSrc {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -330,6 +330,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveConfig> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellStandaloneClockSource> for KliveConfig {
+    fn as_ref(&self) -> &ShellStandaloneClockSource {
+        &self.standalone_src
+    }
+}
+
+impl AsMut<ShellStandaloneClockSource> for KliveConfig {
+    fn as_mut(&mut self) -> &mut ShellStandaloneClockSource {
+        &mut self.standalone_src
+    }
+}
+
 impl AsRef<TcKonnektStandaloneClockRate> for KliveConfig {
     fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
         &self.standalone_rate

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -242,6 +242,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveKnob> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektLoadedProgram> for KliveKnob {
+    fn as_ref(&self) -> &TcKonnektLoadedProgram {
+        &self.prog
+    }
+}
+
+impl AsMut<TcKonnektLoadedProgram> for KliveKnob {
+    fn as_mut(&mut self) -> &mut TcKonnektLoadedProgram {
+        &mut self.prog
+    }
+}
+
 /// Configuration.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveConfig {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -342,6 +342,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveConfig> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellCoaxOutPairSrc> for KliveConfig {
+    fn as_ref(&self) -> &ShellCoaxOutPairSrc {
+        &self.coax_out_src
+    }
+}
+
+impl AsMut<ShellCoaxOutPairSrc> for KliveConfig {
+    fn as_mut(&mut self) -> &mut ShellCoaxOutPairSrc {
+        &mut self.coax_out_src
+    }
+}
+
 impl AsRef<ShellStandaloneClockSource> for KliveConfig {
     fn as_ref(&self) -> &ShellStandaloneClockSource {
         &self.standalone_src

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -576,6 +576,18 @@ impl AsMut<ShellMixerState> for KliveMixerState {
     }
 }
 
+impl AsRef<ShellReverbReturn> for KliveMixerState {
+    fn as_ref(&self) -> &ShellReverbReturn {
+        &self.reverb_return
+    }
+}
+
+impl AsMut<ShellReverbReturn> for KliveMixerState {
+    fn as_mut(&mut self) -> &mut ShellReverbReturn {
+        &mut self.reverb_return
+    }
+}
+
 /// Configuration for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveReverbState(pub ReverbState);

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -540,6 +540,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveReverbState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_REVERB_NOTIFY_FLAG;
 }
 
+impl AsRef<ReverbState> for KliveReverbState {
+    fn as_ref(&self) -> &ReverbState {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbState> for KliveReverbState {
+    fn as_mut(&mut self) -> &mut ReverbState {
+        &mut self.0
+    }
+}
+
 /// Configuration for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveChStripStates(pub [ChStripState; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -644,6 +644,18 @@ impl TcKonnektSegmentSerdes<KliveMixerMeter> for KliveProtocol {
     }
 }
 
+impl AsRef<ShellMixerMeter> for KliveMixerMeter {
+    fn as_ref(&self) -> &ShellMixerMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ShellMixerMeter> for KliveMixerMeter {
+    fn as_mut(&mut self) -> &mut ShellMixerMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveReverbMeter(pub ReverbMeter);

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -624,6 +624,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveHwState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for KliveHwState {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.0.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for KliveHwState {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.0.firewire_led
+    }
+}
+
 const KLIVE_METER_ANALOG_INPUT_COUNT: usize = 4;
 const KLIVE_METER_DIGITAL_INPUT_COUNT: usize = 8;
 

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -624,6 +624,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveHwState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellHwState> for KliveHwState {
+    fn as_ref(&self) -> &ShellHwState {
+        &self.0
+    }
+}
+
+impl AsMut<ShellHwState> for KliveHwState {
+    fn as_mut(&mut self) -> &mut ShellHwState {
+        &mut self.0
+    }
+}
+
 impl AsRef<FireWireLedState> for KliveHwState {
     fn as_ref(&self) -> &FireWireLedState {
         &self.0.firewire_led

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -342,6 +342,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveConfig> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellOptIfaceConfig> for KliveConfig {
+    fn as_ref(&self) -> &ShellOptIfaceConfig {
+        &self.opt
+    }
+}
+
+impl AsMut<ShellOptIfaceConfig> for KliveConfig {
+    fn as_mut(&mut self) -> &mut ShellOptIfaceConfig {
+        &mut self.opt
+    }
+}
+
 impl AsRef<ShellCoaxOutPairSrc> for KliveConfig {
     fn as_ref(&self) -> &ShellCoaxOutPairSrc {
         &self.coax_out_src

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -692,6 +692,18 @@ impl TcKonnektSegmentSerdes<KliveChStripMeters> for KliveProtocol {
     }
 }
 
+impl AsRef<[ChStripMeter]> for KliveChStripMeters {
+    fn as_ref(&self) -> &[ChStripMeter] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripMeter]> for KliveChStripMeters {
+    fn as_mut(&mut self) -> &mut [ChStripMeter] {
+        &mut self.0
+    }
+}
+
 /// Impedance of output.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OutputImpedance {

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -516,6 +516,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveMixerState> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_MIXER_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellMixerState> for KliveMixerState {
+    fn as_ref(&self) -> &ShellMixerState {
+        &self.mixer
+    }
+}
+
+impl AsMut<ShellMixerState> for KliveMixerState {
+    fn as_mut(&mut self) -> &mut ShellMixerState {
+        &mut self.mixer
+    }
+}
+
 /// Configuration for reverb effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveReverbState(pub ReverbState);

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -242,6 +242,18 @@ impl TcKonnektNotifiedSegmentOperation<KliveKnob> for KliveProtocol {
     const NOTIFY_FLAG: u32 = SHELL_KNOB_NOTIFY_FLAG;
 }
 
+impl AsRef<ShellKnob0Target> for KliveKnob {
+    fn as_ref(&self) -> &ShellKnob0Target {
+        &self.knob0_target
+    }
+}
+
+impl AsMut<ShellKnob0Target> for KliveKnob {
+    fn as_mut(&mut self) -> &mut ShellKnob0Target {
+        &mut self.knob0_target
+    }
+}
+
 impl AsRef<TcKonnektLoadedProgram> for KliveKnob {
     fn as_ref(&self) -> &TcKonnektLoadedProgram {
         &self.prog

--- a/protocols/dice/src/tcelectronic/shell/klive.rs
+++ b/protocols/dice/src/tcelectronic/shell/klive.rs
@@ -650,6 +650,18 @@ impl TcKonnektSegmentSerdes<KliveReverbMeter> for KliveProtocol {
     }
 }
 
+impl AsRef<ReverbMeter> for KliveReverbMeter {
+    fn as_ref(&self) -> &ReverbMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbMeter> for KliveReverbMeter {
+    fn as_mut(&mut self) -> &mut ReverbMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct KliveChStripMeters(pub [ChStripMeter; SHELL_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -661,6 +661,18 @@ impl AsMut<TcKonnektStandaloneClockRate> for StudioConfig {
     }
 }
 
+impl AsRef<TcKonnektMidiSender> for StudioConfig {
+    fn as_ref(&self) -> &TcKonnektMidiSender {
+        &self.midi_send
+    }
+}
+
+impl AsMut<TcKonnektMidiSender> for StudioConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektMidiSender {
+        &mut self.midi_send
+    }
+}
+
 /// Entry of signal source.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SrcEntry {

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1636,6 +1636,18 @@ impl TcKonnektSegmentSerdes<StudioReverbMeter> for Studiok48Protocol {
     }
 }
 
+impl AsRef<ReverbMeter> for StudioReverbMeter {
+    fn as_ref(&self) -> &ReverbMeter {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbMeter> for StudioReverbMeter {
+    fn as_mut(&mut self) -> &mut ReverbMeter {
+        &mut self.0
+    }
+}
+
 /// Hardware metering for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioChStripMeters(pub [ChStripMeter; STUDIO_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1454,6 +1454,18 @@ impl TcKonnektNotifiedSegmentOperation<StudioChStripStates> for Studiok48Protoco
     const NOTIFY_FLAG: u32 = STUDIO_CH_STRIP_NOTIFY_01_CHANGE | STUDIO_CH_STRIP_NOTIFY_23_CHANGE;
 }
 
+impl AsRef<[ChStripState]> for StudioChStripStates {
+    fn as_ref(&self) -> &[ChStripState] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripState]> for StudioChStripStates {
+    fn as_mut(&mut self) -> &mut [ChStripState] {
+        &mut self.0
+    }
+}
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 /// State of jack sense for analog input.
 pub enum StudioAnalogJackState {

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1677,3 +1677,15 @@ impl TcKonnektSegmentSerdes<StudioChStripMeters> for Studiok48Protocol {
         deserialize_ch_strip_meters(&mut params.0, raw)
     }
 }
+
+impl AsRef<[ChStripMeter]> for StudioChStripMeters {
+    fn as_ref(&self) -> &[ChStripMeter] {
+        &self.0
+    }
+}
+
+impl AsMut<[ChStripMeter]> for StudioChStripMeters {
+    fn as_mut(&mut self) -> &mut [ChStripMeter] {
+        &mut self.0
+    }
+}

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1418,6 +1418,18 @@ impl TcKonnektNotifiedSegmentOperation<StudioReverbState> for Studiok48Protocol 
     const NOTIFY_FLAG: u32 = STUDIO_REVERB_NOTIFY_CHANGE;
 }
 
+impl AsRef<ReverbState> for StudioReverbState {
+    fn as_ref(&self) -> &ReverbState {
+        &self.0
+    }
+}
+
+impl AsMut<ReverbState> for StudioReverbState {
+    fn as_mut(&mut self) -> &mut ReverbState {
+        &mut self.0
+    }
+}
+
 /// Configuration for channel strip effect.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioChStripStates(pub [ChStripState; STUDIO_CH_STRIP_COUNT]);

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -507,6 +507,18 @@ impl TcKonnektNotifiedSegmentOperation<StudioRemote> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_REMOTE_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektLoadedProgram> for StudioRemote {
+    fn as_ref(&self) -> &TcKonnektLoadedProgram {
+        &self.prog
+    }
+}
+
+impl AsMut<TcKonnektLoadedProgram> for StudioRemote {
+    fn as_mut(&mut self) -> &mut TcKonnektLoadedProgram {
+        &mut self.prog
+    }
+}
+
 /// Mode of optical interface.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum OptIfaceMode {

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -1583,6 +1583,18 @@ impl TcKonnektNotifiedSegmentOperation<StudioHwState> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_HW_STATE_NOTIFY_FLAG;
 }
 
+impl AsRef<FireWireLedState> for StudioHwState {
+    fn as_ref(&self) -> &FireWireLedState {
+        &self.firewire_led
+    }
+}
+
+impl AsMut<FireWireLedState> for StudioHwState {
+    fn as_mut(&mut self) -> &mut FireWireLedState {
+        &mut self.firewire_led
+    }
+}
+
 /// Hardware metering for mixer function.
 #[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StudioMixerMeter {

--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -637,6 +637,18 @@ impl TcKonnektNotifiedSegmentOperation<StudioConfig> for Studiok48Protocol {
     const NOTIFY_FLAG: u32 = STUDIO_CONFIG_NOTIFY_FLAG;
 }
 
+impl AsRef<TcKonnektStandaloneClockRate> for StudioConfig {
+    fn as_ref(&self) -> &TcKonnektStandaloneClockRate {
+        &self.standalone_rate
+    }
+}
+
+impl AsMut<TcKonnektStandaloneClockRate> for StudioConfig {
+    fn as_mut(&mut self) -> &mut TcKonnektStandaloneClockRate {
+        &mut self.standalone_rate
+    }
+}
+
 /// Entry of signal source.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum SrcEntry {

--- a/runtime/dice/src/tcelectronic.rs
+++ b/runtime/dice/src/tcelectronic.rs
@@ -24,4 +24,5 @@ use {
     self::standalone_ctl::*,
     super::*,
     protocols::tcelectronic::{ch_strip::*, reverb::*, *},
+    std::marker::PhantomData,
 };

--- a/runtime/dice/src/tcelectronic/ch_strip_ctl.rs
+++ b/runtime/dice/src/tcelectronic/ch_strip_ctl.rs
@@ -3,6 +3,20 @@
 
 use super::*;
 
+#[derive(Default, Debug)]
+pub struct ChStripStateCtl<T, U>
+where
+    T: TcKonnektSegmentOperation<U>
+        + TcKonnektMutableSegmentOperation<U>
+        + TcKonnektNotifiedSegmentOperation<U>,
+    TcKonnektSegment<U>: Default,
+    U: Debug + Clone + AsRef<[ChStripState]> + AsMut<[ChStripState]>,
+{
+    pub elem_id_list: Vec<ElemId>,
+    segment: TcKonnektSegment<U>,
+    _phantom: PhantomData<T>,
+}
+
 const SRC_TYPE_NAME: &str = "ch-strip-source-type";
 const DEESSER_BYPASS_NAME: &str = "deesser-bypass";
 const EQ_BYPASS_NAME: &str = "equalizer-bypass";
@@ -28,6 +42,31 @@ const INPUT_METER_NAME: &str = "ch-strip-input-meter";
 const LIMIT_METER_NAME: &str = "ch-strip-limit-meter";
 const OUTPUT_METER_NAME: &str = "ch-strip-output-meter";
 const GAIN_METER_NAME: &str = "ch-strip-gain-meter";
+
+const SRC_TYPES: &[ChStripSrcType] = &[
+    ChStripSrcType::FemaleVocal,
+    ChStripSrcType::MaleVocal,
+    ChStripSrcType::Guitar,
+    ChStripSrcType::Piano,
+    ChStripSrcType::Speak,
+    ChStripSrcType::Choir,
+    ChStripSrcType::Horns,
+    ChStripSrcType::Bass,
+    ChStripSrcType::Kick,
+    ChStripSrcType::Snare,
+    ChStripSrcType::MixRock,
+    ChStripSrcType::MixSoft,
+    ChStripSrcType::Percussion,
+    ChStripSrcType::Kit,
+    ChStripSrcType::MixAcoustic,
+    ChStripSrcType::MixPurist,
+    ChStripSrcType::House,
+    ChStripSrcType::Trance,
+    ChStripSrcType::Chill,
+    ChStripSrcType::HipHop,
+    ChStripSrcType::DrumAndBass,
+    ChStripSrcType::ElectroTechno,
+];
 
 fn src_type_to_str(t: &ChStripSrcType) -> &'static str {
     match t {
@@ -56,344 +95,257 @@ fn src_type_to_str(t: &ChStripSrcType) -> &'static str {
     }
 }
 
-pub trait ChStripStateCtlOperation<S, T>
+const COMP_GAIN_MIN: i32 = 0;
+const COMP_GAIN_MAX: i32 = 36;
+const COMP_GAIN_STEP: i32 = 1;
+const COMP_GAIN_TLV: DbInterval = DbInterval {
+    min: -1800,
+    max: 1800,
+    linear: false,
+    mute_avail: false,
+};
+
+const COMP_CTL_MIN: i32 = 0;
+const COMP_CTL_MAX: i32 = 200;
+const COMP_CTL_STEP: i32 = 1;
+
+const COMP_LEVEL_MIN: i32 = 0;
+const COMP_LEVEL_MAX: i32 = 48;
+const COMP_LEVEL_STEP: i32 = 1;
+const COMP_LEVEL_TLV: DbInterval = DbInterval {
+    min: -1800,
+    max: 600,
+    linear: false,
+    mute_avail: false,
+};
+
+const DEESSER_RATIO_MIN: i32 = 0;
+const DEESSER_RATIO_MAX: i32 = 10;
+const DEESSER_RATIO_STEP: i32 = 1;
+const DEESSER_RATIO_TLV: DbInterval = DbInterval {
+    min: 0,
+    max: 100,
+    linear: false,
+    mute_avail: false,
+};
+
+const EQ_BANDWIDTH_MIN: i32 = 0;
+const EQ_BANDWIDTH_MAX: i32 = 39;
+const EQ_BANDWIDTH_STEP: i32 = 1;
+
+const EQ_GAIN_MIN: i32 = 0;
+const EQ_GAIN_MAX: i32 = 240;
+const EQ_GAIN_STEP: i32 = 1;
+const EQ_GAIN_TLV: DbInterval = DbInterval {
+    min: -1200,
+    max: 1200,
+    linear: false,
+    mute_avail: false,
+};
+
+const EQ_FREQ_MIN: i32 = 0;
+const EQ_FREQ_MAX: i32 = 240;
+const EQ_FREQ_STEP: i32 = 1;
+
+const LIMITTER_THRESHOLD_MIN: i32 = 0;
+const LIMITTER_THRESHOLD_MAX: i32 = 72;
+const LIMITTER_THRESHOLD_STEP: i32 = 1;
+const LIMITTER_THRESHOLD_TLV: DbInterval = DbInterval {
+    min: -1200,
+    max: 0,
+    linear: false,
+    mute_avail: false,
+};
+
+impl<T, U> ChStripStateCtl<T, U>
 where
-    S: Clone + Debug,
-    T: TcKonnektSegmentOperation<S>
-        + TcKonnektMutableSegmentOperation<S>
-        + TcKonnektNotifiedSegmentOperation<S>,
+    T: TcKonnektSegmentOperation<U>
+        + TcKonnektMutableSegmentOperation<U>
+        + TcKonnektNotifiedSegmentOperation<U>,
+    TcKonnektSegment<U>: Default,
+    U: Debug + Clone + AsRef<[ChStripState]> + AsMut<[ChStripState]>,
 {
-    fn segment(&self) -> &TcKonnektSegment<S>;
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<S>;
-
-    fn states(params: &S) -> &[ChStripState];
-    fn states_mut(params: &mut S) -> &mut [ChStripState];
-
-    const COMP_GAIN_MIN: i32 = 0;
-    const COMP_GAIN_MAX: i32 = 36;
-    const COMP_GAIN_STEP: i32 = 1;
-    const COMP_GAIN_TLV: DbInterval = DbInterval {
-        min: -1800,
-        max: 1800,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const COMP_CTL_MIN: i32 = 0;
-    const COMP_CTL_MAX: i32 = 200;
-    const COMP_CTL_STEP: i32 = 1;
-
-    const COMP_LEVEL_MIN: i32 = 0;
-    const COMP_LEVEL_MAX: i32 = 48;
-    const COMP_LEVEL_STEP: i32 = 1;
-    const COMP_LEVEL_TLV: DbInterval = DbInterval {
-        min: -1800,
-        max: 600,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const DEESSER_RATIO_MIN: i32 = 0;
-    const DEESSER_RATIO_MAX: i32 = 10;
-    const DEESSER_RATIO_STEP: i32 = 1;
-    const DEESSER_RATIO_TLV: DbInterval = DbInterval {
-        min: 0,
-        max: 100,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const EQ_BANDWIDTH_MIN: i32 = 0;
-    const EQ_BANDWIDTH_MAX: i32 = 39;
-    const EQ_BANDWIDTH_STEP: i32 = 1;
-
-    const EQ_GAIN_MIN: i32 = 0;
-    const EQ_GAIN_MAX: i32 = 240;
-    const EQ_GAIN_STEP: i32 = 1;
-    const EQ_GAIN_TLV: DbInterval = DbInterval {
-        min: -1200,
-        max: 1200,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const EQ_FREQ_MIN: i32 = 0;
-    const EQ_FREQ_MAX: i32 = 240;
-    const EQ_FREQ_STEP: i32 = 1;
-
-    const LIMITTER_THRESHOLD_MIN: i32 = 0;
-    const LIMITTER_THRESHOLD_MAX: i32 = 72;
-    const LIMITTER_THRESHOLD_STEP: i32 = 1;
-    const LIMITTER_THRESHOLD_TLV: DbInterval = DbInterval {
-        min: -1200,
-        max: 0,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const LIMIT_METER_MIN: i32 = -12;
-    const LIMIT_METER_MAX: i32 = 0;
-    const LIMIT_METER_STEP: i32 = 1;
-    const LIMIT_METER_TLV: DbInterval = DbInterval {
-        min: -1200,
-        max: 0,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const INOUT_METER_MIN: i32 = -72;
-    const INOUT_METER_MAX: i32 = 0;
-    const INOUT_METER_STEP: i32 = 1;
-    const INOUT_METER_TLV: DbInterval = DbInterval {
-        min: -7200,
-        max: 0,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const GAIN_METER_MIN: i32 = -24;
-    const GAIN_METER_MAX: i32 = 18;
-    const GAIN_METER_STEP: i32 = 1;
-    const GAIN_METER_TLV: DbInterval = DbInterval {
-        min: -2400,
-        max: 1800,
-        linear: false,
-        mute_avail: false,
-    };
-
-    const SRC_TYPES: [ChStripSrcType; 22] = [
-        ChStripSrcType::FemaleVocal,
-        ChStripSrcType::MaleVocal,
-        ChStripSrcType::Guitar,
-        ChStripSrcType::Piano,
-        ChStripSrcType::Speak,
-        ChStripSrcType::Choir,
-        ChStripSrcType::Horns,
-        ChStripSrcType::Bass,
-        ChStripSrcType::Kick,
-        ChStripSrcType::Snare,
-        ChStripSrcType::MixRock,
-        ChStripSrcType::MixSoft,
-        ChStripSrcType::Percussion,
-        ChStripSrcType::Kit,
-        ChStripSrcType::MixAcoustic,
-        ChStripSrcType::MixPurist,
-        ChStripSrcType::House,
-        ChStripSrcType::Trance,
-        ChStripSrcType::Chill,
-        ChStripSrcType::HipHop,
-        ChStripSrcType::DrumAndBass,
-        ChStripSrcType::ElectroTechno,
-    ];
-
-    fn are_bypassed(&self) -> bool {
-        Self::states(&self.segment().data)
+    pub fn are_bypassed(&self) -> bool {
+        self.segment
+            .data
+            .as_ref()
             .iter()
             .find(|s| s.bypass)
             .is_some()
     }
 
-    fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = T::cache_whole_segment(req, node, self.segment_mut(), timeout_ms);
-        debug!(params = ?self.segment().data, ?res);
+    pub fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        let res = T::cache_whole_segment(req, node, &mut self.segment, timeout_ms);
+        debug!(params = ?self.segment.data, ?res);
         res
     }
 
-    fn load(&self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
-        let channels = Self::states(&self.segment().data).len();
-        let mut notified_elem_id_list = Vec::new();
+    pub fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let channels = self.segment.data.as_ref().len();
 
-        // Overall controls.
-        let labels: Vec<&str> = Self::SRC_TYPES.iter().map(|t| src_type_to_str(t)).collect();
-        state_add_enum_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            SRC_TYPE_NAME,
-            1,
-            &labels,
-            true,
-        )?;
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
+        // For overall.
+        let labels: Vec<&str> = SRC_TYPES.iter().map(|t| src_type_to_str(t)).collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, SRC_TYPE_NAME, 0);
+        card_cntr
+            .add_enum_elems(&elem_id, 1, channels, &labels, None, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        [
             DEESSER_BYPASS_NAME,
-            1,
-            true,
-        )?;
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
             EQ_BYPASS_NAME,
-            1,
-            true,
-        )?;
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
             LIMITTER_BYPASS_NAME,
-            1,
-            true,
-        )?;
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
             BYPASS_NAME,
-            1,
-            true,
-        )?;
+        ]
+        .iter()
+        .try_for_each(|name| {
+            let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
+            card_cntr
+                .add_bool_elems(&elem_id, 1, channels, true)
+                .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))
+        })?;
 
-        // Controls for compressor part.
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            COMP_INPUT_GAIN_NAME,
-            1,
-            Self::COMP_GAIN_MIN,
-            Self::COMP_GAIN_MAX,
-            Self::COMP_GAIN_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::COMP_GAIN_TLV)),
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            COMP_MAKE_UP_GAIN_NAME,
-            1,
-            Self::COMP_GAIN_MIN,
-            Self::COMP_GAIN_MAX,
-            Self::COMP_GAIN_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::COMP_GAIN_TLV)),
-            true,
-        )?;
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            COMP_FULL_BAND_ENABLE_NAME,
-            1,
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            COMP_CTL_NAME,
-            3,
-            Self::COMP_CTL_MIN,
-            Self::COMP_CTL_MAX,
-            Self::COMP_CTL_STEP,
-            None,
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            COMP_LEVEL_NAME,
-            3,
-            Self::COMP_LEVEL_MIN,
-            Self::COMP_LEVEL_MAX,
-            Self::COMP_LEVEL_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::COMP_LEVEL_TLV)),
-            true,
-        )?;
+        // For compressors.
+        [COMP_INPUT_GAIN_NAME, COMP_MAKE_UP_GAIN_NAME]
+            .iter()
+            .try_for_each(|name| {
+                let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
+                card_cntr
+                    .add_int_elems(
+                        &elem_id,
+                        1,
+                        COMP_GAIN_MIN,
+                        COMP_GAIN_MAX,
+                        COMP_GAIN_STEP,
+                        channels,
+                        Some(&Into::<Vec<u32>>::into(COMP_GAIN_TLV)),
+                        true,
+                    )
+                    .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))
+            })?;
 
-        // Controls for deesser part.
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            DEESSER_RATIO_NAME,
-            1,
-            Self::DEESSER_RATIO_MIN,
-            Self::DEESSER_RATIO_MAX,
-            Self::DEESSER_RATIO_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::DEESSER_RATIO_TLV)),
-            true,
-        )?;
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMP_FULL_BAND_ENABLE_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, channels, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        // Controls for equalizer part.
-        state_add_bool_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            EQ_ENABLE_NAME,
-            4,
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            EQ_BANDWIDTH_NAME,
-            4,
-            Self::EQ_BANDWIDTH_MIN,
-            Self::EQ_BANDWIDTH_MAX,
-            Self::EQ_BANDWIDTH_STEP,
-            None,
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            EQ_GAIN_NAME,
-            4,
-            Self::EQ_GAIN_MIN,
-            Self::EQ_GAIN_MAX,
-            Self::EQ_GAIN_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::EQ_GAIN_TLV)),
-            true,
-        )?;
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            EQ_FREQ_NAME,
-            4,
-            Self::EQ_FREQ_MIN,
-            Self::EQ_FREQ_MAX,
-            Self::EQ_FREQ_STEP,
-            None,
-            true,
-        )?;
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMP_CTL_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                3,
+                COMP_CTL_MIN,
+                COMP_CTL_MAX,
+                COMP_CTL_STEP,
+                channels,
+                None,
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        // Controls for limitter part.
-        state_add_int_elem(
-            card_cntr,
-            &mut notified_elem_id_list,
-            channels,
-            LIMITTER_THRESHOLD_NAME,
-            1,
-            Self::LIMITTER_THRESHOLD_MIN,
-            Self::LIMITTER_THRESHOLD_MAX,
-            Self::LIMITTER_THRESHOLD_STEP,
-            Some(&Into::<Vec<u32>>::into(Self::LIMITTER_THRESHOLD_TLV)),
-            true,
-        )?;
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, COMP_LEVEL_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                3,
+                COMP_LEVEL_MIN,
+                COMP_LEVEL_MAX,
+                COMP_LEVEL_STEP,
+                channels,
+                Some(&Into::<Vec<u32>>::into(COMP_LEVEL_TLV)),
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
-        Ok(notified_elem_id_list)
+        // For deessers.
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, DEESSER_RATIO_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                1,
+                DEESSER_RATIO_MIN,
+                DEESSER_RATIO_MAX,
+                DEESSER_RATIO_STEP,
+                channels,
+                Some(&Into::<Vec<u32>>::into(DEESSER_RATIO_TLV)),
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        // For equalizers.
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQ_ENABLE_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, channels, true)
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQ_BANDWIDTH_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                4,
+                EQ_BANDWIDTH_MIN,
+                EQ_BANDWIDTH_MAX,
+                EQ_BANDWIDTH_STEP,
+                channels,
+                None,
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQ_GAIN_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                4,
+                EQ_GAIN_MIN,
+                EQ_GAIN_MAX,
+                EQ_GAIN_STEP,
+                channels,
+                Some(&Into::<Vec<u32>>::into(EQ_GAIN_TLV)),
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EQ_FREQ_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                4,
+                EQ_FREQ_MIN,
+                EQ_FREQ_MAX,
+                EQ_FREQ_STEP,
+                channels,
+                None,
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        // For limitters.
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, LIMITTER_THRESHOLD_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                1,
+                LIMITTER_THRESHOLD_MIN,
+                LIMITTER_THRESHOLD_MAX,
+                LIMITTER_THRESHOLD_STEP,
+                channels,
+                Some(&Into::<Vec<u32>>::into(LIMITTER_THRESHOLD_TLV)),
+                true,
+            )
+            .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
+
+        Ok(())
     }
 
-    fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+    pub fn read(&self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             SRC_TYPE_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<u32> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<u32> = params
                     .iter()
-                    .map(|state| {
-                        let pos = Self::SRC_TYPES
-                            .iter()
-                            .position(|t| state.src_type.eq(t))
-                            .unwrap();
+                    .map(|param| {
+                        let pos = SRC_TYPES.iter().position(|t| param.src_type.eq(t)).unwrap();
                         pos as u32
                     })
                     .collect();
@@ -401,142 +353,127 @@ where
                 Ok(true)
             }
             DEESSER_BYPASS_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<bool> = states.iter().map(|state| state.deesser.bypass).collect();
+                let params = self.segment.data.as_ref();
+                let vals: Vec<bool> = params.iter().map(|param| param.deesser.bypass).collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EQ_BYPASS_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<bool> = states.iter().map(|state| state.eq_bypass).collect();
+                let params = self.segment.data.as_ref();
+                let vals: Vec<bool> = params.iter().map(|param| param.eq_bypass).collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             LIMITTER_BYPASS_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<bool> = states.iter().map(|state| state.limitter_bypass).collect();
+                let params = self.segment.data.as_ref();
+                let vals: Vec<bool> = params.iter().map(|param| param.limitter_bypass).collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             BYPASS_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<bool> = states.iter().map(|state| state.bypass).collect();
+                let params = self.segment.data.as_ref();
+                let vals: Vec<bool> = params.iter().map(|param| param.bypass).collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             COMP_INPUT_GAIN_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<i32> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.comp.input_gain as i32)
+                    .map(|param| param.comp.input_gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             COMP_MAKE_UP_GAIN_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<i32> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.comp.make_up_gain as i32)
+                    .map(|param| param.comp.make_up_gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             COMP_FULL_BAND_ENABLE_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<bool> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<bool> = params
                     .iter()
-                    .map(|state| state.comp.full_band_enabled)
+                    .map(|param| param.comp.full_band_enabled)
                     .collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             COMP_CTL_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<i32> = states
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.comp.ctl[idx] as i32)
+                    .map(|params| params.comp.ctl[idx] as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             COMP_LEVEL_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<i32> = states
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.comp.level[idx] as i32)
+                    .map(|param| param.comp.level[idx] as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             DEESSER_RATIO_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<i32> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.deesser.ratio as i32)
+                    .map(|param| param.deesser.ratio as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             EQ_ENABLE_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<bool> = states.iter().map(|state| state.eq[idx].enabled).collect();
+                let vals: Vec<bool> = params.iter().map(|param| param.eq[idx].enabled).collect();
                 elem_value.set_bool(&vals);
                 Ok(true)
             }
             EQ_BANDWIDTH_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<i32> = states
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.eq[idx].bandwidth as i32)
+                    .map(|param| param.eq[idx].bandwidth as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             EQ_GAIN_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<i32> = states
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.eq[idx].gain as i32)
+                    .map(|param| param.eq[idx].gain as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             EQ_FREQ_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
+                let params = self.segment.data.as_ref();
                 let idx = elem_id.index() as usize;
-                let vals: Vec<i32> = states
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.eq[idx].freq as i32)
+                    .map(|param| param.eq[idx].freq as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
             }
             LIMITTER_THRESHOLD_NAME => {
-                let params = &self.segment().data;
-                let states = Self::states(&params);
-                let vals: Vec<i32> = states
+                let params = self.segment.data.as_ref();
+                let vals: Vec<i32> = params
                     .iter()
-                    .map(|state| state.limitter.threshold as i32)
+                    .map(|param| param.limitter.threshold as i32)
                     .collect();
                 elem_value.set_int(&vals);
                 Ok(true)
@@ -545,7 +482,7 @@ where
         }
     }
 
-    fn write(
+    pub fn write(
         &mut self,
         req: &FwReq,
         node: &FwNode,
@@ -555,279 +492,232 @@ where
     ) -> Result<bool, Error> {
         match elem_id.name().as_str() {
             SRC_TYPE_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.enumerated())
-                    .try_for_each(|(state, &val)| {
+                    .try_for_each(|(param, &val)| {
                         let pos = val as usize;
-                        Self::SRC_TYPES
+                        SRC_TYPES
                             .iter()
-                            .nth(val as usize)
+                            .nth(pos)
                             .ok_or_else(|| {
                                 let msg = format!("Source type not found for position {}", pos);
                                 Error::new(FileError::Inval, &msg)
                             })
-                            .map(|&t| state.src_type = t)
+                            .map(|&t| param.src_type = t)
                     })?;
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             DEESSER_BYPASS_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.deesser.bypass = val);
+                    .for_each(|(param, val)| param.deesser.bypass = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             EQ_BYPASS_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.eq_bypass = val);
+                    .for_each(|(param, val)| param.eq_bypass = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             LIMITTER_BYPASS_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.limitter_bypass = val);
+                    .for_each(|(param, val)| param.limitter_bypass = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             BYPASS_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.bypass = val);
+                    .for_each(|(param, val)| param.bypass = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             COMP_INPUT_GAIN_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.comp.input_gain = val as u32);
+                    .for_each(|(params, &val)| params.comp.input_gain = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             COMP_MAKE_UP_GAIN_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.comp.make_up_gain = val as u32);
+                    .for_each(|(params, &val)| params.comp.make_up_gain = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             COMP_FULL_BAND_ENABLE_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.comp.full_band_enabled = val);
+                    .for_each(|(params, val)| params.comp.full_band_enabled = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             COMP_CTL_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.comp.ctl[idx] = val as u32);
+                    .for_each(|(params, &val)| params.comp.ctl[idx] = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             COMP_LEVEL_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.comp.level[idx] = val as u32);
+                    .for_each(|(params, &val)| params.comp.level[idx] = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             DEESSER_RATIO_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.deesser.ratio = val as u32);
+                    .for_each(|(params, &val)| params.deesser.ratio = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             EQ_ENABLE_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.boolean())
-                    .for_each(|(state, val)| state.eq[idx].enabled = val);
+                    .for_each(|(param, val)| param.eq[idx].enabled = val);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             EQ_BANDWIDTH_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.eq[idx].bandwidth = val as u32);
+                    .for_each(|(param, &val)| param.eq[idx].bandwidth = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             EQ_GAIN_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.eq[idx].gain = val as u32);
+                    .for_each(|(param, &val)| param.eq[idx].gain = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             EQ_FREQ_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
                 let idx = elem_id.index() as usize;
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.eq[idx].freq = val as u32);
+                    .for_each(|(param, &val)| param.eq[idx].freq = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             LIMITTER_THRESHOLD_NAME => {
-                let mut params = self.segment().data.clone();
-                let states = Self::states_mut(&mut params);
-                states
+                let mut data = self.segment.data.clone();
+                let params = data.as_mut();
+                params
                     .iter_mut()
                     .zip(elem_value.int())
-                    .for_each(|(state, &val)| state.limitter.threshold = val as u32);
+                    .for_each(|(param, &val)| param.limitter.threshold = val as u32);
                 let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
+                    T::update_partial_segment(req, node, &data, &mut self.segment, timeout_ms);
+                debug!(params = ?self.segment.data, ?res);
                 res.map(|_| true)
             }
             _ => Ok(false),
         }
     }
 
-    fn parse_notification(
+    pub fn parse_notification(
         &mut self,
         req: &FwReq,
         node: &FwNode,
         msg: u32,
         timeout_ms: u32,
     ) -> Result<(), Error> {
-        if T::is_notified_segment(self.segment(), msg) {
-            let res = T::cache_whole_segment(req, node, self.segment_mut(), timeout_ms);
-            debug!(params = ?self.segment().data, ?res);
+        if T::is_notified_segment(&self.segment, msg) {
+            let res = T::cache_whole_segment(req, node, &mut self.segment, timeout_ms);
+            debug!(params = ?self.segment.data, ?res);
             res
         } else {
             Ok(())
         }
     }
-}
-
-fn state_add_int_elem(
-    card_cntr: &mut CardCntr,
-    notified_elem_id_list: &mut Vec<ElemId>,
-    channels: usize,
-    name: &str,
-    count: usize,
-    min: i32,
-    max: i32,
-    step: i32,
-    tlv: Option<&[u32]>,
-    unlock: bool,
-) -> Result<(), Error> {
-    let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
-    card_cntr
-        .add_int_elems(&elem_id, count, min, max, step, channels, tlv, unlock)
-        .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))
-}
-
-fn state_add_enum_elem<T: AsRef<str>>(
-    card_cntr: &mut CardCntr,
-    notified_elem_id_list: &mut Vec<ElemId>,
-    channels: usize,
-    name: &str,
-    count: usize,
-    labels: &[T],
-    locked: bool,
-) -> Result<(), Error> {
-    let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
-    card_cntr
-        .add_enum_elems(&elem_id, count, channels, labels, None, locked)
-        .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))
-}
-
-fn state_add_bool_elem(
-    card_cntr: &mut CardCntr,
-    notified_elem_id_list: &mut Vec<ElemId>,
-    channels: usize,
-    name: &str,
-    count: usize,
-    unlock: bool,
-) -> Result<(), Error> {
-    let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
-    card_cntr
-        .add_bool_elems(&elem_id, count, channels, unlock)
-        .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))
 }
 
 const LIMIT_METER_MIN: i32 = -12;

--- a/runtime/dice/src/tcelectronic/desktopk6_model.rs
+++ b/runtime/dice/src/tcelectronic/desktopk6_model.rs
@@ -18,21 +18,21 @@ pub struct Desktopk6Model {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
-    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         Desktopk6Protocol::read_general_sections(
-            &self.req,
-            &unit.1,
+            &mut self.req,
+            node,
             &mut self.sections,
             TIMEOUT_MS,
         )?;
 
         self.common_ctl
-            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.panel_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_whole_params(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.config_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.panel_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -69,14 +69,14 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (unit, node): &mut (SndDice, FwNode),
         elem_id: &ElemId,
         elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
-            &unit.0,
+            unit,
             &self.req,
-            &unit.1,
+            node,
             &mut self.sections,
             elem_id,
             elem_value,
@@ -85,22 +85,22 @@ impl CtlModel<(SndDice, FwNode)> for Desktopk6Model {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .mixer_ctl
-            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .panel_ctl
-            .write(&self.req, &unit.1, elem_id, elem_value, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -118,22 +118,17 @@ impl NotifyModel<(SndDice, FwNode), u32> for Desktopk6Model {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (_, node): &mut (SndDice, FwNode),
         &msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl.parse_notification(
-            &self.req,
-            &unit.1,
-            &mut self.sections,
-            msg,
-            TIMEOUT_MS,
-        )?;
+        self.common_ctl
+            .parse_notification(&self.req, node, &mut self.sections, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.panel_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -145,10 +140,10 @@ impl MeasureModel<(SndDice, FwNode)> for Desktopk6Model {
         elem_id_list.extend_from_slice(&self.meter_ctl.1);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 }

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -332,34 +332,6 @@ impl ShellMixerStreamSrcCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
     }
 }
 
-impl StandaloneCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
-    fn segment(&self) -> &ItwinConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut ItwinConfigSegment {
-        &mut self.0
-    }
-
-    fn standalone_rate(params: &ItwinConfig) -> &TcKonnektStandaloneClockRate {
-        &params.standalone_rate
-    }
-
-    fn standalone_rate_mut(params: &mut ItwinConfig) -> &mut TcKonnektStandaloneClockRate {
-        &mut params.standalone_rate
-    }
-}
-
-impl ShellStandaloneCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
-    fn standalone_src(params: &ItwinConfig) -> &ShellStandaloneClockSource {
-        &params.standalone_src
-    }
-
-    fn standalone_src_mut(params: &mut ItwinConfig) -> &mut ShellStandaloneClockSource {
-        &mut params.standalone_src
-    }
-}
-
 const OUT_SRC_NAME: &str = "output-source";
 
 fn itwin_phys_out_src_to_string(src: &ItwinOutputPairSrc) -> &'static str {
@@ -411,7 +383,7 @@ impl ConfigCtl {
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_mixer_stream_src(card_cntr)?;
-        self.load_standalone(card_cntr)?;
+        load_standalone::<ItwinProtocol, ItwinConfig>(card_cntr)?;
 
         let labels: Vec<&str> = Self::OUT_SRCS
             .iter()
@@ -433,7 +405,7 @@ impl ConfigCtl {
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.read_mixer_stream_src(elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_standalone(elem_id, elem_value)? {
+        } else if read_standalone::<ItwinProtocol, ItwinConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -465,7 +437,14 @@ impl ConfigCtl {
     ) -> Result<bool, Error> {
         if self.write_mixer_stream_src(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_standalone::<ItwinProtocol, ItwinConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -18,7 +18,7 @@ pub struct ItwinModel {
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<ItwinProtocol, ItwinReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<ItwinProtocol, ItwinReverbMeter>,
-    ch_strip_state_ctl: ChStripStateCtl,
+    ch_strip_state_ctl: ChStripStateCtl<ItwinProtocol, ItwinChStripStates>,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
 
@@ -60,9 +60,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
-        self.ch_strip_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
+        self.ch_strip_state_ctl.load(card_cntr)?;
         self.ch_strip_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| {
@@ -167,7 +165,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.elem_id_list);
     }
 
     fn parse_notification(
@@ -791,27 +789,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ChStripStateCtl(ItwinChStripStatesSegment, Vec<ElemId>);
-
-impl ChStripStateCtlOperation<ItwinChStripStates, ItwinProtocol> for ChStripStateCtl {
-    fn segment(&self) -> &ItwinChStripStatesSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut ItwinChStripStatesSegment {
-        &mut self.0
-    }
-
-    fn states(params: &ItwinChStripStates) -> &[ChStripState] {
-        &params.0
-    }
-
-    fn states_mut(params: &mut ItwinChStripStates) -> &mut [ChStripState] {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -17,7 +17,7 @@ pub struct ItwinModel {
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<ItwinProtocol, ItwinReverbState>,
-    reverb_meter_ctl: ReverbMeterCtl,
+    reverb_meter_ctl: ReverbMeterCtl<ItwinProtocol, ItwinReverbMeter>,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
@@ -59,9 +59,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
-        self.reverb_meter_ctl
-            .load(card_cntr)
-            .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
+        self.reverb_meter_ctl.load(card_cntr)?;
         self.ch_strip_state_ctl
             .load(card_cntr)
             .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
@@ -199,7 +197,7 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
@@ -793,23 +791,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbMeterCtl(ItwinReverbMeterSegment, Vec<ElemId>);
-
-impl ReverbMeterCtlOperation<ItwinReverbMeter, ItwinProtocol> for ReverbMeterCtl {
-    fn meter(&self) -> &ReverbMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<ItwinReverbMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<ItwinReverbMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -16,7 +16,7 @@ pub struct ItwinModel {
     mixer_state_ctl: MixerStateCtl,
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
-    reverb_state_ctl: ReverbStateCtl,
+    reverb_state_ctl: ReverbStateCtl<ItwinProtocol, ItwinReverbState>,
     reverb_meter_ctl: ReverbMeterCtl,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
@@ -58,9 +58,7 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
         self.mixer_state_ctl.load(card_cntr)?;
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
-        self.reverb_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.reverb_state_ctl.1 = notified_elem_id_list)?;
+        self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
@@ -170,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
     }
 
@@ -795,27 +793,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbStateCtl(ItwinReverbStateSegment, Vec<ElemId>);
-
-impl ReverbStateCtlOpreation<ItwinReverbState, ItwinReverbMeter, ItwinProtocol> for ReverbStateCtl {
-    fn segment(&self) -> &ItwinReverbStateSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut ItwinReverbStateSegment {
-        &mut self.0
-    }
-
-    fn state(params: &ItwinReverbState) -> &ReverbState {
-        &params.0
-    }
-
-    fn state_mut(params: &mut ItwinReverbState) -> &mut ReverbState {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -314,24 +314,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(ItwinConfigSegment, Vec<ElemId>);
 
-impl ShellMixerStreamSrcCtlOperation<ItwinConfig, ItwinProtocol> for ConfigCtl {
-    fn segment(&self) -> &ItwinConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut ItwinConfigSegment {
-        &mut self.0
-    }
-
-    fn mixer_stream_src(params: &ItwinConfig) -> &ShellMixerStreamSourcePair {
-        &params.mixer_stream_src_pair
-    }
-
-    fn mixer_stream_src_mut(params: &mut ItwinConfig) -> &mut ShellMixerStreamSourcePair {
-        &mut params.mixer_stream_src_pair
-    }
-}
-
 const OUT_SRC_NAME: &str = "output-source";
 
 fn itwin_phys_out_src_to_string(src: &ItwinOutputPairSrc) -> &'static str {
@@ -382,7 +364,7 @@ impl ConfigCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_mixer_stream_src(card_cntr)?;
+        load_mixer_stream_src::<ItwinProtocol, ItwinConfig>(card_cntr)?;
         load_standalone::<ItwinProtocol, ItwinConfig>(card_cntr)?;
 
         let labels: Vec<&str> = Self::OUT_SRCS
@@ -403,7 +385,7 @@ impl ConfigCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_mixer_stream_src(elem_id, elem_value)? {
+        if read_mixer_stream_src::<ItwinProtocol, ItwinConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if read_standalone::<ItwinProtocol, ItwinConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
@@ -435,7 +417,14 @@ impl ConfigCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer_stream_src(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_mixer_stream_src::<ItwinProtocol, ItwinConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if write_standalone::<ItwinProtocol, ItwinConfig>(
             &mut self.0,

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -14,7 +14,7 @@ pub struct ItwinModel {
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
-    mixer_meter_ctl: MixerMeterCtl,
+    mixer_meter_ctl: MixerMeterCtl<ItwinProtocol, ItwinMixerMeter>,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<ItwinProtocol, ItwinReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<ItwinProtocol, ItwinReverbMeter>,
@@ -190,7 +190,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
 impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.elem_id_list);
     }
@@ -624,23 +624,6 @@ impl MixerStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MixerMeterCtl(ItwinMixerMeterSegment, Vec<ElemId>);
-
-impl ShellMixerMeterCtlOperation<ItwinMixerMeter, ItwinProtocol> for MixerMeterCtl {
-    fn meter(&self) -> &ShellMixerMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<ItwinMixerMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<ItwinMixerMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/itwin_model.rs
+++ b/runtime/dice/src/tcelectronic/itwin_model.rs
@@ -25,25 +25,27 @@ pub struct ItwinModel {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<(SndDice, FwNode)> for ItwinModel {
-    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
-        ItwinProtocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        ItwinProtocol::read_general_sections(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
-        self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.knob_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.config_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_state_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -102,49 +104,58 @@ impl CtlModel<(SndDice, FwNode)> for ItwinModel {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (unit, node): &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
-            &unit.0,
+            unit,
             &self.req,
-            &unit.1,
+            node,
             &mut self.sections,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .knob_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .reverb_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.reverb_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .ch_strip_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.ch_strip_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -165,28 +176,23 @@ impl NotifyModel<(SndDice, FwNode), u32> for ItwinModel {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (_, node): &mut (SndDice, FwNode),
         &msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl.parse_notification(
-            &self.req,
-            &unit.1,
-            &mut self.sections,
-            msg,
-            TIMEOUT_MS,
-        )?;
+        self.common_ctl
+            .parse_notification(&self.req, node, &mut self.sections, msg, TIMEOUT_MS)?;
         self.knob_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.mixer_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         Ok(())
     }
 }
@@ -199,17 +205,15 @@ impl MeasureModel<(SndDice, FwNode)> for ItwinModel {
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.mixer_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         if !self.reverb_state_ctl.is_bypassed() {
-            self.reverb_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.reverb_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         if !self.ch_strip_state_ctl.are_bypassed() {
-            self.ch_strip_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.ch_strip_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -327,24 +327,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(K24dConfigSegment, Vec<ElemId>);
 
-impl ShellOptIfaceCtl<K24dConfig, K24dProtocol> for ConfigCtl {
-    fn segment(&self) -> &K24dConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dConfigSegment {
-        &mut self.0
-    }
-
-    fn opt_iface_config(params: &K24dConfig) -> &ShellOptIfaceConfig {
-        &params.opt
-    }
-
-    fn opt_iface_config_mut(params: &mut K24dConfig) -> &mut ShellOptIfaceConfig {
-        &mut params.opt
-    }
-}
-
 const OUT_23_SRC_NAME: &str = "output-3/4-source";
 
 impl ConfigCtl {
@@ -356,7 +338,7 @@ impl ConfigCtl {
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         load_coax_out_src::<K24dProtocol, K24dConfig>(card_cntr)?;
-        self.load_opt_iface_config(card_cntr)?;
+        load_opt_iface_config::<K24dProtocol, K24dConfig>(card_cntr)?;
         load_standalone::<K24dProtocol, K24dConfig>(card_cntr)?;
 
         let labels: Vec<&str> = PHYS_OUT_SRCS
@@ -372,7 +354,7 @@ impl ConfigCtl {
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if read_coax_out_src::<K24dProtocol, K24dConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_opt_iface_config(elem_id, elem_value)? {
+        } else if read_opt_iface_config::<K24dProtocol, K24dConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if read_standalone::<K24dProtocol, K24dConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
@@ -408,7 +390,14 @@ impl ConfigCtl {
             timeout_ms,
         )? {
             Ok(true)
-        } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_opt_iface_config::<K24dProtocol, K24dConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if write_standalone::<K24dProtocol, K24dConfig>(
             &mut self.0,

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -327,24 +327,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(K24dConfigSegment, Vec<ElemId>);
 
-impl ShellCoaxIfaceCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
-    fn segment(&self) -> &K24dConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dConfigSegment {
-        &mut self.0
-    }
-
-    fn coax_out_src(params: &K24dConfig) -> &ShellCoaxOutPairSrc {
-        &params.coax_out_src
-    }
-
-    fn coax_out_src_mut(params: &mut K24dConfig) -> &mut ShellCoaxOutPairSrc {
-        &mut params.coax_out_src
-    }
-}
-
 impl ShellOptIfaceCtl<K24dConfig, K24dProtocol> for ConfigCtl {
     fn segment(&self) -> &K24dConfigSegment {
         &self.0
@@ -373,7 +355,7 @@ impl ConfigCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_coax_out_src(card_cntr)?;
+        load_coax_out_src::<K24dProtocol, K24dConfig>(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
         load_standalone::<K24dProtocol, K24dConfig>(card_cntr)?;
 
@@ -388,7 +370,7 @@ impl ConfigCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_coax_out_src(elem_id, elem_value)? {
+        if read_coax_out_src::<K24dProtocol, K24dConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_opt_iface_config(elem_id, elem_value)? {
             Ok(true)
@@ -417,7 +399,14 @@ impl ConfigCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_coax_out_src(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_coax_out_src::<K24dProtocol, K24dConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -16,7 +16,7 @@ pub struct K24dModel {
     mixer_state_ctl: MixerStateCtl,
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
-    reverb_state_ctl: ReverbStateCtl,
+    reverb_state_ctl: ReverbStateCtl<K24dProtocol, K24dReverbState>,
     reverb_meter_ctl: ReverbMeterCtl,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
@@ -58,9 +58,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         self.mixer_state_ctl.load(card_cntr)?;
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
-        self.reverb_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.reverb_state_ctl.1 = notified_elem_id_list)?;
+        self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
@@ -170,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
     }
 
@@ -791,27 +789,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbStateCtl(K24dReverbStateSegment, Vec<ElemId>);
-
-impl ReverbStateCtlOpreation<K24dReverbState, K24dReverbMeter, K24dProtocol> for ReverbStateCtl {
-    fn segment(&self) -> &K24dReverbStateSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dReverbStateSegment {
-        &mut self.0
-    }
-
-    fn state(params: &K24dReverbState) -> &ReverbState {
-        &params.0
-    }
-
-    fn state_mut(params: &mut K24dReverbState) -> &mut ReverbState {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -249,24 +249,6 @@ impl ShellKnob1CtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
     }
 }
 
-impl ProgramCtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
-    fn segment(&self) -> &K24dKnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dKnobSegment {
-        &mut self.0
-    }
-
-    fn prog(params: &K24dKnob) -> &TcKonnektLoadedProgram {
-        &params.prog
-    }
-
-    fn prog_mut(params: &mut K24dKnob) -> &mut TcKonnektLoadedProgram {
-        &mut params.prog
-    }
-}
-
 impl KnobCtl {
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
         let res = K24dProtocol::cache_whole_segment(req, node, &mut self.0, timeout_ms);
@@ -281,7 +263,7 @@ impl KnobCtl {
         self.load_knob1_target(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        self.load_prog(card_cntr)
+        load_prog::<K24dProtocol, K24dKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         Ok(())
@@ -292,7 +274,7 @@ impl KnobCtl {
             Ok(true)
         } else if self.read_knob1_target(elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_prog(elem_id, elem_value)? {
+        } else if read_prog::<K24dProtocol, K24dKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -311,7 +293,14 @@ impl KnobCtl {
             Ok(true)
         } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_prog(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_prog::<K24dProtocol, K24dKnob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else {
             Ok(false)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -14,7 +14,7 @@ pub struct K24dModel {
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
-    mixer_meter_ctl: MixerMeterCtl,
+    mixer_meter_ctl: MixerMeterCtl<K24dProtocol, K24dMixerMeter>,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<K24dProtocol, K24dReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<K24dProtocol, K24dReverbMeter>,
@@ -191,7 +191,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
 impl MeasureModel<(SndDice, FwNode)> for K24dModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.elem_id_list);
     }
@@ -679,23 +679,6 @@ impl MixerStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MixerMeterCtl(K24dMixerMeterSegment, Vec<ElemId>);
-
-impl ShellMixerMeterCtlOperation<K24dMixerMeter, K24dProtocol> for MixerMeterCtl {
-    fn meter(&self) -> &ShellMixerMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<K24dMixerMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<K24dMixerMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -25,25 +25,27 @@ pub struct K24dModel {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<(SndDice, FwNode)> for K24dModel {
-    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
-        K24dProtocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        K24dProtocol::read_general_sections(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
-        self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.knob_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.config_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_state_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -102,49 +104,58 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (unit, node): &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
-            &unit.0,
+            unit,
             &self.req,
-            &unit.1,
+            node,
             &mut self.sections,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .knob_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .reverb_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.reverb_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .ch_strip_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.ch_strip_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else {
             Ok(false)
@@ -165,29 +176,24 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (_, node): &mut (SndDice, FwNode),
         &msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl.parse_notification(
-            &self.req,
-            &unit.1,
-            &mut self.sections,
-            msg,
-            TIMEOUT_MS,
-        )?;
+        self.common_ctl
+            .parse_notification(&self.req, node, &mut self.sections, msg, TIMEOUT_MS)?;
 
         self.knob_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.mixer_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         Ok(())
     }
 }
@@ -200,17 +206,15 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.mixer_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         if !self.reverb_state_ctl.is_bypassed() {
-            self.reverb_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.reverb_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         if !self.ch_strip_state_ctl.are_bypassed() {
-            self.ch_strip_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.ch_strip_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -17,7 +17,7 @@ pub struct K24dModel {
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<K24dProtocol, K24dReverbState>,
-    reverb_meter_ctl: ReverbMeterCtl,
+    reverb_meter_ctl: ReverbMeterCtl<K24dProtocol, K24dReverbMeter>,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
@@ -59,9 +59,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
-        self.reverb_meter_ctl
-            .load(card_cntr)
-            .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
+        self.reverb_meter_ctl.load(card_cntr)?;
         self.ch_strip_state_ctl
             .load(card_cntr)
             .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
@@ -200,7 +198,7 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
@@ -789,23 +787,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbMeterCtl(K24dReverbMeterSegment, Vec<ElemId>);
-
-impl ReverbMeterCtlOperation<K24dReverbMeter, K24dProtocol> for ReverbMeterCtl {
-    fn meter(&self) -> &ReverbMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<K24dReverbMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<K24dReverbMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -374,34 +374,6 @@ impl ShellOptIfaceCtl<K24dConfig, K24dProtocol> for ConfigCtl {
     }
 }
 
-impl StandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
-    fn segment(&self) -> &K24dConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dConfigSegment {
-        &mut self.0
-    }
-
-    fn standalone_rate(params: &K24dConfig) -> &TcKonnektStandaloneClockRate {
-        &params.standalone_rate
-    }
-
-    fn standalone_rate_mut(params: &mut K24dConfig) -> &mut TcKonnektStandaloneClockRate {
-        &mut params.standalone_rate
-    }
-}
-
-impl ShellStandaloneCtlOperation<K24dConfig, K24dProtocol> for ConfigCtl {
-    fn standalone_src(params: &K24dConfig) -> &ShellStandaloneClockSource {
-        &params.standalone_src
-    }
-
-    fn standalone_src_mut(params: &mut K24dConfig) -> &mut ShellStandaloneClockSource {
-        &mut params.standalone_src
-    }
-}
-
 const OUT_23_SRC_NAME: &str = "output-3/4-source";
 
 impl ConfigCtl {
@@ -414,7 +386,7 @@ impl ConfigCtl {
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.load_coax_out_src(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
-        self.load_standalone(card_cntr)?;
+        load_standalone::<K24dProtocol, K24dConfig>(card_cntr)?;
 
         let labels: Vec<&str> = PHYS_OUT_SRCS
             .iter()
@@ -431,7 +403,7 @@ impl ConfigCtl {
             Ok(true)
         } else if self.read_opt_iface_config(elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_standalone(elem_id, elem_value)? {
+        } else if read_standalone::<K24dProtocol, K24dConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -460,7 +432,14 @@ impl ConfigCtl {
             Ok(true)
         } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_standalone::<K24dProtocol, K24dConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -213,24 +213,6 @@ impl MeasureModel<(SndDice, FwNode)> for K24dModel {
 #[derive(Default, Debug)]
 struct KnobCtl(K24dKnobSegment, Vec<ElemId>);
 
-impl ShellKnob0CtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
-    fn segment(&self) -> &K24dKnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dKnobSegment {
-        &mut self.0
-    }
-
-    fn knob0_target(params: &K24dKnob) -> &ShellKnob0Target {
-        &params.knob0_target
-    }
-
-    fn knob0_target_mut(params: &mut K24dKnob) -> &mut ShellKnob0Target {
-        &mut params.knob0_target
-    }
-}
-
 impl ShellKnob1CtlOperation<K24dKnob, K24dProtocol> for KnobCtl {
     fn segment(&self) -> &K24dKnobSegment {
         &self.0
@@ -257,7 +239,7 @@ impl KnobCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_knob0_target(card_cntr)
+        load_knob0_target::<K24dProtocol, K24dKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         self.load_knob1_target(card_cntr)
@@ -270,7 +252,7 @@ impl KnobCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_knob0_target(elem_id, elem_value)? {
+        if read_knob0_target::<K24dProtocol, K24dKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_knob1_target(elem_id, elem_value)? {
             Ok(true)
@@ -289,7 +271,14 @@ impl KnobCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob0_target(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_knob0_target::<K24dProtocol, K24dKnob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/k24d_model.rs
+++ b/runtime/dice/src/tcelectronic/k24d_model.rs
@@ -18,7 +18,7 @@ pub struct K24dModel {
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<K24dProtocol, K24dReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<K24dProtocol, K24dReverbMeter>,
-    ch_strip_state_ctl: ChStripStateCtl,
+    ch_strip_state_ctl: ChStripStateCtl<K24dProtocol, K24dChStripStates>,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
 
@@ -60,9 +60,7 @@ impl CtlModel<(SndDice, FwNode)> for K24dModel {
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
-        self.ch_strip_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
+        self.ch_strip_state_ctl.load(card_cntr)?;
         self.ch_strip_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| {
@@ -167,7 +165,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K24dModel {
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.elem_id_list);
     }
 
     fn parse_notification(
@@ -787,27 +785,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ChStripStateCtl(K24dChStripStatesSegment, Vec<ElemId>);
-
-impl ChStripStateCtlOperation<K24dChStripStates, K24dProtocol> for ChStripStateCtl {
-    fn segment(&self) -> &K24dChStripStatesSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K24dChStripStatesSegment {
-        &mut self.0
-    }
-
-    fn states(params: &K24dChStripStates) -> &[ChStripState] {
-        &params.0
-    }
-
-    fn states_mut(params: &mut K24dChStripStates) -> &mut [ChStripState] {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -257,24 +257,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(K8ConfigSegment, Vec<ElemId>);
 
-impl ShellCoaxIfaceCtlOperation<K8Config, K8Protocol> for ConfigCtl {
-    fn segment(&self) -> &K8ConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K8ConfigSegment {
-        &mut self.0
-    }
-
-    fn coax_out_src(params: &K8Config) -> &ShellCoaxOutPairSrc {
-        &params.coax_out_src
-    }
-
-    fn coax_out_src_mut(params: &mut K8Config) -> &mut ShellCoaxOutPairSrc {
-        &mut params.coax_out_src
-    }
-}
-
 impl ConfigCtl {
     fn cache(&mut self, req: &FwReq, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
         let res = K8Protocol::cache_whole_segment(req, node, &mut self.0, timeout_ms);
@@ -283,14 +265,14 @@ impl ConfigCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_coax_out_src(card_cntr)?;
+        load_coax_out_src::<K8Protocol, K8Config>(card_cntr)?;
         load_standalone::<K8Protocol, K8Config>(card_cntr)?;
 
         Ok(())
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_coax_out_src(elem_id, elem_value)? {
+        if read_coax_out_src::<K8Protocol, K8Config>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if read_standalone::<K8Protocol, K8Config>(&self.0, elem_id, elem_value)? {
             Ok(true)
@@ -307,7 +289,14 @@ impl ConfigCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_coax_out_src(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_coax_out_src::<K8Protocol, K8Config>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if write_standalone::<K8Protocol, K8Config>(
             &mut self.0,

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -14,7 +14,7 @@ pub struct K8Model {
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
-    mixer_meter_ctl: MixerMeterCtl,
+    mixer_meter_ctl: MixerMeterCtl<K8Protocol, K8MixerMeter>,
     hw_state_ctl: HwStateCtl,
 }
 
@@ -144,7 +144,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for K8Model {
 impl MeasureModel<(SndDice, FwNode)> for K8Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.elem_id_list);
     }
 
     fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -465,23 +465,6 @@ impl MixerStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MixerMeterCtl(K8MixerMeterSegment, Vec<ElemId>);
-
-impl ShellMixerMeterCtlOperation<K8MixerMeter, K8Protocol> for MixerMeterCtl {
-    fn meter(&self) -> &ShellMixerMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<K8MixerMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<K8MixerMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -158,24 +158,6 @@ impl MeasureModel<(SndDice, FwNode)> for K8Model {
 #[derive(Default, Debug)]
 struct KnobCtl(K8KnobSegment, Vec<ElemId>);
 
-impl ShellKnob0CtlOperation<K8Knob, K8Protocol> for KnobCtl {
-    fn segment(&self) -> &K8KnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut K8KnobSegment {
-        &mut self.0
-    }
-
-    fn knob0_target(params: &K8Knob) -> &ShellKnob0Target {
-        &params.knob0_target
-    }
-
-    fn knob0_target_mut(params: &mut K8Knob) -> &mut ShellKnob0Target {
-        &mut params.knob0_target
-    }
-}
-
 impl ShellKnob1CtlOperation<K8Knob, K8Protocol> for KnobCtl {
     fn segment(&self) -> &K8KnobSegment {
         &self.0
@@ -202,7 +184,7 @@ impl KnobCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_knob0_target(card_cntr)
+        load_knob0_target::<K8Protocol, K8Knob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
         self.load_knob1_target(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
@@ -211,7 +193,7 @@ impl KnobCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_knob0_target(elem_id, elem_value)? {
+        if read_knob0_target::<K8Protocol, K8Knob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_knob1_target(elem_id, elem_value)? {
             Ok(true)
@@ -228,7 +210,14 @@ impl KnobCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob0_target(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_knob0_target::<K8Protocol, K8Knob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/k8_model.rs
+++ b/runtime/dice/src/tcelectronic/k8_model.rs
@@ -21,17 +21,19 @@ pub struct K8Model {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<(SndDice, FwNode)> for K8Model {
-    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
-        K8Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        K8Protocol::read_general_sections(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
-        self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.knob_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.config_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_state_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -68,38 +70,41 @@ impl CtlModel<(SndDice, FwNode)> for K8Model {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (unit, node): &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
-            &unit.0,
-            &self.req,
-            &unit.1,
+            unit,
+            &mut self.req,
+            node,
             &mut self.sections,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .knob_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -119,24 +124,19 @@ impl NotifyModel<(SndDice, FwNode), u32> for K8Model {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (_, node): &mut (SndDice, FwNode),
         &msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl.parse_notification(
-            &self.req,
-            &unit.1,
-            &mut self.sections,
-            msg,
-            TIMEOUT_MS,
-        )?;
+        self.common_ctl
+            .parse_notification(&self.req, node, &mut self.sections, msg, TIMEOUT_MS)?;
         self.knob_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.mixer_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         Ok(())
     }
 }
@@ -147,10 +147,10 @@ impl MeasureModel<(SndDice, FwNode)> for K8Model {
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.mixer_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 }

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -18,7 +18,7 @@ pub struct KliveModel {
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<KliveProtocol, KliveReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<KliveProtocol, KliveReverbMeter>,
-    ch_strip_state_ctl: ChStripStateCtl,
+    ch_strip_state_ctl: ChStripStateCtl<KliveProtocol, KliveChStripStates>,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
 
@@ -60,9 +60,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
-        self.ch_strip_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
+        self.ch_strip_state_ctl.load(card_cntr)?;
         self.ch_strip_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| {
@@ -167,7 +165,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.elem_id_list);
     }
 
     fn parse_notification(
@@ -1036,27 +1034,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ChStripStateCtl(KliveChStripStatesSegment, Vec<ElemId>);
-
-impl ChStripStateCtlOperation<KliveChStripStates, KliveProtocol> for ChStripStateCtl {
-    fn segment(&self) -> &KliveChStripStatesSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveChStripStatesSegment {
-        &mut self.0
-    }
-
-    fn states(params: &KliveChStripStates) -> &[ChStripState] {
-        &params.0
-    }
-
-    fn states_mut(params: &mut KliveChStripStates) -> &mut [ChStripState] {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -25,25 +25,27 @@ pub struct KliveModel {
 const TIMEOUT_MS: u32 = 20;
 
 impl CtlModel<(SndDice, FwNode)> for KliveModel {
-    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
-        KliveProtocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        KliveProtocol::read_general_sections(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
         self.common_ctl
-            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+            .cache_whole_params(&mut self.req, node, &mut self.sections, TIMEOUT_MS)?;
 
-        self.knob_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.config_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
-        self.hw_state_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+        self.knob_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.config_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_state_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.mixer_meter_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.hw_state_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.reverb_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
         self.ch_strip_meter_ctl
-            .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
 
         Ok(())
     }
@@ -102,48 +104,57 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
 
     fn write(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (unit, node): &mut (SndDice, FwNode),
         elem_id: &ElemId,
-        new: &ElemValue,
+        elem_value: &ElemValue,
     ) -> Result<bool, Error> {
         if self.common_ctl.write(
-            &unit.0,
-            &self.req,
-            &unit.1,
+            unit,
+            &mut self.req,
+            node,
             &mut self.sections,
             elem_id,
-            new,
+            elem_value,
             TIMEOUT_MS,
         )? {
             Ok(true)
         } else if self
             .knob_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else if self
             .config_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
-        } else if self
-            .mixer_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.mixer_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .reverb_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.reverb_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
-        } else if self
-            .ch_strip_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
-        {
+        } else if self.ch_strip_state_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
             Ok(true)
         } else if self
             .hw_state_ctl
-            .write(&self.req, &unit.1, elem_id, new, TIMEOUT_MS)?
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
         {
             Ok(true)
         } else {
@@ -165,28 +176,23 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
 
     fn parse_notification(
         &mut self,
-        unit: &mut (SndDice, FwNode),
+        (_, node): &mut (SndDice, FwNode),
         &msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl.parse_notification(
-            &self.req,
-            &unit.1,
-            &mut self.sections,
-            msg,
-            TIMEOUT_MS,
-        )?;
+        self.common_ctl
+            .parse_notification(&self.req, node, &mut self.sections, msg, TIMEOUT_MS)?;
         self.knob_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.config_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.mixer_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.hw_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.reverb_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         self.ch_strip_state_ctl
-            .parse_notification(&self.req, &unit.1, msg, TIMEOUT_MS)?;
+            .parse_notification(&self.req, node, msg, TIMEOUT_MS)?;
         Ok(())
     }
 }
@@ -199,17 +205,15 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
-    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
-            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
-        self.mixer_meter_ctl.cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            .cache_partial_params(&self.req, node, &mut self.sections, TIMEOUT_MS)?;
+        self.mixer_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         if !self.reverb_state_ctl.is_bypassed() {
-            self.reverb_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.reverb_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         if !self.ch_strip_state_ctl.are_bypassed() {
-            self.ch_strip_meter_ctl
-                .cache(&self.req, &unit.1, TIMEOUT_MS)?;
+            self.ch_strip_meter_ctl.cache(&self.req, node, TIMEOUT_MS)?;
         }
         Ok(())
     }

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -17,7 +17,7 @@ pub struct KliveModel {
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<KliveProtocol, KliveReverbState>,
-    reverb_meter_ctl: ReverbMeterCtl,
+    reverb_meter_ctl: ReverbMeterCtl<KliveProtocol, KliveReverbMeter>,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
 }
@@ -59,9 +59,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
         self.reverb_state_ctl.load(card_cntr)?;
-        self.reverb_meter_ctl
-            .load(card_cntr)
-            .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
+        self.reverb_meter_ctl.load(card_cntr)?;
         self.ch_strip_state_ctl
             .load(card_cntr)
             .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
@@ -199,7 +197,7 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
@@ -1038,23 +1036,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbMeterCtl(KliveReverbMeterSegment, Vec<ElemId>);
-
-impl ReverbMeterCtlOperation<KliveReverbMeter, KliveProtocol> for ReverbMeterCtl {
-    fn meter(&self) -> &ReverbMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<KliveReverbMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<KliveReverbMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -456,34 +456,6 @@ impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
     }
 }
 
-impl StandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn segment(&self) -> &KliveConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveConfigSegment {
-        &mut self.0
-    }
-
-    fn standalone_rate(params: &KliveConfig) -> &TcKonnektStandaloneClockRate {
-        &params.standalone_rate
-    }
-
-    fn standalone_rate_mut(params: &mut KliveConfig) -> &mut TcKonnektStandaloneClockRate {
-        &mut params.standalone_rate
-    }
-}
-
-impl ShellStandaloneCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn standalone_src(params: &KliveConfig) -> &ShellStandaloneClockSource {
-        &params.standalone_src
-    }
-
-    fn standalone_src_mut(params: &mut KliveConfig) -> &mut ShellStandaloneClockSource {
-        &mut params.standalone_src
-    }
-}
-
 impl MidiSendCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
     fn segment(&self) -> &KliveConfigSegment {
         &self.0
@@ -516,7 +488,7 @@ impl ConfigCtl {
         self.load_mixer_stream_src(card_cntr)?;
         self.load_coax_out_src(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
-        self.load_standalone(card_cntr)?;
+        load_standalone::<KliveProtocol, KliveConfig>(card_cntr)?;
         self.load_midi_sender(card_cntr)?;
 
         let labels: Vec<&str> = PHYS_OUT_SRCS
@@ -539,7 +511,7 @@ impl ConfigCtl {
             Ok(true)
         } else if self.read_opt_iface_config(elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_standalone(elem_id, elem_value)? {
+        } else if read_standalone::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_midi_sender(elem_id, elem_value)? {
             Ok(true)
@@ -582,7 +554,14 @@ impl ConfigCtl {
             Ok(true)
         } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_standalone(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_standalone::<KliveProtocol, KliveConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_midi_sender(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -391,24 +391,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(KliveConfigSegment, Vec<ElemId>);
 
-impl ShellCoaxIfaceCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn segment(&self) -> &KliveConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveConfigSegment {
-        &mut self.0
-    }
-
-    fn coax_out_src(params: &KliveConfig) -> &ShellCoaxOutPairSrc {
-        &params.coax_out_src
-    }
-
-    fn coax_out_src_mut(params: &mut KliveConfig) -> &mut ShellCoaxOutPairSrc {
-        &mut params.coax_out_src
-    }
-}
-
 impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
     fn segment(&self) -> &KliveConfigSegment {
         &self.0
@@ -439,7 +421,7 @@ impl ConfigCtl {
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         load_mixer_stream_src::<KliveProtocol, KliveConfig>(card_cntr)?;
-        self.load_coax_out_src(card_cntr)?;
+        load_coax_out_src::<KliveProtocol, KliveConfig>(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
         load_standalone::<KliveProtocol, KliveConfig>(card_cntr)?;
         load_midi_sender::<KliveProtocol, KliveConfig>(card_cntr)?;
@@ -460,7 +442,7 @@ impl ConfigCtl {
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if read_mixer_stream_src::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_coax_out_src(elem_id, elem_value)? {
+        } else if read_coax_out_src::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_opt_iface_config(elem_id, elem_value)? {
             Ok(true)
@@ -510,7 +492,14 @@ impl ConfigCtl {
             timeout_ms,
         )? {
             Ok(true)
-        } else if self.write_coax_out_src(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_coax_out_src::<KliveProtocol, KliveConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -391,24 +391,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(KliveConfigSegment, Vec<ElemId>);
 
-impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn segment(&self) -> &KliveConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveConfigSegment {
-        &mut self.0
-    }
-
-    fn opt_iface_config(params: &KliveConfig) -> &ShellOptIfaceConfig {
-        &params.opt
-    }
-
-    fn opt_iface_config_mut(params: &mut KliveConfig) -> &mut ShellOptIfaceConfig {
-        &mut params.opt
-    }
-}
-
 const OUT_01_SRC_NAME: &str = "output-1/2-source";
 const OUT_23_SRC_NAME: &str = "output-3/4-source";
 
@@ -422,7 +404,7 @@ impl ConfigCtl {
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         load_mixer_stream_src::<KliveProtocol, KliveConfig>(card_cntr)?;
         load_coax_out_src::<KliveProtocol, KliveConfig>(card_cntr)?;
-        self.load_opt_iface_config(card_cntr)?;
+        load_opt_iface_config::<KliveProtocol, KliveConfig>(card_cntr)?;
         load_standalone::<KliveProtocol, KliveConfig>(card_cntr)?;
         load_midi_sender::<KliveProtocol, KliveConfig>(card_cntr)?;
 
@@ -444,7 +426,8 @@ impl ConfigCtl {
             Ok(true)
         } else if read_coax_out_src::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_opt_iface_config(elem_id, elem_value)? {
+        } else if read_opt_iface_config::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)?
+        {
             Ok(true)
         } else if read_standalone::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
@@ -501,7 +484,14 @@ impl ConfigCtl {
             timeout_ms,
         )? {
             Ok(true)
-        } else if self.write_opt_iface_config(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_opt_iface_config::<KliveProtocol, KliveConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if write_standalone::<KliveProtocol, KliveConfig>(
             &mut self.0,

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -212,24 +212,6 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
 #[derive(Default, Debug)]
 struct KnobCtl(KliveKnobSegment, Vec<ElemId>);
 
-impl ShellKnob0CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
-    fn segment(&self) -> &KliveKnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveKnobSegment {
-        &mut self.0
-    }
-
-    fn knob0_target(params: &KliveKnob) -> &ShellKnob0Target {
-        &params.knob0_target
-    }
-
-    fn knob0_target_mut(params: &mut KliveKnob) -> &mut ShellKnob0Target {
-        &mut params.knob0_target
-    }
-}
-
 impl ShellKnob1CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
     fn segment(&self) -> &KliveKnobSegment {
         &self.0
@@ -268,7 +250,7 @@ impl KnobCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_knob0_target(card_cntr)
+        load_knob0_target::<KliveProtocol, KliveKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
         self.load_knob1_target(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
@@ -286,7 +268,7 @@ impl KnobCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_knob0_target(elem_id, elem_value)? {
+        if read_knob0_target::<KliveProtocol, KliveKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_knob1_target(elem_id, elem_value)? {
             Ok(true)
@@ -324,7 +306,14 @@ impl KnobCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_knob0_target(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_knob0_target::<KliveProtocol, KliveKnob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -445,24 +445,6 @@ impl ShellOptIfaceCtl<KliveConfig, KliveProtocol> for ConfigCtl {
     }
 }
 
-impl MidiSendCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn segment(&self) -> &KliveConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveConfigSegment {
-        &mut self.0
-    }
-
-    fn midi_sender(params: &KliveConfig) -> &TcKonnektMidiSender {
-        &params.midi_sender
-    }
-
-    fn midi_sender_mut(params: &mut KliveConfig) -> &mut TcKonnektMidiSender {
-        &mut params.midi_sender
-    }
-}
-
 const OUT_01_SRC_NAME: &str = "output-1/2-source";
 const OUT_23_SRC_NAME: &str = "output-3/4-source";
 
@@ -478,7 +460,7 @@ impl ConfigCtl {
         self.load_coax_out_src(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
         load_standalone::<KliveProtocol, KliveConfig>(card_cntr)?;
-        self.load_midi_sender(card_cntr)?;
+        load_midi_sender::<KliveProtocol, KliveConfig>(card_cntr)?;
 
         let labels: Vec<&str> = PHYS_OUT_SRCS
             .iter()
@@ -502,7 +484,7 @@ impl ConfigCtl {
             Ok(true)
         } else if read_standalone::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_midi_sender(elem_id, elem_value)? {
+        } else if read_midi_sender::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -552,7 +534,14 @@ impl ConfigCtl {
             timeout_ms,
         )? {
             Ok(true)
-        } else if self.write_midi_sender(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_midi_sender::<KliveProtocol, KliveConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -14,7 +14,7 @@ pub struct KliveModel {
     knob_ctl: KnobCtl,
     config_ctl: ConfigCtl,
     mixer_state_ctl: MixerStateCtl,
-    mixer_meter_ctl: MixerMeterCtl,
+    mixer_meter_ctl: MixerMeterCtl<KliveProtocol, KliveMixerMeter>,
     hw_state_ctl: HwStateCtl,
     reverb_state_ctl: ReverbStateCtl<KliveProtocol, KliveReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<KliveProtocol, KliveReverbMeter>,
@@ -190,7 +190,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
 impl MeasureModel<(SndDice, FwNode)> for KliveModel {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
-        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.mixer_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.elem_id_list);
     }
@@ -936,23 +936,6 @@ impl MixerStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct MixerMeterCtl(KliveMixerMeterSegment, Vec<ElemId>);
-
-impl ShellMixerMeterCtlOperation<KliveMixerMeter, KliveProtocol> for MixerMeterCtl {
-    fn meter(&self) -> &ShellMixerMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<KliveMixerMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<KliveMixerMeter> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -16,7 +16,7 @@ pub struct KliveModel {
     mixer_state_ctl: MixerStateCtl,
     mixer_meter_ctl: MixerMeterCtl,
     hw_state_ctl: HwStateCtl,
-    reverb_state_ctl: ReverbStateCtl,
+    reverb_state_ctl: ReverbStateCtl<KliveProtocol, KliveReverbState>,
     reverb_meter_ctl: ReverbMeterCtl,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
@@ -58,9 +58,7 @@ impl CtlModel<(SndDice, FwNode)> for KliveModel {
         self.mixer_state_ctl.load(card_cntr)?;
         self.mixer_meter_ctl.load(card_cntr)?;
         self.hw_state_ctl.load(card_cntr)?;
-        self.reverb_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.reverb_state_ctl.1 = notified_elem_id_list)?;
+        self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
@@ -170,7 +168,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for KliveModel {
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
     }
 
@@ -1040,27 +1038,6 @@ impl HwStateCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbStateCtl(KliveReverbStateSegment, Vec<ElemId>);
-
-impl ReverbStateCtlOpreation<KliveReverbState, KliveReverbMeter, KliveProtocol> for ReverbStateCtl {
-    fn segment(&self) -> &KliveReverbStateSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveReverbStateSegment {
-        &mut self.0
-    }
-
-    fn state(params: &KliveReverbState) -> &ReverbState {
-        &params.0
-    }
-
-    fn state_mut(params: &mut KliveReverbState) -> &mut ReverbState {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -248,24 +248,6 @@ impl ShellKnob1CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
     }
 }
 
-impl ProgramCtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
-    fn segment(&self) -> &KliveKnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveKnobSegment {
-        &mut self.0
-    }
-
-    fn prog(params: &KliveKnob) -> &TcKonnektLoadedProgram {
-        &params.prog
-    }
-
-    fn prog_mut(params: &mut KliveKnob) -> &mut TcKonnektLoadedProgram {
-        &mut params.prog
-    }
-}
-
 const OUTPUT_IMPEDANCE_NAME: &str = "output-impedance";
 
 fn impedance_to_str(impedance: &OutputImpedance) -> &'static str {
@@ -290,7 +272,7 @@ impl KnobCtl {
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
         self.load_knob1_target(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
-        self.load_prog(card_cntr)
+        load_prog::<KliveProtocol, KliveKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         let labels: Vec<&str> = Self::OUTPUT_IMPEDANCES
@@ -308,7 +290,7 @@ impl KnobCtl {
             Ok(true)
         } else if self.read_knob1_target(elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_prog(elem_id, elem_value)? {
+        } else if read_prog::<KliveProtocol, KliveKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {
@@ -346,7 +328,14 @@ impl KnobCtl {
             Ok(true)
         } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)
-        } else if self.write_prog(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_prog::<KliveProtocol, KliveKnob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else {
             match elem_id.name().as_str() {

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -391,24 +391,6 @@ impl KnobCtl {
 #[derive(Default, Debug)]
 struct ConfigCtl(KliveConfigSegment, Vec<ElemId>);
 
-impl ShellMixerStreamSrcCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
-    fn segment(&self) -> &KliveConfigSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveConfigSegment {
-        &mut self.0
-    }
-
-    fn mixer_stream_src(params: &KliveConfig) -> &ShellMixerStreamSourcePair {
-        &params.mixer_stream_src_pair
-    }
-
-    fn mixer_stream_src_mut(params: &mut KliveConfig) -> &mut ShellMixerStreamSourcePair {
-        &mut params.mixer_stream_src_pair
-    }
-}
-
 impl ShellCoaxIfaceCtlOperation<KliveConfig, KliveProtocol> for ConfigCtl {
     fn segment(&self) -> &KliveConfigSegment {
         &self.0
@@ -456,7 +438,7 @@ impl ConfigCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_mixer_stream_src(card_cntr)?;
+        load_mixer_stream_src::<KliveProtocol, KliveConfig>(card_cntr)?;
         self.load_coax_out_src(card_cntr)?;
         self.load_opt_iface_config(card_cntr)?;
         load_standalone::<KliveProtocol, KliveConfig>(card_cntr)?;
@@ -476,7 +458,7 @@ impl ConfigCtl {
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.read_mixer_stream_src(elem_id, elem_value)? {
+        if read_mixer_stream_src::<KliveProtocol, KliveConfig>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if self.read_coax_out_src(elem_id, elem_value)? {
             Ok(true)
@@ -519,7 +501,14 @@ impl ConfigCtl {
         elem_value: &ElemValue,
         timeout_ms: u32,
     ) -> Result<bool, Error> {
-        if self.write_mixer_stream_src(req, node, elem_id, elem_value, timeout_ms)? {
+        if write_mixer_stream_src::<KliveProtocol, KliveConfig>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if self.write_coax_out_src(req, node, elem_id, elem_value, timeout_ms)? {
             Ok(true)

--- a/runtime/dice/src/tcelectronic/klive_model.rs
+++ b/runtime/dice/src/tcelectronic/klive_model.rs
@@ -3,7 +3,7 @@
 
 use {
     super::{shell_ctl::*, *},
-    protocols::tcelectronic::shell::{klive::*, *},
+    protocols::tcelectronic::shell::klive::*,
 };
 
 #[derive(Default, Debug)]
@@ -212,24 +212,6 @@ impl MeasureModel<(SndDice, FwNode)> for KliveModel {
 #[derive(Default, Debug)]
 struct KnobCtl(KliveKnobSegment, Vec<ElemId>);
 
-impl ShellKnob1CtlOperation<KliveKnob, KliveProtocol> for KnobCtl {
-    fn segment(&self) -> &KliveKnobSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut KliveKnobSegment {
-        &mut self.0
-    }
-
-    fn knob1_target(params: &KliveKnob) -> &ShellKnob1Target {
-        &params.knob1_target
-    }
-
-    fn knob1_target_mut(params: &mut KliveKnob) -> &mut ShellKnob1Target {
-        &mut params.knob1_target
-    }
-}
-
 const OUTPUT_IMPEDANCE_NAME: &str = "output-impedance";
 
 fn impedance_to_str(impedance: &OutputImpedance) -> &'static str {
@@ -252,7 +234,7 @@ impl KnobCtl {
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         load_knob0_target::<KliveProtocol, KliveKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
-        self.load_knob1_target(card_cntr)
+        load_knob1_target::<KliveProtocol, KliveKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
         load_prog::<KliveProtocol, KliveKnob>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
@@ -270,7 +252,7 @@ impl KnobCtl {
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if read_knob0_target::<KliveProtocol, KliveKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
-        } else if self.read_knob1_target(elem_id, elem_value)? {
+        } else if read_knob1_target::<KliveProtocol, KliveKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
         } else if read_prog::<KliveProtocol, KliveKnob>(&self.0, elem_id, elem_value)? {
             Ok(true)
@@ -315,7 +297,14 @@ impl KnobCtl {
             timeout_ms,
         )? {
             Ok(true)
-        } else if self.write_knob1_target(req, node, elem_id, elem_value, timeout_ms)? {
+        } else if write_knob1_target::<KliveProtocol, KliveKnob>(
+            &mut self.0,
+            req,
+            node,
+            elem_id,
+            elem_value,
+            timeout_ms,
+        )? {
             Ok(true)
         } else if write_prog::<KliveProtocol, KliveKnob>(
             &mut self.0,

--- a/runtime/dice/src/tcelectronic/standalone_ctl.rs
+++ b/runtime/dice/src/tcelectronic/standalone_ctl.rs
@@ -3,7 +3,16 @@
 
 use super::*;
 
-fn standalone_rate_to_str(rate: &TcKonnektStandaloneClockRate) -> &'static str {
+const RATE_NAME: &str = "standalone-clock-rate";
+
+const RATES: &[TcKonnektStandaloneClockRate] = &[
+    TcKonnektStandaloneClockRate::R44100,
+    TcKonnektStandaloneClockRate::R48000,
+    TcKonnektStandaloneClockRate::R88200,
+    TcKonnektStandaloneClockRate::R96000,
+];
+
+fn standalone_rate_to_str(rate: &TcKonnektStandaloneClockRate) -> &str {
     match rate {
         TcKonnektStandaloneClockRate::R44100 => "44100",
         TcKonnektStandaloneClockRate::R48000 => "48000",
@@ -12,80 +21,66 @@ fn standalone_rate_to_str(rate: &TcKonnektStandaloneClockRate) -> &'static str {
     }
 }
 
-const RATE_NAME: &str = "standalone-clock-rate";
-
-pub trait StandaloneCtlOperation<S, T>
+pub fn load_standalone_rate<T, U>(card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error>
 where
-    S: Clone + Debug,
-    T: TcKonnektSegmentOperation<S> + TcKonnektMutableSegmentOperation<S>,
+    T: TcKonnektSegmentOperation<U> + TcKonnektMutableSegmentOperation<U>,
+    U: Debug + Clone + AsRef<TcKonnektStandaloneClockRate> + AsMut<TcKonnektStandaloneClockRate>,
 {
-    fn segment(&self) -> &TcKonnektSegment<S>;
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<S>;
+    let labels: Vec<&str> = RATES.iter().map(|r| standalone_rate_to_str(r)).collect();
+    let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
+    card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)
+}
 
-    fn standalone_rate(params: &S) -> &TcKonnektStandaloneClockRate;
-    fn standalone_rate_mut(params: &mut S) -> &mut TcKonnektStandaloneClockRate;
-
-    const RATES: [TcKonnektStandaloneClockRate; 4] = [
-        TcKonnektStandaloneClockRate::R44100,
-        TcKonnektStandaloneClockRate::R48000,
-        TcKonnektStandaloneClockRate::R88200,
-        TcKonnektStandaloneClockRate::R96000,
-    ];
-
-    fn load_standalone_rate(&self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels: Vec<&str> = Self::RATES
-            .iter()
-            .map(|r| standalone_rate_to_str(r))
-            .collect();
-        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, RATE_NAME, 0);
-        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
-        Ok(())
-    }
-
-    fn read_standalone_rate(
-        &mut self,
-        elem_id: &ElemId,
-        elem_value: &ElemValue,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            RATE_NAME => {
-                let params = &self.segment().data;
-                let rate = Self::standalone_rate(&params);
-                let pos = Self::RATES.iter().position(|r| rate.eq(r)).unwrap();
-                elem_value.set_enum(&[pos as u32]);
-                Ok(true)
-            }
-            _ => Ok(false),
+pub fn read_standalone_rate<T, U>(
+    segment: &TcKonnektSegment<U>,
+    elem_id: &ElemId,
+    elem_value: &ElemValue,
+) -> Result<bool, Error>
+where
+    T: TcKonnektSegmentOperation<U> + TcKonnektMutableSegmentOperation<U>,
+    U: Debug + Clone + AsRef<TcKonnektStandaloneClockRate> + AsMut<TcKonnektStandaloneClockRate>,
+{
+    match elem_id.name().as_str() {
+        RATE_NAME => {
+            let params = segment.data.as_ref();
+            let pos = RATES.iter().position(|r| params.eq(r)).unwrap();
+            elem_value.set_enum(&[pos as u32]);
+            Ok(true)
         }
+        _ => Ok(false),
     }
+}
 
-    fn write_standalone_rate(
-        &mut self,
-        req: &FwReq,
-        node: &FwNode,
-        elem_id: &ElemId,
-        elem_value: &ElemValue,
-        timeout_ms: u32,
-    ) -> Result<bool, Error> {
-        match elem_id.name().as_str() {
-            RATE_NAME => {
-                let pos = elem_value.enumerated()[0] as usize;
-                let rate = Self::RATES
-                    .iter()
-                    .nth(pos)
-                    .ok_or_else(|| {
-                        let msg = format!("Invalid index of clock rate: {}", pos);
-                        Error::new(FileError::Inval, &msg)
-                    })
-                    .copied()?;
-                let mut params = self.segment_mut().data.clone();
-                *Self::standalone_rate_mut(&mut params) = rate;
-                let res =
-                    T::update_partial_segment(req, node, &params, self.segment_mut(), timeout_ms);
-                debug!(params = ?self.segment().data, ?res);
-                res.map(|_| true)
-            }
-            _ => Ok(false),
+pub fn write_standalone_rate<T, U>(
+    segment: &mut TcKonnektSegment<U>,
+    req: &FwReq,
+    node: &FwNode,
+    elem_id: &ElemId,
+    elem_value: &ElemValue,
+    timeout_ms: u32,
+) -> Result<bool, Error>
+where
+    T: TcKonnektSegmentOperation<U> + TcKonnektMutableSegmentOperation<U>,
+    U: Debug + Clone + AsRef<TcKonnektStandaloneClockRate> + AsMut<TcKonnektStandaloneClockRate>,
+{
+    match elem_id.name().as_str() {
+        RATE_NAME => {
+            let mut data = segment.data.clone();
+            let pos = elem_value.enumerated()[0] as usize;
+            RATES
+                .iter()
+                .nth(pos)
+                .ok_or_else(|| {
+                    let msg = format!("Invalid index of clock rate: {}", pos);
+                    Error::new(FileError::Inval, &msg)
+                })
+                .map(|&rate| {
+                    *data.as_mut() = rate;
+                })?;
+            let res = T::update_partial_segment(req, node, &data, segment, timeout_ms);
+            debug!(params = ?segment.data, ?res);
+            res.map(|_| true)
         }
+        _ => Ok(false),
     }
 }

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -14,7 +14,7 @@ pub struct Studiok48Model {
     mixer_state_ctl: MixerStateCtl,
     mixer_meter_ctl: MixerMeterCtl,
     phys_out_ctl: PhysOutCtl,
-    ch_strip_state_ctl: ChStripStateCtl,
+    ch_strip_state_ctl: ChStripStateCtl<Studiok48Protocol, StudioChStripStates>,
     ch_strip_meter_ctl: ChStripMeterCtl,
     reverb_state_ctl: ReverbStateCtl<Studiok48Protocol, StudioReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<Studiok48Protocol, StudioReverbMeter>,
@@ -68,9 +68,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
 
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
-        self.ch_strip_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
+        self.ch_strip_state_ctl.load(card_cntr)?;
         self.ch_strip_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| {
@@ -192,7 +190,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.phys_out_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
     }
 
@@ -2697,27 +2695,6 @@ impl PhysOutCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ChStripStateCtl(Studiok48ChStripStatesSegment, Vec<ElemId>);
-
-impl ChStripStateCtlOperation<StudioChStripStates, Studiok48Protocol> for ChStripStateCtl {
-    fn segment(&self) -> &Studiok48ChStripStatesSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut Studiok48ChStripStatesSegment {
-        &mut self.0
-    }
-
-    fn states(params: &StudioChStripStates) -> &[ChStripState] {
-        &params.0
-    }
-
-    fn states_mut(params: &mut StudioChStripStates) -> &mut [ChStripState] {
-        &mut params.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -17,7 +17,7 @@ pub struct Studiok48Model {
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
     reverb_state_ctl: ReverbStateCtl<Studiok48Protocol, StudioReverbState>,
-    reverb_meter_ctl: ReverbMeterCtl,
+    reverb_meter_ctl: ReverbMeterCtl<Studiok48Protocol, StudioReverbMeter>,
     hw_state_ctl: HwStateCtl,
 }
 
@@ -67,9 +67,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         self.phys_out_ctl.load(card_cntr)?;
 
         self.reverb_state_ctl.load(card_cntr)?;
-        self.reverb_meter_ctl
-            .load(card_cntr)
-            .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
+        self.reverb_meter_ctl.load(card_cntr)?;
         self.ch_strip_state_ctl
             .load(card_cntr)
             .map(|notified_elem_id_list| self.ch_strip_state_ctl.1 = notified_elem_id_list)?;
@@ -230,7 +228,7 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
     }
 
@@ -2736,23 +2734,6 @@ impl ChStripMeterCtlOperation<StudioChStripMeters, Studiok48Protocol> for ChStri
     }
 
     fn segment_mut(&mut self) -> &mut TcKonnektSegment<StudioChStripMeters> {
-        &mut self.0
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbMeterCtl(Studiok48ReverbMeterSegment, Vec<ElemId>);
-
-impl ReverbMeterCtlOperation<StudioReverbMeter, Studiok48Protocol> for ReverbMeterCtl {
-    fn meter(&self) -> &ReverbMeter {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<StudioReverbMeter> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<StudioReverbMeter> {
         &mut self.0
     }
 }

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -15,7 +15,7 @@ pub struct Studiok48Model {
     mixer_meter_ctl: MixerMeterCtl,
     phys_out_ctl: PhysOutCtl,
     ch_strip_state_ctl: ChStripStateCtl<Studiok48Protocol, StudioChStripStates>,
-    ch_strip_meter_ctl: ChStripMeterCtl,
+    ch_strip_meter_ctl: ChStripMeterCtl<Studiok48Protocol, StudioChStripMeters>,
     reverb_state_ctl: ReverbStateCtl<Studiok48Protocol, StudioReverbState>,
     reverb_meter_ctl: ReverbMeterCtl<Studiok48Protocol, StudioReverbMeter>,
     hw_state_ctl: HwStateCtl,
@@ -69,11 +69,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
         self.ch_strip_state_ctl.load(card_cntr)?;
-        self.ch_strip_meter_ctl
-            .load(card_cntr)
-            .map(|measured_elem_id_list| {
-                self.ch_strip_meter_ctl.1 = measured_elem_id_list;
-            })?;
+        self.ch_strip_meter_ctl.load(card_cntr)?;
 
         self.hw_state_ctl.load(card_cntr)?;
 
@@ -227,7 +223,7 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
         elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
         elem_id_list.extend_from_slice(&self.mixer_meter_ctl.1);
         elem_id_list.extend_from_slice(&self.reverb_meter_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.1);
+        elem_id_list.extend_from_slice(&self.ch_strip_meter_ctl.elem_id_list);
     }
 
     fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -2695,23 +2691,6 @@ impl PhysOutCtl {
         } else {
             Ok(())
         }
-    }
-}
-
-#[derive(Default, Debug)]
-struct ChStripMeterCtl(Studiok48ChStripMetersSegment, Vec<ElemId>);
-
-impl ChStripMeterCtlOperation<StudioChStripMeters, Studiok48Protocol> for ChStripMeterCtl {
-    fn meters(&self) -> &[ChStripMeter] {
-        &self.0.data.0
-    }
-
-    fn segment(&self) -> &TcKonnektSegment<StudioChStripMeters> {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut TcKonnektSegment<StudioChStripMeters> {
-        &mut self.0
     }
 }
 

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -395,24 +395,6 @@ impl LineoutCtl {
 #[derive(Default, Debug)]
 struct RemoteCtl(Studiok48RemoteSegment, Vec<ElemId>);
 
-impl ProgramCtlOperation<StudioRemote, Studiok48Protocol> for RemoteCtl {
-    fn segment(&self) -> &Studiok48RemoteSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut Studiok48RemoteSegment {
-        &mut self.0
-    }
-
-    fn prog(params: &StudioRemote) -> &TcKonnektLoadedProgram {
-        &params.prog
-    }
-
-    fn prog_mut(params: &mut StudioRemote) -> &mut TcKonnektLoadedProgram {
-        &mut params.prog
-    }
-}
-
 const USER_ASSIGN_NAME: &str = "remote-user-assign";
 const EFFECT_BUTTON_MODE_NAME: &str = "remote-effect-button-mode";
 const FALLBACK_TO_MASTER_ENABLE_NAME: &str = "remote-fallback-to-master-enable";
@@ -450,7 +432,7 @@ impl RemoteCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.load_prog(card_cntr)
+        load_prog::<Studiok48Protocol, StudioRemote>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
         let labels: Vec<String> = MixerStateCtl::SRC_PAIR_ENTRIES
@@ -567,7 +549,7 @@ impl RemoteCtl {
                 elem_value.set_enum(&[pos as u32]);
                 Ok(true)
             }
-            _ => self.read_prog(elem_id, elem_value),
+            _ => read_prog::<Studiok48Protocol, StudioRemote>(&self.0, elem_id, elem_value),
         }
     }
 
@@ -676,7 +658,14 @@ impl RemoteCtl {
                 debug!(params = ?self.0.data, ?res);
                 res.map(|_| true)
             }
-            _ => self.write_prog(req, node, elem_id, elem_value, timeout_ms),
+            _ => write_prog::<Studiok48Protocol, StudioRemote>(
+                &mut self.0,
+                req,
+                node,
+                elem_id,
+                elem_value,
+                timeout_ms,
+            ),
         }
     }
 

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -16,7 +16,7 @@ pub struct Studiok48Model {
     phys_out_ctl: PhysOutCtl,
     ch_strip_state_ctl: ChStripStateCtl,
     ch_strip_meter_ctl: ChStripMeterCtl,
-    reverb_state_ctl: ReverbStateCtl,
+    reverb_state_ctl: ReverbStateCtl<Studiok48Protocol, StudioReverbState>,
     reverb_meter_ctl: ReverbMeterCtl,
     hw_state_ctl: HwStateCtl,
 }
@@ -66,9 +66,7 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
         self.mixer_meter_ctl.load(card_cntr)?;
         self.phys_out_ctl.load(card_cntr)?;
 
-        self.reverb_state_ctl
-            .load(card_cntr)
-            .map(|notified_elem_id_list| self.reverb_state_ctl.1 = notified_elem_id_list)?;
+        self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl
             .load(card_cntr)
             .map(|measured_elem_id_list| self.reverb_meter_ctl.1 = measured_elem_id_list)?;
@@ -195,7 +193,7 @@ impl NotifyModel<(SndDice, FwNode), u32> for Studiok48Model {
         elem_id_list.extend_from_slice(&self.config_ctl.1);
         elem_id_list.extend_from_slice(&self.mixer_state_ctl.1);
         elem_id_list.extend_from_slice(&self.phys_out_ctl.1);
-        elem_id_list.extend_from_slice(&self.reverb_state_ctl.1);
+        elem_id_list.extend_from_slice(&self.reverb_state_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.ch_strip_state_ctl.1);
         elem_id_list.extend_from_slice(&self.hw_state_ctl.1);
     }
@@ -2739,29 +2737,6 @@ impl ChStripMeterCtlOperation<StudioChStripMeters, Studiok48Protocol> for ChStri
 
     fn segment_mut(&mut self) -> &mut TcKonnektSegment<StudioChStripMeters> {
         &mut self.0
-    }
-}
-
-#[derive(Default, Debug)]
-struct ReverbStateCtl(Studiok48ReverbStateSegment, Vec<ElemId>);
-
-impl ReverbStateCtlOpreation<StudioReverbState, StudioReverbMeter, Studiok48Protocol>
-    for ReverbStateCtl
-{
-    fn segment(&self) -> &Studiok48ReverbStateSegment {
-        &self.0
-    }
-
-    fn segment_mut(&mut self) -> &mut Studiok48ReverbStateSegment {
-        &mut self.0
-    }
-
-    fn state(params: &StudioReverbState) -> &ReverbState {
-        &params.0
-    }
-
-    fn state_mut(params: &mut StudioReverbState) -> &mut ReverbState {
-        &mut params.0
     }
 }
 


### PR DESCRIPTION
It is convenient for runtime implementation to use AsRef/AsMut trait implementations
since segment operation can be done transparently. This patchset is for the purpose.

```
Takashi Sakamoto (35):
  runtime/dice: tcelectronic: code refactoring to dispatch arguments in
    common trait implementation
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for state of
    reverb effect
  runtime/dice: tcelectronic: use generic structure for state of reverb
    effect
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for meter of
    reverb effect
  runtime/dice: tcelectronic: use generic structure for meter of reverb
    effect
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for state of
    channel strip effect
  runtime/dice: tcelectronic: use generic structure for state of channel
    strip effect
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for meter of
    channel strip effect
  runtime/dice: tcelectronic: use generic structure for meter of channel
    strip effect
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for meter of
    mixer in shell models
  runtime/dice: tcelectronic: use generic structure for meter of mixer
    in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for state of
    mixer in shell models
  runtime/dice: tcelectronic: use generic functions for state of mixer
    in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for state of
    FireWire LED
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for state of
    hardware in shell models
  runtime/dice: tcelectronic: use generic functions for state of
    hardware
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for rate of
    sampling clock at standalone mode
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for source
    of sampling clock at standalone mode in shell models
  runtime/dice: tcelectronic: use generic functions for sampling clock
    at standalone mode
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for loaded
    program
  runtime/dice: tcelectronic: use generic functions for loaded program
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for MIDI
    message sender
  runtime/dice: tcelectronic: use generic functions for MIDI message
    sender
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for reverb
    return in shell models
  runtime/dice: tcelectronic: use generic functions for reverb return in
    shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for mixer
    stream source in shell models
  runtime/dice: tcelectronic: use generic functions for mixer stream
    source in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for source
    of coaxial output in shell models
  runtime/dice: tcelectronic: use generic functions for source of
    coaxial output in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for optical
    interface parameters in shell models
  runtime/dice: tcelectronic: use generic functions for optical
    interface parameters in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for first
    knob target in shell models
  runtime/dice: tcelectronic: use generic functions for first knob
    target in shell models
  protocols/dice: tcelectronic: implement AsRef/AsMut trait for second
    knob target in shell models
  runtime/dice: tcelectronic: use generic functions for second knob
    target in shell models

 protocols/dice/src/tcelectronic/desktop.rs    |   24 +
 protocols/dice/src/tcelectronic/shell.rs      |   27 +-
 .../dice/src/tcelectronic/shell/itwin.rs      |  144 ++
 protocols/dice/src/tcelectronic/shell/k24d.rs |  192 ++
 protocols/dice/src/tcelectronic/shell/k8.rs   |  108 +
 .../dice/src/tcelectronic/shell/klive.rs      |  216 ++
 protocols/dice/src/tcelectronic/studio.rs     |   96 +
 runtime/dice/src/tcelectronic.rs              |    1 +
 runtime/dice/src/tcelectronic/ch_strip_ctl.rs |  993 ++++----
 .../dice/src/tcelectronic/desktopk6_model.rs  |  126 +-
 runtime/dice/src/tcelectronic/fw_led_ctl.rs   |  131 +-
 runtime/dice/src/tcelectronic/itwin_model.rs  |  546 ++--
 runtime/dice/src/tcelectronic/k24d_model.rs   |  567 ++---
 runtime/dice/src/tcelectronic/k8_model.rs     |  327 +--
 runtime/dice/src/tcelectronic/klive_model.rs  |  625 ++---
 .../dice/src/tcelectronic/midi_send_ctl.rs    |  262 +-
 runtime/dice/src/tcelectronic/prog_ctl.rs     |  125 +-
 runtime/dice/src/tcelectronic/reverb_ctl.rs   |  777 +++---
 runtime/dice/src/tcelectronic/shell_ctl.rs    | 2235 +++++++++--------
 .../dice/src/tcelectronic/standalone_ctl.rs   |  133 +-
 .../dice/src/tcelectronic/studiok48_model.rs  |  370 +--
 21 files changed, 3847 insertions(+), 4178 deletions(-)
```