### PR TITLE
[PATCH 0/1] Use crates based on glib 0.19

### DIFF
--- a/protocols/bebob/Cargo.toml
+++ b/protocols/bebob/Cargo.toml
@@ -19,8 +19,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
+glib = "0.19"
+hinawa = "0.11"
 ta1394-avc-general = "0.2"
 ta1394-avc-audio = "0.2"
 ta1394-avc-stream-format = "0.2"

--- a/protocols/bebob/src/lib.rs
+++ b/protocols/bebob/src/lib.rs
@@ -20,7 +20,7 @@ pub mod yamaha_terratec;
 
 use {
     self::bridgeco::{ExtendedStreamFormatSingle, *},
-    glib::{Error, FileError, IsA},
+    glib::{prelude::IsA, Error, FileError},
     hinawa::{
         prelude::{FwFcpExt, FwFcpExtManual, FwReqExtManual},
         FwFcp, FwNode, FwReq, FwTcode,

--- a/protocols/dice/Cargo.toml
+++ b/protocols/dice/Cargo.toml
@@ -19,8 +19,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
+glib = "0.19"
+hinawa = "0.11"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 

--- a/protocols/dice/src/weiss/avc.rs
+++ b/protocols/dice/src/weiss/avc.rs
@@ -23,7 +23,7 @@
 use {
     super::*,
     crate::{tcelectronic::*, *},
-    glib::{Error, FileError, IsA},
+    glib::{prelude::IsA, Error, FileError},
     hinawa::{
         prelude::{FwFcpExt, FwFcpExtManual},
         FwFcp, FwNode,

--- a/protocols/digi00x/Cargo.toml
+++ b/protocols/digi00x/Cargo.toml
@@ -18,5 +18,5 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
+glib = "0.19"
+hinawa = "0.11"

--- a/protocols/fireface/Cargo.toml
+++ b/protocols/fireface/Cargo.toml
@@ -18,8 +18,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
+glib = "0.19"
+hinawa = "0.11"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/protocols/fireworks/Cargo.toml
+++ b/protocols/fireworks/Cargo.toml
@@ -18,6 +18,6 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"

--- a/protocols/fireworks/src/transaction.rs
+++ b/protocols/fireworks/src/transaction.rs
@@ -9,6 +9,7 @@
 
 use {
     glib::{
+        object::{Cast, ObjectExt},
         subclass::{object::*, prelude::*},
         Properties, *,
     },

--- a/protocols/motu/Cargo.toml
+++ b/protocols/motu/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
 ieee1212-config-rom = "0.1"

--- a/protocols/motu/src/version_1.rs
+++ b/protocols/motu/src/version_1.rs
@@ -481,7 +481,8 @@ const CONF_828_OPT_IN_IFACE_LABEL: &str = "opt-in-iface-v1";
 
 impl F828Protocol {
     /// The available modes of optical interface.
-    pub const OPT_IFACE_MODES: &'static [V1OptIfaceMode] = &[V1OptIfaceMode::Adat, V1OptIfaceMode::Spdif];
+    pub const OPT_IFACE_MODES: &'static [V1OptIfaceMode] =
+        &[V1OptIfaceMode::Adat, V1OptIfaceMode::Spdif];
 }
 
 impl MotuWhollyCacheableParamsOperation<F828OpticalIfaceParameters> for F828Protocol {

--- a/protocols/oxfw/Cargo.toml
+++ b/protocols/oxfw/Cargo.toml
@@ -18,8 +18,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
+glib = "0.19"
+hinawa = "0.11"
 ta1394-avc-general = "0.2"
 ta1394-avc-audio = "0.2"
 ta1394-avc-ccm = "0.2"

--- a/protocols/oxfw/src/lib.rs
+++ b/protocols/oxfw/src/lib.rs
@@ -11,7 +11,7 @@ pub mod oxford;
 pub mod tascam;
 
 use {
-    glib::{Error, FileError, IsA},
+    glib::{prelude::IsA, Error, FileError},
     hinawa::{
         prelude::{FwFcpExt, FwFcpExtManual, FwReqExtManual},
         FwFcp, FwNode, FwReq, FwTcode,

--- a/protocols/tascam/Cargo.toml
+++ b/protocols/tascam/Cargo.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/protocols/tascam/src/asynch.rs
+++ b/protocols/tascam/src/asynch.rs
@@ -11,6 +11,7 @@ pub mod fe8;
 use {
     super::*,
     glib::{
+        object::{Cast, ObjectExt},
         subclass::{object::*, types::*},
         *,
     },

--- a/runtime/bebob/Cargo.toml
+++ b/runtime/bebob/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 [dependencies]
 libc = "0.2"
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
-alsaseq = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
+alsaseq = "0.6"
 clap = { version = "3.2", features = ["derive"] }
 tracing = "0.1"

--- a/runtime/core/src/dispatcher.rs
+++ b/runtime/core/src/dispatcher.rs
@@ -5,7 +5,7 @@ use {
     super::*,
     alsactl::{prelude::CardExt, Card},
     alsaseq::{prelude::UserClientExt, UserClient},
-    glib::{source, ControlFlow, IsA, MainContext, MainLoop, Source},
+    glib::{prelude::IsA, source, ControlFlow, MainContext, MainLoop, Source},
     hinawa::{prelude::FwNodeExt, FwNode},
     hitaki::{prelude::AlsaFirewireExt, AlsaFirewire},
     nix::sys::signal,

--- a/runtime/dice/Cargo.toml
+++ b/runtime/dice/Cargo.toml
@@ -12,11 +12,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.18"
+glib = "0.19"
 nix = { version = ">=0.24", features = ["signal"] }
-alsactl = "0.5"
-hinawa = "0.10"
-hitaki = "0.4"
+alsactl = "0.6"
+hinawa = "0.11"
+hitaki = "0.5"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-dice-protocols = "0.3"

--- a/runtime/digi00x/Cargo.toml
+++ b/runtime/digi00x/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/fireface/Cargo.toml
+++ b/runtime/fireface/Cargo.toml
@@ -12,11 +12,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.18"
+glib = "0.19"
 nix = { version = ">=0.24", features = ["signal"] }
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-fireface-protocols = "0.2"

--- a/runtime/fireworks/Cargo.toml
+++ b/runtime/fireworks/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/motu/Cargo.toml
+++ b/runtime/motu/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-motu-protocols = "0.3"

--- a/runtime/oxfw/Cargo.toml
+++ b/runtime/oxfw/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 ta1394-avc-stream-format = "0.2"

--- a/runtime/tascam/Cargo.toml
+++ b/runtime/tascam/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.18"
-hinawa = "0.10"
-hitaki = "0.4"
-alsactl = "0.5"
-alsaseq = "0.5"
+glib = "0.19"
+hinawa = "0.11"
+hitaki = "0.5"
+alsactl = "0.6"
+alsaseq = "0.6"
 ieee1212-config-rom = "0.1"
 alsa-ctl-tlv-codec = "0.1"
 firewire-tascam-protocols = "0.2"

--- a/runtime/tascam/src/main.rs
+++ b/runtime/tascam/src/main.rs
@@ -18,7 +18,7 @@ use {
     asynch_runtime::*,
     clap::Parser,
     firewire_tascam_protocols as protocols,
-    glib::{Error, FileError, IsA},
+    glib::{prelude::IsA, Error, FileError},
     hinawa::{
         prelude::{FwNodeExt, FwNodeExtManual},
         FwNode, FwReq,


### PR DESCRIPTION
This commit switches the versions of dependent crates based on glib 0.19. This is the list of crates:

* glib crate 0.19
* hinawa crate 0.11
* hitaki crate 0.5
* alsactl crate 0.6
* alsaseq crate 0.6

```
Takashi Sakamoto (1):
  Use crates based on glib 0.19

 protocols/bebob/Cargo.toml             |  4 ++--
 protocols/bebob/src/lib.rs             |  2 +-
 protocols/dice/Cargo.toml              |  4 ++--
 protocols/dice/src/weiss/avc.rs        |  2 +-
 protocols/digi00x/Cargo.toml           |  4 ++--
 protocols/fireface/Cargo.toml          |  4 ++--
 protocols/fireworks/Cargo.toml         |  6 +++---
 protocols/fireworks/src/transaction.rs |  1 +
 protocols/motu/Cargo.toml              |  6 +++---
 protocols/motu/src/version_1.rs        |  3 ++-
 protocols/oxfw/Cargo.toml              |  4 ++--
 protocols/oxfw/src/lib.rs              |  2 +-
 protocols/tascam/Cargo.toml            |  6 +++---
 protocols/tascam/src/asynch.rs         |  1 +
 runtime/bebob/Cargo.toml               |  8 ++++----
 runtime/core/Cargo.toml                | 10 +++++-----
 runtime/core/src/dispatcher.rs         |  2 +-
 runtime/dice/Cargo.toml                |  8 ++++----
 runtime/digi00x/Cargo.toml             |  8 ++++----
 runtime/fireface/Cargo.toml            |  8 ++++----
 runtime/fireworks/Cargo.toml           |  8 ++++----
 runtime/motu/Cargo.toml                |  8 ++++----
 runtime/oxfw/Cargo.toml                |  8 ++++----
 runtime/tascam/Cargo.toml              | 10 +++++-----
 runtime/tascam/src/main.rs             |  2 +-
 25 files changed, 66 insertions(+), 63 deletions(-)
```