### PR TITLE
dice: focusrite: add support for Saffire Pro 40, TCD3070 version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,7 +224,8 @@ However, we welcome any assistance that can enhance the project.
   * The most of monitor parameters may not work for Alesis iO 14/26 FireWire. This may come from
     firmware version.
   * The channel strip dynamics, equalizer, and reverb are not available for Lexicon I-ONIX 810s.
-  * No control is available for Focusrite Saffire Pro 40 (TCD3070 ASIC).
+  * Late versions of Focusrite Saffire Pro 40 (using TCD3070 ASIC) are only partial supported.
+    Mixer levels, metering and routing are supported.
   * No control is available for Solid State Logic Duende Classic and Mini.
 
 * snd-firewire-digi00x-ctl-service

--- a/protocols/dice/src/focusrite.rs
+++ b/protocols/dice/src/focusrite.rs
@@ -12,6 +12,7 @@ pub mod spro24;
 pub mod spro24dsp;
 pub mod spro26;
 pub mod spro40;
+pub mod spro40d3;
 
 use super::{
     tcat::{extension::*, *},

--- a/protocols/dice/src/focusrite/spro40d3.rs
+++ b/protocols/dice/src/focusrite/spro40d3.rs
@@ -1,0 +1,376 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later
+// Copyright (c) 2025 Andreas Persson
+
+//! Protocol specific to Focusrite Saffire Pro 40 D3.
+//!
+//! The module includes structure and its implementation for protocol
+//! defined by Focusrite for Saffire Pro 40 D3 (TCD3070 ASIC).
+
+use {
+    super::*,
+    hinawa::{
+        prelude::{FwReqExtManual, FwRespExt, FwRespExtManual},
+        FwTcode, FwResp, FwRcode,
+    },
+    std::{sync::mpsc, time::Duration},
+};
+
+/// Protocol implementation specific to Saffire Pro 40 D3.
+#[derive(Default, Debug)]
+pub struct SPro40D3Protocol {
+    req: FwReq,
+    resp: FwResp,
+    write_address: u64,
+    read_address: u64,
+    rx: Option<mpsc::Receiver<(u32, u16)>>,
+    counter: u16,
+    pub master_meter: [i32; 2],
+    pub mixer_meter: [i32; 18],
+}
+
+const NONE: u32 = 0;
+const ANALOG: u32 = 0x80;
+const SPDIF: u32 = 0x180;
+const ADAT: u32 = 0x200;
+const MIXER: u32 = 0x300;
+const STREAM: u32 = 0x400;
+
+impl TcatOperation for SPro40D3Protocol {}
+
+impl TcatGlobalSectionSpecification for SPro40D3Protocol {}
+
+fn deserialize_address(val: &mut u64, raw: &[u8]) {
+    let mut a1 = 0u32;
+    deserialize_u32(&mut a1, &raw[..4]);
+    let mut a2 = 0u32;
+    deserialize_u32(&mut a2, &raw[4..8]);
+    *val = (a1 as u64) | ((a2 as u64) << 32);
+}
+
+
+fn serialize_route(from: u32, to: u32, raw: &mut [u8]) {
+    let source = if from < 1 {
+        NONE
+    } else if from < 9 {
+        ANALOG + from - 1
+    } else if from < 11 {
+        SPDIF + from - 9
+    } else if from < 19 {
+        ADAT + from - 11
+    } else if from < 39 {
+        STREAM + from - 19
+    } else {
+        MIXER + from - 39
+    };
+    let val = (source << 12) | to;
+    serialize_u32(&val, raw)
+}
+
+impl SPro40D3Protocol {
+    pub fn init_communication(&mut self, node: &FwNode, timeout_ms: u32) -> Result<(), Error> {
+        let base_address = 0xffffe0400000u64;
+        let mut frame = vec![0u8; 48];
+
+        self.req.transaction(node, FwTcode::ReadBlockRequest, base_address, 48,
+                             &mut frame, timeout_ms)?;
+        deserialize_address(&mut self.write_address, &frame[32..40]);
+        deserialize_address(&mut self.read_address, &frame[40..48]);
+        let mut notification_address = 0u64;
+        deserialize_address(&mut notification_address, &frame[8..16]);
+
+        let (tx, rx) = mpsc::channel();
+        self.rx = Some(rx);
+        self.resp.connect_requested(
+            move |_, _tcode, _, _src, _, _, _, _, frame| {
+                let rlen = ((frame[6] as u16) << 8) | (frame[7] as u16);
+                let mut rstatus = 0u32;
+                deserialize_u32(&mut rstatus, &frame[8..12]);
+                let _ = tx.send((rstatus, rlen));
+
+                FwRcode::Complete
+            });
+        
+        self.resp.reserve_within_region(node, 0, 0x1000000000000, 16)?;
+        let new_notification_address = self.resp.offset();
+
+        if new_notification_address != notification_address {
+            let mut data = vec![0u8; 16];
+
+            serialize_u32(&(notification_address as u32), &mut data[0..]);
+            serialize_u32(&((notification_address >> 32) as u32),
+                          &mut data[4..]);
+            serialize_u32(&(new_notification_address as u32), &mut data[8..]);
+            serialize_u32(&((new_notification_address >> 32) as u32),
+                          &mut data[12..]);
+
+            self.req.transaction(node, FwTcode::LockCompareSwap,
+                                 base_address + 8, 8, &mut data, timeout_ms)?;
+        }
+        
+        Ok(())
+    }
+
+    fn send_message(
+        &mut self,
+        node: &FwNode,
+        len: usize,
+        message: &mut [u8],
+        timeout_ms: u32,
+    ) -> Result<u32, Error> {
+        message[4] = (self.counter >> 8) as u8;
+        message[5] = self.counter as u8;
+        message[6] = ((len - 16) >> 8) as u8;
+        message[7] = (len - 16) as u8;
+
+        self.counter = self.counter.wrapping_add(1);
+        
+        self.req.transaction(node, FwTcode::WriteBlockRequest,
+                             self.write_address, len,
+                             message, timeout_ms)?;
+
+        let (rstatus,rlen) = self.rx.as_ref().unwrap()
+            .recv_timeout(Duration::from_millis(timeout_ms.into()))
+            .map_err(|cause| Error::new(ProtocolExtensionError::Appl, &cause.to_string()))?;
+
+        self.req.transaction(node, FwTcode::ReadBlockRequest,
+                             self.read_address, (rlen + 16).into(),
+                             message, timeout_ms)?;
+        Ok(rstatus)
+    }
+
+    fn send_command(
+        &mut self,
+        node: &FwNode,
+        len: usize,
+        message: &mut [u8],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let rstatus = self.send_message(node, len, message, timeout_ms)?;
+        if rstatus != 0 {
+            self.counter = 0;
+
+            let mut reset = vec![0u8; 16];
+            reset[0] = 0x80;
+            self.send_message(node, reset.len(), &mut reset, timeout_ms)?;
+
+            self.send_message(node, len, message, timeout_ms)?;
+        }
+        Ok(())
+    }
+    
+    pub fn set_volume(
+        &mut self,
+        node: &FwNode,
+        channel: usize,
+        mix: usize,
+        volume: i32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut frame: Vec<u8> = vec![
+            0x80, 0x00, 0x20, 0x02,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            (volume >> 8) as u8, volume as u8,
+            channel as u8, mix as u8
+        ];
+        self.send_command(node, frame.len(), &mut frame, timeout_ms)
+    }
+
+    pub fn get_master_meter(
+        &mut self,
+        node: &FwNode,
+        current_rate: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut frame: Vec<u8> = vec![
+            0x80, 0x00, 0x10, 0x01,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 2, 0, if current_rate > 48000 {0x32} else {0x3a},
+            0, 0, 0, 0
+        ];
+        self.send_command(node, frame.len(), &mut frame, timeout_ms)?;
+
+        deserialize_i32(&mut self.master_meter[0], &frame[16..20]);
+        deserialize_i32(&mut self.master_meter[1], &frame[20..24]);
+        Ok(())
+    }
+
+    pub fn get_mixer_meter(
+        &mut self,
+        node: &FwNode,
+        current_rate: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let cmd: [u8; 24] = [
+            0x80, 0x00, 0x10, 0x01,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 0, 0, 0,
+            0, 18, 0, if current_rate > 48000 {0x20} else {0x28},
+            0, 0, 0, 0
+        ];
+        let mut frame: Vec<u8> = vec![0; 88];
+        frame[..cmd.len()].copy_from_slice(&cmd);
+        self.send_command(node, cmd.len(), &mut frame, timeout_ms)?;
+
+        self
+            .mixer_meter
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, m)| {
+                let pos = 16 + i * 4;
+                deserialize_i32(m, &frame[pos..(pos + 4)]);
+            });
+        Ok(())
+    }
+
+    pub fn set_routing(
+        &mut self,
+        node: &FwNode,
+        router_out_src: &[u32],
+        router_mixer_src: &[u32],
+        router_meter_src: &[u32],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        // There are two separate routing tables, one for sample rates
+        // 44100 and 48000 with eight ADAT channels, and one for 88200
+        // and 96000 with four ADAT. Both tables are updated here, to
+        // be ready if the sample rate is changed.
+        self.set_routing_low_rate(node, router_out_src, router_mixer_src, router_meter_src, timeout_ms)?;
+        self.set_routing_high_rate(node, router_out_src, router_mixer_src, router_meter_src, timeout_ms)
+    }
+    
+    fn set_routing_low_rate(
+        &mut self,
+        node: &FwNode,
+        router_out_src: &[u32],
+        router_mixer_src: &[u32],
+        router_meter_src: &[u32],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut frame: Vec<u8> = vec![0; 316];
+        frame[..4].copy_from_slice(&[0x80, 0x00, 0x30, 0x02]);
+
+        // to stream, fixed
+        for i in 0..18 {
+            serialize_route(1 + i as u32, STREAM + i as u32,
+                            &mut frame[20 + i * 4..][..4]);
+        }
+
+        // to outputs
+        for i in 0..5 {
+            serialize_route(router_out_src[i * 2],
+                            ANALOG + 8 - i as u32 * 2,
+                            &mut frame[92 + i * 8..][..4]); // korta: 76 osv
+            serialize_route(router_out_src[1 + i * 2],
+                            ANALOG + 9 - i as u32 * 2,
+                            &mut frame[96 + i * 8..][..4]);
+        }
+        serialize_route(router_out_src[10],
+                        SPDIF, &mut frame[132..136]);
+        serialize_route(router_out_src[11],
+                        SPDIF + 1, &mut frame[136..140]);
+
+        for i in 0..8 {
+            serialize_route(router_out_src[12 + i],
+                            ADAT + i as u32,
+                            &mut frame[140 + i * 4..][..4]);
+        }
+        // loopback
+        serialize_route(router_out_src[20],
+                        STREAM + 18, &mut frame[172..176]);
+        serialize_route(router_out_src[21],
+                        STREAM + 19, &mut frame[176..180]);
+
+        // to mixer
+        for i in 0..8 {
+            serialize_route(router_mixer_src[i],
+                            MIXER + i as u32,
+                            &mut frame[180 + i * 4..][..4]);
+        }
+        for i in 0..8 {
+            serialize_route(router_mixer_src[8 + i],
+                            MIXER + 8 + i as u32,
+                            &mut frame[212 + i * 4..][..4]);
+        }
+        serialize_route(router_mixer_src[16],
+                        MIXER + 16, &mut frame[244..248]);
+        serialize_route(router_mixer_src[17],
+                        MIXER + 17, &mut frame[248..252]);
+
+        // master meter
+        serialize_route(router_meter_src[0], 0x0, &mut frame[252..256]);
+        serialize_route(router_meter_src[1], 0x0, &mut frame[256..260]);
+
+        self.send_command(node, frame.len(), &mut frame, timeout_ms)
+    }
+
+    fn set_routing_high_rate(
+        &mut self,
+        node: &FwNode,
+        router_out_src: &[u32],
+        router_mixer_src: &[u32],
+        router_meter_src: &[u32],
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut frame: Vec<u8> = vec![0; 284];
+        frame[..4].copy_from_slice(&[0x80, 0x00, 0x30, 0x02]);
+        frame[17] = 1;
+
+        // to stream, fixed
+        for i in 0..14 {
+            serialize_route(1 + i as u32, STREAM + i as u32,
+                            &mut frame[20 + i * 4..][..4]);
+        }
+
+        // to outputs
+        for i in 0..5 {
+            serialize_route(router_out_src[i * 2],
+                            ANALOG + 8 - i as u32 * 2,
+                            &mut frame[76 + i * 8..][..4]);
+            serialize_route(router_out_src[1 + i * 2],
+                            ANALOG + 9 - i as u32 * 2,
+                            &mut frame[80 + i * 8..][..4]);
+        }
+        serialize_route(router_out_src[10],
+                        SPDIF, &mut frame[116..120]);
+        serialize_route(router_out_src[11],
+                        SPDIF + 1, &mut frame[120..124]);
+
+        for i in 0..4 {
+            serialize_route(router_out_src[12 + i],
+                            ADAT + i as u32,
+                            &mut frame[124 + i * 4..][..4]);
+        }
+        // loopback
+        serialize_route(router_out_src[20],
+                        STREAM + 14, &mut frame[140..144]);
+        serialize_route(router_out_src[21],
+                        STREAM + 15, &mut frame[144..148]);
+
+        // to mixer
+        for i in 0..8 {
+            serialize_route(router_mixer_src[i],
+                            MIXER + i as u32,
+                            &mut frame[148 + i * 4..][..4]);
+        }
+        for i in 0..8 {
+            serialize_route(router_mixer_src[8 + i],
+                            MIXER + 8 + i as u32,
+                            &mut frame[180 + i * 4..][..4]);
+        }
+        serialize_route(router_mixer_src[16],
+                        MIXER + 16, &mut frame[212..216]);
+        serialize_route(router_mixer_src[17],
+                        MIXER + 17, &mut frame[216..220]);
+
+        // master meter
+        serialize_route(router_meter_src[0], 0x0, &mut frame[220..224]);
+        serialize_route(router_meter_src[1], 0x0, &mut frame[224..228]);
+
+        self.send_command(node, frame.len(), &mut frame, timeout_ms)
+    }
+}

--- a/runtime/dice/src/focusrite.rs
+++ b/runtime/dice/src/focusrite.rs
@@ -7,6 +7,7 @@ pub mod spro24_model;
 pub mod spro24dsp_model;
 pub mod spro26_model;
 pub mod spro40_model;
+pub mod spro40d3_model;
 
 use {
     super::{tcd22xx_ctl::*, *},

--- a/runtime/dice/src/focusrite/spro40d3_model.rs
+++ b/runtime/dice/src/focusrite/spro40d3_model.rs
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (c) 2025 Andreas Persson
+
+use {
+    super::*,
+    protocols::focusrite::spro40d3::*,
+    alsa_ctl_tlv_codec::CTL_VALUE_MUTE,
+};
+
+#[derive(Default)]
+pub struct SPro40D3Model {
+    req: FwReq,
+    sections: GeneralSections,
+    common_ctl: CommonCtl<SPro40D3Protocol>,
+    notified_elem_id_list: Vec<ElemId>,
+    measured_elem_id_list: Vec<ElemId>,
+    protocol: SPro40D3Protocol,
+    gain_values: Vec<ElemValue>,
+    router_out_src: ElemValue,
+    router_mixer_src: ElemValue,
+    router_meter_src: ElemValue,
+}
+
+const TIMEOUT_MS: u32 = 20;
+    
+const COEF_MIN: i32 = 0;
+const COEF_MAX: i32 = 0x7fff;
+const COEF_STEP: i32 = 1;
+// 0dB is 0x1fff
+const COEF_TLV: DbInterval = DbInterval {
+    min: CTL_VALUE_MUTE,
+    max: 1204,
+    linear: true,
+    mute_avail: false,
+};
+
+impl CtlModel<(SndDice, FwNode)> for SPro40D3Model {
+    fn cache(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+        SPro40D3Protocol::read_general_sections(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+
+        self.common_ctl
+            .cache_whole_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+
+        self.protocol.init_communication(&unit.1, TIMEOUT_MS)?;
+
+        // There is not much to cache here, as I don't know any way to
+        // read the current settings from the card.
+
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let mut notified_elem_id_list = Vec::new();
+        let mut measured_elem_id_list = Vec::new();
+        
+        self.common_ctl.load(card_cntr)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_SRC_GAIN_NAME, 0);
+        card_cntr.add_int_elems(
+            &elem_id,
+            18,
+            COEF_MIN,
+            COEF_MAX,
+            COEF_STEP,
+            16,
+            Some(&Into::<Vec<u32>>::into(COEF_TLV)),
+            true,
+        )
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        for elem_id in &notified_elem_id_list {
+            let mut v = ElemValue::new();
+            card_cntr.card.read_elem_value(elem_id, &mut v)?;
+            self.gain_values.push(v);
+        }
+        
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUT_METER_NAME, 0);
+        card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            0,
+            0xfff,
+            1,
+            2,
+            None,
+            false,
+        )
+            .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MIXER_INPUT_METER_NAME, 0);
+        card_cntr.add_int_elems(
+            &elem_id,
+            1,
+            0,
+            0xfff,
+            1,
+            18,
+            None,
+            false,
+        )
+            .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ROUTER_OUT_SRC_NAME, 0);
+        let supported_source_labels = vec![
+            "None",
+            "Analog-1", "Analog-2", "Analog-3", "Analog-4",
+            "Analog-5", "Analog-6", "Analog-7", "Analog-8",
+            "S/PDIF-1", "S/PDIF-2",
+            "ADAT-1", "ADAT-2", "ADAT-3", "ADAT-4",
+            "ADAT-5", "ADAT-6", "ADAT-7", "ADAT-8",
+            "Stream-1", "Stream-2", "Stream-3", "Stream-4",
+            "Stream-5", "Stream-6", "Stream-7", "Stream-8",
+            "Stream-9", "Stream-10", "Stream-11", "Stream-12",
+            "Stream-13", "Stream-14", "Stream-15", "Stream-16",
+            "Stream-17", "Stream-18", "Stream-19", "Stream-20",
+            "Mixer-1", "Mixer-2", "Mixer-3", "Mixer-4",
+            "Mixer-5", "Mixer-6", "Mixer-7", "Mixer-8",
+            "Mixer-9", "Mixer-10", "Mixer-11", "Mixer-12",
+            "Mixer-13", "Mixer-14", "Mixer-15", "Mixer-16"
+        ];
+        card_cntr.add_enum_elems(
+            &elem_id,
+            1,
+            22,
+            &supported_source_labels,
+            None,
+            true,
+        )
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        card_cntr.card.read_elem_value(&elem_id, &mut self.router_out_src)?;
+        
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ROUTER_MIXER_SRC_NAME, 0);
+        card_cntr.add_enum_elems(
+            &elem_id,
+            1,
+            18,
+            &supported_source_labels[..39], // all, except the mixes
+            None,
+            true,
+        )
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        card_cntr.card.read_elem_value(&elem_id, &mut self.router_mixer_src)?;
+        
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, ROUTER_METER_SRC_NAME, 0);
+        card_cntr.add_enum_elems(
+            &elem_id,
+            1,
+            2,
+            &supported_source_labels,
+            None,
+            true,
+        )
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        card_cntr.card.read_elem_value(&elem_id, &mut self.router_meter_src)?;
+        
+        self.notified_elem_id_list = notified_elem_id_list;
+        self.measured_elem_id_list = measured_elem_id_list;
+        
+        Ok(())
+    }
+
+    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
+        if self.common_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else {
+            match elem_id.name().as_str() {
+                OUT_METER_NAME => {
+                    elem_value.set_int(&self.protocol.master_meter);
+                    Ok(true)
+                }
+                MIXER_INPUT_METER_NAME => {
+                    elem_value.set_int(&self.protocol.mixer_meter);
+                    Ok(true)
+                }
+                _ => Ok(false),
+            }
+        }
+    }
+
+    fn write(
+        &mut self,
+        unit: &mut (SndDice, FwNode),
+        elem_id: &ElemId,
+        new: &ElemValue,
+    ) -> Result<bool, Error> {
+        self.common_ctl.write(
+            &unit.0,
+            &self.req,
+            &unit.1,
+            &mut self.sections,
+            elem_id,
+            new,
+            TIMEOUT_MS,
+        )?;
+
+        let dst_ch = elem_id.index() as usize;
+        match elem_id.name().as_str() {
+            MIXER_SRC_GAIN_NAME => {
+                let old_values = self.gain_values[dst_ch].int();
+                let new_values = new.int();
+                for i in 0..16 {
+                    let old_value = old_values[i];
+                    let new_value = new_values[i];
+                    if new_value != old_value {
+                        self.protocol.set_volume(&unit.1, dst_ch, i, new_value, TIMEOUT_MS)?;
+                    }
+                }
+                self.gain_values[dst_ch].set_int(new_values);
+                Ok(true)
+            }
+            ROUTER_OUT_SRC_NAME => {
+                let new_values = new.enumerated();
+                self.router_out_src.set_enum(new_values);
+                self.protocol.set_routing(
+                    &unit.1,
+                    new_values,
+                    self.router_mixer_src.enumerated(),
+                    self.router_meter_src.enumerated(),
+                    TIMEOUT_MS,
+                )?;
+                Ok(true)
+            }
+            ROUTER_MIXER_SRC_NAME => {
+                let new_values = new.enumerated();
+                self.router_mixer_src.set_enum(new_values);
+                self.protocol.set_routing(
+                    &unit.1,
+                    self.router_out_src.enumerated(),
+                    new_values,
+                    self.router_meter_src.enumerated(),
+                    TIMEOUT_MS,
+                )?;
+                Ok(true)
+            }
+            ROUTER_METER_SRC_NAME => {
+                let new_values = new.enumerated();
+                self.router_meter_src.set_enum(new_values);
+                self.protocol.set_routing(
+                    &unit.1,
+                    self.router_out_src.enumerated(),
+                    self.router_mixer_src.enumerated(),
+                    new_values,
+                    TIMEOUT_MS,
+                )?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+impl NotifyModel<(SndDice, FwNode), u32> for SPro40D3Model {
+    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.notified_elem_id_list);
+        elem_id_list.extend_from_slice(&self.notified_elem_id_list);
+    }
+
+    fn parse_notification(&mut self, unit: &mut (SndDice, FwNode), msg: &u32) -> Result<(), Error> {
+        self.common_ctl
+            .parse_notification(&self.req, &unit.1, &mut self.sections, *msg, TIMEOUT_MS)
+    }
+}
+
+impl MeasureModel<(SndDice, FwNode)> for SPro40D3Model {
+    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
+        elem_id_list.extend_from_slice(&self.common_ctl.measured_elem_id_list);
+        elem_id_list.extend_from_slice(&self.measured_elem_id_list);
+    }
+
+    fn measure_states(&mut self, unit: &mut (SndDice, FwNode)) -> Result<(), Error> {
+        self.common_ctl
+            .cache_partial_params(&self.req, &unit.1, &mut self.sections, TIMEOUT_MS)?;
+
+        self.protocol.get_master_meter(&unit.1, self.common_ctl.global_params.current_rate, TIMEOUT_MS)?;
+        self.protocol.get_mixer_meter(&unit.1, self.common_ctl.global_params.current_rate, TIMEOUT_MS)
+    }
+}
+
+const OUT_METER_NAME: &str = "output-source-meter";
+const MIXER_INPUT_METER_NAME: &str = "mixer-source-meter";
+
+const ROUTER_OUT_SRC_NAME: &str = "output-source";
+const ROUTER_MIXER_SRC_NAME: &str = "mixer-source";
+const ROUTER_METER_SRC_NAME: &str = "meter-source";
+
+const MIXER_SRC_GAIN_NAME: &str = "mixer-source-gain";

--- a/runtime/dice/src/model.rs
+++ b/runtime/dice/src/model.rs
@@ -11,6 +11,7 @@ use {
         focusrite::spro24dsp_model::*,
         focusrite::spro26_model::*,
         focusrite::spro40_model::*,
+        focusrite::spro40d3_model::*,
         io_fw_model::*,
         ionix_model::*,
         mbox3_model::*,
@@ -52,6 +53,7 @@ enum Model {
     AvidMbox3(Mbox3Model),
     LoudBlackbird(BlackbirdModel),
     FocusriteSPro40(SPro40Model),
+    FocusriteSPro40D3(SPro40D3Model),
     FocusriteLiquidS56(LiquidS56Model),
     FocusriteSPro24(SPro24Model),
     FocusriteSPro24Dsp(SPro24DspModel),
@@ -124,6 +126,7 @@ impl DiceModel {
             (0x00130e, 0x000008) => Model::FocusriteSPro24Dsp(Default::default()),
             (0x00130e, 0x000009) => Model::FocusriteSPro14(Default::default()),
             (0x00130e, 0x000012) => Model::FocusriteSPro26(SPro26Model::default()),
+            (0x00130e, 0x0000de) => Model::FocusriteSPro40D3(SPro40D3Model::default()),
             (0x000a92, 0x00000b) => Model::PresonusFStudioProject(FStudioProjectModel::default()),
             (0x000a92, 0x00000c) => Model::PresonusFStudioTube(FStudioTubeModel::default()),
             (0x000a92, 0x000011) => Model::PresonusFStudioMobile(FStudioMobileModel::default()),
@@ -185,6 +188,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.cache(unit),
             Model::LoudBlackbird(m) => m.cache(unit),
             Model::FocusriteSPro40(m) => m.cache(unit),
+            Model::FocusriteSPro40D3(m) => m.cache(unit),
             Model::FocusriteLiquidS56(m) => m.cache(unit),
             Model::FocusriteSPro24(m) => m.cache(unit),
             Model::FocusriteSPro24Dsp(m) => m.cache(unit),
@@ -222,6 +226,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.load(card_cntr),
             Model::LoudBlackbird(m) => m.load(card_cntr),
             Model::FocusriteSPro40(m) => m.load(card_cntr),
+            Model::FocusriteSPro40D3(m) => m.load(card_cntr),
             Model::FocusriteLiquidS56(m) => m.load(card_cntr),
             Model::FocusriteSPro24(m) => m.load(card_cntr),
             Model::FocusriteSPro24Dsp(m) => m.load(card_cntr),
@@ -257,6 +262,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::LoudBlackbird(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro40(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
+            Model::FocusriteSPro40D3(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro24(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
             Model::FocusriteSPro24Dsp(m) => m.get_notified_elem_list(&mut self.notified_elem_list),
@@ -296,6 +302,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::LoudBlackbird(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro40(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
+            Model::FocusriteSPro40D3(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteLiquidS56(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro24(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
             Model::FocusriteSPro24Dsp(m) => m.get_measure_elem_list(&mut self.measured_elem_list),
@@ -345,6 +352,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::LoudBlackbird(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteSPro40(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
+            Model::FocusriteSPro40D3(m) => card_cntr.dispatch_elem_event(unit, &elem_id, &events, m),
             Model::FocusriteLiquidS56(m) => {
                 card_cntr.dispatch_elem_event(unit, &elem_id, &events, m)
             }
@@ -431,6 +439,9 @@ impl DiceModel {
             Model::FocusriteSPro40(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
+            Model::FocusriteSPro40D3(m) => {
+                card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
+            }
             Model::FocusriteLiquidS56(m) => {
                 card_cntr.dispatch_notification(unit, &msg, &self.notified_elem_list, m)
             }
@@ -502,6 +513,7 @@ impl DiceModel {
             Model::AvidMbox3(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::LoudBlackbird(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteSPro40(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
+            Model::FocusriteSPro40D3(m) => card_cntr.measure_elems(unit, &self.measured_elem_list, m),
             Model::FocusriteLiquidS56(m) => {
                 card_cntr.measure_elems(unit, &self.measured_elem_list, m)
             }


### PR DESCRIPTION
Add partial support for late versions of Focusrite Saffire Pro 40. Mixer levels, metering and routing are supported.