### PR TITLE
fireface: latter: inactive and shifted mixer stream source gain controls

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -178,6 +178,8 @@ pub trait RmeFfLatterSpecification {
     const ADAT_INPUT_COUNT: usize;
     /// The number of stream inputs.
     const STREAM_INPUT_COUNT: usize;
+    /// The number of fx returns.
+    const FX_RETURN_COUNT: usize;
 
     /// The number of line outputs.
     const LINE_OUTPUT_COUNT: usize;
@@ -927,6 +929,8 @@ pub struct FfLatterMixer {
     pub adat_gains: Vec<u16>,
     /// The gain of sources from stream inputs.
     pub stream_gains: Vec<u16>,
+    /// The gain of sources from fx return
+    pub fx_return_gains: Vec<u16>,
 }
 
 /// State of mixers.
@@ -951,6 +955,7 @@ pub trait RmeFfLatterMixerSpecification: RmeFfLatterDspSpecification {
                 mic_gains: vec![Default::default(); Self::MIC_INPUT_COUNT],
                 spdif_gains: vec![Default::default(); Self::SPDIF_INPUT_COUNT],
                 adat_gains: vec![Default::default(); Self::ADAT_INPUT_COUNT],
+                fx_return_gains: vec![Default::default(); Self::FX_RETURN_COUNT],
                 stream_gains: vec![Default::default(); Self::STREAM_INPUT_COUNT],
             };
             Self::OUTPUT_COUNT
@@ -974,6 +979,8 @@ impl<O: RmeFfLatterMixerSpecification> RmeFfCommandParamsSerialize<FfLatterMixer
                     .chain(&mixer.mic_gains)
                     .chain(&mixer.spdif_gains)
                     .chain(&mixer.adat_gains)
+                    .chain(&mixer.fx_return_gains)
+                    .chain(&mixer.stream_gains)
                     .enumerate()
                     .map(|(j, &gain)| {
                         let ch = j as u16;

--- a/protocols/fireface/src/latter/ff802.rs
+++ b/protocols/fireface/src/latter/ff802.rs
@@ -397,6 +397,7 @@ impl RmeFfLatterSpecification for Ff802Protocol {
     const SPDIF_INPUT_COUNT: usize = 2;
     const ADAT_INPUT_COUNT: usize = 16;
     const STREAM_INPUT_COUNT: usize = 30;
+    const FX_RETURN_COUNT: usize = 2;
 
     const LINE_OUTPUT_COUNT: usize = 8;
     const HP_OUTPUT_COUNT: usize = 4;

--- a/protocols/fireface/src/latter/ucx.rs
+++ b/protocols/fireface/src/latter/ucx.rs
@@ -356,6 +356,7 @@ impl RmeFfLatterSpecification for FfUcxProtocol {
     const SPDIF_INPUT_COUNT: usize = 2;
     const ADAT_INPUT_COUNT: usize = 8;
     const STREAM_INPUT_COUNT: usize = 18;
+    const FX_RETURN_COUNT: usize = 2;
 
     const LINE_OUTPUT_COUNT: usize = 6;
     const HP_OUTPUT_COUNT: usize = 2;


### PR DESCRIPTION
The controls for mixer stream source gains where inactive, and while fixing it I found out I needed to shift them by two channels to make them work as expected which I assumed was due to the 2 fx return channels, I may be wrong here but since the fx output are handled differently than the mixer gains I guess it's not so important.