### PR TITLE
fireface: latter: fix eq gain range

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -1278,9 +1278,9 @@ impl AsMut<FfLatterEqState> for FfLatterOutputEqualizerParameters {
 /// The trait for specification of equalizer.
 pub trait RmeFfLatterEqualizerSpecification {
     /// The minimum value of gain.
-    const EQ_GAIN_MIN: i32 = -20;
+    const EQ_GAIN_MIN: i32 = -200;
     /// The maximum value of gain.
-    const EQ_GAIN_MAX: i32 = 20;
+    const EQ_GAIN_MAX: i32 = 200;
     /// The step value of gain.
     const EQ_GAIN_STEP: i32 = 1;
 

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -1216,6 +1216,13 @@ where
     const EQ_HIGH_FREQ_NAME: &'static str;
     const EQ_HIGH_QUALITY_NAME: &'static str;
 
+    const EQ_GAIN_TLV: DbInterval = DbInterval {
+        min: -2000,
+        max: 2000,
+        linear: false,
+        mute_avail: false,
+    };
+
     fn params(&self) -> &U;
     fn params_mut(&mut self) -> &mut U;
 
@@ -1270,7 +1277,7 @@ where
                     T::EQ_GAIN_MAX,
                     T::EQ_GAIN_STEP,
                     Self::CH_COUNT,
-                    None,
+                    Some(&Vec::<u32>::from(&Self::EQ_GAIN_TLV)),
                     true,
                 )
                 .map(|mut list| elem_id_list.append(&mut list))


### PR DESCRIPTION
The current implementation only allows setting eq gains between -2 and +2dB (should be between -20 and +20) , this PR fixes it.