### PR TITLE
dice: fix Studio Konnekt 48 source routing panic and mute count

### DIFF
--- a/protocols/dice/src/tcelectronic/studio.rs
+++ b/protocols/dice/src/tcelectronic/studio.rs
@@ -41,7 +41,7 @@
 //! analog-input-7/8 --------------------------------------------> stream-output-A-7/8
 //! analog-input-9/10 -------------------------------------------> stream-output-A-9/10
 //! analog-input-11/12 ------------------------------------------> stream-output-A-11/12
-//! (blank) -----------------------------------------------------> stream-output-A-13/14
+//! (blank at ≤96 kHz; optical at 192 kHz) ----------------------> stream-output-A-13/14
 //! coaxial-input-1/2 -------------------------------------------> stream-output-A-15/16
 //! optical-input-1..8 ------------------------------------------> stream-output-B-1..8
 //! channel-strip-effect-output-1/2 -----------------------------> stream-output-B-9/10
@@ -99,7 +99,7 @@
 //! stream-input-A-7/8 ----------------------> ||            || --> mixer-source-19/20
 //! stream-input-A-9/10 ---------------------> ||            || --> mixer-source-21/22
 //! stream-input-A-11/12 --------------------> ||            || --> mixer-source-23/24
-//! stream-input-A-13/14 (unused)              ||            ||
+//! stream-input-A-13/14 (unused at ≤96 kHz)   ||            ||
 //! stream-input-A-15/16 --------------------> ||            ||
 //!                                            ||            ||
 //! stream-input-B-1/2 ----------------------> ||            ||
@@ -191,7 +191,7 @@
 //! stream-input-A-7/8 ----------------------> ||          || --> coaxial-output-1/2
 //! stream-input-A-9/10 ---------------------> ||          || --> coaxial-output-1/2
 //! stream-input-A-11/12 --------------------> ||          || --> optical-output-1..8
-//! stream-input-A-13/14 (unused)              ||          ||
+//! stream-input-A-13/14 (unused at ≤96 kHz)   ||          ||
 //! stream-input-A-15/16 --------------------> ||          ||
 //!                                            ||          ||
 //! stream-input-B-1/2 ----------------------> ||          ||
@@ -208,6 +208,7 @@
 //! ```
 
 use super::{ch_strip::*, reverb::*, *};
+use crate::tcat::global_section::ClockRate;
 
 /// Protocol implementation of Studio Konnekt 48.
 #[derive(Default, Debug)]
@@ -684,11 +685,18 @@ pub enum SrcEntry {
     Spdif(usize), // 0x0d..0x0e
     /// For ADAT 0..7.
     Adat(usize), // 0x0f..0x16
-    /// For stream A 0..11, 14,15.
-    StreamA(usize), // 0x37..0x46
-    /// For stream B 0..8.
-    StreamB(usize), // 0x47..0x58
-    /// For mixer output (main/aux0/aux1/reverb)
+    /// For stream A 0..15 (wire 0x37..0x46).
+    ///
+    /// Per TC manual, FW stream channel assignment depends on sample rate:
+    /// - ≤96 kHz: indices 12–13 unused; 14–15 carry coax S/PDIF.
+    /// - 176.4/192 kHz: indices 12–13 carry optical (TOS); 14–15 carry coax S/PDIF.
+    ///
+    /// ALSA labels for these channels are chosen at service startup; restart after rate changes.
+    StreamA(usize),
+    /// For stream B 0..13.
+    StreamB(usize), // 0x47..0x54
+    /// For mixer outputs 0..7. Per-channel labels denote stereo pairs:
+    /// Mixer-1/2 (main output), Aux-1..4 (aux1 and aux2 buses), Reverb-1/2 (return bus).
     Mixer(usize), // 0x55..0x5c
 }
 
@@ -708,8 +716,148 @@ impl Default for SrcEntry {
     }
 }
 
+/// All assignable signal sources for Studio Konnekt 48 routing controls.
+pub const STUDIO_SRC_ENTRIES: [SrcEntry; 61] = [
+    SrcEntry::Unused,
+    SrcEntry::Analog(0),
+    SrcEntry::Analog(1),
+    SrcEntry::Analog(2),
+    SrcEntry::Analog(3),
+    SrcEntry::Analog(4),
+    SrcEntry::Analog(5),
+    SrcEntry::Analog(6),
+    SrcEntry::Analog(7),
+    SrcEntry::Analog(8),
+    SrcEntry::Analog(9),
+    SrcEntry::Analog(10),
+    SrcEntry::Analog(11),
+    SrcEntry::Spdif(0),
+    SrcEntry::Spdif(1),
+    SrcEntry::Adat(0),
+    SrcEntry::Adat(1),
+    SrcEntry::Adat(2),
+    SrcEntry::Adat(3),
+    SrcEntry::Adat(4),
+    SrcEntry::Adat(5),
+    SrcEntry::Adat(6),
+    SrcEntry::Adat(7),
+    SrcEntry::StreamA(0),
+    SrcEntry::StreamA(1),
+    SrcEntry::StreamA(2),
+    SrcEntry::StreamA(3),
+    SrcEntry::StreamA(4),
+    SrcEntry::StreamA(5),
+    SrcEntry::StreamA(6),
+    SrcEntry::StreamA(7),
+    SrcEntry::StreamA(8),
+    SrcEntry::StreamA(9),
+    SrcEntry::StreamA(10),
+    SrcEntry::StreamA(11),
+    SrcEntry::StreamA(12),
+    SrcEntry::StreamA(13),
+    SrcEntry::StreamA(14),
+    SrcEntry::StreamA(15),
+    SrcEntry::StreamB(0),
+    SrcEntry::StreamB(1),
+    SrcEntry::StreamB(2),
+    SrcEntry::StreamB(3),
+    SrcEntry::StreamB(4),
+    SrcEntry::StreamB(5),
+    SrcEntry::StreamB(6),
+    SrcEntry::StreamB(7),
+    SrcEntry::StreamB(8),
+    SrcEntry::StreamB(9),
+    SrcEntry::StreamB(10),
+    SrcEntry::StreamB(11),
+    SrcEntry::StreamB(12),
+    SrcEntry::StreamB(13),
+    SrcEntry::Mixer(0),
+    SrcEntry::Mixer(1),
+    SrcEntry::Mixer(2),
+    SrcEntry::Mixer(3),
+    SrcEntry::Mixer(4),
+    SrcEntry::Mixer(5),
+    SrcEntry::Mixer(6),
+    SrcEntry::Mixer(7),
+];
+
+/// Returns the ALSA enum index for the given source entry.
+pub fn studio_src_entry_index(entry: SrcEntry) -> Option<usize> {
+    STUDIO_SRC_ENTRIES.iter().position(|e| *e == entry)
+}
+
+/// Returns the source entry for the given ALSA enum index.
+pub fn studio_src_entry_at(index: usize) -> Option<&'static SrcEntry> {
+    STUDIO_SRC_ENTRIES.get(index)
+}
+
+/// Returns whether FW stream A channels 12–13 carry optical (TOS) at the given rate.
+pub fn studio_src_stream_a_high_rate(rate: ClockRate) -> bool {
+    matches!(
+        rate,
+        ClockRate::R176400 | ClockRate::R192000 | ClockRate::AnyHigh
+    )
+}
+
+fn studio_stream_a_to_string(ch: usize, high_rate: bool) -> String {
+    match ch {
+        0..=11 => format!("Stream-A-{}", ch + 1),
+        12 if high_rate => "Stream-A-13-TOS".to_string(),
+        13 if high_rate => "Stream-A-14-TOS".to_string(),
+        12 | 13 => format!("Stream-A-{}-unused", ch + 1),
+        14 => "Stream-A-15-S/PDIF-coax".to_string(),
+        15 => "Stream-A-16-S/PDIF-coax".to_string(),
+        ch => format!("Stream-A-{}", ch + 1),
+    }
+}
+
+/// Returns human-readable labels for all assignable sources at the given sampling rate.
+///
+/// Stream A channels 12–15 are rate-dependent; see [`SrcEntry::StreamA`]. Labels are fixed when
+/// ALSA elements are registered at service startup from the then-current `clock-rate`. Restart
+/// `snd-dice-ctl-service` after changing the sampling rate to refresh them.
+pub fn studio_src_entry_labels_for_rate(rate: ClockRate) -> Vec<String> {
+    STUDIO_SRC_ENTRIES
+        .iter()
+        .map(|entry| studio_src_entry_to_string_for_rate(*entry, rate))
+        .collect()
+}
+
+pub fn studio_src_entry_to_string_for_rate(entry: SrcEntry, rate: ClockRate) -> String {
+    let high_rate = studio_src_stream_a_high_rate(rate);
+    match entry {
+        SrcEntry::StreamA(ch) => studio_stream_a_to_string(ch, high_rate),
+        _ => studio_src_entry_to_string(entry),
+    }
+}
+
+pub fn studio_src_entry_to_string(entry: SrcEntry) -> String {
+    match entry {
+        SrcEntry::Unused => "Unused".to_string(),
+        SrcEntry::Analog(ch) => format!("Analog-{}", ch + 1),
+        SrcEntry::Spdif(ch) => format!("S/PDIF-{}", ch + 1),
+        SrcEntry::Adat(ch) => format!("ADAT-{}", ch + 1),
+        SrcEntry::StreamA(ch) => format!("Stream-A-{}", ch + 1),
+        SrcEntry::StreamB(ch) => format!("Stream-B-{}", ch + 1),
+        SrcEntry::Mixer(ch) => {
+            // Per-channel names for stereo pairs: main, two aux buses, reverb.
+            if ch < 2 {
+                format!("Mixer-{}", ch + 1)
+            } else if ch < 6 {
+                format!("Aux-{}", ch - 1)
+            } else {
+                format!("Reverb-{}", ch - 5)
+            }
+        }
+    }
+}
+
 fn serialize_src_entry(entry: &SrcEntry, raw: &mut [u8]) -> Result<(), String> {
     assert!(raw.len() >= 4);
+
+    if studio_src_entry_index(*entry).is_none() {
+        return Err(format!("source entry {:?} is not supported", entry));
+    }
 
     let val = (match entry {
         SrcEntry::Unused => SrcEntry::UNUSED,
@@ -1735,5 +1883,82 @@ impl AsRef<[ChStripMeter]> for StudioChStripMeters {
 impl AsMut<[ChStripMeter]> for StudioChStripMeters {
     fn as_mut(&mut self) -> &mut [ChStripMeter] {
         &mut self.0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn studio_src_entry_stream_a_labels() {
+        let low = ClockRate::R48000;
+        let high = ClockRate::R192000;
+
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(11), low),
+            "Stream-A-12"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(12), low),
+            "Stream-A-13-unused"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(13), low),
+            "Stream-A-14-unused"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(12), high),
+            "Stream-A-13-TOS"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(13), high),
+            "Stream-A-14-TOS"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(14), low),
+            "Stream-A-15-S/PDIF-coax"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::StreamA(15), high),
+            "Stream-A-16-S/PDIF-coax"
+        );
+        assert_eq!(
+            studio_src_entry_to_string_for_rate(SrcEntry::Analog(0), high),
+            "Analog-1"
+        );
+    }
+
+    #[test]
+    fn studio_src_entries() {
+        for (i, entry) in STUDIO_SRC_ENTRIES.iter().enumerate() {
+            assert_eq!(studio_src_entry_index(*entry), Some(i));
+            assert_eq!(studio_src_entry_at(i), Some(entry));
+
+            let mut raw = [0u8; 4];
+            serialize_src_entry(entry, &mut raw).unwrap();
+
+            let mut deserialized = SrcEntry::Unused;
+            deserialize_src_entry(&mut deserialized, &raw).unwrap();
+            assert_eq!(*entry, deserialized);
+        }
+
+        let mut raw = [0u8; 4];
+        assert!(serialize_src_entry(&SrcEntry::Analog(99), &mut raw).is_err());
+
+        for v in 0x00..=0x5c {
+            let raw = (v as u32).to_le_bytes();
+            let mut entry = SrcEntry::Unused;
+            deserialize_src_entry(&mut entry, &raw).unwrap();
+
+            if entry != SrcEntry::Unused {
+                assert!(
+                    studio_src_entry_index(entry).is_some(),
+                    "deserialized {:?} from wire 0x{:02x} is missing from STUDIO_SRC_ENTRIES",
+                    entry,
+                    v
+                );
+            }
+        }
     }
 }

--- a/runtime/dice/src/tcelectronic/studiok48_model.rs
+++ b/runtime/dice/src/tcelectronic/studiok48_model.rs
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (c) 2020 Takashi Sakamoto
 
-use {super::*, protocols::tcelectronic::studio::*};
+use {
+    super::*,
+    protocols::tcat::global_section::ClockRate,
+    protocols::tcelectronic::studio::*,
+};
 
 #[derive(Default, Debug)]
 pub struct Studiok48Model {
@@ -22,6 +26,22 @@ pub struct Studiok48Model {
 }
 
 const TIMEOUT_MS: u32 = 20;
+
+fn studio_src_index(entry: &SrcEntry) -> Result<u32, Error> {
+    studio_src_entry_index(*entry)
+        .map(|i| i as u32)
+        .ok_or_else(|| {
+            let msg = format!("Unknown source entry: {entry:?}");
+            Error::new(FileError::Inval, &msg)
+        })
+}
+
+fn studio_src_from_index(pos: usize, what: &str) -> Result<SrcEntry, Error> {
+    studio_src_entry_at(pos).copied().ok_or_else(|| {
+        let msg = format!("Invalid {what}: {pos}");
+        Error::new(FileError::Inval, &msg)
+    })
+}
 
 impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
     fn cache(&mut self, (_, node): &mut (SndDice, FwNode)) -> Result<(), Error> {
@@ -59,12 +79,15 @@ impl CtlModel<(SndDice, FwNode)> for Studiok48Model {
     fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
         self.common_ctl.load(card_cntr)?;
 
+        // Source routing enum labels depend on the current clock rate and are fixed at registration.
+        let clk_rate = self.common_ctl.global_params.clock_config.rate;
+
         self.lineout_ctl.load(card_cntr)?;
-        self.remote_ctl.load(card_cntr)?;
+        self.remote_ctl.load(card_cntr, clk_rate)?;
         self.config_ctl.load(card_cntr)?;
-        self.mixer_state_ctl.load(card_cntr)?;
+        self.mixer_state_ctl.load(card_cntr, clk_rate)?;
         self.mixer_meter_ctl.load(card_cntr)?;
-        self.phys_out_ctl.load(card_cntr)?;
+        self.phys_out_ctl.load(card_cntr, clk_rate)?;
 
         self.reverb_state_ctl.load(card_cntr)?;
         self.reverb_meter_ctl.load(card_cntr)?;
@@ -254,14 +277,6 @@ fn elements_to_str_vector<'a, T: 'a, I, F>(elements: I, element_to_string: F) ->
 where
     I: IntoIterator<Item = &'a T>,
     F: Fn(&'a T) -> &'static str,
-{
-    elements.into_iter().map(element_to_string).collect()
-}
-
-fn elements_to_string_vector<'a, T: 'a, I, F>(elements: I, element_to_string: F) -> Vec<String>
-where
-    I: IntoIterator<Item = &'a T>,
-    F: Fn(&'a T) -> String,
 {
     elements.into_iter().map(element_to_string).collect()
 }
@@ -457,12 +472,11 @@ impl RemoteCtl {
         res
     }
 
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, card_cntr: &mut CardCntr, clk_rate: ClockRate) -> Result<(), Error> {
         load_prog::<Studiok48Protocol, StudioRemote>(card_cntr)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels =
-            elements_to_string_vector(&MixerStateCtl::SRC_PAIR_ENTRIES, src_pair_entry_to_string);
+        let labels = studio_src_entry_labels_for_rate(clk_rate);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, USER_ASSIGN_NAME, 0);
         card_cntr
             .add_enum_elems(
@@ -528,14 +542,8 @@ impl RemoteCtl {
                 let vals: Vec<u32> = params
                     .user_assigns
                     .iter()
-                    .map(|assign| {
-                        let pos = MixerStateCtl::SRC_PAIR_ENTRIES
-                            .iter()
-                            .position(|a| assign.eq(a))
-                            .unwrap();
-                        pos as u32
-                    })
-                    .collect();
+                    .map(|assign| studio_src_index(assign))
+                    .collect::<Result<Vec<_>, _>>()?;
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
@@ -587,12 +595,8 @@ impl RemoteCtl {
                     .iter_mut()
                     .zip(elem_value.enumerated())
                     .try_for_each(|(assign, &val)| {
-                        element_at_or_error(
-                            &MixerStateCtl::SRC_PAIR_ENTRIES,
-                            val as usize,
-                            "source of user assignment",
-                        )
-                        .map(|&s| *assign = s)
+                        studio_src_from_index(val as usize, "user assignment source index")
+                            .map(|s| *assign = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -955,60 +959,6 @@ impl MixerStateCtl {
         MonitorSrcPairMode::Fixed,
     ];
 
-    const SRC_PAIR_ENTRIES: [SrcEntry; 51] = [
-        SrcEntry::Unused,
-        SrcEntry::Analog(0),
-        SrcEntry::Analog(1),
-        SrcEntry::Analog(2),
-        SrcEntry::Analog(3),
-        SrcEntry::Analog(4),
-        SrcEntry::Analog(5),
-        SrcEntry::Analog(6),
-        SrcEntry::Analog(7),
-        SrcEntry::Analog(8),
-        SrcEntry::Analog(9),
-        SrcEntry::Analog(10),
-        SrcEntry::Analog(11),
-        SrcEntry::Spdif(0),
-        SrcEntry::Spdif(1),
-        SrcEntry::Adat(0),
-        SrcEntry::Adat(1),
-        SrcEntry::Adat(2),
-        SrcEntry::Adat(3),
-        SrcEntry::Adat(4),
-        SrcEntry::Adat(5),
-        SrcEntry::Adat(6),
-        SrcEntry::Adat(7),
-        SrcEntry::StreamA(0),
-        SrcEntry::StreamA(1),
-        SrcEntry::StreamA(2),
-        SrcEntry::StreamA(3),
-        SrcEntry::StreamA(4),
-        SrcEntry::StreamA(5),
-        SrcEntry::StreamA(6),
-        SrcEntry::StreamA(7),
-        SrcEntry::StreamA(8),
-        SrcEntry::StreamA(9),
-        SrcEntry::StreamA(10),
-        SrcEntry::StreamA(11),
-        SrcEntry::StreamA(12),
-        SrcEntry::StreamA(13),
-        SrcEntry::StreamA(14),
-        SrcEntry::StreamA(15),
-        SrcEntry::StreamB(0),
-        SrcEntry::StreamB(1),
-        SrcEntry::StreamB(2),
-        SrcEntry::StreamB(3),
-        SrcEntry::StreamB(4),
-        SrcEntry::StreamB(5),
-        SrcEntry::StreamB(6),
-        SrcEntry::StreamB(7),
-        SrcEntry::StreamB(8),
-        SrcEntry::StreamB(9),
-        SrcEntry::StreamB(10),
-        SrcEntry::StreamB(11),
-    ];
-
     const OUT_LABELS: [&'static str; 3] = ["Main-1/2", "Aux-1/2", "Aux-3/4"];
     const SEND_TARGET_LABELS: [&'static str; 3] = ["Reverb-1/2", "Aux-1/2", "Aux-3/4"];
 
@@ -1032,22 +982,22 @@ impl MixerStateCtl {
         res
     }
 
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
-        let labels = generate_channel_pair_labels("Mixer-source", self.0.data.src_pairs.len());
+    fn load(&mut self, card_cntr: &mut CardCntr, clk_rate: ClockRate) -> Result<(), Error> {
+        let pair_labels = generate_channel_pair_labels("Mixer-source", self.0.data.src_pairs.len());
         let item_labels = elements_to_str_vector(&Self::SRC_PAIR_MODES, src_pair_mode_to_str);
-        self.state_add_elem_enum(card_cntr, SRC_PAIR_MODE_NAME, 1, labels.len(), &item_labels)?;
-        self.state_add_elem_bool(card_cntr, SRC_STEREO_LINK_NAME, 1, labels.len())?;
+        self.state_add_elem_enum(card_cntr, SRC_PAIR_MODE_NAME, 1, pair_labels.len(), &item_labels)?;
+        self.state_add_elem_bool(card_cntr, SRC_STEREO_LINK_NAME, 1, pair_labels.len())?;
+        self.state_add_elem_bool(card_cntr, SRC_MUTE_NAME, 1, pair_labels.len())?;
 
-        let labels = generate_channel_labels("Mixer-source", self.0.data.src_pairs.len() * 2);
-        let item_labels =
-            elements_to_string_vector(&Self::SRC_PAIR_ENTRIES, src_pair_entry_to_string);
-        self.state_add_elem_enum(card_cntr, SRC_ENTRY_NAME, 1, labels.len(), &item_labels)?;
-        self.state_add_elem_level(card_cntr, SRC_GAIN_NAME, 1, labels.len())?;
-        self.state_add_elem_pan(card_cntr, SRC_PAN_NAME, 1, labels.len())?;
-        self.state_add_elem_level(card_cntr, REVERB_SRC_GAIN_NAME, 1, labels.len())?;
-        self.state_add_elem_level(card_cntr, AUX01_SRC_GAIN_NAME, 1, labels.len())?;
-        self.state_add_elem_level(card_cntr, AUX23_SRC_GAIN_NAME, 1, labels.len())?;
-        self.state_add_elem_bool(card_cntr, SRC_MUTE_NAME, 1, labels.len())?;
+        let channel_labels =
+            generate_channel_labels("Mixer-source", self.0.data.src_pairs.len() * 2);
+        let item_labels = studio_src_entry_labels_for_rate(clk_rate);
+        self.state_add_elem_enum(card_cntr, SRC_ENTRY_NAME, 1, channel_labels.len(), &item_labels)?;
+        self.state_add_elem_level(card_cntr, SRC_GAIN_NAME, 1, channel_labels.len())?;
+        self.state_add_elem_pan(card_cntr, SRC_PAN_NAME, 1, channel_labels.len())?;
+        self.state_add_elem_level(card_cntr, REVERB_SRC_GAIN_NAME, 1, channel_labels.len())?;
+        self.state_add_elem_level(card_cntr, AUX01_SRC_GAIN_NAME, 1, channel_labels.len())?;
+        self.state_add_elem_level(card_cntr, AUX23_SRC_GAIN_NAME, 1, channel_labels.len())?;
 
         let labels = &Self::OUT_LABELS;
         self.state_add_elem_bool(card_cntr, REVERB_RETURN_MUTE_NAME, 1, labels.len())?;
@@ -1167,14 +1117,8 @@ impl MixerStateCtl {
             }
             SRC_ENTRY_NAME => {
                 let vals: Vec<u32> = mixer_monitor_src_params_iter(&self.0.data)
-                    .map(|param| {
-                        Self::SRC_PAIR_ENTRIES
-                            .iter()
-                            .position(|m| param.src.eq(m))
-                            .map(|pos| pos as u32)
-                            .unwrap()
-                    })
-                    .collect();
+                    .map(|param| studio_src_index(&param.src))
+                    .collect::<Result<Vec<_>, _>>()?;
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
@@ -1265,14 +1209,8 @@ impl MixerStateCtl {
                 let vals: Vec<u32> = params
                     .ch_strip_src
                     .iter()
-                    .map(|src| {
-                        let pos = Self::SRC_PAIR_ENTRIES
-                            .iter()
-                            .position(|s| src.eq(s))
-                            .unwrap();
-                        pos as u32
-                    })
-                    .collect();
+                    .map(|src| studio_src_index(src))
+                    .collect::<Result<Vec<_>, _>>()?;
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
@@ -1331,9 +1269,8 @@ impl MixerStateCtl {
                 mixer_monitor_src_params_iter_mut(&mut params)
                     .zip(elem_value.enumerated())
                     .try_for_each(|(entry, &val)| {
-                        let pos = val as usize;
-                        element_at_or_error(&Self::SRC_PAIR_ENTRIES, pos, "mixer source entry")
-                            .map(|&s| entry.src = s)
+                        studio_src_from_index(val as usize, "mixer source index")
+                            .map(|s| entry.src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -1561,9 +1498,8 @@ impl MixerStateCtl {
                     .iter_mut()
                     .zip(elem_value.enumerated())
                     .try_for_each(|(src, &val)| {
-                        let pos = val as usize;
-                        element_at_or_error(&Self::SRC_PAIR_ENTRIES, pos, "ch strip source")
-                            .map(|&s| *src = s)
+                        studio_src_from_index(val as usize, "channel strip source index")
+                            .map(|s| *src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,
@@ -1739,26 +1675,6 @@ const OUT_GRP_SUB_LEVEL_TO_SUB_NAME: &str = "output-group:sub-level-to-sub";
 const OUT_GRP_MAIN_FILTER_FOR_MAIN_NAME: &str = "output-group:main-filter-for-main";
 const OUT_GRP_MAIN_FILTER_FOR_SUB_NAME: &str = "output-group:main-filter-for-sub";
 
-fn src_pair_entry_to_string(entry: &SrcEntry) -> String {
-    match entry {
-        SrcEntry::Unused => "Unused".to_string(),
-        SrcEntry::Analog(ch) => format!("Analog-{}", ch + 1),
-        SrcEntry::Spdif(ch) => format!("S/PDIF-{}", ch + 1),
-        SrcEntry::Adat(ch) => format!("ADAT-{}", ch + 1),
-        SrcEntry::StreamA(ch) => format!("Stream-A-{}", ch + 1),
-        SrcEntry::StreamB(ch) => format!("Stream-B-{}", ch + 1),
-        SrcEntry::Mixer(ch) => {
-            if *ch < 2 {
-                format!("Mixer-{}", ch + 1)
-            } else if *ch < 6 {
-                format!("Aux-{}", ch - 1)
-            } else {
-                format!("Reverb-{}", ch - 5)
-            }
-        }
-    }
-}
-
 fn cross_over_freq_to_str(freq: &CrossOverFreq) -> &'static str {
     match freq {
         CrossOverFreq::F50 => "50Hz",
@@ -1806,68 +1722,6 @@ fn phys_out_src_params_iter_mut(
 }
 
 impl PhysOutCtl {
-    const PHYS_OUT_SRCS: [SrcEntry; 59] = [
-        SrcEntry::Unused,
-        SrcEntry::Analog(0),
-        SrcEntry::Analog(1),
-        SrcEntry::Analog(2),
-        SrcEntry::Analog(3),
-        SrcEntry::Analog(4),
-        SrcEntry::Analog(5),
-        SrcEntry::Analog(6),
-        SrcEntry::Analog(7),
-        SrcEntry::Analog(8),
-        SrcEntry::Analog(9),
-        SrcEntry::Analog(10),
-        SrcEntry::Analog(11),
-        SrcEntry::Spdif(0),
-        SrcEntry::Spdif(1),
-        SrcEntry::Adat(0),
-        SrcEntry::Adat(1),
-        SrcEntry::Adat(2),
-        SrcEntry::Adat(3),
-        SrcEntry::Adat(4),
-        SrcEntry::Adat(5),
-        SrcEntry::Adat(6),
-        SrcEntry::Adat(7),
-        SrcEntry::StreamA(0),
-        SrcEntry::StreamA(1),
-        SrcEntry::StreamA(2),
-        SrcEntry::StreamA(3),
-        SrcEntry::StreamA(4),
-        SrcEntry::StreamA(5),
-        SrcEntry::StreamA(6),
-        SrcEntry::StreamA(7),
-        SrcEntry::StreamA(8),
-        SrcEntry::StreamA(9),
-        SrcEntry::StreamA(10),
-        SrcEntry::StreamA(11),
-        SrcEntry::StreamA(12),
-        SrcEntry::StreamA(13),
-        SrcEntry::StreamA(14),
-        SrcEntry::StreamA(15),
-        SrcEntry::StreamB(0),
-        SrcEntry::StreamB(1),
-        SrcEntry::StreamB(2),
-        SrcEntry::StreamB(3),
-        SrcEntry::StreamB(4),
-        SrcEntry::StreamB(5),
-        SrcEntry::StreamB(6),
-        SrcEntry::StreamB(7),
-        SrcEntry::StreamB(8),
-        SrcEntry::StreamB(9),
-        SrcEntry::StreamB(10),
-        SrcEntry::StreamB(11),
-        SrcEntry::Mixer(0),
-        SrcEntry::Mixer(1),
-        SrcEntry::Mixer(2),
-        SrcEntry::Mixer(3),
-        SrcEntry::Mixer(4),
-        SrcEntry::Mixer(5),
-        SrcEntry::Mixer(6),
-        SrcEntry::Mixer(7),
-    ];
-
     const VOL_MIN: i32 = -1000;
     const VOL_MAX: i32 = 0;
     const VOL_STEP: i32 = 1;
@@ -1911,7 +1765,7 @@ impl PhysOutCtl {
         res
     }
 
-    fn load(&mut self, card_cntr: &mut CardCntr) -> Result<(), Error> {
+    fn load(&mut self, card_cntr: &mut CardCntr, clk_rate: ClockRate) -> Result<(), Error> {
         // For master output.
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, MASTER_OUT_DIM_NAME, 0);
         card_cntr
@@ -1957,7 +1811,7 @@ impl PhysOutCtl {
             .add_bool_elems(&elem_id, 1, STUDIO_PHYS_OUT_PAIR_COUNT * 2, true)
             .map(|mut elem_id_list| self.1.append(&mut elem_id_list))?;
 
-        let labels = elements_to_string_vector(&Self::PHYS_OUT_SRCS, src_pair_entry_to_string);
+        let labels = studio_src_entry_labels_for_rate(clk_rate);
         let elem_id = ElemId::new_by_name(ElemIfaceType::Mixer, 0, 0, OUT_SRC_NAME, 0);
         card_cntr
             .add_enum_elems(
@@ -2127,14 +1981,8 @@ impl PhysOutCtl {
             OUT_SRC_NAME => {
                 let params = &self.0.data;
                 let vals: Vec<u32> = phys_out_src_params_iter(params)
-                    .map(|params| {
-                        let pos = Self::PHYS_OUT_SRCS
-                            .iter()
-                            .position(|s| params.src.eq(s))
-                            .unwrap();
-                        pos as u32
-                    })
-                    .collect();
+                    .map(|params| studio_src_index(&params.src))
+                    .collect::<Result<Vec<_>, _>>()?;
                 elem_value.set_enum(&vals);
                 Ok(true)
             }
@@ -2339,9 +2187,8 @@ impl PhysOutCtl {
                 phys_out_src_params_iter_mut(&mut params)
                     .zip(elem_value.enumerated())
                     .try_for_each(|(entry, &val)| {
-                        let pos = val as usize;
-                        element_at_or_error(&Self::PHYS_OUT_SRCS, pos, "output source")
-                            .map(|&s| entry.src = s)
+                        studio_src_from_index(val as usize, "output source index")
+                            .map(|s| entry.src = s)
                     })?;
                 let res = Studiok48Protocol::update_partial_segment(
                     req,


### PR DESCRIPTION
When the device has a mixer bus (or StreamB 12/13) assigned as a mixer
input source, snd-dice-ctl-service panics in MixerStateCtl::read because
SRC_PAIR_ENTRIES is incomplete and the code unwraps on .position().

This moves a full source entry table (61 entries) into the protocol crate,
uses it for remote / mixer / physical-output routing controls, and registers
mixer-input-mute with 12 pair slots to match StudioMixerState.mutes.

Pair labels (1/2, 3/4, …) were already fixed in #223; this keeps those
helpers.

Tested:
- cargo test -p firewire-dice-protocols tcelectronic::studio::test
- on hardware: set mixer-input-source to Mixer-1, no panic on read;
  mixer-input-mute shows 12 values

Fixes: #222
