### PR TITLE
digi00x: support optical interface mode operation for digi 002 as well as digi 003

### DIFF
--- a/protocols/digi00x/src/lib.rs
+++ b/protocols/digi00x/src/lib.rs
@@ -277,7 +277,10 @@ impl Default for OpticalInterfaceMode {
     }
 }
 
-impl Dg00xWhollyCachableParamsOperation<OpticalInterfaceMode> for Digi003Protocol {
+impl<O> Dg00xWhollyCachableParamsOperation<OpticalInterfaceMode> for O
+where
+    O: Dg00xHardwareSpecification,
+{
     fn cache_wholly(
         req: &mut FwReq,
         node: &mut FwNode,
@@ -294,7 +297,10 @@ impl Dg00xWhollyCachableParamsOperation<OpticalInterfaceMode> for Digi003Protoco
     }
 }
 
-impl Dg00xWhollyUpdatableParamsOperation<OpticalInterfaceMode> for Digi003Protocol {
+impl<O> Dg00xWhollyUpdatableParamsOperation<OpticalInterfaceMode> for O
+where
+    O: Dg00xHardwareSpecification,
+{
     fn update_wholly(
         req: &mut FwReq,
         node: &mut FwNode,

--- a/runtime/digi00x/src/main.rs
+++ b/runtime/digi00x/src/main.rs
@@ -15,6 +15,7 @@ use {
     ieee1212_config_rom::ConfigRom,
     model::*,
     nix::sys::signal,
+    protocols::{Digi002Protocol, Digi003Protocol},
     runtime_core::{card_cntr::*, cmdline::*, dispatcher::*, LogLevel, *},
     std::{convert::TryFrom, sync::mpsc, thread},
     ta1394_avc_general::config_rom::Ta1394ConfigRom,
@@ -31,8 +32,8 @@ enum Event {
 }
 
 enum Model {
-    Digi002(Digi002Model),
-    Digi003(Digi003Model),
+    Digi002(Digi00xModel<Digi002Protocol>),
+    Digi003(Digi00xModel<Digi003Protocol>),
 }
 
 struct Dg00xRuntime {

--- a/runtime/digi00x/src/model.rs
+++ b/runtime/digi00x/src/model.rs
@@ -11,6 +11,7 @@ pub struct Digi002Model {
     common_ctl: CommonCtl<Digi002Protocol>,
     meter_ctl: MeterCtl<Digi002Protocol>,
     monitor_ctl: MonitorCtl<Digi002Protocol>,
+    opt_iface_ctl: OpticalIfaceCtl<Digi003Protocol>,
 }
 
 impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
@@ -19,6 +20,7 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.monitor_ctl
             .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
+        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         Ok(())
     }
 
@@ -26,6 +28,7 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         self.common_ctl.load(card_cntr)?;
         self.meter_ctl.load(card_cntr)?;
         self.monitor_ctl.load(card_cntr)?;
+        self.opt_iface_ctl.load(card_cntr)?;
         Ok(())
     }
 
@@ -35,6 +38,8 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         } else if self.meter_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else if self.monitor_ctl.read(elem_id, elem_value)? {
+            Ok(true)
+        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
             Ok(true)
         } else {
             Ok(false)
@@ -53,6 +58,15 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
         {
             Ok(true)
         } else if self.monitor_ctl.write(
+            unit,
+            &mut self.req,
+            node,
+            elem_id,
+            elem_value,
+            TIMEOUT_MS,
+        )? {
+            Ok(true)
+        } else if self.opt_iface_ctl.write(
             unit,
             &mut self.req,
             node,
@@ -103,7 +117,7 @@ pub struct Digi003Model {
     common_ctl: CommonCtl<Digi003Protocol>,
     meter_ctl: MeterCtl<Digi003Protocol>,
     monitor_ctl: MonitorCtl<Digi003Protocol>,
-    opt_iface_ctl: OpticalIfaceCtl,
+    opt_iface_ctl: OpticalIfaceCtl<Digi003Protocol>,
 }
 
 impl CtlModel<(SndDigi00x, FwNode)> for Digi003Model {
@@ -368,9 +382,15 @@ where
 }
 
 #[derive(Default, Debug)]
-struct OpticalIfaceCtl {
+struct OpticalIfaceCtl<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<OpticalInterfaceMode>
+        + Dg00xWhollyUpdatableParamsOperation<OpticalInterfaceMode>,
+{
     elem_id_list: Vec<ElemId>,
     opt_iface_mode: OpticalInterfaceMode,
+    _phantom: PhantomData<T>,
 }
 
 fn optical_interface_mode_to_str(mode: &OpticalInterfaceMode) -> &'static str {
@@ -382,12 +402,17 @@ fn optical_interface_mode_to_str(mode: &OpticalInterfaceMode) -> &'static str {
 
 const OPT_IFACE_NAME: &str = "optical-interface";
 
-impl OpticalIfaceCtl {
+impl<T> OpticalIfaceCtl<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<OpticalInterfaceMode>
+        + Dg00xWhollyUpdatableParamsOperation<OpticalInterfaceMode>,
+{
     const OPTICAL_INTERFACE_MODES: &'static [OpticalInterfaceMode] =
         &[OpticalInterfaceMode::Adat, OpticalInterfaceMode::Spdif];
 
     fn cache(&mut self, req: &mut FwReq, node: &mut FwNode, timeout_ms: u32) -> Result<(), Error> {
-        let res = Digi003Protocol::cache_wholly(req, node, &mut self.opt_iface_mode, timeout_ms);
+        let res = T::cache_wholly(req, node, &mut self.opt_iface_mode, timeout_ms);
         debug!(params = ?self.opt_iface_mode, ?res);
         res
     }
@@ -444,7 +469,7 @@ impl OpticalIfaceCtl {
                         Error::new(FileError::Inval, &msg)
                     })
                     .copied()?;
-                let res = Digi003Protocol::update_wholly(req, node, &params, timeout_ms)
+                let res = T::update_wholly(req, node, &params, timeout_ms)
                     .map(|_| self.opt_iface_mode = params);
                 debug!(params = ?self.opt_iface_mode, ?res);
                 res.map(|_| true)

--- a/runtime/digi00x/src/model.rs
+++ b/runtime/digi00x/src/model.rs
@@ -6,15 +6,35 @@ use {super::*, alsa_ctl_tlv_codec::DbInterval, protocols::*, std::marker::Phanto
 const TIMEOUT_MS: u32 = 100;
 
 #[derive(Default, Debug)]
-pub struct Digi002Model {
+pub struct Digi00xModel<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMonitorState>
+        + Dg00xPartiallyUpdatableParamsOperation<Dg00xMonitorState>
+        + Dg00xWhollyCachableParamsOperation<Dg00xExternalClockParameters>,
+{
     req: FwReq,
-    common_ctl: CommonCtl<Digi002Protocol>,
-    meter_ctl: MeterCtl<Digi002Protocol>,
-    monitor_ctl: MonitorCtl<Digi002Protocol>,
-    opt_iface_ctl: OpticalIfaceCtl<Digi003Protocol>,
+    common_ctl: CommonCtl<T>,
+    meter_ctl: MeterCtl<T>,
+    monitor_ctl: MonitorCtl<T>,
+    opt_iface_ctl: OpticalIfaceCtl<T>,
 }
 
-impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
+impl<T> CtlModel<(SndDigi00x, FwNode)> for Digi00xModel<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMonitorState>
+        + Dg00xPartiallyUpdatableParamsOperation<Dg00xMonitorState>
+        + Dg00xWhollyCachableParamsOperation<Dg00xExternalClockParameters>,
+{
     fn cache(&mut self, (unit, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
         self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
         self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
@@ -81,7 +101,17 @@ impl CtlModel<(SndDigi00x, FwNode)> for Digi002Model {
     }
 }
 
-impl MeasureModel<(SndDigi00x, FwNode)> for Digi002Model {
+impl<T> MeasureModel<(SndDigi00x, FwNode)> for Digi00xModel<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMonitorState>
+        + Dg00xPartiallyUpdatableParamsOperation<Dg00xMonitorState>
+        + Dg00xWhollyCachableParamsOperation<Dg00xExternalClockParameters>,
+{
     fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
     }
@@ -91,113 +121,17 @@ impl MeasureModel<(SndDigi00x, FwNode)> for Digi002Model {
     }
 }
 
-impl NotifyModel<(SndDigi00x, FwNode), bool> for Digi002Model {
-    fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.common_ctl.elem_id_list);
-        elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);
-    }
-
-    fn parse_notification(
-        &mut self,
-        (unit, node): &mut (SndDigi00x, FwNode),
-        &locked: &bool,
-    ) -> Result<(), Error> {
-        if locked {
-            self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        }
-        self.monitor_ctl
-            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
-        Ok(())
-    }
-}
-
-#[derive(Default, Debug)]
-pub struct Digi003Model {
-    req: FwReq,
-    common_ctl: CommonCtl<Digi003Protocol>,
-    meter_ctl: MeterCtl<Digi003Protocol>,
-    monitor_ctl: MonitorCtl<Digi003Protocol>,
-    opt_iface_ctl: OpticalIfaceCtl<Digi003Protocol>,
-}
-
-impl CtlModel<(SndDigi00x, FwNode)> for Digi003Model {
-    fn cache(&mut self, (unit, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
-        self.common_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        self.monitor_ctl
-            .cache(unit, &mut self.req, node, TIMEOUT_MS)?;
-        self.opt_iface_ctl.cache(&mut self.req, node, TIMEOUT_MS)?;
-        Ok(())
-    }
-
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        self.common_ctl.load(card_cntr)?;
-        self.meter_ctl.load(card_cntr)?;
-        self.monitor_ctl.load(card_cntr)?;
-        self.opt_iface_ctl.load(card_cntr)?;
-        Ok(())
-    }
-
-    fn read(&mut self, elem_id: &ElemId, elem_value: &mut ElemValue) -> Result<bool, Error> {
-        if self.common_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.meter_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.monitor_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else if self.opt_iface_ctl.read(elem_id, elem_value)? {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn write(
-        &mut self,
-        (unit, node): &mut (SndDigi00x, FwNode),
-        elem_id: &ElemId,
-        elem_value: &ElemValue,
-    ) -> Result<bool, Error> {
-        if self
-            .common_ctl
-            .write(unit, &mut self.req, node, elem_id, elem_value, TIMEOUT_MS)?
-        {
-            Ok(true)
-        } else if self.monitor_ctl.write(
-            unit,
-            &mut self.req,
-            node,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else if self.opt_iface_ctl.write(
-            unit,
-            &mut self.req,
-            node,
-            elem_id,
-            elem_value,
-            TIMEOUT_MS,
-        )? {
-            Ok(true)
-        } else {
-            Ok(false)
-        }
-    }
-}
-
-impl MeasureModel<(SndDigi00x, FwNode)> for Digi003Model {
-    fn get_measure_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
-        elem_id_list.extend_from_slice(&self.meter_ctl.elem_id_list);
-    }
-
-    fn measure_states(&mut self, (_, node): &mut (SndDigi00x, FwNode)) -> Result<(), Error> {
-        self.meter_ctl.cache(&mut self.req, node, TIMEOUT_MS)
-    }
-}
-
-impl NotifyModel<(SndDigi00x, FwNode), bool> for Digi003Model {
+impl<T> NotifyModel<(SndDigi00x, FwNode), bool> for Digi00xModel<T>
+where
+    T: Dg00xHardwareSpecification
+        + Dg00xWhollyCachableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xSamplingClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyUpdatableParamsOperation<Dg00xMediaClockParameters>
+        + Dg00xWhollyCachableParamsOperation<Dg00xMonitorState>
+        + Dg00xPartiallyUpdatableParamsOperation<Dg00xMonitorState>
+        + Dg00xWhollyCachableParamsOperation<Dg00xExternalClockParameters>,
+{
     fn get_notified_elem_list(&mut self, elem_id_list: &mut Vec<ElemId>) {
         elem_id_list.extend_from_slice(&self.common_ctl.elem_id_list);
         elem_id_list.extend_from_slice(&self.monitor_ctl.elem_id_list);


### PR DESCRIPTION
Closes #213 

It was assumed that Dig 002 does not allow the host system to control its mode of optical interface, unlike Digi 003, thus ALSA control element set for the mode is just available in Digi 003.

Simon Wood (@mungewell) figured out that the assumption is wrong. These two models are almost the same in term of the operation for it. This patchset adds the control element set for both models.