### PR TITLE
runtime: update clap crate version to v4.5

### DIFF
--- a/runtime/bebob/Cargo.toml
+++ b/runtime/bebob/Cargo.toml
@@ -21,7 +21,7 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 firewire-bebob-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/bebob/src/main.rs
+++ b/runtime/bebob/src/main.rs
@@ -318,7 +318,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -18,5 +18,5 @@ hinawa = "0.11"
 hitaki = "0.5"
 alsactl = "0.6"
 alsaseq = "0.6"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"

--- a/runtime/core/src/lib.rs
+++ b/runtime/core/src/lib.rs
@@ -4,10 +4,10 @@ pub mod card_cntr;
 pub mod cmdline;
 pub mod dispatcher;
 
-use {clap::ArgEnum, glib::Error};
+use {clap::ValueEnum, glib::Error};
 
 /// The level to debug runtime.
-#[derive(ArgEnum, Debug, Copy, Clone, Eq, PartialEq)]
+#[derive(ValueEnum, Debug, Copy, Clone, Eq, PartialEq)]
 pub enum LogLevel {
     Debug,
 }

--- a/runtime/dice/Cargo.toml
+++ b/runtime/dice/Cargo.toml
@@ -20,7 +20,7 @@ hitaki = "0.5"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-dice-protocols = "0.3"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/dice/src/main.rs
+++ b/runtime/dice/src/main.rs
@@ -330,7 +330,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/digi00x/Cargo.toml
+++ b/runtime/digi00x/Cargo.toml
@@ -21,7 +21,7 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 firewire-digi00x-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/digi00x/src/main.rs
+++ b/runtime/digi00x/src/main.rs
@@ -349,7 +349,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/fireface/Cargo.toml
+++ b/runtime/fireface/Cargo.toml
@@ -20,7 +20,7 @@ alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-fireface-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/fireface/src/main.rs
+++ b/runtime/fireface/src/main.rs
@@ -183,7 +183,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/fireworks/Cargo.toml
+++ b/runtime/fireworks/Cargo.toml
@@ -21,7 +21,7 @@ alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 firewire-fireworks-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/fireworks/src/main.rs
+++ b/runtime/fireworks/src/main.rs
@@ -313,7 +313,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/motu/Cargo.toml
+++ b/runtime/motu/Cargo.toml
@@ -20,7 +20,7 @@ alsactl = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-motu-protocols = "0.3"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/motu/src/main.rs
+++ b/runtime/motu/src/main.rs
@@ -250,7 +250,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/oxfw/Cargo.toml
+++ b/runtime/oxfw/Cargo.toml
@@ -21,7 +21,7 @@ ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 ta1394-avc-stream-format = "0.2"
 firewire-oxfw-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/oxfw/src/main.rs
+++ b/runtime/oxfw/src/main.rs
@@ -308,7 +308,7 @@ struct Arguments {
     card_id: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 

--- a/runtime/tascam/Cargo.toml
+++ b/runtime/tascam/Cargo.toml
@@ -21,7 +21,7 @@ alsaseq = "0.6"
 ieee1212-config-rom = "0.1"
 alsa-ctl-tlv-codec = "0.1"
 firewire-tascam-protocols = "0.2"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "4.5", features = ["derive"] }
 runtime-core = { path = "../core" }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/runtime/tascam/src/main.rs
+++ b/runtime/tascam/src/main.rs
@@ -230,7 +230,7 @@ struct Arguments {
     sysnum: u32,
 
     /// The level to debug runtime, disabled as a default.
-    #[clap(long, short, arg_enum)]
+    #[clap(long, short, value_enum)]
     log_level: Option<LogLevel>,
 }
 


### PR DESCRIPTION
This commit includes the changes to migrate to clap crate version 4.5.