### PR TITLE
fireface: latter: fix output stereo link and balance

### DIFF
--- a/protocols/fireface/src/latter.rs
+++ b/protocols/fireface/src/latter.rs
@@ -868,7 +868,7 @@ impl<O: RmeFfLatterOutputSpecification> RmeFfCommandParamsSerialize<FfLatterOutp
             .iter()
             .enumerate()
             .for_each(|(i, &balance)| {
-                let ch = ch_offset + i as u8;
+                let ch = ch_offset + (i * 2) as u8;
                 cmds.push(create_phys_port_cmd(ch, OUTPUT_STEREO_BALANCE_CMD, balance));
             });
 
@@ -877,7 +877,7 @@ impl<O: RmeFfLatterOutputSpecification> RmeFfCommandParamsSerialize<FfLatterOutp
             .iter()
             .enumerate()
             .for_each(|(i, &link)| {
-                let ch = ch_offset + i as u8;
+                let ch = ch_offset + (i * 2) as u8;
                 cmds.push(create_phys_port_cmd(
                     ch,
                     OUTPUT_STEREO_LINK_CMD,


### PR DESCRIPTION
Here's another little fix for the latter RME's stereo output links ! Thanks for making this possible (not quite finished but getting there):
<img width="1864" height="824" alt="Capture d’écran_2025-07-30_18-29-02" src="https://github.com/user-attachments/assets/71d6c945-93fb-48d3-9381-e24222b4eab0" />
 