### PR TITLE
dice: spro40d3: add output-group and io-params controls

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -224,8 +224,8 @@ However, we welcome any assistance that can enhance the project.
   * The most of monitor parameters may not work for Alesis iO 14/26 FireWire. This may come from
     firmware version.
   * The channel strip dynamics, equalizer, and reverb are not available for Lexicon I-ONIX 810s.
-  * Late versions of Focusrite Saffire Pro 40 (using TCD3070 ASIC) are only partial supported.
-    Mixer levels, metering and routing are supported.
+  * Late versions of Focusrite Saffire Pro 40 (using TCD3070 ASIC) are supported, but support
+    for saving and loading settings for standalone mode is missing.
   * No control is available for Solid State Logic Duende Classic and Mini.
 
 * snd-firewire-digi00x-ctl-service

--- a/protocols/dice/src/focusrite/spro40d3.rs
+++ b/protocols/dice/src/focusrite/spro40d3.rs
@@ -71,6 +71,24 @@ fn deserialize_meter(meter: &mut [i32], frame: &[u8]) {
     });
 }
 
+fn serialize_get_control(pos: u32, len: u32, frame: &mut [u8]) {
+    frame[..4].copy_from_slice(&[0x80, 0x80, 0x00, 0x00]);
+    serialize_u32(&pos, &mut frame[16..20]);
+    serialize_u32(&len, &mut frame[20..24]);
+}
+
+fn serialize_set_control(pos: u32, len: u32, value: &[u8], frame: &mut [u8]) {
+    frame[..4].copy_from_slice(&[0x80, 0x80, 0x00, 0x01]);
+    serialize_u32(&pos, &mut frame[16..20]);
+    serialize_u32(&len, &mut frame[20..24]);
+    frame[24..].copy_from_slice(value);
+}
+
+fn serialize_write_sw_notice(frame: &mut [u8], notice: u32) {
+    frame[..4].copy_from_slice(&[0x80, 0x80, 0x00, 0x02]);
+    serialize_u32(&notice, &mut frame[16..20]);
+}
+
 fn serialize_route(from: u32, to: u32, raw: &mut [u8]) {
     let source = if from < 1 {
         NONE
@@ -134,22 +152,13 @@ fn serialize_routing_low_rate(
     serialize_route(router_out_src[21], STREAM + 19, &mut frame[176..180]);
 
     // to mixer
-    for i in 0..8 {
+    for i in 0..18 {
         serialize_route(
             router_mixer_src[i],
             MIXER + i as u32,
             &mut frame[180 + i * 4..][..4],
         );
     }
-    for i in 0..8 {
-        serialize_route(
-            router_mixer_src[8 + i],
-            MIXER + 8 + i as u32,
-            &mut frame[212 + i * 4..][..4],
-        );
-    }
-    serialize_route(router_mixer_src[16], MIXER + 16, &mut frame[244..248]);
-    serialize_route(router_mixer_src[17], MIXER + 17, &mut frame[248..252]);
 
     // master meter
     serialize_route(router_meter_src[0], 0x0, &mut frame[252..256]);
@@ -202,22 +211,13 @@ fn serialize_routing_high_rate(
     serialize_route(router_out_src[21], STREAM + 15, &mut frame[144..148]);
 
     // to mixer
-    for i in 0..8 {
+    for i in 0..18 {
         serialize_route(
             router_mixer_src[i],
             MIXER + i as u32,
             &mut frame[148 + i * 4..][..4],
         );
     }
-    for i in 0..8 {
-        serialize_route(
-            router_mixer_src[8 + i],
-            MIXER + 8 + i as u32,
-            &mut frame[180 + i * 4..][..4],
-        );
-    }
-    serialize_route(router_mixer_src[16], MIXER + 16, &mut frame[212..216]);
-    serialize_route(router_mixer_src[17], MIXER + 17, &mut frame[216..220]);
 
     // master meter
     serialize_route(router_meter_src[0], 0x0, &mut frame[220..224]);
@@ -387,6 +387,238 @@ impl SPro40D3Protocol {
         self.send_command(node, 24, &mut frame, timeout_ms)?;
         deserialize_meter(mixer_meter, &frame);
         Ok(())
+    }
+
+    fn get_control_u32(&mut self, node: &FwNode, pos: u32, timeout_ms: u32) -> Result<u32, Error> {
+        let mut frame = vec![0; 24];
+        serialize_get_control(pos, 4, &mut frame);
+        self.send_command(node, 24, &mut frame, timeout_ms)?;
+        let mut val = 0;
+        deserialize_u32(&mut val, &frame[16..20]);
+        Ok(val)
+    }
+
+    fn set_control_u32(
+        &mut self,
+        node: &FwNode,
+        pos: u32,
+        value: u32,
+        notice: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut frame = vec![0; 28];
+        let mut raw = [0; 4];
+        serialize_u32(&value, &mut raw);
+        serialize_set_control(pos, 4, &raw, &mut frame);
+        self.send_command(node, 28, &mut frame, timeout_ms)?;
+
+        frame[0..20].fill(0);
+        serialize_write_sw_notice(&mut frame, notice);
+        self.send_command(node, 20, &mut frame, timeout_ms)?;
+        Ok(())
+    }
+
+    pub fn get_use_adat_as_spdif(&mut self, node: &FwNode, timeout_ms: u32) -> Result<u32, Error> {
+        self.get_control_u32(node, 0x5c, timeout_ms)
+    }
+
+    pub fn set_use_adat_as_spdif(
+        &mut self,
+        node: &FwNode,
+        value: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_control_u32(node, 0x5c, value, 4, timeout_ms)
+    }
+
+    pub fn get_active_monitor_pad(&mut self, node: &FwNode, timeout_ms: u32) -> Result<u32, Error> {
+        self.get_control_u32(node, 0x40, timeout_ms)
+    }
+
+    pub fn set_active_monitor_pad(
+        &mut self,
+        node: &FwNode,
+        value: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.set_control_u32(node, 0x40, value, 3, timeout_ms)
+    }
+
+    pub fn cache_dim_mute(
+        &mut self,
+        state: &mut OutGroupState,
+        node: &FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        state.dim_enabled = self.get_dim(node, timeout_ms)? != 0;
+        state.mute_enabled = self.get_mute(node, timeout_ms)? != 0;
+        Ok(())
+    }
+
+    pub fn cache_output_group(
+        &mut self,
+        node: &FwNode,
+        state: &mut OutGroupState,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        state.vols = vec![0; 10];
+        state.vol_mutes = vec![false; 10];
+        state.vol_hwctls = vec![false; 10];
+        state.mute_hwctls = vec![false; 10];
+        state.dim_hwctls = vec![false; 10];
+
+        state.mute_enabled = self.get_mute(node, timeout_ms)? != 0;
+        state.dim_enabled = self.get_dim(node, timeout_ms)? != 0;
+
+        for i in 0..(state.vols.len() / 2) {
+            let pos = 0x0c + 0x08 + i as u32 * 4;
+            let val = self.get_control_u32(node, pos, timeout_ms)?;
+            state.vols[(i * 2)..(i * 2 + 2)]
+                .iter_mut()
+                .enumerate()
+                .for_each(|(j, vol)| {
+                    let v = ((val >> (j * 8)) & 0xff) as i8;
+                    // NOTE: inverted.
+                    *vol = VOL_MAX - v;
+                });
+        }
+
+        for i in 0..(state.vol_hwctls.len() / 2) {
+            let pos = 0x0c + 0x1c + i as u32 * 4;
+            let val = self.get_control_u32(node, pos, timeout_ms)?;
+            let idx = i * 2;
+
+            state.vol_hwctls[idx..(idx + 2)]
+                .iter_mut()
+                .enumerate()
+                .for_each(|(i, vol_hwctl)| *vol_hwctl = val & (1 << i) > 0);
+
+            state.vol_mutes[idx..(idx + 2)]
+                .iter_mut()
+                .enumerate()
+                .for_each(|(i, vol_mute)| *vol_mute = val & (1 << (i + 2)) > 0);
+        }
+
+        let val = self.get_control_u32(node, 0x3c, timeout_ms)?;
+        state
+            .dim_hwctls
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, assign)| *assign = val & (1 << (i + 10)) > 0);
+        state
+            .mute_hwctls
+            .iter_mut()
+            .enumerate()
+            .for_each(|(i, assign)| *assign = val & (1 << i) > 0);
+
+        state.hw_knob_value = self.get_monitor_volume(node, timeout_ms)? as i8;
+        Ok(())
+    }
+
+    pub fn get_dim(&mut self, node: &FwNode, timeout_ms: u32) -> Result<u32, Error> {
+        self.get_control_u32(node, 0x10, timeout_ms)
+    }
+
+    pub fn set_dim(&mut self, node: &FwNode, value: u32, timeout_ms: u32) -> Result<(), Error> {
+        self.set_control_u32(node, 0x10, value, 2, timeout_ms)
+    }
+
+    pub fn get_mute(&mut self, node: &FwNode, timeout_ms: u32) -> Result<u32, Error> {
+        self.get_control_u32(node, 0x0c, timeout_ms)
+    }
+
+    pub fn set_mute(&mut self, node: &FwNode, value: u32, timeout_ms: u32) -> Result<(), Error> {
+        self.set_control_u32(node, 0x0c, value, 2, timeout_ms)
+    }
+
+    pub fn set_output_vol(
+        &mut self,
+        node: &FwNode,
+        params: &OutGroupState,
+        prev: &mut OutGroupState,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        for i in 0..(params.vols.len() / 2) {
+            let idx = i * 2;
+            if params.vols[idx..(idx + 2)] != prev.vols[idx..(idx + 2)] {
+                let mut val = 0u32;
+                params.vols[idx..(idx + 2)]
+                    .iter()
+                    .enumerate()
+                    .for_each(|(j, &vol)| {
+                        // NOTE: inverted.
+                        let v = VOL_MAX - vol;
+                        val |= (v as u32) << (8 * j);
+                    });
+                let pos = 0x0c + 0x08 + i as u32 * 4;
+                self.set_control_u32(node, pos, val, 1, timeout_ms)?;
+
+                prev.vols[idx..(idx + 2)].copy_from_slice(&params.vols[idx..(idx + 2)]);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_vol_hwctl_mute(
+        &mut self,
+        node: &FwNode,
+        params: &OutGroupState,
+        prev: &mut OutGroupState,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        for i in 0..(params.vol_hwctls.len() / 2) {
+            let idx = i * 2;
+            if params.vol_hwctls[idx..(idx + 2)] != prev.vol_hwctls[idx..(idx + 2)]
+                || params.vol_mutes[idx..(idx + 2)] != prev.vol_mutes[idx..(idx + 2)]
+            {
+                let mut val = 0u32;
+
+                params.vol_hwctls[idx..(idx + 2)]
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, &vol_hwctl)| vol_hwctl)
+                    .for_each(|(i, _)| val |= 1 << i);
+
+                params.vol_mutes[idx..(idx + 2)]
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, &vol_mute)| vol_mute)
+                    .for_each(|(i, _)| val |= 1 << (i + 2));
+
+                let pos = 0x0c + 0x1c + i as u32 * 4;
+                self.set_control_u32(node, pos, val, 1, timeout_ms)?;
+
+                prev.vol_hwctls[idx..(idx + 2)].copy_from_slice(&params.vol_hwctls[idx..(idx + 2)]);
+                prev.vol_mutes[idx..(idx + 2)].copy_from_slice(&params.vol_mutes[idx..(idx + 2)]);
+            }
+        }
+        Ok(())
+    }
+
+    pub fn set_dim_mute_hwctl(
+        &mut self,
+        node: &FwNode,
+        state: &OutGroupState,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        let mut val = 0u32;
+        state
+            .dim_hwctls
+            .iter()
+            .enumerate()
+            .filter(|(_, &assigned)| assigned)
+            .for_each(|(i, _)| val |= 1 << (i + 10));
+        state
+            .mute_hwctls
+            .iter()
+            .enumerate()
+            .filter(|(_, &assigned)| assigned)
+            .for_each(|(i, _)| val |= 1 << i);
+        self.set_control_u32(node, 0x3c, val, 3, timeout_ms)
+    }
+
+    pub fn get_monitor_volume(&mut self, node: &FwNode, timeout_ms: u32) -> Result<u32, Error> {
+        self.get_control_u32(node, 0x54, timeout_ms)
     }
 
     pub fn set_routing(

--- a/runtime/dice/src/focusrite/spro40d3_model.rs
+++ b/runtime/dice/src/focusrite/spro40d3_model.rs
@@ -349,6 +349,277 @@ impl MeterCtls {
 }
 
 #[derive(Default)]
+struct OutGroupCtl {
+    state: OutGroupState,
+}
+
+impl OutGroupCtl {
+    const LEVEL_MIN: i32 = 0;
+    const LEVEL_MAX: i32 = i8::MAX as i32;
+    const LEVEL_STEP: i32 = 0x01;
+
+    fn cache(
+        &mut self,
+        protocol: &mut SPro40D3Protocol,
+        node: &FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        protocol.cache_output_group(node, &mut self.state, timeout_ms)
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<Vec<ElemId>, Error> {
+        let mut notified_elem_id_list = Vec::new();
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MUTE_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, DIM_NAME, 0);
+        card_cntr
+            .add_bool_elems(&elem_id, 1, 1, true)
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, VOL_NAME, 0);
+        card_cntr
+            .add_int_elems(
+                &elem_id,
+                1,
+                Self::LEVEL_MIN,
+                Self::LEVEL_MAX,
+                Self::LEVEL_STEP,
+                10,
+                None,
+                true,
+            )
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, VOL_MUTE_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 10, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, VOL_TARGET_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 10, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, DIM_TARGET_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 10, true)?;
+
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, MUTE_TARGET_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 10, true)?;
+
+        Ok(notified_elem_id_list)
+    }
+
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+        let params = &self.state;
+        match elem_id.name().as_str() {
+            VOL_NAME => {
+                let vals: Vec<i32> = params.vols.iter().map(|&vol| vol as i32).collect();
+                elem_value.set_int(&vals);
+                Ok(true)
+            }
+            VOL_MUTE_NAME => {
+                elem_value.set_bool(&params.vol_mutes);
+                Ok(true)
+            }
+            VOL_TARGET_NAME => {
+                elem_value.set_bool(&params.vol_hwctls);
+                Ok(true)
+            }
+            MUTE_NAME => {
+                elem_value.set_bool(&[params.mute_enabled]);
+                Ok(true)
+            }
+            MUTE_TARGET_NAME => {
+                elem_value.set_bool(&params.mute_hwctls);
+                Ok(true)
+            }
+            DIM_NAME => {
+                elem_value.set_bool(&[params.dim_enabled]);
+                Ok(true)
+            }
+            DIM_TARGET_NAME => {
+                elem_value.set_bool(&params.dim_hwctls);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(
+        &mut self,
+        protocol: &mut SPro40D3Protocol,
+        node: &FwNode,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            VOL_NAME => {
+                let mut params = self.state.clone();
+                params
+                    .vols
+                    .iter_mut()
+                    .zip(elem_value.int())
+                    .for_each(|(vol, &val)| *vol = val as i8);
+
+                protocol.set_output_vol(node, &params, &mut self.state, timeout_ms)?;
+                Ok(true)
+            }
+            VOL_MUTE_NAME => {
+                let mut params = self.state.clone();
+                params
+                    .vol_mutes
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(vol_mute, val)| *vol_mute = val);
+
+                protocol.set_vol_hwctl_mute(node, &params, &mut self.state, timeout_ms)?;
+                Ok(true)
+            }
+            VOL_TARGET_NAME => {
+                let mut params = self.state.clone();
+                params
+                    .vol_hwctls
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(vol_hwctl, val)| *vol_hwctl = val);
+
+                protocol.set_vol_hwctl_mute(node, &params, &mut self.state, timeout_ms)?;
+                Ok(true)
+            }
+            MUTE_NAME => {
+                self.state.mute_enabled = elem_value.boolean()[0];
+                protocol.set_mute(node, self.state.mute_enabled as u32, timeout_ms)?;
+                Ok(true)
+            }
+            MUTE_TARGET_NAME => {
+                let params = &mut self.state;
+                params
+                    .mute_hwctls
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(mute_hwctl, val)| *mute_hwctl = val);
+                protocol.set_dim_mute_hwctl(node, params, timeout_ms)?;
+                Ok(true)
+            }
+            DIM_NAME => {
+                self.state.dim_enabled = elem_value.boolean()[0];
+                protocol.set_dim(node, self.state.dim_enabled as u32, timeout_ms)?;
+                Ok(true)
+            }
+            DIM_TARGET_NAME => {
+                let params = &mut self.state;
+                params
+                    .dim_hwctls
+                    .iter_mut()
+                    .zip(elem_value.boolean())
+                    .for_each(|(dim_hwctl, val)| *dim_hwctl = val);
+                protocol.set_dim_mute_hwctl(node, params, timeout_ms)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn parse_notification(
+        &mut self,
+        protocol: &mut SPro40D3Protocol,
+        node: &FwNode,
+        msg: u32,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        if msg & NOTIFY_DIM_MUTE_CHANGE != 0 {
+            protocol.cache_dim_mute(&mut self.state, node, timeout_ms)?;
+        }
+        if msg & NOTIFY_VOL_CHANGE != 0 {
+            self.state.hw_knob_value = protocol.get_monitor_volume(node, timeout_ms)? as i8;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Default)]
+struct IoParamsCtl {
+    params: SaffireproIoParams,
+}
+
+impl IoParamsCtl {
+    fn cache(
+        &mut self,
+        protocol: &mut SPro40D3Protocol,
+        node: &FwNode,
+        timeout_ms: u32,
+    ) -> Result<(), Error> {
+        self.params.opt_out_iface_mode = match protocol.get_use_adat_as_spdif(node, timeout_ms)? {
+            1 => OpticalOutIfaceMode::Spdif,
+            _ => OpticalOutIfaceMode::Adat,
+        };
+        self.params.analog_out_0_1_pad = protocol.get_active_monitor_pad(node, timeout_ms)? != 0;
+        Ok(())
+    }
+
+    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+        let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ANALOG_OUT_0_1_PAD_NAME, 0);
+        card_cntr.add_bool_elems(&elem_id, 1, 1, true)?;
+
+        let optical_out_iface_modes = ["ADAT", "S/PDIF"];
+        let elem_id =
+            ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPTICAL_OUT_IFACE_MODE_NAME, 0);
+        card_cntr.add_enum_elems(&elem_id, 1, 1, &optical_out_iface_modes, None, true)?;
+
+        Ok(())
+    }
+
+    fn read(&self, elem_id: &ElemId, elem_value: &ElemValue) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            ANALOG_OUT_0_1_PAD_NAME => {
+                elem_value.set_bool(&[self.params.analog_out_0_1_pad]);
+                Ok(true)
+            }
+            OPTICAL_OUT_IFACE_MODE_NAME => {
+                let mode = match self.params.opt_out_iface_mode {
+                    OpticalOutIfaceMode::Spdif => 1,
+                    _ => 0,
+                };
+                elem_value.set_enum(&[mode]);
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    fn write(
+        &mut self,
+        protocol: &mut SPro40D3Protocol,
+        node: &FwNode,
+        elem_id: &ElemId,
+        elem_value: &ElemValue,
+        timeout_ms: u32,
+    ) -> Result<bool, Error> {
+        match elem_id.name().as_str() {
+            ANALOG_OUT_0_1_PAD_NAME => {
+                protocol.set_active_monitor_pad(
+                    node,
+                    elem_value.boolean()[0] as u32,
+                    timeout_ms,
+                )?;
+                Ok(true)
+            }
+            OPTICAL_OUT_IFACE_MODE_NAME => {
+                let value = elem_value.enumerated()[0];
+                self.params.opt_out_iface_mode = match value {
+                    1 => OpticalOutIfaceMode::Spdif,
+                    _ => OpticalOutIfaceMode::Adat,
+                };
+                protocol.set_use_adat_as_spdif(node, value, timeout_ms)?;
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+}
+
+#[derive(Default)]
 pub struct SPro40D3Model {
     req: FwReq,
     sections: GeneralSections,
@@ -359,6 +630,8 @@ pub struct SPro40D3Model {
     mixer_ctls: MixerCtls,
     router_ctls: RouterCtls,
     meter_ctls: MeterCtls,
+    out_grp_ctl: OutGroupCtl,
+    io_params_ctl: IoParamsCtl,
 }
 
 const TIMEOUT_MS: u32 = 20;
@@ -374,7 +647,12 @@ impl CtlModel<(SndDice, FwNode)> for SPro40D3Model {
 
         self.mixer_ctls
             .cache(&mut self.protocol, node, TIMEOUT_MS)?;
-        self.router_ctls.cache(&mut self.protocol, node, TIMEOUT_MS)
+        self.router_ctls
+            .cache(&mut self.protocol, node, TIMEOUT_MS)?;
+        self.out_grp_ctl
+            .cache(&mut self.protocol, node, TIMEOUT_MS)?;
+        self.io_params_ctl
+            .cache(&mut self.protocol, node, TIMEOUT_MS)
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
@@ -395,6 +673,12 @@ impl CtlModel<(SndDice, FwNode)> for SPro40D3Model {
             .load(card_cntr)
             .map(|mut elem_id_list| measured_elem_id_list.append(&mut elem_id_list))?;
 
+        self.out_grp_ctl
+            .load(card_cntr)
+            .map(|mut elem_id_list| notified_elem_id_list.append(&mut elem_id_list))?;
+
+        self.io_params_ctl.load(card_cntr)?;
+
         self.notified_elem_id_list = notified_elem_id_list;
         self.measured_elem_id_list = measured_elem_id_list;
 
@@ -405,7 +689,9 @@ impl CtlModel<(SndDice, FwNode)> for SPro40D3Model {
         let res = self.common_ctl.read(elem_id, elem_value)?
             || self.mixer_ctls.read(elem_id, elem_value)?
             || self.router_ctls.read(elem_id, elem_value)?
-            || self.meter_ctls.read(elem_id, elem_value)?;
+            || self.meter_ctls.read(elem_id, elem_value)?
+            || self.out_grp_ctl.read(elem_id, elem_value)?
+            || self.io_params_ctl.read(elem_id, elem_value)?;
         Ok(res)
     }
 
@@ -435,6 +721,18 @@ impl CtlModel<(SndDice, FwNode)> for SPro40D3Model {
             elem_id,
             elem_value,
             TIMEOUT_MS,
+        )? || self.out_grp_ctl.write(
+            &mut self.protocol,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? || self.io_params_ctl.write(
+            &mut self.protocol,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
         )?;
         Ok(res)
     }
@@ -451,8 +749,15 @@ impl NotifyModel<(SndDice, FwNode), u32> for SPro40D3Model {
         (_, node): &mut (SndDice, FwNode),
         msg: &u32,
     ) -> Result<(), Error> {
-        self.common_ctl
-            .parse_notification(&self.req, node, &mut self.sections, *msg, TIMEOUT_MS)
+        self.common_ctl.parse_notification(
+            &self.req,
+            node,
+            &mut self.sections,
+            *msg,
+            TIMEOUT_MS,
+        )?;
+        self.out_grp_ctl
+            .parse_notification(&mut self.protocol, node, *msg, TIMEOUT_MS)
     }
 }
 
@@ -483,3 +788,6 @@ const ROUTER_MIXER_SRC_NAME: &str = "mixer-source";
 const ROUTER_METER_SRC_NAME: &str = "meter-source";
 
 const MIXER_SRC_GAIN_NAME: &str = "mixer-source-gain";
+
+const NOTIFY_DIM_MUTE_CHANGE: u32 = 0x00200000;
+const NOTIFY_VOL_CHANGE: u32 = 0x00400000;


### PR DESCRIPTION
Add more controls for Focusrite Saffire Pro 40 D3, of type output-group and io-params, same as the ones for the earlier Pro 40 versions.