### PR TITLE
protocols/dice: fix wrong annotations in diagrams for Saffire Pro 40 and Liquid Saffire 56

### DIFF
--- a/protocols/dice/src/focusrite/liquids56.rs
+++ b/protocols/dice/src/focusrite/liquids56.rs
@@ -49,14 +49,14 @@
 //!                          ||             || ----> analog-output-9/10
 //! spdif-input-1/2 -------> ||             || ----> spdif-output-1/2
 //! spdif-input-3/4 -------> ||             || ----> spdif-output-3/4
-//! adat-input-1/2 --------> ||             || ----> adat-input-1/2
-//! adat-input-3/4 --------> ||             || ----> adat-input-3/4
-//! adat-input-5/6 --------> ||             || ----> adat-input-5/6
-//! adat-input-7/8 --------> ||             || ----> adat-input-7/8
-//! adat-input-9/10 -------> ||             || ----> adat-input-9/10
-//! adat-input-11/12 ------> ||             || ----> adat-input-11/12
-//! adat-input-13/14 ------> ||             || ----> adat-input-13/14
-//! adat-input-15/16 ------> ||             || ----> adat-input-15/16
+//! adat-input-1/2 --------> ||             || ----> adat-output-1/2
+//! adat-input-3/4 --------> ||             || ----> adat-output-3/4
+//! adat-input-5/6 --------> ||             || ----> adat-output-5/6
+//! adat-input-7/8 --------> ||             || ----> adat-output-7/8
+//! adat-input-9/10 -------> ||             || ----> adat-output-9/10
+//! adat-input-11/12 ------> ||             || ----> adat-output-11/12
+//! adat-input-13/14 ------> ||             || ----> adat-output-13/14
+//! adat-input-15/16 ------> ||             || ----> adat-output-15/16
 //!                          ||             ||
 //! stream-input-A-1/2 ----> ||             || ----> stream-output-A-1/2
 //! stream-input-A-3/4 ----> ||             || ----> stream-output-A-3/4

--- a/protocols/dice/src/focusrite/spro40.rs
+++ b/protocols/dice/src/focusrite/spro40.rs
@@ -28,10 +28,10 @@
 //!                          ||             || ----> analog-output-9/10
 //! spdif-input-1/2 -------> ||             || ----> spdif-output-1/2
 //! spdif-input-3/4 -------> ||             || ----> spdif-output-3/4
-//! adat-input-1/2 --------> ||             || ----> adat-input-1/2
-//! adat-input-3/4 --------> ||             || ----> adat-input-3/4
-//! adat-input-5/6 --------> ||             || ----> adat-input-5/6
-//! adat-input-7/8 --------> ||             || ----> adat-input-7/8
+//! adat-input-1/2 --------> ||             || ----> adat-output-1/2
+//! adat-input-3/4 --------> ||             || ----> adat-output-3/4
+//! adat-input-5/6 --------> ||             || ----> adat-output-5/6
+//! adat-input-7/8 --------> ||             || ----> adat-output-7/8
 //!                          ||             ||
 //! stream-input-A-1/2 ----> ||             || ----> stream-output-A-1/2
 //! stream-input-A-3/4 ----> ||             || ----> stream-output-A-3/4

--- a/protocols/dice/src/focusrite/spro40.rs
+++ b/protocols/dice/src/focusrite/spro40.rs
@@ -6,7 +6,7 @@
 //! The module includes structure, enumeration, and trait and its implementation for protocol
 //! defined by Focusrite for Saffire Pro 40.
 //!
-//! ## Diagram of internal signal flow for Saffire Pro 26.
+//! ## Diagram of internal signal flow for Saffire Pro 40.
 //!
 //! I note that optical input interface is available exclusively for ADAT input and S/PDIF input.
 //!


### PR DESCRIPTION
The router outputs of ADAT signals are annotated with 'adat-input' wrongly for both Saffire Pro 40 and Liquid Saffire 56. This issue was reported at https://github.com/alsa-project/snd-firewire-ctl-services/issues/220.

Closes: https://github.com/alsa-project/snd-firewire-ctl-services/issues/220

Cc: @firstnevyn