### PR TITLE
runtime/dice: tcelectronic: use helper functions to generate kinds of labels for Studio Konnekt 48

### DIFF
--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -240,6 +240,14 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     }
 }
 
+fn element_at_or_error<'a, L>(slice: &'a [L], pos: usize, label: &'a str) -> Result<&'a L, Error> {
+    slice.get(pos).ok_or_else(|| {
+        let upper_bound = slice.len();
+        let msg = format!("Index of {label} should be less than {upper_bound}, but {pos}");
+        Error::new(FileError::Inval, &msg)
+    })
+}
+
 fn nominal_signal_level_to_str(level: &NominalSignalLevel) -> &'static str {
     match level {
         NominalSignalLevel::Professional => "+4dBu",
@@ -361,13 +369,7 @@ impl LineoutCtl {
     {
         let mut params = self.0.data.clone();
         let pos = elem_value.enumerated()[0] as usize;
-        Self::NOMINAL_SIGNAL_LEVELS
-            .iter()
-            .nth(pos)
-            .ok_or_else(|| {
-                let msg = format!("Invalid index of nominal level: {}", pos);
-                Error::new(FileError::Inval, &msg)
-            })
+        element_at_or_error(&Self::NOMINAL_SIGNAL_LEVELS, pos, "nominal level")
             .map(|&l| cb(&mut params, l))?;
         let res =
             Studiok48Protocol::update_partial_segment(req, node, &params, &mut self.0, timeout_ms);
@@ -569,16 +571,12 @@ impl RemoteCtl {
                     .iter_mut()
                     .zip(elem_value.enumerated())
                     .try_for_each(|(assign, &val)| {
-                        let pos = val as usize;
-                        MixerStateCtl::SRC_PAIR_ENTRIES
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg =
-                                    format!("Invalid index of source of user assignment: {}", val);
-                                Error::new(FileError::Inval, &msg)
-                            })
-                            .map(|&s| *assign = s)
+                        element_at_or_error(
+                            &MixerStateCtl::SRC_PAIR_ENTRIES,
+                            val as usize,
+                            "source of user assignment",
+                        )
+                        .map(|&s| *assign = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -592,14 +590,8 @@ impl RemoteCtl {
             }
             EFFECT_BUTTON_MODE_NAME => {
                 let mut params = self.0.data.clone();
-                let val = elem_value.enumerated()[0] as usize;
-                Self::EFFECT_BUTTON_MODES
-                    .iter()
-                    .nth(val)
-                    .ok_or_else(|| {
-                        let msg = format!("Invalid index of source of user assignment: {}", val);
-                        Error::new(FileError::Inval, &msg)
-                    })
+                let pos = elem_value.enumerated()[0] as usize;
+                element_at_or_error(&Self::EFFECT_BUTTON_MODES, pos, "effect button mode")
                     .map(|&m| params.effect_button_mode = m)?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -640,13 +632,7 @@ impl RemoteCtl {
             KNOB_PUSH_MODE_NAME => {
                 let mut params = self.0.data.clone();
                 let pos = elem_value.enumerated()[0] as usize;
-                Self::KNOB_PUSH_MODES
-                    .iter()
-                    .nth(pos)
-                    .ok_or_else(|| {
-                        let msg = format!("Invalid index of source of user assignment: {}", pos);
-                        Error::new(FileError::Inval, &msg)
-                    })
+                element_at_or_error(&Self::KNOB_PUSH_MODES, pos, "knob push mode")
                     .map(|&m| params.knob_push_mode = m)?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -837,13 +823,7 @@ impl ConfigCtl {
                 OPT_IFACE_MODE_NAME => {
                     let mut params = self.0.data.clone();
                     let pos = elem_value.enumerated()[0] as usize;
-                    Self::OPT_IFACE_MODES
-                        .iter()
-                        .nth(pos)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index of standalone clock source: {}", pos);
-                            Error::new(FileError::Inval, &msg)
-                        })
+                    element_at_or_error(&Self::OPT_IFACE_MODES, pos, "optical interface mode")
                         .map(|&m| params.opt_iface_mode = m)?;
                     let res = Studiok48Protocol::update_partial_segment(
                         req,
@@ -858,13 +838,7 @@ impl ConfigCtl {
                 STANDALONE_CLK_SRC_NAME => {
                     let mut params = self.0.data.clone();
                     let pos = elem_value.enumerated()[0] as usize;
-                    Self::STANDALONE_CLK_SRCS
-                        .iter()
-                        .nth(pos)
-                        .ok_or_else(|| {
-                            let msg = format!("Invalid index of standalone clock source: {}", pos);
-                            Error::new(FileError::Inval, &msg)
-                        })
+                    element_at_or_error(&Self::STANDALONE_CLK_SRCS, pos, "standalone clock source")
                         .map(|&s| params.standalone_src = s)?;
                     let res = Studiok48Protocol::update_partial_segment(
                         req,
@@ -1330,15 +1304,8 @@ impl MixerStateCtl {
                     .zip(elem_value.enumerated())
                     .try_for_each(|(pair, &val)| {
                         let pos = val as usize;
-                        let mode = Self::SRC_PAIR_MODES
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg =
-                                    format!("Invalid value for index of mixer source: {}", pos);
-                                Error::new(FileError::Inval, &msg)
-                            })
-                            .copied()?;
+                        let mode =
+                            *element_at_or_error(&Self::SRC_PAIR_MODES, pos, "mixer source pair")?;
                         if mode == MonitorSrcPairMode::Fixed {
                             let msg = format!("The fixed mode is not newly available: {}", pos);
                             Err(Error::new(FileError::Inval, &msg))
@@ -1366,14 +1333,7 @@ impl MixerStateCtl {
                     .zip(elem_value.enumerated())
                     .try_for_each(|(entry, &val)| {
                         let pos = val as usize;
-                        Self::SRC_PAIR_ENTRIES
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg =
-                                    format!("Invalid value for index of mixer source: {}", pos);
-                                Error::new(FileError::Inval, &msg)
-                            })
+                        element_at_or_error(&Self::SRC_PAIR_ENTRIES, pos, "mixer source entry")
                             .map(|&s| entry.src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
@@ -1603,14 +1563,7 @@ impl MixerStateCtl {
                     .zip(elem_value.enumerated())
                     .try_for_each(|(src, &val)| {
                         let pos = val as usize;
-                        Self::SRC_PAIR_ENTRIES
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg =
-                                    format!("Invalid value for index of ch strip source: {}", pos);
-                                Error::new(FileError::Inval, &msg)
-                            })
+                        element_at_or_error(&Self::SRC_PAIR_ENTRIES, pos, "ch strip source")
                             .map(|&s| *src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
@@ -2400,13 +2353,7 @@ impl PhysOutCtl {
                     .zip(elem_value.enumerated())
                     .try_for_each(|(entry, &val)| {
                         let pos = val as usize;
-                        Self::PHYS_OUT_SRCS
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg = format!("output source not found for position {}", pos);
-                                Error::new(FileError::Inval, &msg)
-                            })
+                        element_at_or_error(&Self::PHYS_OUT_SRCS, pos, "output source")
                             .map(|&s| entry.src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
@@ -2527,18 +2474,13 @@ impl PhysOutCtl {
                     .out_grps
                     .iter_mut()
                     .zip(elem_value.enumerated())
-                    .try_for_each(|(out_grp, &val)| {
-                        Self::CROSS_OVER_FREQS
-                            .iter()
-                            .nth(val as usize)
-                            .ok_or_else(|| {
-                                let msg = format!(
-                                    "Invalid value for index of cross over frequency: {}",
-                                    val
-                                );
-                                Error::new(FileError::Inval, &msg)
-                            })
-                            .map(|&freq| out_grp.main_cross_over_freq = freq)
+                    .try_for_each(|(out_grp, &pos)| {
+                        element_at_or_error(
+                            &Self::CROSS_OVER_FREQS,
+                            pos as usize,
+                            "cross over frequency",
+                        )
+                        .map(|&freq| out_grp.main_cross_over_freq = freq)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -2592,16 +2534,7 @@ impl PhysOutCtl {
                     .zip(elem_value.int())
                     .try_for_each(|(out_grp, &val)| {
                         let pos = val as usize;
-                        Self::HIGH_PASS_FREQS
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg = format!(
-                                    "Invalid value for index of high pass frequency: {}",
-                                    pos
-                                );
-                                Error::new(FileError::Inval, &msg)
-                            })
+                        element_at_or_error(&Self::HIGH_PASS_FREQS, pos, "high pass frequency")
                             .map(|&freq| out_grp.main_filter_for_main = freq)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
@@ -2622,16 +2555,7 @@ impl PhysOutCtl {
                     .zip(elem_value.int())
                     .try_for_each(|(out_grp, &val)| {
                         let pos = val as usize;
-                        Self::LOW_PASS_FREQS
-                            .iter()
-                            .nth(pos)
-                            .ok_or_else(|| {
-                                let msg = format!(
-                                    "Invalid value for index of low pass frequency: {}",
-                                    pos
-                                );
-                                Error::new(FileError::Inval, &msg)
-                            })
+                        element_at_or_error(&Self::LOW_PASS_FREQS, pos, "low pass frequency")
                             .map(|&freq| out_grp.main_filter_for_sub = freq)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -240,6 +240,14 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     }
 }
 
+fn elements_to_str_vector<'a, T: 'a, I, F>(elements: I, element_to_string: F) -> Vec<&'static str>
+where
+    I: IntoIterator<Item = &'a T>,
+    F: Fn(&'a T) -> &'static str,
+{
+    elements.into_iter().map(element_to_string).collect()
+}
+
 fn element_at_or_error<'a, L>(slice: &'a [L], pos: usize, label: &'a str) -> Result<&'a L, Error> {
     slice.get(pos).ok_or_else(|| {
         let upper_bound = slice.len();
@@ -276,10 +284,8 @@ impl LineoutCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels: Vec<&str> = Self::NOMINAL_SIGNAL_LEVELS
-            .iter()
-            .map(|m| nominal_signal_level_to_str(m))
-            .collect();
+        let labels =
+            elements_to_str_vector(&Self::NOMINAL_SIGNAL_LEVELS, nominal_signal_level_to_str);
 
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, LINE_OUT_45_LEVEL_NAME, 0);
         card_cntr
@@ -453,10 +459,7 @@ impl RemoteCtl {
             )
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<&str> = Self::EFFECT_BUTTON_MODES
-            .iter()
-            .map(|m| effect_button_mode_to_str(m))
-            .collect();
+        let labels = elements_to_str_vector(&Self::EFFECT_BUTTON_MODES, effect_button_mode_to_str);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, EFFECT_BUTTON_MODE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
@@ -493,10 +496,7 @@ impl RemoteCtl {
             )
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<&str> = Self::KNOB_PUSH_MODES
-            .iter()
-            .map(|m| knob_push_mode_to_str(m))
-            .collect();
+        let labels = elements_to_str_vector(&Self::KNOB_PUSH_MODES, knob_push_mode_to_str);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, KNOB_PUSH_MODE_NAME, 0);
         card_cntr
             .add_enum_elems(&elem_id, 1, 1, &labels, None, true)
@@ -736,17 +736,11 @@ impl ConfigCtl {
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
         load_midi_sender::<Studiok48Protocol, StudioConfig>(card_cntr)?;
 
-        let labels: Vec<&str> = Self::OPT_IFACE_MODES
-            .iter()
-            .map(|m| opt_iface_mode_to_str(m))
-            .collect();
+        let labels = elements_to_str_vector(&Self::OPT_IFACE_MODES, opt_iface_mode_to_str);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, OPT_IFACE_MODE_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
-        let labels: Vec<&str> = Self::STANDALONE_CLK_SRCS
-            .iter()
-            .map(|r| standalone_clk_src_to_str(r))
-            .collect();
+        let labels = elements_to_str_vector(&Self::STANDALONE_CLK_SRCS, standalone_clk_src_to_str);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, STANDALONE_CLK_SRC_NAME, 0);
         let _ = card_cntr.add_enum_elems(&elem_id, 1, 1, &labels, None, true)?;
 
@@ -1026,10 +1020,7 @@ impl MixerStateCtl {
         let labels: Vec<String> = (0..self.0.data.src_pairs.len())
             .map(|i| format!("Mixer-source-{}/{}", i + 1, i + 2))
             .collect();
-        let item_labels: Vec<&str> = Self::SRC_PAIR_MODES
-            .iter()
-            .map(|m| src_pair_mode_to_str(m))
-            .collect();
+        let item_labels = elements_to_str_vector(&Self::SRC_PAIR_MODES, src_pair_mode_to_str);
         self.state_add_elem_enum(card_cntr, SRC_PAIR_MODE_NAME, 1, labels.len(), &item_labels)?;
         self.state_add_elem_bool(card_cntr, SRC_STEREO_LINK_NAME, 1, labels.len())?;
 
@@ -2029,10 +2020,7 @@ impl PhysOutCtl {
             .add_bool_elems(&elem_id, 1, STUDIO_OUTPUT_GROUP_COUNT, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<&str> = Self::CROSS_OVER_FREQS
-            .iter()
-            .map(|src| cross_over_freq_to_str(src))
-            .collect();
+        let labels = elements_to_str_vector(&Self::CROSS_OVER_FREQS, cross_over_freq_to_str);
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,
             0,
@@ -2074,10 +2062,7 @@ impl PhysOutCtl {
             )
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<&str> = Self::HIGH_PASS_FREQS
-            .iter()
-            .map(|src| high_pass_freq_to_str(src))
-            .collect();
+        let labels = elements_to_str_vector(&Self::HIGH_PASS_FREQS, high_pass_freq_to_str);
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,
             0,
@@ -2089,10 +2074,7 @@ impl PhysOutCtl {
             .add_enum_elems(&elem_id, 1, STUDIO_OUTPUT_GROUP_COUNT, &labels, None, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<&str> = Self::LOW_PASS_FREQS
-            .iter()
-            .map(|src| low_pass_freq_to_str(src))
-            .collect();
+        let labels = elements_to_str_vector(&Self::LOW_PASS_FREQS, low_pass_freq_to_str);
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,
             0,
@@ -2621,10 +2603,7 @@ impl HwStateCtl {
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         load_firewire_led::<Studiok48Protocol, StudioHwState>(card_cntr)?;
 
-        let labels = Self::ANALOG_JACK_STATES
-            .iter()
-            .map(|s| analog_jack_state_to_str(s))
-            .collect::<Vec<_>>();
+        let labels = elements_to_str_vector(&Self::ANALOG_JACK_STATES, analog_jack_state_to_str);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Card, 0, 0, ANALOG_JACK_STATE_NAME, 0);
         card_cntr
             .add_enum_elems(

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -240,6 +240,10 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     }
 }
 
+fn generate_channel_labels(name: &str, count: usize) -> Vec<String> {
+    (0..count).map(|i| format!("{}-{}", name, i + 1)).collect()
+}
+
 fn generate_channel_pair_labels(name: &str, count: usize) -> Vec<String> {
     (0..count)
         .map(|i| format!("{}-{}/{}", name, i * 2 + 1, i * 2 + 2))
@@ -1034,9 +1038,7 @@ impl MixerStateCtl {
         self.state_add_elem_enum(card_cntr, SRC_PAIR_MODE_NAME, 1, labels.len(), &item_labels)?;
         self.state_add_elem_bool(card_cntr, SRC_STEREO_LINK_NAME, 1, labels.len())?;
 
-        let labels: Vec<String> = (0..(self.0.data.src_pairs.len() * 2))
-            .map(|i| format!("Mixer-source-{}", i + 1))
-            .collect();
+        let labels = generate_channel_labels("Mixer-source", self.0.data.src_pairs.len() * 2);
         let item_labels =
             elements_to_string_vector(&Self::SRC_PAIR_ENTRIES, src_pair_entry_to_string);
         self.state_add_elem_enum(card_cntr, SRC_ENTRY_NAME, 1, labels.len(), &item_labels)?;
@@ -1059,7 +1061,7 @@ impl MixerStateCtl {
 
         let labels = generate_channel_pair_labels("Channel-strip", 2);
         self.state_add_elem_bool(card_cntr, CH_STRIP_AS_PLUGIN_NAME, 1, labels.len())?;
-        let labels: Vec<String> = (0..4).map(|i| format!("Channel-strip-{}", i)).collect();
+        let labels = generate_channel_labels("Channel-strip", 4);
         self.state_add_elem_enum(card_cntr, CH_STRIP_SRC_NAME, 1, labels.len(), &item_labels)?;
         self.state_add_elem_bool(card_cntr, CH_STRIP_23_AT_MID_RATE, 1, 1)?;
 
@@ -1675,7 +1677,7 @@ impl MixerMeterCtl {
         ]
         .iter()
         .try_for_each(|&(name, count, label)| {
-            let labels: Vec<String> = (0..count).map(|i| format!("{}-{}", label, i)).collect();
+            let labels = generate_channel_labels(label, count);
             let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, name, 0);
             card_cntr
                 .add_int_elems(

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -1760,29 +1760,29 @@ fn src_pair_entry_to_string(entry: &SrcEntry) -> String {
     }
 }
 
-fn cross_over_freq_to_string(freq: &CrossOverFreq) -> String {
+fn cross_over_freq_to_str(freq: &CrossOverFreq) -> &'static str {
     match freq {
-        CrossOverFreq::F50 => "50Hz".to_string(),
-        CrossOverFreq::F80 => "80Hz".to_string(),
-        CrossOverFreq::F95 => "95Hz".to_string(),
-        CrossOverFreq::F110 => "110Hz".to_string(),
-        CrossOverFreq::F115 => "115Hz".to_string(),
-        CrossOverFreq::F120 => "120Hz".to_string(),
+        CrossOverFreq::F50 => "50Hz",
+        CrossOverFreq::F80 => "80Hz",
+        CrossOverFreq::F95 => "95Hz",
+        CrossOverFreq::F110 => "110Hz",
+        CrossOverFreq::F115 => "115Hz",
+        CrossOverFreq::F120 => "120Hz",
     }
 }
 
-fn high_pass_freq_to_string(freq: &HighPassFreq) -> String {
+fn high_pass_freq_to_str(freq: &HighPassFreq) -> &'static str {
     match freq {
-        HighPassFreq::Off => "Off".to_string(),
-        HighPassFreq::Above12 => "12HzAbove".to_string(),
-        HighPassFreq::Above24 => "24HzAbove".to_string(),
+        HighPassFreq::Off => "Off",
+        HighPassFreq::Above12 => "12HzAbove",
+        HighPassFreq::Above24 => "24HzAbove",
     }
 }
 
-fn low_pass_freq_to_string(freq: &LowPassFreq) -> String {
+fn low_pass_freq_to_str(freq: &LowPassFreq) -> &'static str {
     match freq {
-        LowPassFreq::Below12 => "12HzBelow".to_string(),
-        LowPassFreq::Below24 => "24HzBelow".to_string(),
+        LowPassFreq::Below12 => "12HzBelow",
+        LowPassFreq::Below24 => "24HzBelow",
     }
 }
 
@@ -2029,9 +2029,9 @@ impl PhysOutCtl {
             .add_bool_elems(&elem_id, 1, STUDIO_OUTPUT_GROUP_COUNT, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = Self::CROSS_OVER_FREQS
+        let labels: Vec<&str> = Self::CROSS_OVER_FREQS
             .iter()
-            .map(|src| cross_over_freq_to_string(src))
+            .map(|src| cross_over_freq_to_str(src))
             .collect();
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,
@@ -2074,9 +2074,9 @@ impl PhysOutCtl {
             )
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = Self::HIGH_PASS_FREQS
+        let labels: Vec<&str> = Self::HIGH_PASS_FREQS
             .iter()
-            .map(|src| high_pass_freq_to_string(src))
+            .map(|src| high_pass_freq_to_str(src))
             .collect();
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,
@@ -2089,9 +2089,9 @@ impl PhysOutCtl {
             .add_enum_elems(&elem_id, 1, STUDIO_OUTPUT_GROUP_COUNT, &labels, None, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = Self::LOW_PASS_FREQS
+        let labels: Vec<&str> = Self::LOW_PASS_FREQS
             .iter()
-            .map(|src| low_pass_freq_to_string(src))
+            .map(|src| low_pass_freq_to_str(src))
             .collect();
         let elem_id = ElemId::new_by_name(
             ElemIfaceType::Card,

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -240,6 +240,12 @@ impl MeasureModel<(SndDice, FwNode)> for Studiok48Model {
     }
 }
 
+fn generate_channel_pair_labels(name: &str, count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| format!("{}-{}/{}", name, i * 2 + 1, i * 2 + 2))
+        .collect()
+}
+
 fn elements_to_str_vector<'a, T: 'a, I, F>(elements: I, element_to_string: F) -> Vec<&'static str>
 where
     I: IntoIterator<Item = &'a T>,
@@ -1023,9 +1029,7 @@ impl MixerStateCtl {
     }
 
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels: Vec<String> = (0..self.0.data.src_pairs.len())
-            .map(|i| format!("Mixer-source-{}/{}", i + 1, i + 2))
-            .collect();
+        let labels = generate_channel_pair_labels("Mixer-source", self.0.data.src_pairs.len());
         let item_labels = elements_to_str_vector(&Self::SRC_PAIR_MODES, src_pair_mode_to_str);
         self.state_add_elem_enum(card_cntr, SRC_PAIR_MODE_NAME, 1, labels.len(), &item_labels)?;
         self.state_add_elem_bool(card_cntr, SRC_STEREO_LINK_NAME, 1, labels.len())?;
@@ -1053,9 +1057,7 @@ impl MixerStateCtl {
         let labels = &Self::SEND_TARGET_LABELS;
         self.state_add_elem_bool(card_cntr, POST_FADER_NAME, 1, labels.len())?;
 
-        let labels: Vec<String> = (0..2)
-            .map(|i| format!("Channel-strip-{}/{}", i + 1, i + 2))
-            .collect();
+        let labels = generate_channel_pair_labels("Channel-strip", 2);
         self.state_add_elem_bool(card_cntr, CH_STRIP_AS_PLUGIN_NAME, 1, labels.len())?;
         let labels: Vec<String> = (0..4).map(|i| format!("Channel-strip-{}", i)).collect();
         self.state_add_elem_enum(card_cntr, CH_STRIP_SRC_NAME, 1, labels.len(), &item_labels)?;

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -248,6 +248,14 @@ where
     elements.into_iter().map(element_to_string).collect()
 }
 
+fn elements_to_string_vector<'a, T: 'a, I, F>(elements: I, element_to_string: F) -> Vec<String>
+where
+    I: IntoIterator<Item = &'a T>,
+    F: Fn(&'a T) -> String,
+{
+    elements.into_iter().map(element_to_string).collect()
+}
+
 fn element_at_or_error<'a, L>(slice: &'a [L], pos: usize, label: &'a str) -> Result<&'a L, Error> {
     slice.get(pos).ok_or_else(|| {
         let upper_bound = slice.len();
@@ -443,10 +451,8 @@ impl RemoteCtl {
         load_prog::<Studiok48Protocol, StudioRemote>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = MixerStateCtl::SRC_PAIR_ENTRIES
-            .iter()
-            .map(|src| src_pair_entry_to_string(src))
-            .collect();
+        let labels =
+            elements_to_string_vector(&MixerStateCtl::SRC_PAIR_ENTRIES, src_pair_entry_to_string);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, USER_ASSIGN_NAME, 0);
         card_cntr
             .add_enum_elems(
@@ -1027,10 +1033,8 @@ impl MixerStateCtl {
         let labels: Vec<String> = (0..(self.0.data.src_pairs.len() * 2))
             .map(|i| format!("Mixer-source-{}", i + 1))
             .collect();
-        let item_labels: Vec<String> = Self::SRC_PAIR_ENTRIES
-            .iter()
-            .map(|s| src_pair_entry_to_string(s))
-            .collect();
+        let item_labels =
+            elements_to_string_vector(&Self::SRC_PAIR_ENTRIES, src_pair_entry_to_string);
         self.state_add_elem_enum(card_cntr, SRC_ENTRY_NAME, 1, labels.len(), &item_labels)?;
         self.state_add_elem_level(card_cntr, SRC_GAIN_NAME, 1, labels.len())?;
         self.state_add_elem_pan(card_cntr, SRC_PAN_NAME, 1, labels.len())?;
@@ -1949,10 +1953,7 @@ impl PhysOutCtl {
             .add_bool_elems(&elem_id, 1, STUDIO_PHYS_OUT_PAIR_COUNT * 2, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels: Vec<String> = Self::PHYS_OUT_SRCS
-            .iter()
-            .map(|src| src_pair_entry_to_string(src))
-            .collect();
+        let labels = elements_to_string_vector(&Self::PHYS_OUT_SRCS, src_pair_entry_to_string);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUT_SRC_NAME, 0);
         card_cntr
             .add_enum_elems(


### PR DESCRIPTION
In #222, the control elements added by snd-dice-ctl-service includes sort of wrong string labels. Indeed, it handles channel labels somehow wrongly. This patchset fixes the issue with code refactorings for robustness to generate string labels.