### PR TITLE
fireface: latter: fix meter db scale

### DIFF
--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -33,9 +33,9 @@ where
     T: RmeFfLatterMeterSpecification + RmeFfCacheableParamsOperation<FfLatterMeterState>,
 {
     const LEVEL_TLV: DbInterval = DbInterval {
-        min: -9003,
-        max: 600,
-        linear: false,
+        min: -13800,
+        max: 0,
+        linear: true,
         mute_avail: false,
     };
 


### PR DESCRIPTION
This one is just a quality of life improvement for when using generic apps such as QasHCtl to check on meter values, the dB values where incorrect before. 