### PR TITLE
[PATCH 0/2] dice: add support for Weiss Engineering models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
 #    "protocols/motu",
 #    "protocols/oxfw",
 #    "protocols/bebob",
-#    "protocols/dice",
+    "protocols/dice",
 #    "protocols/fireface",
 ]
 
@@ -36,7 +36,7 @@ members = [
 #ta1394-avc-ccm = { path = "protocols/ta1394/ccm" }
 #firewire-bebob-protocols = { path = "protocols/bebob" }
 #firewire-digi00x-protocols = { path = "protocols/digi00x" }
-#firewire-dice-protocols = { path = "protocols/dice" }
+firewire-dice-protocols = { path = "protocols/dice" }
 #firewire-fireworks-protocols = { path = "protocols/fireworks" }
 #firewire-fireface-protocols = { path = "protocols/fireface" }
 #firewire-motu-protocols = { path = "protocols/motu" }

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2023/04/19
+2023/08/22
 Takashi Sakamoto
 
 Introduction
@@ -180,6 +180,12 @@ contact to developer.
   * PreSonus FireStudio Project
   * PreSonus FireStudio Tube
   * PreSonus FireStudio Mobile
+  * Weiss Engineering ADC2
+  * Weiss Engineering Vesta
+  * Weiss Engineering DAC2, Minerva
+  * Weiss Engineering AFI1
+  * Weiss Engineering INT202, INT203, DAC1 FireWire option card
+  * Weiss Engineering DAC202, Maya
   * For the others, common controls are available. If supported, control extension is also available.
 
 * snd-fireface-ctl-service

--- a/protocols/dice/README.md
+++ b/protocols/dice/README.md
@@ -97,6 +97,12 @@ This is the list of models currently supported.
  * PreSonus FireStudio Project
  * PreSonus FireStudio Tube
  * PreSonus FireStudio Mobile
+ * Weiss Engineering ADC2
+ * Weiss Engineering Vesta
+ * Weiss Engineering DAC2, Minerva
+ * Weiss Engineering AFI1
+ * Weiss Engineering INT202, INT203, DAC1 FireWire option card
+ * Weiss Engineering DAC202, Maya
 
 For the other models, implementation for common and extension protocol is available without any
 care of vendor's customization.

--- a/protocols/dice/src/lib.rs
+++ b/protocols/dice/src/lib.rs
@@ -12,6 +12,7 @@ pub mod maudio;
 pub mod presonus;
 pub mod tcat;
 pub mod tcelectronic;
+pub mod weiss;
 
 use {
     glib::Error,

--- a/protocols/dice/src/weiss.rs
+++ b/protocols/dice/src/weiss.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+//! Protocol specific to Weiss Engineering models.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Weiss Engineering.
+
+use super::tcat::{global_section::*, *};
+
+/// Protocol implementation specific to ADC2.
+#[derive(Default, Debug)]
+pub struct WeissAdc2Protocol;
+
+impl TcatOperation for WeissAdc2Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1
+// clock source names: AES12\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\\
+impl TcatGlobalSectionSpecification for WeissAdc2Protocol {}
+
+/// Protocol implementation specific to Vesta.
+#[derive(Default, Debug)]
+pub struct WeissVestaProtocol;
+
+impl TcatOperation for WeissVestaProtocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissVestaProtocol {}
+
+/// Protocol implementation specific to DAC2/Minerva.
+#[derive(Default, Debug)]
+pub struct WeissDac2Protocol;
+
+impl TcatOperation for WeissDac2Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissDac2Protocol {}
+
+/// Protocol implementation specific to AFI1.
+#[derive(Default, Debug)]
+pub struct WeissAfi1Protocol;
+
+impl TcatOperation for WeissAfi1Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 aes4 adat wc internal
+// clock source names: AES12\AES34\AES56\AES78\Unused\ADAT\Unused\Word Clock\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissAfi1Protocol {}
+
+/// Protocol implementation specific to DAC202 and Maya Edition.
+#[derive(Default, Debug)]
+pub struct WeissDac202Protocol;
+
+impl TcatOperation for WeissDac202Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 wc arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Word Clock\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissDac202Protocol {}
+
+/// Protocol implementation specific to INT202, INT203, and FireWire option card for DAC1.
+#[derive(Default, Debug)]
+pub struct WeissInt203Protocol;
+
+impl TcatOperation for WeissInt203Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissInt203Protocol {}

--- a/runtime/dice/src/main.rs
+++ b/runtime/dice/src/main.rs
@@ -15,6 +15,7 @@ mod focusrite;
 mod mbox3_model;
 mod pfire_model;
 mod tcd22xx_ctl;
+mod weiss_model;
 
 use {
     alsa_ctl_tlv_codec::DbInterval,

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -10,7 +10,7 @@ use {
         presonus::fstudiomobile_model::*, presonus::fstudioproject_model::*,
         presonus::fstudiotube_model::*, tcelectronic::desktopk6_model::*,
         tcelectronic::itwin_model::*, tcelectronic::k24d_model::*, tcelectronic::k8_model::*,
-        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, *,
+        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, weiss_model::*, *,
     },
     ieee1212_config_rom::*,
     protocols::tcat::config_rom::*,
@@ -43,6 +43,12 @@ enum Model {
     PresonusFStudioProject(FStudioProjectModel),
     PresonusFStudioTube(FStudioTubeModel),
     PresonusFStudioMobile(FStudioMobileModel),
+    WeissAdc2Model(Adc2Model),
+    WeissVestaModel(VestaModel),
+    WeissDac2Model(Dac2Model),
+    WeissAfi1Model(Afi1Model),
+    WeissDac202Model(Dac202Model),
+    WeissInt203Model(Int203Model),
 }
 
 pub struct DiceModel {
@@ -99,6 +105,14 @@ impl DiceModel {
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
             (0x000a92, 0x00000c) => Model::PresonusFStudioTube(FStudioTubeModel::default()),
             (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
+            (0x001c6a, 0x000001) => Model::WeissAdc2Model(Default::default()),
+            (0x001c6a, 0x000002) => Model::WeissVestaModel(Default::default()),
+            (0x001c6a, 0x000003) => Model::WeissDac2Model(Default::default()),
+            (0x001c6a, 0x000004) => Model::WeissAfi1Model(Default::default()),
+            (0x001c6a, 0x000007) |
+            (0x001c6a, 0x000008) => Model::WeissDac202Model(Default::default()),
+            (0x001c6a, 0x000006) |
+            (0x001c6a, 0x00000a) => Model::WeissInt203Model(Default::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -156,6 +170,12 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => m.cache(unit),
             Model::PresonusFStudioTube(m) => m.cache(unit),
             Model::PresonusFStudioMobile(m) => m.cache(unit),
+            Model::WeissAdc2Model(m) => m.cache(unit),
+            Model::WeissVestaModel(m) => m.cache(unit),
+            Model::WeissDac2Model(m) => m.cache(unit),
+            Model::WeissAfi1Model(m) => m.cache(unit),
+            Model::WeissDac202Model(m) => m.cache(unit),
+            Model::WeissInt203Model(m) => m.cache(unit),
         }
     }
 
@@ -186,6 +206,12 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => m.load(card_cntr),
             Model::PresonusFStudioTube(m) => m.load(card_cntr),
             Model::PresonusFStudioMobile(m) => m.load(card_cntr),
+            Model::WeissAdc2Model(m) => m.load(card_cntr),
+            Model::WeissVestaModel(m) => m.load(card_cntr),
+            Model::WeissDac2Model(m) => m.load(card_cntr),
+            Model::WeissAfi1Model(m) => m.load(card_cntr),
+            Model::WeissDac202Model(m) => m.load(card_cntr),
+            Model::WeissInt203Model(m) => m.load(card_cntr),
         }?;
 
         match &mut self.model {
@@ -218,6 +244,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 m.get_notified_elem_list(&mut self.notified_elem_list)
             }
+            Model::WeissAdc2Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissVestaModel(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissDac2Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissAfi1Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissDac202Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissInt203Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -250,6 +282,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 m.get_measure_elem_list(&mut self.measured_elem_list)
             }
+            Model::WeissAdc2Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissVestaModel(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissDac2Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissAfi1Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissDac202Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissInt203Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -298,6 +336,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.dispatch_elem_event(unit, &elem_id, &events, m)
             }
+            Model::WeissAdc2Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissVestaModel(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissDac2Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissAfi1Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissDac202Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissInt203Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -383,6 +427,24 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
+            Model::WeissAdc2Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissVestaModel(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissDac2Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissAfi1Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissDac202Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissInt203Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
         }
     }
 
@@ -425,6 +487,16 @@ impl DiceModel {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
             Model::PresonusFStudioMobile(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
+            Model::WeissAdc2Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissVestaModel(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissDac2Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissAfi1Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissDac202Model(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
+            Model::WeissInt203Model(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
         }

--- a/runtime/dice/src/weiss_model.rs
+++ b/runtime/dice/src/weiss_model.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2023 Takashi Sakamoto
+
+use {super::*, protocols::weiss::*};
+
+pub type Adc2Model = WeissModel<WeissAdc2Protocol>;
+pub type VestaModel = WeissModel<WeissVestaProtocol>;
+pub type Dac2Model = WeissModel<WeissDac2Protocol>;
+pub type Afi1Model = WeissModel<WeissAfi1Protocol>;
+pub type Dac202Model = WeissModel<WeissDac202Protocol>;
+pub type Int203Model = WeissModel<WeissInt203Protocol>;
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default)]
+pub struct WeissModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    req: FwReq,
+    sections: GeneralSections,
+    common_ctl: CommonCtl<T>,
+}
+
+impl<T> CtlModel<(SndDice, FwNode)> for WeissModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        T::read_general_sections(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
+
+        self.common_ctl
+            .cache_whole_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr)
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        self.common_ctl.read(elem_id, elem_value)
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        new: &ElemValue,
+    ) -> Result<bool, Error> {
+        self.common_ctl.write(
+            &unit,
+            &self.req,
+            &node,
+            &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )
+    }
+}
+
+impl<T> NotifyModel<(SndDice, FwNode), u32> for WeissModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndDice, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
+        self.common_ctl
+            .parse_notification(&self.req, &node, &mut self.sections, *msg, TIMEOUT_MS)
+    }
+}
+
+impl<T> MeasureModel<(SndDice, FwNode)> for WeissModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
+    }
+
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        self.common_ctl
+            .cache_partial_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)
+    }
+}


### PR DESCRIPTION
Hardware specification is provided by Weiss Engineering for some models. The series adds support for models from Weiss Engineering. At present, common functions are available.

```
Takashi Sakamoto (2):
  protocols/dice: weiss: add support for Weiss Engineering models in common protocol
  runtime/dice: weiss: add support for Weiss Engineering models

 Cargo.toml                      |   4 +-
 README.rst                      |  10 ++-
 protocols/dice/README.md        |   8 +++
 protocols/dice/src/lib.rs       |   1 +
 protocols/dice/src/weiss.rs     |  89 ++++++++++++++++++++++++
 runtime/dice/src/main.rs        |   1 +
 runtime/dice/src/model.rs       |  99 ++++++++++++++++++++++++++-
 runtime/dice/src/weiss_model.rs | 116 ++++++++++++++++++++++++++++++++
 8 files changed, 324 insertions(+), 4 deletions(-)
 create mode 100644 protocols/dice/src/weiss.rs
 create mode 100644 runtime/dice/src/weiss_model.rs
```