### PR TITLE
migrate to glib crate v0.20

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 snd-firewire-ctl-services
 ========================
 
-2024/03/03
+2024/10/07
 Takashi Sakamoto
 
 Introduction
@@ -302,7 +302,7 @@ License
 Dependencies
 ============
 
-* Rust programming language `<https://www.rust-lang.org/>`_ v1.65 or later.
+* Rust programming language `<https://www.rust-lang.org/>`_ v1.70 or later.
 * Cargo
 * glib `<https://developer.gnome.org/glib/>`_
 * libhinawa v4.0 or later `<https://git.kernel.org/pub/scm/libs/ieee1394/libhinawa.git/>`_

--- a/protocols/bebob/Cargo.toml
+++ b/protocols/bebob/Cargo.toml
@@ -19,8 +19,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
+glib = "0.20"
+hinawa = "0.12"
 ta1394-avc-general = "0.2"
 ta1394-avc-audio = "0.2"
 ta1394-avc-stream-format = "0.2"

--- a/protocols/dice/Cargo.toml
+++ b/protocols/dice/Cargo.toml
@@ -19,8 +19,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
+glib = "0.20"
+hinawa = "0.12"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 

--- a/protocols/digi00x/Cargo.toml
+++ b/protocols/digi00x/Cargo.toml
@@ -18,5 +18,5 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
+glib = "0.20"
+hinawa = "0.12"

--- a/protocols/fireface/Cargo.toml
+++ b/protocols/fireface/Cargo.toml
@@ -18,8 +18,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
+glib = "0.20"
+hinawa = "0.12"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/protocols/fireworks/Cargo.toml
+++ b/protocols/fireworks/Cargo.toml
@@ -18,6 +18,6 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"

--- a/protocols/motu/Cargo.toml
+++ b/protocols/motu/Cargo.toml
@@ -18,7 +18,7 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
 ieee1212-config-rom = "0.1"

--- a/protocols/oxfw/Cargo.toml
+++ b/protocols/oxfw/Cargo.toml
@@ -18,8 +18,8 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
+glib = "0.20"
+hinawa = "0.12"
 ta1394-avc-general = "0.2"
 ta1394-avc-audio = "0.2"
 ta1394-avc-ccm = "0.2"

--- a/protocols/tascam/Cargo.toml
+++ b/protocols/tascam/Cargo.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/alsa-project/snd-firewire-ctl-services"
 features = ["dox"]
 
 [dependencies]
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
 ieee1212-config-rom = "0.1"
 
 [[bin]]

--- a/runtime/bebob/Cargo.toml
+++ b/runtime/bebob/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/core/Cargo.toml
+++ b/runtime/core/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 [dependencies]
 libc = "0.2"
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
-alsaseq = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
+alsaseq = "0.7"
 clap = { version = "4.5", features = ["derive"] }
 tracing = "0.1"

--- a/runtime/dice/Cargo.toml
+++ b/runtime/dice/Cargo.toml
@@ -12,11 +12,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.19"
+glib = "0.20"
 nix = { version = ">=0.24", features = ["signal"] }
-alsactl = "0.6"
-hinawa = "0.11"
-hitaki = "0.5"
+alsactl = "0.7"
+hinawa = "0.12"
+hitaki = "0.6"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-dice-protocols = "0.3"

--- a/runtime/digi00x/Cargo.toml
+++ b/runtime/digi00x/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/fireface/Cargo.toml
+++ b/runtime/fireface/Cargo.toml
@@ -12,11 +12,11 @@ license = "GPL-3.0-or-later"
 publish = false
 
 [dependencies]
-glib = "0.19"
+glib = "0.20"
 nix = { version = ">=0.24", features = ["signal"] }
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-fireface-protocols = "0.2"

--- a/runtime/fireworks/Cargo.toml
+++ b/runtime/fireworks/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"

--- a/runtime/motu/Cargo.toml
+++ b/runtime/motu/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 alsa-ctl-tlv-codec = "0.1"
 ieee1212-config-rom = "0.1"
 firewire-motu-protocols = "0.3"

--- a/runtime/oxfw/Cargo.toml
+++ b/runtime/oxfw/Cargo.toml
@@ -13,10 +13,10 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
 ieee1212-config-rom = "0.1"
 ta1394-avc-general = "0.2"
 ta1394-avc-stream-format = "0.2"

--- a/runtime/tascam/Cargo.toml
+++ b/runtime/tascam/Cargo.toml
@@ -13,11 +13,11 @@ publish = false
 
 [dependencies]
 nix = { version = ">=0.24", features = ["signal"] }
-glib = "0.19"
-hinawa = "0.11"
-hitaki = "0.5"
-alsactl = "0.6"
-alsaseq = "0.6"
+glib = "0.20"
+hinawa = "0.12"
+hitaki = "0.6"
+alsactl = "0.7"
+alsaseq = "0.7"
 ieee1212-config-rom = "0.1"
 alsa-ctl-tlv-codec = "0.1"
 firewire-tascam-protocols = "0.2"


### PR DESCRIPTION
The new release of gtk-rs stack was published in this July [1].

This commit changes the dependency on glib crate to version 0.20. MSRV is version 1.70.

[1] https://gtk-rs.org/blog/2024/07/17/new-release.html