### PR TITLE
protocols/dice: weiss: add support for Weiss Engineering models

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ members = [
     "protocols/motu",
 #    "protocols/oxfw",
 #    "protocols/bebob",
-#    "protocols/dice",
+    "protocols/dice",
 #    "protocols/fireface",
 ]
 
@@ -36,7 +36,7 @@ members = [
 #ta1394-avc-ccm = { path = "protocols/ta1394/ccm" }
 #firewire-bebob-protocols = { path = "protocols/bebob" }
 #firewire-digi00x-protocols = { path = "protocols/digi00x" }
-#firewire-dice-protocols = { path = "protocols/dice" }
+firewire-dice-protocols = { path = "protocols/dice" }
 #firewire-fireworks-protocols = { path = "protocols/fireworks" }
 #firewire-fireface-protocols = { path = "protocols/fireface" }
 firewire-motu-protocols = { path = "protocols/motu" }

--- a/README.rst
+++ b/README.rst
@@ -182,6 +182,12 @@ contact to developer.
   * PreSonus FireStudio Project
   * PreSonus FireStudio Tube
   * PreSonus FireStudio Mobile
+  * Weiss Engineering ADC2
+  * Weiss Engineering Vesta
+  * Weiss Engineering DAC2, Minerva
+  * Weiss Engineering AFI1
+  * Weiss Engineering INT202, INT203, DAC1 FireWire option card
+  * Weiss Engineering DAC202, Maya
   * For the others, common controls are available. If supported, control extension is also available.
 
 * snd-fireface-ctl-service

--- a/README.rst
+++ b/README.rst
@@ -188,6 +188,7 @@ contact to developer.
   * Weiss Engineering AFI1
   * Weiss Engineering INT202, INT203, DAC1 FireWire option card
   * Weiss Engineering DAC202, Maya
+  * Weiss Engineering MAN301
   * For the others, common controls are available. If supported, control extension is also available.
 
 * snd-fireface-ctl-service

--- a/protocols/dice/Cargo.toml
+++ b/protocols/dice/Cargo.toml
@@ -22,6 +22,7 @@ features = ["dox"]
 glib = "0.15"
 hinawa = "0.7"
 ieee1212-config-rom = "0.1"
+ta1394-avc-general = "0.2"
 
 [[bin]]
 name = "tcat-general-parser"

--- a/protocols/dice/README.md
+++ b/protocols/dice/README.md
@@ -103,6 +103,7 @@ This is the list of models currently supported.
  * Weiss Engineering AFI1
  * Weiss Engineering INT202, INT203, DAC1 FireWire option card
  * Weiss Engineering DAC202, Maya
+ * Weiss Engineering MAN301
 
 For the other models, implementation for common and extension protocol is available without any
 care of vendor's customization.

--- a/protocols/dice/README.md
+++ b/protocols/dice/README.md
@@ -97,6 +97,12 @@ This is the list of models currently supported.
  * PreSonus FireStudio Project
  * PreSonus FireStudio Tube
  * PreSonus FireStudio Mobile
+ * Weiss Engineering ADC2
+ * Weiss Engineering Vesta
+ * Weiss Engineering DAC2, Minerva
+ * Weiss Engineering AFI1
+ * Weiss Engineering INT202, INT203, DAC1 FireWire option card
+ * Weiss Engineering DAC202, Maya
 
 For the other models, implementation for common and extension protocol is available without any
 care of vendor's customization.

--- a/protocols/dice/src/bin/tcat-config-rom-parser.rs
+++ b/protocols/dice/src/bin/tcat-config-rom-parser.rs
@@ -88,13 +88,18 @@ fn main() {
                 println!("  product_name:   '{}'", root.product_name);
             });
 
-            config_rom.get_unit_data().map(|unit| {
-                println!("Unit:");
-                println!("  model_id:       0x{:06x}", unit.model_id);
-                println!("  model_name:     '{}'", unit.model_name);
-                println!("  specifier_id:   0x{:06x}", unit.specifier_id);
-                println!("  version:        0x{:06x}", unit.version);
-            });
+            let units = config_rom.get_unit_data();
+            if units.len() > 0 {
+                println!("Units:");
+
+                units.iter().enumerate().for_each(|(i, unit)| {
+                    println!("  {}:", i);
+                    println!("    model_id:     0x{:06x}", unit.model_id);
+                    println!("    model_name:   '{}'", unit.model_name);
+                    println!("    specifier_id: 0x{:06x}", unit.specifier_id);
+                    println!("    version:      0x{:06x}", unit.version);
+                });
+            }
 
             Ok(())
         })

--- a/protocols/dice/src/lib.rs
+++ b/protocols/dice/src/lib.rs
@@ -12,6 +12,7 @@ pub mod maudio;
 pub mod presonus;
 pub mod tcat;
 pub mod tcelectronic;
+pub mod weiss;
 
 use {
     glib::Error,

--- a/protocols/dice/src/weiss.rs
+++ b/protocols/dice/src/weiss.rs
@@ -6,6 +6,7 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Weiss Engineering.
 
+pub mod avc;
 pub mod normal;
 
 use super::tcat::{global_section::*, *};

--- a/protocols/dice/src/weiss.rs
+++ b/protocols/dice/src/weiss.rs
@@ -10,3 +10,5 @@ pub mod avc;
 pub mod normal;
 
 use super::tcat::{global_section::*, *};
+
+const WEISS_OUI: [u8; 3] = [0x00, 0x1c, 0x6a];

--- a/protocols/dice/src/weiss.rs
+++ b/protocols/dice/src/weiss.rs
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+//! Protocol specific to Weiss Engineering models.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Weiss Engineering.
+
+pub mod normal;
+
+use super::tcat::{global_section::*, *};

--- a/protocols/dice/src/weiss/avc.rs
+++ b/protocols/dice/src/weiss/avc.rs
@@ -11,12 +11,13 @@
 
 use {
     super::*,
+    crate::{tcelectronic::*, *},
     glib::{Error, FileError, IsA},
     hinawa::{
         prelude::{FwFcpExt, FwFcpExtManual},
         FwFcp, FwNode,
     },
-    ta1394_avc_general::*,
+    ta1394_avc_general::{general::*, *},
 };
 
 /// Protocol implementation specific to MAN301.
@@ -77,5 +78,137 @@ impl WeissAvc {
         timeout_ms: u32,
     ) -> Result<(), Error> {
         Ta1394Avc::<Error>::status(self, addr, op, timeout_ms).map_err(|err| from_avc_err(err))
+    }
+}
+
+/// The content of command to operate parameter.
+#[derive(Debug)]
+pub struct WeissAvcParamCmd {
+    /// The numeric identifier of parameter.
+    pub numeric_id: u32,
+    /// The value of parameter.
+    pub value: u32,
+    /// For future use.
+    pub reserved: [u32; 4],
+    op: TcAvcCmd,
+}
+
+impl Default for WeissAvcParamCmd {
+    fn default() -> Self {
+        let mut op = TcAvcCmd::new(&WEISS_OUI);
+        op.class_id = 1;
+        op.sequence_id = u8::MAX;
+        op.command_id = 0x8002;
+        Self {
+            numeric_id: u32::MAX,
+            value: u32::MAX,
+            reserved: [u32::MAX; 4],
+            op: TcAvcCmd::new(&WEISS_OUI),
+        }
+    }
+}
+
+impl AvcOp for WeissAvcParamCmd {
+    const OPCODE: u8 = VendorDependent::OPCODE;
+}
+
+fn build_param_command_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), AvcCmdBuildError> {
+    cmd.op.arguments.resize(24, u8::MAX);
+    serialize_u32(&cmd.numeric_id, &mut cmd.op.arguments[..4]);
+    (0..4).for_each(|i| {
+        let pos = 8 + i * 4;
+        serialize_u32(&cmd.reserved[i], &mut cmd.op.arguments[pos..(pos + 4)]);
+    });
+    Ok(())
+}
+
+fn build_param_command_control_data(cmd: &mut WeissAvcParamCmd) -> Result<(), AvcCmdBuildError> {
+    cmd.op.arguments.resize(24, u8::MIN);
+    serialize_u32(&cmd.numeric_id, &mut cmd.op.arguments[..4]);
+    serialize_u32(&cmd.value, &mut cmd.op.arguments[4..8]);
+    (0..4).for_each(|i| {
+        let pos = 8 + i * 4;
+        serialize_u32(&cmd.reserved[i], &mut cmd.op.arguments[pos..(pos + 4)]);
+    });
+    Ok(())
+}
+
+fn parse_param_command_response_data(cmd: &mut WeissAvcParamCmd) -> Result<(), AvcRespParseError> {
+    if cmd.op.arguments.len() < 24 {
+        Err(AvcRespParseError::TooShortResp(24))?
+    }
+
+    deserialize_u32(&mut cmd.numeric_id, &cmd.op.arguments[..4]);
+    deserialize_u32(&mut cmd.value, &cmd.op.arguments[4..8]);
+    (0..4).for_each(|i| {
+        let pos = 8 + i * 4;
+        deserialize_u32(&mut cmd.reserved[i], &cmd.op.arguments[pos..(pos + 4)]);
+    });
+
+    Ok(())
+}
+
+impl AvcStatus for WeissAvcParamCmd {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
+        build_param_command_status_data(self)?;
+        AvcStatus::build_operands(&mut self.op, addr)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
+        AvcStatus::parse_operands(&mut self.op, addr, operands)?;
+        parse_param_command_response_data(self)
+    }
+}
+
+impl AvcControl for WeissAvcParamCmd {
+    fn build_operands(&mut self, addr: &AvcAddr) -> Result<Vec<u8>, AvcCmdBuildError> {
+        build_param_command_control_data(self)?;
+        AvcControl::build_operands(&mut self.op, addr)
+    }
+
+    fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
+        AvcControl::parse_operands(&mut self.op, addr, operands)?;
+        parse_param_command_response_data(self)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn weiss_avc_param_command_operands() {
+        let operands = [
+            0x00, 0x1c, 0x6a, 0x01, 0x7f, 0x80, 0x02, 0x76, 0x54, 0x32, 0x10, 0xfe, 0xdc, 0xba,
+            0x98, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+            0xff, 0xff, 0xff,
+        ];
+        let mut op = WeissAvcParamCmd::default();
+        AvcStatus::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.op.class_id, 0x01);
+        assert_eq!(op.op.sequence_id, 0x7f);
+        assert_eq!(op.op.command_id, 0x8002);
+        assert_eq!(op.op.arguments, &operands[7..]);
+        assert_eq!(op.numeric_id, 0x76543210);
+        assert_eq!(op.value, 0xfedcba98);
+
+        let target = AvcStatus::build_operands(&mut op, &AvcAddr::Unit).unwrap();
+        assert_eq!(&target[..4], &operands[..4]);
+        // The value of sequence_id field is never matched.
+        assert_eq!(&target[5..], &operands[5..]);
+
+        let target = AvcControl::build_operands(&mut op, &AvcAddr::Unit).unwrap();
+        assert_eq!(&target[..4], &operands[..4]);
+        // The value of sequence_id field is never matched.
+        assert_eq!(&target[5..], &operands[5..]);
+
+        let mut op = WeissAvcParamCmd::default();
+        AvcControl::parse_operands(&mut op, &AvcAddr::Unit, &operands).unwrap();
+        assert_eq!(op.op.class_id, 0x01);
+        assert_eq!(op.op.sequence_id, 0x7f);
+        assert_eq!(op.op.command_id, 0x8002);
+        assert_eq!(op.op.arguments, &operands[7..]);
+        assert_eq!(op.numeric_id, 0x76543210);
+        assert_eq!(op.value, 0xfedcba98);
     }
 }

--- a/protocols/dice/src/weiss/avc.rs
+++ b/protocols/dice/src/weiss/avc.rs
@@ -9,7 +9,15 @@
 //! MAN301 includes two units in the root directory of its configuration ROM. The first unit
 //! expresses AV/C protocol, and the second unit expresses TCAT protocol.
 
-use super::*;
+use {
+    super::*,
+    glib::{Error, FileError, IsA},
+    hinawa::{
+        prelude::{FwFcpExt, FwFcpExtManual},
+        FwFcp, FwNode,
+    },
+    ta1394_avc_general::*,
+};
 
 /// Protocol implementation specific to MAN301.
 #[derive(Default, Debug)]
@@ -20,3 +28,54 @@ impl TcatOperation for WeissMan301Protocol {}
 // clock caps: 44100 48000 88200 96000 176400 192000
 // clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOS)\Unused\Unused\Unused\Unused\Word Clock (BNC)\Unused\Unused\Unused\Unused\Internal\\
 impl TcatGlobalSectionSpecification for WeissMan301Protocol {}
+
+/// The implementation of AV/C transaction.
+#[derive(Default, Debug)]
+pub struct WeissAvc(FwFcp);
+
+impl Ta1394Avc<Error> for WeissAvc {
+    fn transaction(&self, command_frame: &[u8], timeout_ms: u32) -> Result<Vec<u8>, Error> {
+        let mut resp = vec![0; Self::FRAME_SIZE];
+        self.0
+            .avc_transaction(&command_frame, &mut resp, timeout_ms)
+            .map(|len| {
+                resp.truncate(len);
+                resp
+            })
+    }
+}
+
+fn from_avc_err(err: Ta1394AvcError<Error>) -> Error {
+    match err {
+        Ta1394AvcError::CmdBuild(cause) => Error::new(FileError::Inval, &cause.to_string()),
+        Ta1394AvcError::CommunicationFailure(cause) => cause,
+        Ta1394AvcError::RespParse(cause) => Error::new(FileError::Io, &cause.to_string()),
+    }
+}
+
+impl WeissAvc {
+    /// Bind FCP protocol to the given node for AV/C operation.
+    pub fn bind(&self, node: &impl IsA<FwNode>) -> Result<(), Error> {
+        self.0.bind(node)
+    }
+
+    /// Request AV/C control operation and wait for response.
+    pub fn control<O: AvcOp + AvcControl>(
+        &self,
+        addr: &AvcAddr,
+        op: &mut O,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Ta1394Avc::<Error>::control(self, addr, op, timeout_ms).map_err(|err| from_avc_err(err))
+    }
+
+    /// Request AV/C status operation and wait for response.
+    pub fn status<O: AvcOp + AvcStatus>(
+        &self,
+        addr: &AvcAddr,
+        op: &mut O,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        Ta1394Avc::<Error>::status(self, addr, op, timeout_ms).map_err(|err| from_avc_err(err))
+    }
+}

--- a/protocols/dice/src/weiss/avc.rs
+++ b/protocols/dice/src/weiss/avc.rs
@@ -8,6 +8,17 @@
 //!
 //! MAN301 includes two units in the root directory of its configuration ROM. The first unit
 //! expresses AV/C protocol, and the second unit expresses TCAT protocol.
+//!
+//! ```text
+//! spdif-opt-input-1/2  ---+
+//! spdif-coax-input-1/2 --(or)--> digital-input-1/2 -----------------> stream-output-1/2
+//! aesebu-xlr-input-1/2 ---+             |
+//!                                       v
+//! stream-input-1/2 --------------------(or)--+----------------------> spdif-coax-output-1/2
+//!                                            +----------------------> aesebu-xlr-output-1/2
+//!                                            +--analog-output-1/2 --> analog-xlr-output-1/2
+//!                                                       +-----------> analog-coax-output-1/2
+//! ```
 
 use {
     super::*,
@@ -169,6 +180,396 @@ impl AvcControl for WeissAvcParamCmd {
     fn parse_operands(&mut self, addr: &AvcAddr, operands: &[u8]) -> Result<(), AvcRespParseError> {
         AvcControl::parse_operands(&mut self.op, addr, operands)?;
         parse_param_command_response_data(self)
+    }
+}
+
+impl WeissMan301Protocol {
+    const PARAM_ID_DIGITAL_CAPTURE_SOURCE: u32 = 0;
+    const PARAM_ID_DIGITAL_OUTPUT_MODE: u32 = 1;
+    const PARAM_ID_WORD_CLOCK_OUTPUT_HALF_RATE: u32 = 2;
+    const PARAM_ID_AESEBU_XLR_OUTPUT_MUTE: u32 = 3;
+    const PARAM_ID_SPDIF_COAXIAL_OUTPUT_MUTE: u32 = 4;
+    const PARAM_ID_ANALOG_OUTPUT_POLARITY_INVERSION: u32 = 5;
+    const PARAM_ID_ANALOG_OUTPUT_FILTER_TYPE: u32 = 6;
+    const PARAM_ID_ANALOG_OUTPUT_MUTE: u32 = 7;
+    const PARAM_ID_ANALOG_OUTPUT_LEVEL: u32 = 8;
+}
+
+/// Convert between parameter and command.
+pub trait WeissAvcParamConvert<T> {
+    /// Build data for status command.
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error>;
+    /// Build data for control command.
+    fn build_control_data(param: &T, cmd: &mut WeissAvcParamCmd) -> Result<(), Error>;
+    /// Parse data for response.
+    fn parse_response_data(param: &mut T, cmd: &WeissAvcParamCmd) -> Result<(), Error>;
+}
+
+/// The source of digital input captured for output packet stream.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WeissAvcDigitalCaptureSource {
+    /// AES/EBU signal in XLR input interface.
+    AesebuXlr,
+    /// S/PDIF signal in coaxial input interface.
+    SpdifCoaxial,
+    /// S/PDIF signal in optical input interface.
+    SpdifOptical,
+}
+
+impl Default for WeissAvcDigitalCaptureSource {
+    fn default() -> Self {
+        Self::AesebuXlr
+    }
+}
+
+impl WeissAvcParamConvert<WeissAvcDigitalCaptureSource> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_DIGITAL_CAPTURE_SOURCE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcDigitalCaptureSource,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_DIGITAL_CAPTURE_SOURCE;
+        cmd.value = match param {
+            WeissAvcDigitalCaptureSource::SpdifOptical => 2,
+            WeissAvcDigitalCaptureSource::SpdifCoaxial => 1,
+            WeissAvcDigitalCaptureSource::AesebuXlr => 0,
+        };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcDigitalCaptureSource,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_DIGITAL_CAPTURE_SOURCE);
+        *param = match cmd.value {
+            2 => WeissAvcDigitalCaptureSource::SpdifOptical,
+            1 => WeissAvcDigitalCaptureSource::SpdifCoaxial,
+            _ => WeissAvcDigitalCaptureSource::AesebuXlr,
+        };
+        Ok(())
+    }
+}
+
+/// The mode of AES/EBU XLR output and S/PDIF coaxial output. When enabled, it is in "dual wire"
+/// mode at 176.4/192.0 kHz; i.e. the former is for the left audio channel, and the latter is for
+/// right audio channel.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcDigitalOutputMode(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcDigitalOutputMode> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_DIGITAL_OUTPUT_MODE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcDigitalOutputMode,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_DIGITAL_OUTPUT_MODE;
+        cmd.value = if param.0 { 1 } else { 0 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcDigitalOutputMode,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_DIGITAL_OUTPUT_MODE);
+        param.0 = cmd.value > 0;
+        Ok(())
+    }
+}
+
+/// The mode of word clock at dual wire mode. When enabled, the output of BNC for word clock is at
+/// half of sampling rate.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcWordClockOutputHalfRate(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcWordClockOutputHalfRate> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_WORD_CLOCK_OUTPUT_HALF_RATE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcWordClockOutputHalfRate,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_WORD_CLOCK_OUTPUT_HALF_RATE;
+        cmd.value = if param.0 { 1 } else { 0 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcWordClockOutputHalfRate,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_WORD_CLOCK_OUTPUT_HALF_RATE);
+        param.0 = cmd.value > 0;
+        Ok(())
+    }
+}
+
+/// Mute XLR output.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcAesebuXlrOutputMute(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcAesebuXlrOutputMute> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_AESEBU_XLR_OUTPUT_MUTE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcAesebuXlrOutputMute,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_AESEBU_XLR_OUTPUT_MUTE;
+        cmd.value = if param.0 { 0 } else { 1 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcAesebuXlrOutputMute,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_AESEBU_XLR_OUTPUT_MUTE);
+        param.0 = cmd.value == 0;
+        Ok(())
+    }
+}
+
+/// Mute coaxial output.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcSpdifCoaxialOutputMute(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcSpdifCoaxialOutputMute> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_SPDIF_COAXIAL_OUTPUT_MUTE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcSpdifCoaxialOutputMute,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_SPDIF_COAXIAL_OUTPUT_MUTE;
+        cmd.value = if param.0 { 0 } else { 1 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcSpdifCoaxialOutputMute,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_SPDIF_COAXIAL_OUTPUT_MUTE);
+        param.0 = cmd.value == 0;
+        Ok(())
+    }
+}
+
+/// Invert polarity of analog output.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcAnalogOutputPolarityInversion(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcAnalogOutputPolarityInversion> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_POLARITY_INVERSION;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcAnalogOutputPolarityInversion,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_POLARITY_INVERSION;
+        cmd.value = if param.0 { 1 } else { 0 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcAnalogOutputPolarityInversion,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(
+            cmd.numeric_id,
+            Self::PARAM_ID_ANALOG_OUTPUT_POLARITY_INVERSION
+        );
+        param.0 = cmd.value > 0;
+        Ok(())
+    }
+}
+
+/// The type of oversampling filter in analog output.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WeissAvcAnalogOutputFilterType {
+    A,
+    B,
+}
+
+impl Default for WeissAvcAnalogOutputFilterType {
+    fn default() -> Self {
+        Self::A
+    }
+}
+
+impl WeissAvcParamConvert<WeissAvcAnalogOutputFilterType> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_FILTER_TYPE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcAnalogOutputFilterType,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_FILTER_TYPE;
+        cmd.value = if param.eq(&WeissAvcAnalogOutputFilterType::B) {
+            1
+        } else {
+            0
+        };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcAnalogOutputFilterType,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_ANALOG_OUTPUT_FILTER_TYPE);
+        *param = if cmd.value > 0 {
+            WeissAvcAnalogOutputFilterType::B
+        } else {
+            WeissAvcAnalogOutputFilterType::A
+        };
+        Ok(())
+    }
+}
+
+/// Mute analog output.
+#[derive(Default, Debug, Copy, Clone, PartialEq, Eq)]
+pub struct WeissAvcAnalogOutputMute(pub bool);
+
+impl WeissAvcParamConvert<WeissAvcAnalogOutputMute> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_MUTE;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcAnalogOutputMute,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_MUTE;
+        cmd.value = if param.0 { 0 } else { 1 };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcAnalogOutputMute,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_ANALOG_OUTPUT_MUTE);
+        param.0 = cmd.value == 0;
+        Ok(())
+    }
+}
+
+/// The level of analog output.
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+pub enum WeissAvcAnalogOutputLevel {
+    /// 0 dB.
+    Zero,
+    /// -10 dB.
+    NegativeTen,
+    /// -20 dB.
+    NegativeTwenty,
+    /// -30 dB.
+    NegativeThirty,
+}
+
+impl Default for WeissAvcAnalogOutputLevel {
+    fn default() -> Self {
+        Self::Zero
+    }
+}
+
+impl WeissAvcParamConvert<WeissAvcAnalogOutputLevel> for WeissMan301Protocol {
+    fn build_status_data(cmd: &mut WeissAvcParamCmd) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_LEVEL;
+        cmd.value = u32::MAX;
+        Ok(())
+    }
+
+    fn build_control_data(
+        param: &WeissAvcAnalogOutputLevel,
+        cmd: &mut WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        cmd.numeric_id = Self::PARAM_ID_ANALOG_OUTPUT_LEVEL;
+        cmd.value = match param {
+            WeissAvcAnalogOutputLevel::NegativeThirty => 3,
+            WeissAvcAnalogOutputLevel::NegativeTwenty => 2,
+            WeissAvcAnalogOutputLevel::NegativeTen => 1,
+            WeissAvcAnalogOutputLevel::Zero => 0,
+        };
+        Ok(())
+    }
+
+    fn parse_response_data(
+        param: &mut WeissAvcAnalogOutputLevel,
+        cmd: &WeissAvcParamCmd,
+    ) -> Result<(), Error> {
+        assert_eq!(cmd.numeric_id, Self::PARAM_ID_ANALOG_OUTPUT_LEVEL);
+        *param = match cmd.value {
+            3 => WeissAvcAnalogOutputLevel::NegativeThirty,
+            2 => WeissAvcAnalogOutputLevel::NegativeTwenty,
+            1 => WeissAvcAnalogOutputLevel::NegativeTen,
+            _ => WeissAvcAnalogOutputLevel::Zero,
+        };
+        Ok(())
+    }
+}
+
+/// The operation for parameters in Weiss AV/C protocol.
+pub trait WeissAvcParamOperation<T>: WeissAvcParamConvert<T> {
+    /// Cache current state of parameter.
+    fn cache_param(fcp: &WeissAvc, param: &mut T, timeout_ms: u32) -> Result<(), Error>;
+    /// Update the state of parameter.
+    fn update_param(fcp: &WeissAvc, param: &mut T, timeout_ms: u32) -> Result<(), Error>;
+}
+
+impl<T> WeissAvcParamOperation<T> for WeissMan301Protocol
+where
+    WeissMan301Protocol: WeissAvcParamConvert<T>,
+{
+    fn cache_param(fcp: &WeissAvc, param: &mut T, timeout_ms: u32) -> Result<(), Error> {
+        let mut cmd = WeissAvcParamCmd::default();
+        Self::build_status_data(&mut cmd)?;
+        fcp.status(&AvcAddr::Unit, &mut cmd, timeout_ms)?;
+        Self::parse_response_data(param, &cmd)?;
+        Ok(())
+    }
+
+    fn update_param(fcp: &WeissAvc, param: &mut T, timeout_ms: u32) -> Result<(), Error> {
+        let mut cmd = WeissAvcParamCmd::default();
+        Self::build_control_data(param, &mut cmd)?;
+        fcp.control(&AvcAddr::Unit, &mut cmd, timeout_ms)?;
+        Self::parse_response_data(param, &cmd)?;
+        Ok(())
     }
 }
 

--- a/protocols/dice/src/weiss/avc.rs
+++ b/protocols/dice/src/weiss/avc.rs
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+//! Protocol specific to Weiss Engineering AV/C models.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Weiss Engineering.
+//!
+//! MAN301 includes two units in the root directory of its configuration ROM. The first unit
+//! expresses AV/C protocol, and the second unit expresses TCAT protocol.
+
+use super::*;
+
+/// Protocol implementation specific to MAN301.
+#[derive(Default, Debug)]
+pub struct WeissMan301Protocol;
+
+impl TcatOperation for WeissMan301Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOS)\Unused\Unused\Unused\Unused\Word Clock (BNC)\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissMan301Protocol {}

--- a/protocols/dice/src/weiss/normal.rs
+++ b/protocols/dice/src/weiss/normal.rs
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+//! Protocol specific to Weiss Engineering normal models.
+//!
+//! The module includes structure, enumeration, and trait and its implementation for protocol
+//! defined by Weiss Engineering.
+
+use super::*;
+
+/// Protocol implementation specific to ADC2.
+#[derive(Default, Debug)]
+pub struct WeissAdc2Protocol;
+
+impl TcatOperation for WeissAdc2Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1
+// clock source names: AES12\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\\
+impl TcatGlobalSectionSpecification for WeissAdc2Protocol {}
+
+/// Protocol implementation specific to Vesta.
+#[derive(Default, Debug)]
+pub struct WeissVestaProtocol;
+
+impl TcatOperation for WeissVestaProtocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissVestaProtocol {}
+
+/// Protocol implementation specific to DAC2/Minerva.
+#[derive(Default, Debug)]
+pub struct WeissDac2Protocol;
+
+impl TcatOperation for WeissDac2Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissDac2Protocol {}
+
+/// Protocol implementation specific to AFI1.
+#[derive(Default, Debug)]
+pub struct WeissAfi1Protocol;
+
+impl TcatOperation for WeissAfi1Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 aes4 adat wc internal
+// clock source names: AES12\AES34\AES56\AES78\Unused\ADAT\Unused\Word Clock\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissAfi1Protocol {}
+
+/// Protocol implementation specific to DAC202 and Maya Edition.
+#[derive(Default, Debug)]
+pub struct WeissDac202Protocol;
+
+impl TcatOperation for WeissDac202Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 aes3 wc arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\S/PDIF (TOSLINK)\Unused\Unused\Unused\Unused\Word Clock\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissDac202Protocol {}
+
+/// Protocol implementation specific to INT202, INT203, and FireWire option card for DAC1.
+#[derive(Default, Debug)]
+pub struct WeissInt203Protocol;
+
+impl TcatOperation for WeissInt203Protocol {}
+
+// clock caps: 44100 48000 88200 96000 176400 192000 aes1 aes2 arx1 internal
+// clock source names: AES/EBU (XLR)\S/PDIF (RCA)\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Unused\Internal\\
+impl TcatGlobalSectionSpecification for WeissInt203Protocol {}

--- a/runtime/dice/src/main.rs
+++ b/runtime/dice/src/main.rs
@@ -15,6 +15,7 @@ mod focusrite;
 mod mbox3_model;
 mod pfire_model;
 mod tcd22xx_ctl;
+mod weiss;
 
 use {
     alsa_ctl_tlv_codec::DbInterval,

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -10,7 +10,7 @@ use {
         presonus::fstudiomobile_model::*, presonus::fstudioproject_model::*,
         presonus::fstudiotube_model::*, tcelectronic::desktopk6_model::*,
         tcelectronic::itwin_model::*, tcelectronic::k24d_model::*, tcelectronic::k8_model::*,
-        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, *,
+        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, weiss::normal::*, *,
     },
     ieee1212_config_rom::*,
     protocols::tcat::config_rom::*,
@@ -43,6 +43,12 @@ enum Model {
     PresonusFStudioProject(FStudioProjectModel),
     PresonusFStudioTube(FStudioTubeModel),
     PresonusFStudioMobile(FStudioMobileModel),
+    WeissAdc2Model(Adc2Model),
+    WeissVestaModel(VestaModel),
+    WeissDac2Model(Dac2Model),
+    WeissAfi1Model(Afi1Model),
+    WeissDac202Model(Dac202Model),
+    WeissInt203Model(Int203Model),
 }
 
 pub struct DiceModel {
@@ -99,6 +105,14 @@ impl DiceModel {
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
             (0x000a92, 0x00000c) => Model::PresonusFStudioTube(FStudioTubeModel::default()),
             (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
+            (0x001c6a, 0x000001) => Model::WeissAdc2Model(Default::default()),
+            (0x001c6a, 0x000002) => Model::WeissVestaModel(Default::default()),
+            (0x001c6a, 0x000003) => Model::WeissDac2Model(Default::default()),
+            (0x001c6a, 0x000004) => Model::WeissAfi1Model(Default::default()),
+            (0x001c6a, 0x000007) |
+            (0x001c6a, 0x000008) => Model::WeissDac202Model(Default::default()),
+            (0x001c6a, 0x000006) |
+            (0x001c6a, 0x00000a) => Model::WeissInt203Model(Default::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -156,6 +170,12 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => m.cache(unit),
             Model::PresonusFStudioTube(m) => m.cache(unit),
             Model::PresonusFStudioMobile(m) => m.cache(unit),
+            Model::WeissAdc2Model(m) => m.cache(unit),
+            Model::WeissVestaModel(m) => m.cache(unit),
+            Model::WeissDac2Model(m) => m.cache(unit),
+            Model::WeissAfi1Model(m) => m.cache(unit),
+            Model::WeissDac202Model(m) => m.cache(unit),
+            Model::WeissInt203Model(m) => m.cache(unit),
         }
     }
 
@@ -186,6 +206,12 @@ impl DiceModel {
             Model::PresonusFStudioProject(m) => m.load(card_cntr),
             Model::PresonusFStudioTube(m) => m.load(card_cntr),
             Model::PresonusFStudioMobile(m) => m.load(card_cntr),
+            Model::WeissAdc2Model(m) => m.load(card_cntr),
+            Model::WeissVestaModel(m) => m.load(card_cntr),
+            Model::WeissDac2Model(m) => m.load(card_cntr),
+            Model::WeissAfi1Model(m) => m.load(card_cntr),
+            Model::WeissDac202Model(m) => m.load(card_cntr),
+            Model::WeissInt203Model(m) => m.load(card_cntr),
         }?;
 
         match &mut self.model {
@@ -218,6 +244,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 m.get_notified_elem_list(&mut self.notified_elem_list)
             }
+            Model::WeissAdc2Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissVestaModel(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissDac2Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissAfi1Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissDac202Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissInt203Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -250,6 +282,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 m.get_measure_elem_list(&mut self.measured_elem_list)
             }
+            Model::WeissAdc2Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissVestaModel(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissDac2Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissAfi1Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissDac202Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissInt203Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -298,6 +336,12 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.dispatch_elem_event(unit, &elem_id, &events, m)
             }
+            Model::WeissAdc2Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissVestaModel(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissDac2Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissAfi1Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissDac202Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissInt203Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -383,6 +427,24 @@ impl DiceModel {
             Model::PresonusFStudioMobile(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
+            Model::WeissAdc2Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissVestaModel(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissDac2Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissAfi1Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissDac202Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
+            Model::WeissInt203Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
         }
     }
 
@@ -425,6 +487,16 @@ impl DiceModel {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
             Model::PresonusFStudioMobile(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
+            Model::WeissAdc2Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissVestaModel(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissDac2Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissAfi1Model(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::WeissDac202Model(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
+            Model::WeissInt203Model(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
         }

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -3,14 +3,31 @@
 
 use {
     super::{
-        blackbird_model::*, extension_model::*, focusrite::liquids56_model::*,
-        focusrite::spro14_model::*, focusrite::spro24_model::*, focusrite::spro24dsp_model::*,
-        focusrite::spro26_model::*, focusrite::spro40_model::*, io_fw_model::*, ionix_model::*,
-        mbox3_model::*, minimal_model::*, pfire_model::*, presonus::fstudio_model::*,
-        presonus::fstudiomobile_model::*, presonus::fstudioproject_model::*,
-        presonus::fstudiotube_model::*, tcelectronic::desktopk6_model::*,
-        tcelectronic::itwin_model::*, tcelectronic::k24d_model::*, tcelectronic::k8_model::*,
-        tcelectronic::klive_model::*, tcelectronic::studiok48_model::*, weiss::normal::*, *,
+        blackbird_model::*,
+        extension_model::*,
+        focusrite::liquids56_model::*,
+        focusrite::spro14_model::*,
+        focusrite::spro24_model::*,
+        focusrite::spro24dsp_model::*,
+        focusrite::spro26_model::*,
+        focusrite::spro40_model::*,
+        io_fw_model::*,
+        ionix_model::*,
+        mbox3_model::*,
+        minimal_model::*,
+        pfire_model::*,
+        presonus::fstudio_model::*,
+        presonus::fstudiomobile_model::*,
+        presonus::fstudioproject_model::*,
+        presonus::fstudiotube_model::*,
+        tcelectronic::desktopk6_model::*,
+        tcelectronic::itwin_model::*,
+        tcelectronic::k24d_model::*,
+        tcelectronic::k8_model::*,
+        tcelectronic::klive_model::*,
+        tcelectronic::studiok48_model::*,
+        weiss::{avc::*, normal::*},
+        *,
     },
     ieee1212_config_rom::*,
     protocols::tcat::config_rom::*,
@@ -49,6 +66,7 @@ enum Model {
     WeissAfi1Model(Afi1Model),
     WeissDac202Model(Dac202Model),
     WeissInt203Model(Int203Model),
+    WeissMan301Model(WeissMan301Model),
 }
 
 pub struct DiceModel {
@@ -117,6 +135,7 @@ impl DiceModel {
             (0x001c6a, 0x000008) => Model::WeissDac202Model(Default::default()),
             (0x001c6a, 0x000006) |
             (0x001c6a, 0x00000a) => Model::WeissInt203Model(Default::default()),
+            (0x001c6a, 0x00000b) => Model::WeissMan301Model(Default::default()),
             (0x000166, 0x000030) |  // TC Electronic Digital Konnekt x32.
             (0x000595, 0x000000) |  // Alesis MultiMix 8/12/16 FireWire.
             (0x000595, 0x000002) |  // Alesis MasterControl.
@@ -180,6 +199,7 @@ impl DiceModel {
             Model::WeissAfi1Model(m) => m.cache(unit),
             Model::WeissDac202Model(m) => m.cache(unit),
             Model::WeissInt203Model(m) => m.cache(unit),
+            Model::WeissMan301Model(m) => m.cache(unit),
         }
     }
 
@@ -216,6 +236,7 @@ impl DiceModel {
             Model::WeissAfi1Model(m) => m.load(card_cntr),
             Model::WeissDac202Model(m) => m.load(card_cntr),
             Model::WeissInt203Model(m) => m.load(card_cntr),
+            Model::WeissMan301Model(m) => m.load(card_cntr),
         }?;
 
         match &mut self.model {
@@ -254,6 +275,7 @@ impl DiceModel {
             Model::WeissAfi1Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::WeissDac202Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::WeissInt203Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::WeissMan301Model(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
         }
 
         match &mut self.model {
@@ -292,6 +314,7 @@ impl DiceModel {
             Model::WeissAfi1Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::WeissDac202Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::WeissInt203Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::WeissMan301Model(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
         }
 
         Ok(())
@@ -346,6 +369,7 @@ impl DiceModel {
             Model::WeissAfi1Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::WeissDac202Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::WeissInt203Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::WeissMan301Model(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
         }
     }
 
@@ -449,6 +473,9 @@ impl DiceModel {
             Model::WeissInt203Model(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
+            Model::WeissMan301Model(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
         }
     }
 
@@ -501,6 +528,9 @@ impl DiceModel {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
             Model::WeissInt203Model(m) => {
+                card_cntr.measure_elems(unit, &self.measured_elem_list, m)
+            }
+            Model::WeissMan301Model(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }
         }

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -67,8 +67,12 @@ impl DiceModel {
         let data = config_rom
             .get_root_data()
             .and_then(|root| {
+                // Use the first unit to detect model, ignoring protocols specified by specifier_i
+                // and version fields in each unit directory.
                 config_rom
                     .get_unit_data()
+                    .iter()
+                    .nth(0)
                     .map(|unit| (root.vendor_id, unit.model_id))
             })
             .ok_or_else(|| {

--- a/runtime/dice/src/weiss.rs
+++ b/runtime/dice/src/weiss.rs
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+pub mod normal;
+
+use super::*;

--- a/runtime/dice/src/weiss.rs
+++ b/runtime/dice/src/weiss.rs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2024 Takashi Sakamoto
 
+pub mod avc;
 pub mod normal;
 
 use super::*;

--- a/runtime/dice/src/weiss/avc.rs
+++ b/runtime/dice/src/weiss/avc.rs
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+use {super::*, protocols::weiss::avc::*};
+
+#[derive(Default)]
+pub struct WeissMan301Model {
+    req: FwReq,
+    sections: GeneralSections,
+    common_ctl: CommonCtl<WeissMan301Protocol>,
+}
+
+const TIMEOUT_MS: u32 = 20;
+
+impl CtlModel<(SndDice, FwNode)> for WeissMan301Model {
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        WeissMan301Protocol::read_general_sections(
+            &self.req,
+            &node,
+            &mut self.sections,
+            TIMEOUT_MS,
+        )?;
+
+        self.common_ctl
+            .cache_whole_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr)?;
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+    ) -> Result<bool, Error> {
+        if self.common_ctl.write(
+            &unit,
+            &self.req,
+            &node,
+            &mut self.sections,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+}
+
+impl NotifyModel<(SndDice, FwNode), u32> for WeissMan301Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndDice, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
+        self.common_ctl
+            .parse_notification(&self.req, &node, &mut self.sections, *msg, TIMEOUT_MS)
+    }
+}
+
+impl MeasureModel<(SndDice, FwNode)> for WeissMan301Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
+    }
+
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        self.common_ctl
+            .cache_partial_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)
+    }
+}

--- a/runtime/dice/src/weiss/avc.rs
+++ b/runtime/dice/src/weiss/avc.rs
@@ -6,11 +6,14 @@ use {super::*, protocols::weiss::avc::*};
 #[derive(Default)]
 pub struct WeissMan301Model {
     req: FwReq,
+    avc: WeissAvc,
     sections: GeneralSections,
     common_ctl: CommonCtl<WeissMan301Protocol>,
+    analog_output_ctls: AnalogOutputCtls,
 }
 
 const TIMEOUT_MS: u32 = 20;
+const FCP_TIMEOUT_MS: u32 = 40;
 
 impl CtlModel<(SndDice, FwNode)> for WeissMan301Model {
     fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -24,16 +27,25 @@ impl CtlModel<(SndDice, FwNode)> for WeissMan301Model {
         self.common_ctl
             .cache_whole_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
 
+        self.avc.bind(node)?;
+
+        self.analog_output_ctls.cache(&self.avc, FCP_TIMEOUT_MS)?;
+
         Ok(())
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
+
+        self.analog_output_ctls.load(card_cntr)?;
+
         Ok(())
     }
 
     fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
         if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.analog_output_ctls.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -55,6 +67,11 @@ impl CtlModel<(SndDice, FwNode)> for WeissMan301Model {
             elem_value,
             TIMEOUT_MS,
         )? {
+            Ok(true)
+        } else if self
+            .analog_output_ctls
+            .write(&self.avc, elem_id, elem_value, FCP_TIMEOUT_MS)?
+        {
             Ok(true)
         } else {
             Ok(false)
@@ -85,5 +102,189 @@ impl MeasureModel<(SndDice, FwNode)> for WeissMan301Model {
     fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
         self.common_ctl
             .cache_partial_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)
+    }
+}
+
+#[derive(Default, Debug)]
+struct AnalogOutputCtls {
+    polarity_inversion: WeissAvcAnalogOutputPolarityInversion,
+    filter_type: WeissAvcAnalogOutputFilterType,
+    mute: WeissAvcAnalogOutputMute,
+    level: WeissAvcAnalogOutputLevel,
+}
+
+const ANALOG_OUTPUT_POLARITY_INVERSION_NAME: &str = "DAC::DAC Polarity Inversion Playback Switch";
+const ANALOG_OUTPUT_FILTER_TYPE_NAME: &str = "DAC::DAC Filter Type";
+const ANALOG_OUTPUT_UNMUTE_NAME: &str = "DAC::DAC Output Playback Switch";
+const ANALOG_OUTPUT_LEVEL_NAME: &str = "DAC::Analog Output Level";
+
+fn analog_output_filter_type_to_str(filter_type: &WeissAvcAnalogOutputFilterType) -> &str {
+    match filter_type {
+        WeissAvcAnalogOutputFilterType::A => "A",
+        WeissAvcAnalogOutputFilterType::B => "B",
+    }
+}
+
+const ANALOG_OUTPUT_FILTER_TYPES: &[WeissAvcAnalogOutputFilterType] = &[
+    WeissAvcAnalogOutputFilterType::A,
+    WeissAvcAnalogOutputFilterType::B,
+];
+
+fn analog_output_level_to_str(level: &WeissAvcAnalogOutputLevel) -> &str {
+    match level {
+        WeissAvcAnalogOutputLevel::Zero => "0 dB",
+        WeissAvcAnalogOutputLevel::NegativeTen => "-10 dB",
+        WeissAvcAnalogOutputLevel::NegativeTwenty => "-20 dB",
+        WeissAvcAnalogOutputLevel::NegativeThirty => "-30 dB",
+    }
+}
+
+const ANALOG_OUTPUT_LEVELS: &[WeissAvcAnalogOutputLevel] = &[
+    WeissAvcAnalogOutputLevel::Zero,
+    WeissAvcAnalogOutputLevel::NegativeTen,
+    WeissAvcAnalogOutputLevel::NegativeTwenty,
+    WeissAvcAnalogOutputLevel::NegativeThirty,
+];
+
+impl AnalogOutputCtls {
+    fn cache(&mut self, avc: &WeissAvc, timeout_ms: u32) -> Result<(), Error> {
+        let res = WeissMan301Protocol::cache_param(avc, &mut self.polarity_inversion, timeout_ms);
+        debug!(param = ?self.polarity_inversion, ?res);
+        res?;
+        let res = WeissMan301Protocol::cache_param(avc, &mut self.filter_type, timeout_ms);
+        debug!(param = ?self.filter_type, ?res);
+        res?;
+        let res = WeissMan301Protocol::cache_param(avc, &mut self.mute, timeout_ms);
+        debug!(param = ?self.mute, ?res);
+        res?;
+        let res = WeissMan301Protocol::cache_param(avc, &mut self.level, timeout_ms);
+        debug!(param = ?self.level, ?res);
+        res?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let elem_id = ElemId::new_by_name(
+            ElemIfaceType::Mixer,
+            0,
+            0,
+            ANALOG_OUTPUT_POLARITY_INVERSION_NAME,
+            0,
+        );
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<&str> = ANALOG_OUTPUT_FILTER_TYPES
+            .iter()
+            .map(|t| analog_output_filter_type_to_str(t))
+            .collect();
+        let elem_id = ElemId::new_by_name(
+            ElemIfaceType::Mixer,
+            0,
+            0,
+            ANALOG_OUTPUT_FILTER_TYPE_NAME,
+            0,
+        );
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ANALOG_OUTPUT_UNMUTE_NAME, 0);
+        let _ = card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let labels: Vec<&str> = ANALOG_OUTPUT_LEVELS
+            .iter()
+            .map(|t| analog_output_level_to_str(t))
+            .collect();
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ANALOG_OUTPUT_LEVEL_NAME, 0);
+        let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
+
+        Ok(())
+    }
+
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            ANALOG_OUTPUT_POLARITY_INVERSION_NAME => {
+                elem_value.set_bool(&[self.polarity_inversion.0]);
+                Ok(true)
+            }
+            ANALOG_OUTPUT_FILTER_TYPE_NAME => {
+                let pos = ANALOG_OUTPUT_FILTER_TYPES
+                    .iter()
+                    .position(|filter_type| filter_type.eq(&self.filter_type))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            ANALOG_OUTPUT_UNMUTE_NAME => {
+                elem_value.set_bool(&[!self.mute.0]);
+                Ok(true)
+            }
+            ANALOG_OUTPUT_LEVEL_NAME => {
+                let pos = ANALOG_OUTPUT_LEVELS
+                    .iter()
+                    .position(|level| level.eq(&self.level))
+                    .unwrap() as u32;
+                elem_value.set_enum(&[pos]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(
+        &mut self,
+        avc: &WeissAvc,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            ANALOG_OUTPUT_POLARITY_INVERSION_NAME => {
+                let mut param = self.polarity_inversion.clone();
+                param.0 = elem_value.boolean()[0];
+                let res = WeissMan301Protocol::update_param(avc, &mut param, timeout_ms)
+                    .map(|_| self.polarity_inversion = param);
+                debug!(param = ?self.polarity_inversion, ?res);
+                res.map(|_| true)
+            }
+            ANALOG_OUTPUT_FILTER_TYPE_NAME => {
+                let pos = elem_value.enumerated()[0] as usize;
+                let mut param = ANALOG_OUTPUT_FILTER_TYPES
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid index of analog output filter type: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|filter_type| *filter_type)?;
+                let res = WeissMan301Protocol::update_param(avc, &mut param, timeout_ms)
+                    .map(|_| self.filter_type = param);
+                debug!(param = ?self.filter_type, ?res);
+                res.map(|_| true)
+            }
+            ANALOG_OUTPUT_UNMUTE_NAME => {
+                let mut param = self.mute.clone();
+                param.0 = !elem_value.boolean()[0];
+                let res = WeissMan301Protocol::update_param(avc, &mut param, timeout_ms)
+                    .map(|_| self.mute = param);
+                debug!(param = ?self.mute, ?res);
+                res.map(|_| true)
+            }
+            ANALOG_OUTPUT_LEVEL_NAME => {
+                let pos = elem_value.enumerated()[0] as usize;
+                let mut param = ANALOG_OUTPUT_LEVELS
+                    .iter()
+                    .nth(pos)
+                    .ok_or_else(|| {
+                        let msg = format!("Invalid index of analog output level: {}", pos);
+                        Error::new(FileError::Inval, &msg)
+                    })
+                    .map(|level| *level)?;
+                let res = WeissMan301Protocol::update_param(avc, &mut param, timeout_ms)
+                    .map(|_| self.level = param);
+                debug!(param = ?self.level, ?res);
+                res.map(|_| true)
+            }
+            _ => Ok(false),
+        }
     }
 }

--- a/runtime/dice/src/weiss/normal.rs
+++ b/runtime/dice/src/weiss/normal.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2024 Takashi Sakamoto
+
+use {super::*, protocols::weiss::normal::*};
+
+pub type Adc2Model = WeissNormalModel<WeissAdc2Protocol>;
+pub type VestaModel = WeissNormalModel<WeissVestaProtocol>;
+pub type Dac2Model = WeissNormalModel<WeissDac2Protocol>;
+pub type Afi1Model = WeissNormalModel<WeissAfi1Protocol>;
+pub type Dac202Model = WeissNormalModel<WeissDac202Protocol>;
+pub type Int203Model = WeissNormalModel<WeissInt203Protocol>;
+
+const TIMEOUT_MS: u32 = 100;
+
+#[derive(Default)]
+pub struct WeissNormalModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    req: FwReq,
+    sections: GeneralSections,
+    common_ctl: CommonCtl<T>,
+}
+
+impl<T> CtlModel<(SndDice, FwNode)> for WeissNormalModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        T::read_general_sections(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
+
+        self.common_ctl
+            .cache_whole_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)?;
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        self.common_ctl.load(card_cntr)
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        self.common_ctl.read(elem_id, elem_value)
+    }
+
+    fn write(
+        &mut self,
+        (unit, node): &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        new: &ElemValue,
+    ) -> Result<bool, Error> {
+        self.common_ctl.write(
+            &unit,
+            &self.req,
+            &node,
+            &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )
+    }
+}
+
+impl<T> NotifyModel<(SndDice, FwNode), u32> for WeissNormalModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
+    }
+
+    fn parse_notification(
+        &mut self,
+        (_, node): &mut (SndDice, FwNode),
+        msg: &u32,
+    ) -> Result<(), Error> {
+        self.common_ctl
+            .parse_notification(&self.req, &node, &mut self.sections, *msg, TIMEOUT_MS)
+    }
+}
+
+impl<T> MeasureModel<(SndDice, FwNode)> for WeissNormalModel<T>
+where
+    T: TcatNotifiedSectionOperation<GlobalParameters>
+        + TcatFluctuatedSectionOperation<GlobalParameters>
+        + TcatMutableSectionOperation<GlobalParameters>
+        + TcatNotifiedSectionOperation<TxStreamFormatParameters>
+        + TcatNotifiedSectionOperation<RxStreamFormatParameters>
+        + TcatSectionOperation<ExtendedSyncParameters>,
+{
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
+    }
+
+    fn measure_states(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
+        self.common_ctl
+            .cache_partial_params(&self.req, &node, &mut self.sections, TIMEOUT_MS)
+    }
+}


### PR DESCRIPTION
The series of changes in this MR includes protocol implementation for the following models produced by Weiss Engieering.

* Weiss Engineering ADC2
* Weiss Engineering Vesta
* Weiss Engineering DAC2, Minerva
* Weiss Engineering AFI1
* Weiss Engineering INT202, INT203, DAC1 FireWire option card
* Weiss Engineering DAC202, Maya
* Weiss Engineering MAN301

The remarkable point is AV/C VENDOR-DEPENDENT command specific to TC Electronic. The command is used to configure MAN301. 

To @michele-perrone and @pirx08,

I posted a question about audio signal routing inner MAN301. I appreciate if getting your comments about it.

* https://lore.kernel.org/alsa-devel/20240121140748.GA189921@workstation.local/