### PR TITLE
runtime: dice: fix invalid number of values in control element for Konnekt shell models

### DIFF
--- a/runtime/dice/src/tcelectronic/shell_ctl.rs
+++ b/runtime/dice/src/tcelectronic/shell_ctl.rs
@@ -270,7 +270,7 @@ where
             LEVEL_MIN,
             LEVEL_MAX,
             LEVEL_STEP,
-            1,
+            labels.len(),
             Some(&Into::<Vec<u32>>::into(LEVEL_TLV)),
             true,
         )


### PR DESCRIPTION
Closes #218

For 'shell' models in TC Electronics Konnekt series, the control element for internal mixer function has invalid number of elements (= 1) in integer value array. The number should be different by model.