### PR TITLE
protocols/motu: add support for 896 mk3 (both FireWire only and Hybrid models)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 #    "protocols/digi00x",
 #    "protocols/tascam",
 #    "protocols/fireworks",
-#    "protocols/motu",
+    "protocols/motu",
 #    "protocols/oxfw",
 #    "protocols/bebob",
 #    "protocols/dice",
@@ -39,6 +39,6 @@ members = [
 #firewire-dice-protocols = { path = "protocols/dice" }
 #firewire-fireworks-protocols = { path = "protocols/fireworks" }
 #firewire-fireface-protocols = { path = "protocols/fireface" }
-#firewire-motu-protocols = { path = "protocols/motu" }
+firewire-motu-protocols = { path = "protocols/motu" }
 #firewire-oxfw-protocols = { path = "protocols/oxfw" }
 #firewire-tascam-protocols = { path = "protocols/tascam" }

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2023/11/05
+2024/02/14
 Takashi Sakamoto
 
 Introduction
@@ -108,6 +108,8 @@ contact to developer.
 
     * MOTU 828mk3 (FireWire only)
     * MOTU 828mk3 (Hybrid)
+    * MOTU 896mk3 (FireWire only)
+    * MOTU 896mk3 (Hybrid)
     * MOTU UltraLite mk3 (FireWire only)
     * MOTU UltraLite mk3 (Hybrid)
     * MOTU Traveler mk3
@@ -231,20 +233,25 @@ However, we welcome any assistance that can enhance the project.
     event is converted to controller event with channel 0 which has the consecutive number as param
     and event value. At present, the consecutive number is fixed and not configurable.
 
-* snd-motu-ctl-service
+* snd-firewire-motu-ctl-service
 
+  * For Command DSP models, the monitor functions (the talkback switch, the listenback switch, the
+    talkback volume, the listenback volume, the channel focus, the return assignment) are not
+    operable yet. (The developer completely forgot to implement them.)
   * Due to hardware design, most controls, including hardware metering, are not synchronized to
     hardware expectedly for Register DSP models unless an ALSA PCM application initiates isochronous
     communication.
   * Due to hardware design, hardware metering may not work properly for Command DSP models unless an
     ALSA PCM application initiates isochronous communication.
-  * The channel positionss available in the hardware meter is not adequate in all Command DSP
+  * The channel positions available in the hardware meter is not adequate in all Command DSP
     models.
   * Sometimes, there may be an issue with initializing Command DSP models for communication. In such
     case, the workaround is to simply restart the service program.
-  * 896 mk3 (FireWire only/Hybrid) is not supported since developer has no change to access to it..
   * Due to hardware quirk of Audio Express, asynchronous communication often fails with
     ``unsolicited response`` system message.
+  * Due to asynchronous transaction failure (busy), for Command DSP models, the port assignments, the
+    phone assignments, the configuration for word clock output, and the configuration of programmable
+    level meter are not synchronized expectedly to any action in hardware surface.
 
 * snd-fireface-ctl-service
 

--- a/protocols/motu/README.md
+++ b/protocols/motu/README.md
@@ -81,6 +81,8 @@ This is the list of models currently supported.
  * MOTU AudioExpress
  * MOTU 828mk3 (FireWire only)
  * MOTU 828mk3 (Hybrid)
+ * MOTU 896mk3 (FireWire only)
+ * MOTU 896mk3 (Hybrid)
  * MOTU UltraLite mk3 (FireWire only)
  * MOTU UltraLite mk3 (Hybrid)
  * MOTU Traveler mk3

--- a/protocols/motu/src/lib.rs
+++ b/protocols/motu/src/lib.rs
@@ -482,10 +482,16 @@ impl Default for LevelMetersHoldTimeMode {
 pub enum LevelMetersProgrammableMode {
     /// For analog outputs.
     AnalogOutput,
-    /// For ADAT inputs.
-    AdatInput,
-    /// For ADAT outputs.
-    AdatOutput,
+    /// For ADAT A inputs.
+    AdatAInput,
+    /// For ADAT A outputs.
+    AdatAOutput,
+    /// For ADAT B inputs.
+    AdatBInput,
+    /// For ADAT B outputs.
+    AdatBOutput,
+    /// For AES/EBU inputs and outputs.
+    AesEbuInputOutput,
 }
 
 impl Default for LevelMetersProgrammableMode {
@@ -539,7 +545,7 @@ const LEVEL_METERS_AESEBU_VALS: &[u8] = &[0x00, 0x01];
 
 const LEVEL_METERS_PROGRAMMABLE_MASK: u32 = 0x00000003;
 const LEVEL_METERS_PROGRAMMABLE_SHIFT: usize = 0;
-const LEVEL_METERS_PROGRAMMABLE_VALS: &[u8] = &[0x00, 0x01, 0x02];
+const LEVEL_METERS_PROGRAMMABLE_VALS: &[u8] = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
 
 const LEVEL_METERS_PEAK_HOLD_TIME_LABEL: &str = "level-meters-peak-hold-time";
 const LEVEL_METERS_CLIP_HOLD_TIME_LABEL: &str = "level-meters-clip-hold-time";
@@ -562,11 +568,7 @@ pub trait MotuLevelMetersSpecification {
     const LEVEL_METERS_AESEBU_MODES: &'static [LevelMetersAesebuMode] =
         &[LevelMetersAesebuMode::Output, LevelMetersAesebuMode::Input];
 
-    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode] = &[
-        LevelMetersProgrammableMode::AnalogOutput,
-        LevelMetersProgrammableMode::AdatInput,
-        LevelMetersProgrammableMode::AdatOutput,
-    ];
+    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode];
 }
 
 impl<O> MotuWhollyCacheableParamsOperation<LevelMetersParameters> for O

--- a/protocols/motu/src/version_1.rs
+++ b/protocols/motu/src/version_1.rs
@@ -741,7 +741,13 @@ impl MotuAesebuRateConvertSpecification for F896Protocol {
     const AESEBU_RATE_CONVERT_SHIFT: usize = 5;
 }
 
-impl MotuLevelMetersSpecification for F896Protocol {}
+impl MotuLevelMetersSpecification for F896Protocol {
+    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode] = &[
+        LevelMetersProgrammableMode::AnalogOutput,
+        LevelMetersProgrammableMode::AdatAInput,
+        LevelMetersProgrammableMode::AdatAOutput,
+    ];
+}
 
 #[cfg(test)]
 mod test {

--- a/protocols/motu/src/version_2.rs
+++ b/protocols/motu/src/version_2.rs
@@ -964,7 +964,13 @@ impl MotuAesebuRateConvertSpecification for F896hdProtocol {
     const AESEBU_RATE_CONVERT_SHIFT: usize = 8;
 }
 
-impl MotuLevelMetersSpecification for F896hdProtocol {}
+impl MotuLevelMetersSpecification for F896hdProtocol {
+    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode] = &[
+        LevelMetersProgrammableMode::AnalogOutput,
+        LevelMetersProgrammableMode::AdatAInput,
+        LevelMetersProgrammableMode::AdatAOutput,
+    ];
+}
 
 impl MotuVersion2ClockSpecification for F896hdProtocol {
     const CLK_RATES: &'static [ClkRate] = &[

--- a/protocols/motu/src/version_3.rs
+++ b/protocols/motu/src/version_3.rs
@@ -892,6 +892,526 @@ impl MotuRegisterDspMeterSpecification for H4preProtocol {
     const OUTPUT_PORT_PAIR_POS: &'static [[usize; 2]] = &[[0, 1], [2, 3], [10, 11], [12, 13]];
 }
 
+const F896_MK3_ASSIGN_PORT_TARGETS: &[TargetPort] = &[
+    TargetPort::MainPair,      // = Stream-0/1
+    TargetPort::AnalogPair(0), // = Stream-2/3
+    TargetPort::AnalogPair(1), // = Stream-4/5
+    TargetPort::AnalogPair(2), // = Stream-6/7
+    TargetPort::AnalogPair(3), // = Stream-8/9
+    TargetPort::AesEbuPair,    // = Stream-10/11
+    TargetPort::SpdifPair,     // = Stream-12/13
+    TargetPort::PhonePair,     // = Stream-14/15
+    // = Stream-16/17 for dummy
+    TargetPort::OpticalAPair(0), // = Stream-18/19
+    TargetPort::OpticalAPair(1), // = Stream-20/21
+    TargetPort::OpticalAPair(2), // = Stream-22/23
+    TargetPort::OpticalAPair(3), // = Stream-24/25
+    TargetPort::OpticalBPair(0), // = Stream-26/27
+    TargetPort::OpticalBPair(1), // = Stream-28/29
+    TargetPort::OpticalBPair(2), // = Stream-30/31
+    TargetPort::OpticalBPair(3), // = Stream-32/33
+];
+
+const F896_MK3_ASSIGN_PORT_VALS: &[u8] = &[
+    0x00, // = Stream-0/1
+    0x01, // = Stream-2/3
+    0x02, // = Stream-4/5
+    0x03, // = Stream-6/7
+    0x04, // = Stream-8/9
+    0x05, // = Stream-10/11
+    0x06, // = Stream-12/13
+    0x07, // = Stream-14/15
+    0x08, // = Stream-18/19
+    0x09, // = Stream-20/21
+    0x0a, // = Stream-22/23
+    0x0b, // = Stream-24/25
+    0x0c, // = Stream-26/27
+    0x0d, // = Stream-28/29
+    0x0e, // = Stream-30/31
+    0x0f, // = Stream-32/33
+];
+
+const F896_MK3_CLOCK_RATES: &[ClkRate] = &[
+    ClkRate::R44100,
+    ClkRate::R48000,
+    ClkRate::R88200,
+    ClkRate::R96000,
+    ClkRate::R176400,
+    ClkRate::R192000,
+];
+
+const F896_MK3_CLOCK_RATE_VALS: &[u8] = &[0x00, 0x01, 0x02, 0x03, 0x04, 0x05];
+
+const F896_MK3_CLOCK_SRCS: &[V3ClkSrc] = &[
+    V3ClkSrc::Internal,
+    V3ClkSrc::WordClk,
+    V3ClkSrc::AesEbuXlr,
+    V3ClkSrc::SpdifCoax,
+    V3ClkSrc::SignalOptA,
+    V3ClkSrc::SignalOptB,
+];
+
+const F896_MK3_CLOCK_SRC_VALS: &[u8] = &[0x00, 0x01, 0x08, 0x10, 0x18, 0x19];
+
+const F896_MK3_RETURN_ASSIGN_TARGETS: &[TargetPort] = &[
+    TargetPort::MainPair,
+    TargetPort::AnalogPair(0),
+    TargetPort::AnalogPair(1),
+    TargetPort::AnalogPair(2),
+    TargetPort::AnalogPair(3),
+    TargetPort::AesEbuPair,
+    TargetPort::SpdifPair,
+    TargetPort::PhonePair,
+    TargetPort::OpticalAPair(0),
+    TargetPort::OpticalAPair(1),
+    TargetPort::OpticalAPair(2),
+    TargetPort::OpticalAPair(3),
+    TargetPort::OpticalBPair(0),
+    TargetPort::OpticalBPair(1),
+    TargetPort::OpticalBPair(2),
+    TargetPort::OpticalBPair(3),
+];
+
+const F896_MK3_MIXER_SOURCE_PORTS: &[TargetPort] = &[
+    TargetPort::Analog(0),
+    TargetPort::Analog(1),
+    TargetPort::Analog(2),
+    TargetPort::Analog(3),
+    TargetPort::Analog(4),
+    TargetPort::Analog(5),
+    TargetPort::Analog(6),
+    TargetPort::Analog(7),
+    TargetPort::Analog(8),
+    TargetPort::Analog(9),
+    TargetPort::AesEbu(0),
+    TargetPort::AesEbu(1),
+    TargetPort::Spdif(0),
+    TargetPort::Spdif(1),
+    TargetPort::OpticalA(0),
+    TargetPort::OpticalA(1),
+    TargetPort::OpticalA(2),
+    TargetPort::OpticalA(3),
+    TargetPort::OpticalA(4),
+    TargetPort::OpticalA(5),
+    TargetPort::OpticalA(6),
+    TargetPort::OpticalA(7),
+    TargetPort::OpticalB(0),
+    TargetPort::OpticalB(1),
+    TargetPort::OpticalB(2),
+    TargetPort::OpticalB(3),
+    TargetPort::OpticalB(4),
+    TargetPort::OpticalB(5),
+    TargetPort::OpticalB(6),
+    TargetPort::OpticalB(7),
+];
+
+const F896_MK3_MIXER_OUTPUT_PORTS: &[TargetPort] = &[
+    TargetPort::Disabled,
+    TargetPort::MainPair,
+    TargetPort::AnalogPair(0),
+    TargetPort::AnalogPair(1),
+    TargetPort::AnalogPair(2),
+    TargetPort::AnalogPair(3),
+    TargetPort::AesEbuPair,
+    TargetPort::SpdifPair,
+    TargetPort::PhonePair,
+    TargetPort::OpticalAPair(0),
+    TargetPort::OpticalAPair(1),
+    TargetPort::OpticalAPair(2),
+    TargetPort::OpticalAPair(3),
+    TargetPort::OpticalBPair(0),
+    TargetPort::OpticalBPair(1),
+    TargetPort::OpticalBPair(2),
+    TargetPort::OpticalBPair(3),
+];
+
+const F896_MK3_INPUT_PORTS: &[TargetPort] = &[
+    TargetPort::Analog(0),
+    TargetPort::Analog(1),
+    TargetPort::Analog(2),
+    TargetPort::Analog(3),
+    TargetPort::Analog(4),
+    TargetPort::Analog(5),
+    TargetPort::Analog(6),
+    TargetPort::Analog(7),
+    TargetPort::Analog(8),
+    TargetPort::Analog(9),
+    TargetPort::AesEbu(0),
+    TargetPort::AesEbu(1),
+    TargetPort::Spdif(0),
+    TargetPort::Spdif(1),
+    TargetPort::OpticalA(0),
+    TargetPort::OpticalA(1),
+    TargetPort::OpticalA(2),
+    TargetPort::OpticalA(3),
+    TargetPort::OpticalA(4),
+    TargetPort::OpticalA(5),
+    TargetPort::OpticalA(6),
+    TargetPort::OpticalA(7),
+    TargetPort::OpticalB(0),
+    TargetPort::OpticalB(1),
+    TargetPort::OpticalB(2),
+    TargetPort::OpticalB(3),
+    TargetPort::OpticalB(4),
+    TargetPort::OpticalB(5),
+    TargetPort::OpticalB(6),
+    TargetPort::OpticalB(7),
+];
+
+const F896_MK3_OUTPUT_PORTS: &[TargetPort] = &[
+    TargetPort::MainPair,
+    TargetPort::AnalogPair(0),
+    TargetPort::AnalogPair(1),
+    TargetPort::AnalogPair(2),
+    TargetPort::AnalogPair(3),
+    TargetPort::AesEbuPair,
+    TargetPort::SpdifPair,
+    TargetPort::PhonePair,
+    TargetPort::OpticalAPair(0),
+    TargetPort::OpticalAPair(1),
+    TargetPort::OpticalAPair(2),
+    TargetPort::OpticalAPair(3),
+    TargetPort::OpticalBPair(0),
+    TargetPort::OpticalBPair(1),
+    TargetPort::OpticalBPair(2),
+    TargetPort::OpticalBPair(3),
+];
+
+const F896_MK3_METER_INPUT_PORTS: &[(TargetPort, usize)] = &[
+    (TargetPort::Analog(0), 8),
+    (TargetPort::Analog(1), 9),
+    (TargetPort::Analog(2), 10),
+    (TargetPort::Analog(3), 11),
+    (TargetPort::Analog(4), 12),
+    (TargetPort::Analog(5), 13),
+    (TargetPort::Analog(6), 14),
+    (TargetPort::Analog(7), 15),
+    (TargetPort::AesEbu(0), 18),
+    (TargetPort::AesEbu(1), 19),
+    (TargetPort::Spdif(0), 16),
+    (TargetPort::Spdif(1), 17),
+    (TargetPort::OpticalA(0), 20),
+    (TargetPort::OpticalA(1), 21),
+    (TargetPort::OpticalA(2), 22),
+    (TargetPort::OpticalA(3), 23),
+    (TargetPort::OpticalA(4), 24),
+    (TargetPort::OpticalA(5), 25),
+    (TargetPort::OpticalA(6), 26),
+    (TargetPort::OpticalA(7), 27),
+    (TargetPort::OpticalB(0), 28),
+    (TargetPort::OpticalB(1), 29),
+    (TargetPort::OpticalB(2), 30),
+    (TargetPort::OpticalB(3), 31),
+    (TargetPort::OpticalB(4), 32),
+    (TargetPort::OpticalB(5), 33),
+    (TargetPort::OpticalB(6), 34),
+    (TargetPort::OpticalB(7), 35),
+];
+
+const F896_MK3_METER_OUTPUT_PORTS: &[(TargetPort, usize)] = &[
+    (TargetPort::Main(0), 82),
+    (TargetPort::Main(1), 83),
+    (TargetPort::Analog(0), 84),
+    (TargetPort::Analog(1), 85),
+    (TargetPort::Analog(2), 86),
+    (TargetPort::Analog(3), 87),
+    (TargetPort::Analog(4), 88),
+    (TargetPort::Analog(5), 89),
+    (TargetPort::Analog(6), 90),
+    (TargetPort::Analog(7), 91),
+    (TargetPort::AesEbu(0), 92),
+    (TargetPort::AesEbu(1), 93),
+    (TargetPort::Spdif(0), 80),
+    (TargetPort::Spdif(1), 81),
+    (TargetPort::Phone(0), 94),
+    (TargetPort::Phone(1), 95),
+    (TargetPort::OpticalA(0), 96),
+    (TargetPort::OpticalA(1), 97),
+    (TargetPort::OpticalA(2), 98),
+    (TargetPort::OpticalA(3), 99),
+    (TargetPort::OpticalA(4), 100),
+    (TargetPort::OpticalA(5), 101),
+    (TargetPort::OpticalA(6), 102),
+    (TargetPort::OpticalA(7), 103),
+    (TargetPort::OpticalB(0), 104),
+    (TargetPort::OpticalB(1), 105),
+    (TargetPort::OpticalB(2), 106),
+    (TargetPort::OpticalB(3), 107),
+    (TargetPort::OpticalB(4), 108),
+    (TargetPort::OpticalB(5), 109),
+    (TargetPort::OpticalB(6), 110),
+    (TargetPort::OpticalB(7), 111),
+];
+
+const F896_MK3_LEVEL_METERS_PROGRAMMABLE_MODES: &[LevelMetersProgrammableMode] = &[
+    LevelMetersProgrammableMode::AnalogOutput,
+    LevelMetersProgrammableMode::AdatAInput,
+    LevelMetersProgrammableMode::AdatAOutput,
+    LevelMetersProgrammableMode::AdatBInput,
+    LevelMetersProgrammableMode::AdatBOutput,
+    LevelMetersProgrammableMode::AesEbuInputOutput,
+];
+
+const F896_MK3_OFFSET_AES_EBU_RATE_CONVERTER: u32 = 0x0c90;
+
+const F896_MK3_NOTIFY_PORT_CHANGE_MASK: u32 = 0x40000000;
+
+const F896_MK3_NOTIFY_FOOTSWITCH_MASK: u32 = 0x01000000;
+
+/// Mode of rate convert for AES/EBU input/output signals.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum F896mk3AesebuRateConvertMode {
+    /// Not available.
+    None,
+    /// The rate of input signal is converted to system rate.
+    InputToSystem,
+    /// The rate of output signal is slave to input, ignoring system rate.
+    OutputDependsInput,
+    /// The rate of output signal is at 44.1 kHz.
+    Output441,
+    /// The rate of output signal is at 48.0 kHz.
+    Output480,
+    /// The rate of output signal is at 88.2 kHz.
+    Output882,
+    /// The rate of output signal is at 96.0 kHz.
+    Output960,
+}
+
+impl Default for F896mk3AesebuRateConvertMode {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// The trait for specification of AES/EBU sampling rate converter in F896mk3.
+pub trait F896mk3AesebuRateConvertSpecification {}
+
+fn serialize_f896mk3_aes_ebu_rate_converter_mode(
+    mode: &mut F896mk3AesebuRateConvertMode,
+    quad: &u32,
+) {
+    *mode = match quad {
+        6 => F896mk3AesebuRateConvertMode::Output960,
+        5 => F896mk3AesebuRateConvertMode::Output882,
+        4 => F896mk3AesebuRateConvertMode::Output480,
+        3 => F896mk3AesebuRateConvertMode::Output441,
+        2 => F896mk3AesebuRateConvertMode::OutputDependsInput,
+        1 => F896mk3AesebuRateConvertMode::InputToSystem,
+        _ => F896mk3AesebuRateConvertMode::None,
+    }
+}
+
+fn deserialize_f896mk3_aes_ebu_rate_converter_mode(
+    mode: &F896mk3AesebuRateConvertMode,
+    quad: &mut u32,
+) {
+    *quad = match mode {
+        F896mk3AesebuRateConvertMode::Output960 => 6,
+        F896mk3AesebuRateConvertMode::Output882 => 5,
+        F896mk3AesebuRateConvertMode::Output480 => 4,
+        F896mk3AesebuRateConvertMode::Output441 => 3,
+        F896mk3AesebuRateConvertMode::OutputDependsInput => 2,
+        F896mk3AesebuRateConvertMode::InputToSystem => 1,
+        F896mk3AesebuRateConvertMode::None => 0,
+    };
+}
+
+impl<O> MotuWhollyCacheableParamsOperation<F896mk3AesebuRateConvertMode> for O
+where
+    O: F896mk3AesebuRateConvertSpecification,
+{
+    fn cache_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        mode: &mut F896mk3AesebuRateConvertMode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let quad = read_quad(
+            req,
+            node,
+            F896_MK3_OFFSET_AES_EBU_RATE_CONVERTER,
+            timeout_ms,
+        )?;
+        serialize_f896mk3_aes_ebu_rate_converter_mode(mode, &quad);
+        Ok(())
+    }
+}
+
+impl<O> MotuWhollyUpdatableParamsOperation<F896mk3AesebuRateConvertMode> for O
+where
+    O: F896mk3AesebuRateConvertSpecification,
+{
+    fn update_wholly(
+        req: &mut FwReq,
+        node: &mut FwNode,
+        mode: &F896mk3AesebuRateConvertMode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut quad = read_quad(
+            req,
+            node,
+            F896_MK3_OFFSET_AES_EBU_RATE_CONVERTER,
+            timeout_ms,
+        )?;
+        deserialize_f896mk3_aes_ebu_rate_converter_mode(mode, &mut quad);
+        write_quad(
+            req,
+            node,
+            F896_MK3_OFFSET_AES_EBU_RATE_CONVERTER,
+            quad,
+            timeout_ms,
+        )
+    }
+}
+
+/// The protocol implementation for 896 mk3 (FireWire only).
+#[derive(Default, Debug)]
+pub struct F896mk3Protocol;
+
+impl MotuPortAssignSpecification for F896mk3Protocol {
+    const ASSIGN_PORT_TARGETS: &'static [TargetPort] = F896_MK3_ASSIGN_PORT_TARGETS;
+    const ASSIGN_PORT_VALS: &'static [u8] = F896_MK3_ASSIGN_PORT_VALS;
+}
+
+impl MotuWordClockOutputSpecification for F896mk3Protocol {}
+
+impl MotuClockNameDisplaySpecification for F896mk3Protocol {}
+
+impl MotuVersion3ClockSpecification for F896mk3Protocol {
+    const CLOCK_RATES: &'static [ClkRate] = F896_MK3_CLOCK_RATES;
+    const CLOCK_RATE_VALS: &'static [u8] = F896_MK3_CLOCK_RATE_VALS;
+
+    const CLOCK_SRCS: &'static [V3ClkSrc] = F896_MK3_CLOCK_SRCS;
+    const CLOCK_SRC_VALS: &'static [u8] = F896_MK3_CLOCK_SRC_VALS;
+}
+
+impl MotuVersion3OpticalIfaceSpecification for F896mk3Protocol {
+    const OPT_IFACE_COUNT: usize = 2;
+}
+
+impl CommandDspOperation for F896mk3Protocol {}
+
+impl MotuCommandDspReverbSpecification for F896mk3Protocol {}
+
+impl MotuCommandDspMonitorSpecification for F896mk3Protocol {
+    const RETURN_ASSIGN_TARGETS: &'static [TargetPort] = F896_MK3_RETURN_ASSIGN_TARGETS;
+}
+
+impl MotuCommandDspMixerSpecification for F896mk3Protocol {
+    const SOURCE_PORTS: &'static [TargetPort] = F896_MK3_MIXER_SOURCE_PORTS;
+    const OUTPUT_PORTS: &'static [TargetPort] = F896_MK3_MIXER_OUTPUT_PORTS;
+}
+
+impl MotuCommandDspEqualizerSpecification for F896mk3Protocol {}
+
+impl MotuCommandDspDynamicsSpecification for F896mk3Protocol {}
+
+impl MotuCommandDspInputSpecification for F896mk3Protocol {
+    const INPUT_PORTS: &'static [TargetPort] = F896_MK3_INPUT_PORTS;
+    const MIC_COUNT: usize = 0;
+    const LINE_INPUT_COUNT: usize = 0;
+}
+
+impl MotuCommandDspOutputSpecification for F896mk3Protocol {
+    const OUTPUT_PORTS: &'static [TargetPort] = F896_MK3_OUTPUT_PORTS;
+}
+
+impl MotuCommandDspMeterSpecification for F896mk3Protocol {
+    const INPUT_PORTS: &'static [(TargetPort, usize)] = F896_MK3_METER_INPUT_PORTS;
+    const OUTPUT_PORTS: &'static [(TargetPort, usize)] = F896_MK3_METER_OUTPUT_PORTS;
+}
+
+impl MotuLevelMetersSpecification for F896mk3Protocol {
+    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode] =
+        F896_MK3_LEVEL_METERS_PROGRAMMABLE_MODES;
+}
+
+impl F896mk3AesebuRateConvertSpecification for F896mk3Protocol {}
+
+impl F896mk3Protocol {
+    /// Notification mask for main assignment, return assignment, and phone assignment, as well as
+    /// programmable level meter. The change of phone assignment is also notified in command
+    /// message.
+    pub const NOTIFY_PORT_CHANGE_MASK: u32 = F896_MK3_NOTIFY_PORT_CHANGE_MASK;
+
+    /// Notification mask for footswitch.
+    pub const NOTIFY_FOOTSWITCH_MASK: u32 = F896_MK3_NOTIFY_FOOTSWITCH_MASK;
+}
+
+/// The protocol implementation for 896 mk3 (Hybrid).
+#[derive(Default, Debug)]
+pub struct F896mk3HybridProtocol;
+
+impl MotuPortAssignSpecification for F896mk3HybridProtocol {
+    const ASSIGN_PORT_TARGETS: &'static [TargetPort] = F896_MK3_ASSIGN_PORT_TARGETS;
+    const ASSIGN_PORT_VALS: &'static [u8] = F896_MK3_ASSIGN_PORT_VALS;
+}
+
+impl MotuWordClockOutputSpecification for F896mk3HybridProtocol {}
+
+impl MotuClockNameDisplaySpecification for F896mk3HybridProtocol {}
+
+impl MotuVersion3ClockSpecification for F896mk3HybridProtocol {
+    const CLOCK_RATES: &'static [ClkRate] = F896_MK3_CLOCK_RATES;
+    const CLOCK_RATE_VALS: &'static [u8] = F896_MK3_CLOCK_RATE_VALS;
+
+    const CLOCK_SRCS: &'static [V3ClkSrc] = F896_MK3_CLOCK_SRCS;
+    const CLOCK_SRC_VALS: &'static [u8] = F896_MK3_CLOCK_SRC_VALS;
+}
+
+impl MotuVersion3OpticalIfaceSpecification for F896mk3HybridProtocol {
+    const OPT_IFACE_COUNT: usize = 2;
+}
+
+impl CommandDspOperation for F896mk3HybridProtocol {}
+
+impl MotuCommandDspReverbSpecification for F896mk3HybridProtocol {}
+
+impl MotuCommandDspMonitorSpecification for F896mk3HybridProtocol {
+    const RETURN_ASSIGN_TARGETS: &'static [TargetPort] = F896_MK3_RETURN_ASSIGN_TARGETS;
+}
+
+impl MotuCommandDspMixerSpecification for F896mk3HybridProtocol {
+    const SOURCE_PORTS: &'static [TargetPort] = F896_MK3_MIXER_SOURCE_PORTS;
+    const OUTPUT_PORTS: &'static [TargetPort] = F896_MK3_MIXER_OUTPUT_PORTS;
+}
+
+impl MotuCommandDspEqualizerSpecification for F896mk3HybridProtocol {}
+
+impl MotuCommandDspDynamicsSpecification for F896mk3HybridProtocol {}
+
+impl MotuCommandDspInputSpecification for F896mk3HybridProtocol {
+    const INPUT_PORTS: &'static [TargetPort] = F896_MK3_INPUT_PORTS;
+    const MIC_COUNT: usize = 0;
+    const LINE_INPUT_COUNT: usize = 0;
+}
+
+impl MotuCommandDspOutputSpecification for F896mk3HybridProtocol {
+    const OUTPUT_PORTS: &'static [TargetPort] = F896_MK3_OUTPUT_PORTS;
+}
+
+impl MotuCommandDspMeterSpecification for F896mk3HybridProtocol {
+    const INPUT_PORTS: &'static [(TargetPort, usize)] = F896_MK3_METER_INPUT_PORTS;
+    const OUTPUT_PORTS: &'static [(TargetPort, usize)] = F896_MK3_METER_OUTPUT_PORTS;
+}
+
+impl MotuLevelMetersSpecification for F896mk3HybridProtocol {
+    const LEVEL_METERS_PROGRAMMABLE_MODES: &'static [LevelMetersProgrammableMode] =
+        F896_MK3_LEVEL_METERS_PROGRAMMABLE_MODES;
+}
+
+impl F896mk3AesebuRateConvertSpecification for F896mk3HybridProtocol {}
+
+impl F896mk3HybridProtocol {
+    /// Notification mask for main assignment, return assignment, and phone assignment, as well as
+    /// programmable level meter. The change of phone assignment is also notified in command
+    /// message.
+    pub const NOTIFY_PORT_CHANGE_MASK: u32 = F896_MK3_NOTIFY_PORT_CHANGE_MASK;
+
+    /// Notification mask for footswitch.
+    pub const NOTIFY_FOOTSWITCH_MASK: u32 = F896_MK3_NOTIFY_FOOTSWITCH_MASK;
+}
+
 /// The protocol implementation for Ultralite mk3 (FireWire only).
 #[derive(Default, Debug)]
 pub struct UltraliteMk3Protocol;

--- a/runtime/motu/src/command_dsp_runtime.rs
+++ b/runtime/motu/src/command_dsp_runtime.rs
@@ -3,8 +3,9 @@
 
 pub(crate) use {
     super::{
-        f828mk3_hybrid_model::*, f828mk3_model::*, track16_model::*, traveler_mk3_model::*,
-        ultralite_mk3_hybrid_model::*, ultralite_mk3_model::*, *,
+        f828mk3_hybrid_model::*, f828mk3_model::*, f896mk3_hybrid_model::*, f896mk3_model::*,
+        track16_model::*, traveler_mk3_model::*, ultralite_mk3_hybrid_model::*,
+        ultralite_mk3_model::*, *,
     },
     alsactl::{prelude::*, *},
     hinawa::{prelude::FwRespExtManual, FwRcode, FwResp, FwTcode},
@@ -27,6 +28,8 @@ pub type UltraliteMk3Runtime = Version3Runtime<UltraliteMk3Model>;
 pub type UltraliteMk3HybridRuntime = Version3Runtime<UltraliteMk3HybridModel>;
 pub type F828mk3Runtime = Version3Runtime<F828mk3Model>;
 pub type F828mk3HybridRuntime = Version3Runtime<F828mk3HybridModel>;
+pub type F896mk3Runtime = Version3Runtime<F896mk3Model>;
+pub type F896mk3HybridRuntime = Version3Runtime<F896mk3HybridModel>;
 pub type TravelerMk3Runtime = Version3Runtime<TravelerMk3Model>;
 pub type Track16Runtime = Version3Runtime<Track16Model>;
 

--- a/runtime/motu/src/common_ctls.rs
+++ b/runtime/motu/src/common_ctls.rs
@@ -318,11 +318,29 @@ fn level_meters_aesebu_mode_to_string(mode: &LevelMetersAesebuMode) -> &'static 
     }
 }
 
-fn level_meters_programmable_mode_to_string(mode: &LevelMetersProgrammableMode) -> &'static str {
+fn level_meters_programmable_mode_to_string(
+    mode: &LevelMetersProgrammableMode,
+    has_opt_b_iface: bool,
+) -> &'static str {
     match mode {
         LevelMetersProgrammableMode::AnalogOutput => "analog-output",
-        LevelMetersProgrammableMode::AdatInput => "ADAT-input",
-        LevelMetersProgrammableMode::AdatOutput => "ADAT-output",
+        LevelMetersProgrammableMode::AdatAInput => {
+            if has_opt_b_iface {
+                "ADAT-A-input"
+            } else {
+                "ADAT-input"
+            }
+        }
+        LevelMetersProgrammableMode::AdatAOutput => {
+            if has_opt_b_iface {
+                "ADAT-A-output"
+            } else {
+                "ADAT-output"
+            }
+        }
+        LevelMetersProgrammableMode::AdatBInput => "ADAT-B-input",
+        LevelMetersProgrammableMode::AdatBOutput => "ADAT-B-output",
+        LevelMetersProgrammableMode::AesEbuInputOutput => "AES/EBU-input/output",
     }
 }
 
@@ -372,9 +390,14 @@ where
             .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
             .map(|mut elem_id_list| self.elem_id_list.append(&mut elem_id_list))?;
 
+        let has_opt_b_iface = T::LEVEL_METERS_PROGRAMMABLE_MODES.iter().any(|&mode| {
+            mode == LevelMetersProgrammableMode::AdatBInput
+                || mode == LevelMetersProgrammableMode::AdatBOutput
+        });
+
         let labels: Vec<&str> = T::LEVEL_METERS_PROGRAMMABLE_MODES
             .iter()
-            .map(|l| level_meters_programmable_mode_to_string(&l))
+            .map(|l| level_meters_programmable_mode_to_string(&l, has_opt_b_iface))
             .collect();
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, PROGRAMMABLE_MODE_NAME, 0);
         card_cntr

--- a/runtime/motu/src/f896mk3_hybrid_model.rs
+++ b/runtime/motu/src/f896mk3_hybrid_model.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default, Debug)]
+pub struct F896mk3HybridModel {
+    req: FwReq,
+    resp: FwResp,
+    clk_ctls: V3LcdClkCtl<F896mk3HybridProtocol>,
+    port_assign_ctl: V3PortAssignCtl<F896mk3HybridProtocol>,
+    opt_iface_ctl: V3OptIfaceCtl<F896mk3HybridProtocol>,
+    phone_assign_ctl: PhoneAssignCtl<F896mk3HybridProtocol>,
+    word_clk_ctl: WordClockCtl<F896mk3HybridProtocol>,
+    sequence_number: u8,
+    reverb_ctl: CommandDspReverbCtl<F896mk3HybridProtocol>,
+    monitor_ctl: CommandDspMonitorCtl<F896mk3HybridProtocol>,
+    mixer_ctl: CommandDspMixerCtl<F896mk3HybridProtocol>,
+    input_ctl: CommandDspInputCtl<F896mk3HybridProtocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<F896mk3HybridProtocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<F896mk3HybridProtocol>,
+    output_ctl: CommandDspOutputCtl<F896mk3HybridProtocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<F896mk3HybridProtocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<F896mk3HybridProtocol>,
+    resource_ctl: CommandDspResourceCtl,
+    level_meters_ctl: LevelMetersCtl<F896mk3HybridProtocol>,
+    meter_ctl: CommandDspMeterCtl<F896mk3HybridProtocol>,
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F896mk3HybridModel {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.port_assign_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.phone_assign_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.level_meters_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.clk_ctls.load(card_cntr)?;
+        self.port_assign_ctl.load(card_cntr)?;
+        self.opt_iface_ctl.load(card_cntr)?;
+        self.phone_assign_ctl.load(card_cntr)?;
+        self.word_clk_ctl.load(card_cntr)?;
+        self.reverb_ctl.load(card_cntr)?;
+        self.monitor_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
+        self.input_ctl.load(card_cntr)?;
+        self.input_eq_ctl.load(card_cntr)?;
+        self.input_dyn_ctl.load(card_cntr)?;
+        self.output_ctl.load(card_cntr)?;
+        self.output_eq_ctl.load(card_cntr)?;
+        self.output_dyn_ctl.load(card_cntr)?;
+        self.resource_ctl.load(card_cntr)?;
+        self.level_meters_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        if self.clk_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_assign_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.phone_assign_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.word_clk_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.reverb_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.monitor_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.resource_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.level_meters_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndMotu, FwNode),
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.port_assign_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.opt_iface_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.phone_assign_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.reverb_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.monitor_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.mixer_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_eq_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_dyn_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_eq_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_dyn_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.level_meters_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<(SndMotu, FwNode), u32> for F896mk3HybridModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.level_meters_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.word_clk_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.port_assign_ctl.elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndMotu, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
+        if *msg & F896mk3HybridProtocol::NOTIFY_PORT_CHANGE_MASK > 0 {
+            self.port_assign_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.phone_assign_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.level_meters_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+        }
+        // TODO: what kind of event is preferable for NOTIFY_FOOTSWITCH_MASK?
+        Ok(())
+    }
+}
+
+impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F896mk3HybridModel {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndMotu, FwNode),
+        cmds: &Vec<DspCmd>,
+    ) -> Result<(), Error> {
+        for cmd in cmds {
+            let _ = self.reverb_ctl.parse_command(cmd)
+                || self.monitor_ctl.parse_command(cmd)
+                || self.mixer_ctl.parse_command(cmd)
+                || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
+                || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
+                || self.resource_ctl.parse_command(cmd);
+        }
+        Ok(())
+    }
+}
+
+impl MeasureModel<(SndMotu, FwNode)> for F896mk3HybridModel {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
+    }
+
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
+    }
+}
+
+impl CommandDspModel for F896mk3HybridModel {
+    fn prepare_message_handler<F>(
+        &mut self,
+        unit: &mut (SndMotu, FwNode),
+        handler: F,
+    ) -> Result<(), Error>
+    where
+        F: Fn(&FwResp, FwTcode, u64, u32, u32, u32, u32, &[u8]) -> FwRcode + 'static,
+    {
+        F896mk3HybridProtocol::register_message_destination_address(
+            &mut self.resp,
+            &mut self.req,
+            &mut unit.1,
+            TIMEOUT_MS,
+        )?;
+        self.resp.connect_requested2(handler);
+        Ok(())
+    }
+
+    fn begin_messaging(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        F896mk3HybridProtocol::begin_messaging(
+            &mut self.req,
+            &mut unit.1,
+            &mut self.sequence_number,
+            TIMEOUT_MS,
+        )
+    }
+
+    fn release_message_handler(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        F896mk3HybridProtocol::cancel_messaging(
+            &mut self.req,
+            &mut unit.1,
+            &mut self.sequence_number,
+            TIMEOUT_MS,
+        )?;
+        F896mk3HybridProtocol::release_message_destination_address(
+            &mut self.resp,
+            &mut self.req,
+            &mut unit.1,
+            TIMEOUT_MS,
+        )?;
+        Ok(())
+    }
+}

--- a/runtime/motu/src/f896mk3_model.rs
+++ b/runtime/motu/src/f896mk3_model.rs
@@ -1,0 +1,361 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2020 Takashi Sakamoto
+
+use super::{command_dsp_ctls::*, command_dsp_runtime::*, common_ctls::*, v3_ctls::*};
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default, Debug)]
+pub struct F896mk3Model {
+    req: FwReq,
+    resp: FwResp,
+    clk_ctls: V3LcdClkCtl<F896mk3Protocol>,
+    port_assign_ctl: V3PortAssignCtl<F896mk3Protocol>,
+    opt_iface_ctl: V3OptIfaceCtl<F896mk3Protocol>,
+    phone_assign_ctl: PhoneAssignCtl<F896mk3Protocol>,
+    word_clk_ctl: WordClockCtl<F896mk3Protocol>,
+    sequence_number: u8,
+    reverb_ctl: CommandDspReverbCtl<F896mk3Protocol>,
+    monitor_ctl: CommandDspMonitorCtl<F896mk3Protocol>,
+    mixer_ctl: CommandDspMixerCtl<F896mk3Protocol>,
+    input_ctl: CommandDspInputCtl<F896mk3Protocol>,
+    input_eq_ctl: CommandDspInputEqualizerCtl<F896mk3Protocol>,
+    input_dyn_ctl: CommandDspInputDynamicsCtl<F896mk3Protocol>,
+    output_ctl: CommandDspOutputCtl<F896mk3Protocol>,
+    output_eq_ctl: CommandDspOutputEqualizerCtl<F896mk3Protocol>,
+    output_dyn_ctl: CommandDspOutputDynamicsCtl<F896mk3Protocol>,
+    resource_ctl: CommandDspResourceCtl,
+    level_meters_ctl: LevelMetersCtl<F896mk3Protocol>,
+    meter_ctl: CommandDspMeterCtl<F896mk3Protocol>,
+}
+
+impl CtlModel<(SndMotu, FwNode)> for F896mk3Model {
+    fn cache(&mut self, (unit, node): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.clk_ctls.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.port_assign_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.phone_assign_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+        self.level_meters_ctl
+            .cache(&mut self.req, node, TIMEOUT_MS)?;
+
+        self.meter_ctl.read_dsp_meter(unit)?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.clk_ctls.load(card_cntr)?;
+        self.port_assign_ctl.load(card_cntr)?;
+        self.opt_iface_ctl.load(card_cntr)?;
+        self.phone_assign_ctl.load(card_cntr)?;
+        self.word_clk_ctl.load(card_cntr)?;
+        self.reverb_ctl.load(card_cntr)?;
+        self.monitor_ctl.load(card_cntr)?;
+        self.mixer_ctl.load(card_cntr)?;
+        self.input_ctl.load(card_cntr)?;
+        self.input_eq_ctl.load(card_cntr)?;
+        self.input_dyn_ctl.load(card_cntr)?;
+        self.output_ctl.load(card_cntr)?;
+        self.output_eq_ctl.load(card_cntr)?;
+        self.output_dyn_ctl.load(card_cntr)?;
+        self.resource_ctl.load(card_cntr)?;
+        self.level_meters_ctl.load(card_cntr)?;
+        self.meter_ctl.load(card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        if self.clk_ctls.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.port_assign_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.phone_assign_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.word_clk_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.reverb_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.monitor_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.mixer_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.input_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_eq_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.output_dyn_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.resource_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.level_meters_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.meter_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndMotu, FwNode),
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self
+            .clk_ctls
+            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.port_assign_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.opt_iface_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.phone_assign_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self
+            .word_clk_ctl
+            .write(&mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
+        {
+            Ok(true)
+        } else if self.reverb_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.monitor_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.mixer_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_eq_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.input_dyn_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_eq_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.output_dyn_ctl.write(
+            &mut self.sequence_number,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.level_meters_ctl.write(
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<(SndMotu, FwNode), u32> for F896mk3Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<alsactl::ElemId>) {
+        elem_id_list.extend_from_slice(&self.level_meters_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.word_clk_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.phone_assign_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.port_assign_ctl.elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndMotu, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
+        if *msg & F896mk3Protocol::NOTIFY_PORT_CHANGE_MASK > 0 {
+            self.port_assign_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.phone_assign_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.word_clk_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
+            self.level_meters_ctl
+                .cache(&mut self.req, node, TIMEOUT_MS)?;
+        }
+        // TODO: what kind of event is preferable for NOTIFY_FOOTSWITCH_MASK?
+        Ok(())
+    }
+}
+
+impl NotifyModel<(SndMotu, FwNode), Vec<DspCmd>> for F896mk3Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.reverb_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.mixer_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.input_dyn_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_eq_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.output_dyn_ctl.elem_id_list);
+        elem_id_list.extend_from_slice(&self.resource_ctl.elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        _: &mut (SndMotu, FwNode),
+        cmds: &Vec<DspCmd>,
+    ) -> Result<(), Error> {
+        for cmd in cmds {
+            let _ = self.reverb_ctl.parse_command(cmd)
+                || self.monitor_ctl.parse_command(cmd)
+                || self.mixer_ctl.parse_command(cmd)
+                || self.input_ctl.parse_command(cmd)
+                || self.input_eq_ctl.parse_command(cmd)
+                || self.input_dyn_ctl.parse_command(cmd)
+                || self.output_ctl.parse_command(cmd)
+                || self.output_eq_ctl.parse_command(cmd)
+                || self.output_dyn_ctl.parse_command(cmd)
+                || self.resource_ctl.parse_command(cmd);
+        }
+        Ok(())
+    }
+}
+
+impl MeasureModel<(SndMotu, FwNode)> for F896mk3Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
+    }
+
+    fn measure_states(&mut self, (unit, _): &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        self.meter_ctl.read_dsp_meter(unit)
+    }
+}
+
+impl CommandDspModel for F896mk3Model {
+    fn prepare_message_handler<F>(
+        &mut self,
+        unit: &mut (SndMotu, FwNode),
+        handler: F,
+    ) -> Result<(), Error>
+    where
+        F: Fn(&FwResp, FwTcode, u64, u32, u32, u32, u32, &[u8]) -> FwRcode + 'static,
+    {
+        F896mk3Protocol::register_message_destination_address(
+            &mut self.resp,
+            &mut self.req,
+            &mut unit.1,
+            TIMEOUT_MS,
+        )?;
+        self.resp.connect_requested2(handler);
+        Ok(())
+    }
+
+    fn begin_messaging(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        F896mk3Protocol::begin_messaging(
+            &mut self.req,
+            &mut unit.1,
+            &mut self.sequence_number,
+            TIMEOUT_MS,
+        )
+    }
+
+    fn release_message_handler(&mut self, unit: &mut (SndMotu, FwNode)) -> Result<(), Error> {
+        F896mk3Protocol::cancel_messaging(
+            &mut self.req,
+            &mut unit.1,
+            &mut self.sequence_number,
+            TIMEOUT_MS,
+        )?;
+        F896mk3Protocol::release_message_destination_address(
+            &mut self.resp,
+            &mut self.req,
+            &mut unit.1,
+            TIMEOUT_MS,
+        )?;
+        Ok(())
+    }
+}

--- a/runtime/motu/src/main.rs
+++ b/runtime/motu/src/main.rs
@@ -16,6 +16,8 @@ mod ultralite_model;
 mod audioexpress_model;
 mod f828mk3_hybrid_model;
 mod f828mk3_model;
+mod f896mk3_hybrid_model;
+mod f896mk3_model;
 mod h4pre_model;
 mod track16_model;
 mod traveler_mk3_model;
@@ -60,6 +62,8 @@ enum MotuRuntime {
     AudioExpress(AudioExpressRuntime),
     F828mk3(F828mk3Runtime),
     F828mk3Hybrid(F828mk3HybridRuntime),
+    F896mk3(F896mk3Runtime),
+    F896mk3Hybrid(F896mk3HybridRuntime),
     Track16(Track16Runtime),
     H4pre(H4preRuntime),
 }
@@ -116,6 +120,9 @@ impl RuntimeOperation<u32> for MotuRuntime {
             0x000015 => Ok(Self::F828mk3(F828mk3Runtime::new(
                 unit, node, card_id, version,
             )?)),
+            0x000017 => Ok(Self::F896mk3(F896mk3Runtime::new(
+                unit, node, card_id, version,
+            )?)),
             0x000019 => Ok(Self::Ultralitemk3(UltraliteMk3Runtime::new(
                 unit, node, card_id, version,
             )?)),
@@ -129,6 +136,9 @@ impl RuntimeOperation<u32> for MotuRuntime {
                 unit, node, card_id, version,
             )?)),
             0x000035 => Ok(Self::F828mk3Hybrid(F828mk3HybridRuntime::new(
+                unit, node, card_id, version,
+            )?)),
+            0x000037 => Ok(Self::F896mk3Hybrid(F896mk3HybridRuntime::new(
                 unit, node, card_id, version,
             )?)),
             0x000039 => Ok(Self::Track16(Track16Runtime::new(
@@ -154,11 +164,13 @@ impl RuntimeOperation<u32> for MotuRuntime {
             Self::Ultralite(runtime) => runtime.listen(),
             Self::F8pre(runtime) => runtime.listen(),
             Self::F828mk3(runtime) => runtime.listen(),
+            Self::F896mk3(runtime) => runtime.listen(),
             Self::Ultralitemk3(runtime) => runtime.listen(),
             Self::TravelerMk3(runtime) => runtime.listen(),
             Self::Ultralitemk3Hybrid(runtime) => runtime.listen(),
             Self::AudioExpress(runtime) => runtime.listen(),
             Self::F828mk3Hybrid(runtime) => runtime.listen(),
+            Self::F896mk3Hybrid(runtime) => runtime.listen(),
             Self::Track16(runtime) => runtime.listen(),
             Self::H4pre(runtime) => runtime.listen(),
         }
@@ -174,11 +186,13 @@ impl RuntimeOperation<u32> for MotuRuntime {
             Self::Ultralite(runtime) => runtime.run(),
             Self::F8pre(runtime) => runtime.run(),
             Self::F828mk3(runtime) => runtime.run(),
+            Self::F896mk3(runtime) => runtime.run(),
             Self::Ultralitemk3(runtime) => runtime.run(),
             Self::TravelerMk3(runtime) => runtime.run(),
             Self::Ultralitemk3Hybrid(runtime) => runtime.run(),
             Self::AudioExpress(runtime) => runtime.run(),
             Self::F828mk3Hybrid(runtime) => runtime.run(),
+            Self::F896mk3Hybrid(runtime) => runtime.run(),
             Self::Track16(runtime) => runtime.run(),
             Self::H4pre(runtime) => runtime.run(),
         }


### PR DESCRIPTION
Linux kernel v6.9 would support the models[1]. This series of changes adds support for the models in user space as well.

```
Takashi Sakamoto (4):
  protocols/motu: start crate development for v0.3.0
  protocols/motu: extend level meters specification to support for several type of digital inputs
  protocols/motu: add support for MOTU 896 Mk3 models (both FireWire only and Hybrid models)
  runtime/motu: add support for MOTU 896 mk3 models (both FireWire only and Hybrid models)

 Cargo.toml                               |   4 +-
 README.rst                               |  15 +-
 protocols/motu/README.md                 |   2 +
 protocols/motu/src/lib.rs                |  22 +-
 protocols/motu/src/version_1.rs          |   8 +-
 protocols/motu/src/version_2.rs          |   8 +-
 protocols/motu/src/version_3.rs          | 520 +++++++++++++++++++++++
 runtime/motu/src/command_dsp_runtime.rs  |   7 +-
 runtime/motu/src/common_ctls.rs          |  31 +-
 runtime/motu/src/f896mk3_hybrid_model.rs | 361 ++++++++++++++++
 runtime/motu/src/f896mk3_model.rs        | 361 ++++++++++++++++
 runtime/motu/src/main.rs                 |  14 +
 12 files changed, 1329 insertions(+), 24 deletions(-)
 create mode 100644 runtime/motu/src/f896mk3_hybrid_model.rs
 create mode 100644 runtime/motu/src/f896mk3_model.rs
```

[1] https://lore.kernel.org/alsa-devel/20240129022711.254383-1-o-takashi@sakamocchi.jp/