### PR TITLE
Bug #216: Motu: Fix spelling/remove erronious space

### DIFF
--- a/runtime/motu/src/v1_ctls.rs
+++ b/runtime/motu/src/v1_ctls.rs
@@ -26,7 +26,7 @@ fn clk_src_to_str(src: &V1ClkSrc) -> &'static str {
     }
 }
 
-const RATE_NAME: &str = "sampling- rate";
+const RATE_NAME: &str = "sampling-rate";
 const SRC_NAME: &str = "clock-source";
 
 impl<T> V1ClkCtl<T>

--- a/runtime/motu/src/v2_ctls.rs
+++ b/runtime/motu/src/v2_ctls.rs
@@ -15,7 +15,7 @@ where
     _phantom: PhantomData<T>,
 }
 
-const RATE_NAME: &str = "sampling- rate";
+const RATE_NAME: &str = "sampling-rate";
 const SRC_NAME: &str = "clock-source";
 
 impl<T> V2ClkCtl<T>


### PR DESCRIPTION
Remove an erronious space from the 'sampling-rate' parameter name.