### PR TITLE
fireface: latter: set default output volumes to 0dB instead of +6dB

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -761,6 +761,8 @@ pub struct FfLatterOutputState {
 pub trait RmeFfLatterOutputSpecification: RmeFfLatterDspSpecification {
     /// The minimum value for volume of physical output.
     const PHYS_OUTPUT_VOL_MIN: i32 = -650;
+    /// The default value for volume of physical output.
+    const PHYS_OUTPUT_VOL_ZERO: i32 = 0;
     /// The maximum value for volume of physical output.
     const PHYS_OUTPUT_VOL_MAX: i32 = 60;
     /// The step value of for volume physical output.

--- a/runtime/fireface/src/latter_ctls.rs
+++ b/runtime/fireface/src/latter_ctls.rs
@@ -407,7 +407,7 @@ where
         params
             .vols
             .iter_mut()
-            .for_each(|vol| *vol = T::PHYS_OUTPUT_VOL_MAX as i16);
+            .for_each(|vol| *vol = T::PHYS_OUTPUT_VOL_ZERO as i16);
 
         Self {
             elem_id_list: Default::default(),


### PR DESCRIPTION
The current default output volumes (+6dB) may produce saturation,  the usual 0dB seems a more sensible default value.