### PR TITLE
fireface: latter: fix/workaround mixer gain scale

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -913,7 +913,7 @@ impl<O: RmeFfLatterOutputSpecification> RmeFfCommandParamsSerialize<FfLatterOutp
 
 /// State of sources for mixer.
 ///
-/// Each value is between 0x0000 and 0xa000 through 0x9000 to represent -65.00 dB and 6.00 dB
+/// Each value is between 0x8000 and 0xa000 through 0x9000 to represent -78.00 dB and 6.00 dB
 /// through 0.00 dB.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterMixer {
@@ -936,7 +936,7 @@ pub struct FfLatterMixerState(pub Vec<FfLatterMixer>);
 /// The specification of mixer.
 pub trait RmeFfLatterMixerSpecification: RmeFfLatterDspSpecification {
     /// The minimum value of gain for source of mixer.
-    const MIXER_INPUT_GAIN_MIN: i32 = 0x0000;
+    const MIXER_INPUT_GAIN_MIN: i32 = 0x8000;
     /// The zero value of gain for source of mixer.
     const MIXER_INPUT_GAIN_ZERO: i32 = 0x9000;
     /// The maximum value of gain for source of mixer.

--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -913,7 +913,7 @@ impl<O: RmeFfLatterOutputSpecification> RmeFfCommandParamsSerialize<FfLatterOutp
 
 /// State of sources for mixer.
 ///
-/// Each value is between 0x8000 and 0xa000 through 0x9000 to represent -78.00 dB and 6.00 dB
+/// Each value is between 0x8000 and 0xa000 through 0x9000 to represent -65.00 dB and 6.00 dB
 /// through 0.00 dB.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FfLatterMixer {

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -672,7 +672,7 @@ where
         + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>,
 {
     const SRC_GAIN_TLV: DbInterval = DbInterval {
-        min: -7800,
+        min: -6500,
         max: 600,
         linear: true,
         mute_avail: false,

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -672,9 +672,9 @@ where
         + RmeFfPartiallyCommandableParamsOperation<FfLatterMixerState>,
 {
     const SRC_GAIN_TLV: DbInterval = DbInterval {
-        min: -6500,
+        min: -7800,
         max: 600,
-        linear: false,
+        linear: true,
         mute_avail: false,
     };
 


### PR DESCRIPTION
Following up #194, I may be too naive here, but mixer gains do work perfectly between 32768 and 40960 and the dB scaling is consistent across the whole range so it seems safe to me to go on using integer arithmetics after all.